### PR TITLE
fix: Changes license key in package.json to GPL-3.0-only to match SPDX ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "news"
   ],
   "author": "Filipe Deschamps",
-  "license": "GPL-3.0",
+  "license": "GPL-3.0-only",
   "bugs": {
     "url": "https://github.com/filipedeschamps/tabnews.com.br/issues"
   },


### PR DESCRIPTION
Baseado na documentação do npm, no site de licenças da SPDX e no site da Open Source Initiative, alterei a chave da licença no arquivo package.json para `GPL-3.0-only`. Mais detalhes na PR #66.

Mais sobre a chave da licença em:
https://docs.npmjs.com/cli/v7/configuring-npm/package-json#license
https://spdx.org/licenses/
https://opensource.org/licenses/GPL-3.0