### PR TITLE
fix: Bug na rotação mobile construction-02

### DIFF
--- a/pages/pocs/construction-02.public.js
+++ b/pages/pocs/construction-02.public.js
@@ -14,8 +14,8 @@ export default function Page() {
   useEffect(() => {
     setShuffledCollaborators(shuffle(collaborators));
     function handleResize() {
-      setConfettiWidth(window.innerWidth);
-      setConfettiHeight(window.innerHeight);
+      setConfettiWidth(window.screen.width);
+      setConfettiHeight(window.screen.height);
     }
     window.addEventListener("resize", handleResize);
     handleResize();


### PR DESCRIPTION
Não entendi o motivo, mas utilizando **window.innerWidth** quando rotaciona o celular e volta ele volta com BUG no tamanho. Quando altera para **window.screen.width** funciona perfeitamente.
Testei no chrome Linux se possivel testarem em todos navegadores para ver se resolver o BUG.

https://tabnews-git-rodrigokulb-patch-1-filipedeschamps.vercel.app/pocs/construction-02

![Captura de tela em 2021-06-25 11-59-33](https://user-images.githubusercontent.com/5334261/123444651-80174800-d5ad-11eb-96e0-d7be8b642d50.png)
