### PR TITLE
Cria container postgres 13 usando docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+postgres_data/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3.4"
+services:
+
+  postgres:
+    image: postgres:13.3-alpine
+    ports:
+      - 5432:5432
+    expose:
+      - "5432"
+    network_mode: host
+    volumes:
+      - ./postgres_data:/var/lib/postgresql/data
+      - ./docker/entrypoint-initdb.d:/docker-entrypoint-initdb.d
+    environment:
+      POSTGRES_USER: tabnews
+      POSTGRES_PASSWORD: tabnews
+      POSTGRES_DB: tabnews

--- a/docker/entrypoint-initdb.d/initialize-database.sh
+++ b/docker/entrypoint-initdb.d/initialize-database.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
+    CREATE DATABASE tabnews_test;
+    GRANT ALL PRIVILEGES ON DATABASE tabnews_test TO tabnews;
+
+EOSQL


### PR DESCRIPTION
hey @filipedeschamps 

Caso ajude, segue como utilizo o postgres localmente com docker-compose.

Features:
- Usa Posgres 13 para ficar igual a versão que voce criou na D.O
- Usa mesma rede do host para facilitar a aplicação backend fora do container acessar o banco
- Cria um banco tabnews e tabnews_test (para ajudar nos testes no backend)
- Utiliza imagem alpine que é mais leve/rápida para desenvolvimento

Como utilizar:
- `docker-compose up` ou `docker-compose up -d` para iniciar o banco
- `docker-compose logs -f` para ver os logs (quando iniciado com -d = detached)