### PR TITLE
feat: add construction-02 POC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,17 +8,18 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "next": "^11.0.0",
-        "node-pg-migrate": "^5.9.0",
-        "pg": "^8.6.0",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2",
-        "react-icons": "^4.2.0"
+        "next": "11.0.0",
+        "node-pg-migrate": "5.9.0",
+        "pg": "8.6.0",
+        "react": "17.0.2",
+        "react-confetti": "^6.0.1",
+        "react-dom": "17.0.2",
+        "react-icons": "4.2.0"
       },
       "devDependencies": {
-        "autoprefixer": "^10.2.6",
-        "postcss": "^8.3.4",
-        "tailwindcss": "^2.1.4"
+        "autoprefixer": "10.2.6",
+        "postcss": "8.3.4",
+        "tailwindcss": "2.1.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3051,6 +3052,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-confetti": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/react-confetti/-/react-confetti-6.0.1.tgz",
+      "integrity": "sha512-ZpOTBrqSNhWE4rRXCZ6E6U+wGd7iYHF5MGrqwikoiBpgBq9Akdu0DcLW+FdFnLjyZYC+VfAiV2KeFgYRMyMrkA==",
+      "dependencies": {
+        "tween-functions": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=10.18"
+      },
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.1"
+      }
+    },
     "node_modules/react-dom": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
@@ -3647,6 +3662,11 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
       "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw=="
+    },
+    "node_modules/tween-functions": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tween-functions/-/tween-functions-1.2.0.tgz",
+      "integrity": "sha1-GuOlDnxguz3vd06scHrLynO7w/8="
     },
     "node_modules/type-fest": {
       "version": "0.7.1",
@@ -6250,6 +6270,14 @@
         "object-assign": "^4.1.1"
       }
     },
+    "react-confetti": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/react-confetti/-/react-confetti-6.0.1.tgz",
+      "integrity": "sha512-ZpOTBrqSNhWE4rRXCZ6E6U+wGd7iYHF5MGrqwikoiBpgBq9Akdu0DcLW+FdFnLjyZYC+VfAiV2KeFgYRMyMrkA==",
+      "requires": {
+        "tween-functions": "^1.2.0"
+      }
+    },
     "react-dom": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
@@ -6706,6 +6734,11 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
       "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw=="
+    },
+    "tween-functions": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tween-functions/-/tween-functions-1.2.0.tgz",
+      "integrity": "sha1-GuOlDnxguz3vd06scHrLynO7w/8="
     },
     "type-fest": {
       "version": "0.7.1",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "node-pg-migrate": "5.9.0",
     "pg": "8.6.0",
     "react": "17.0.2",
+    "react-confetti": "6.0.1",
     "react-dom": "17.0.2",
     "react-icons": "4.2.0"
   },

--- a/pages/pocs/construction-02.public.js
+++ b/pages/pocs/construction-02.public.js
@@ -1,0 +1,120 @@
+import Head from "next/head";
+import Image from "next/image";
+import Confetti from "react-confetti";
+import { useState, useEffect } from "react";
+
+import { CgTab } from "react-icons/cg";
+import collaborators from "../init/collaborators.json";
+
+export default function Page() {
+  const [shuffledCollaborators, setShuffledCollaborators] = useState([]);
+  const [confettiWidth, setConfettiWidth] = useState(0);
+  const [confettiHeight, setConfettiHeight] = useState(0);
+
+  useEffect(() => {
+    setShuffledCollaborators(shuffle(collaborators));
+    setConfettiWidth(window.innerWidth);
+    setConfettiHeight(window.innerHeight);
+  }, []);
+
+  return (
+    <>
+      <Head>
+        <title>TabNews: Onde tudo começou ("git init")</title>
+        <meta
+          name="description"
+          content="Estamos neste exato momento construindo um novo local na internet para quem trabalha com tecnologia e precisa consumir conteúdos com valor concreto."
+        ></meta>
+      </Head>
+
+      <Confetti
+        width={confettiWidth}
+        height={confettiHeight}
+        recycle={false}
+        numberOfPieces={800}
+        tweenDuration={15000}
+        gravity={0.15}
+      />
+
+      <div className="mt-6 mb-6">
+        <div className="max-w-5xl m-auto text-center">
+          <div className="flex items-center space-x-1 text-gray-800 justify-center">
+            <CgTab className="w-6 h-6" />
+            <h1 className="text-gray-800 text-xl font-bold">TabNews</h1>
+          </div>
+
+          <div className="text-gray-700 text-base mt-6 pl-4 pr-4">
+            Estamos neste exato momento construindo um novo local na internet
+            para quem <strong>trabalha com tecnologia</strong> e precisa
+            consumir conteúdos com <strong>valor concreto</strong>. Somos
+            pessoas brutalmente exatas e empáticas,{" "}
+            <strong>simultaneamente</strong>, onde o termômetro para entender se
+            isso está sendo aplicado é simples: as pessoas estão se{" "}
+            <strong>afastando</strong> ou se <strong>aproximando</strong>? E as{" "}
+            <strong>{collaborators.length}</strong> pessoas listadas abaixo se
+            aproximaram no <strong>Dia 0</strong> deste projeto para apoiar a
+            sua criação, incluindo colocando a mão na massa:
+          </div>
+        </div>
+
+        <div className="collaborators-grid mt-6">
+          {shuffledCollaborators.map((username) => {
+            const collaboratorAvatar = require(`../init/avatars/${username}.jpg`);
+            return (
+              <div key={username} className="avatar">
+                <a
+                  href={`https://github.com/${username}`}
+                  target="_blank"
+                  rel="noopener"
+                >
+                  <Image
+                    src={collaboratorAvatar}
+                    alt={`Colaborador ${username}`}
+                  />
+                </a>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="max-w-4xl m-auto text-center text-gray-700 mt-6 pl-4 pr-4">
+          Esta página é um arquivo histórico e foi publicada em{" "}
+          <strong>25 de Junho de 2021</strong>.
+        </div>
+      </div>
+      <style jsx>{`
+        .collaborators-grid {
+          display: grid;
+          grid-template-columns: repeat(4, minmax(0, 1fr));
+          grid-gap: 0.25rem;
+          padding: 0.25rem;
+          line-height: 0;
+        }
+
+        @media (min-width: 640px) {
+            .collaborators-grid {
+                grid-template-columns: repeat(8, minmax(0, 1fr));
+            }
+
+        @media (min-width: 1024px) {
+            .collaborators-grid {
+                grid-template-columns: repeat(16, minmax(0, 1fr));
+            }
+
+        @media (min-width: 1280px) {
+            .collaborators-grid {
+                grid-template-columns: repeat(25, minmax(0, 1fr));
+            }
+      `}</style>
+    </>
+  );
+}
+
+function shuffle(arr) {
+  const newArr = arr.slice();
+  for (let i = newArr.length - 1; i > 0; i--) {
+    const rand = Math.floor(Math.random() * (i + 1));
+    [newArr[i], newArr[rand]] = [newArr[rand], newArr[i]];
+  }
+  return newArr;
+}


### PR DESCRIPTION
**Turma, segue minha sugestão:**
**https://tabnews-git-construction-filipe-filipedeschamps.vercel.app/pocs/construction-02**

Os pontos principais são:

1. Uma página comemorativa, que ficará **congelada** ao longo dos anos, e as pessoas que participaram vão poder falar: *"Oh, eu tava lá!"*
2. Usar o espaço para o que importa nessa hora: **reforçar nossa postura desde o Dia 0**. Se essa parte do projeto não parar em pé, não vai ter tecnologia que vai construir um ambiente que seja gostoso voltar para contribuir e reencontrar os colegas da área. Então **não sugiro** usarmos esse espaço para capturar leads, isso não importa tanto quanto deixar anotado para sempre a nossa cultura. E lembra que essa página é **para nós** (quem estava no `init`) mais do que é para qualquer outra pessoa.
3. A página é responsiva, e em desktop coube o avatar de todo mundo até agora, então vai dar para tirar o print de todo mundo ao mesmo tempo.
4. Os avatares são randomicamente posicionados a cada refresh para caso você queira ter a chance de tirar um print do seu avatar numa posição mais acima.
5. O click no avatar leva para o Github da pessoa.
6. Bastante código inline para a página ser autossuficiente e permanecer sem alterações ao longo do tempo. Por exemplo: escolhi não estender o `grid` do Tailwind, pois não sei se isso vai ser usado no resto do site, então fiz inline. O que não deu para fazer inline foi o `react-confetti`, mas ele vai ser usado em outros recursos do site, como quando o usuário ganha uma nova habilidade. Tava pensando também fazer inline **todas** as classes do Tailwind. O que vocês acham?
7. A ideia é primeiro publicar ela como a Home do site, e depois mover para o endereço `/init` e ficar lá pra sempre.
8. Isso não substitui uma *"página viva"* de contribuidores/stats do site, mostrando publicamente as estatísticas de contribuições, releases e volume de acessos/cadastros/moedas.

![tabnews-construction-2](https://user-images.githubusercontent.com/4248081/123027209-4f0efb80-d392-11eb-9cd8-d6e404383dff.png)
