### PR TITLE
update: Resize in Confetti construction-02.public.js

### DIFF
--- a/pages/pocs/construction-02.public.js
+++ b/pages/pocs/construction-02.public.js
@@ -13,12 +13,23 @@ export default function Page() {
 
   useEffect(() => {
     setShuffledCollaborators(shuffle(collaborators));
-    setConfettiWidth(window.innerWidth);
-    setConfettiHeight(window.innerHeight);
+    function handleResize() {
+      setConfettiWidth(window.innerWidth);
+      setConfettiHeight(window.innerHeight);
+    }
+    window.addEventListener("resize", handleResize);
+    handleResize();
+    return () => window.removeEventListener("resize", handleResize);
   }, []);
 
   return (
     <>
+      <style>{`
+        body
+        {
+          overflow-x: hidden;
+        }
+      `}</style>
       <Head>
         <title>TabNews: Onde tudo começou ("git init")</title>
         <meta


### PR DESCRIPTION
Conforme solicitado na PR #45 

- Adicionei um EventListener dentro do useEffect para atualizar a largura e altura quando redimensionar a tela.
- Quando o scroll lateral aparece no chrome ele reduz a área aparecendo um pequeno scroll horizontal por isso adicionei um bloqueio via CSS overflow-x: hidden;