### PR TITLE
Implementa um filtro que isola o contexto a query do `health-check` somente para o banco do TabNews

### DIFF
--- a/model/health.js
+++ b/model/health.js
@@ -32,7 +32,8 @@ export default function Health() {
     let result;
     try {
       const openConnectionsResult = await database.query(
-        'SELECT sum(numbackends) as opened_connections FROM pg_stat_database'
+        'SELECT numbackends as opened_connections FROM pg_stat_database where datname = $1',
+        [process.env.POSTGRES_DB]
       );
       const { opened_connections } = openConnectionsResult.rows[0];
 


### PR DESCRIPTION
Implementamos um endpoint que lista as dependências dos projetos e o status deles, conforme issue: https://github.com/filipedeschamps/tabnews.com.br/issues/102

Porém, a query que utilizamos para saber quantas conexões temos no banco de dados estava incorreta, pois não filtrava pelo nome do banco, que é super importante pra nós que nesse momento, utilizamos um banco compartilhado no ambiente de Preview.

Portanto, esse PR implementa esse filtro, que foi fácilmente resolvido com uma envvar.

Caso tenham alguma dúvida, ou tenham alguma sugestão diferente, fico a disposição!