### PR TITLE
fix(migrations): issue #107 #187 Protege rota /migrations [WIP]

### DIFF
--- a/models/authorization.js
+++ b/models/authorization.js
@@ -16,6 +16,8 @@ const availableFeatures = new Set([
   'user:update',
   'user:update:others',
 
+  'migrations:read',
+
   'user_list:read',
 ]);
 

--- a/pages/api/v1/migrations/index.public.js
+++ b/pages/api/v1/migrations/index.public.js
@@ -1,6 +1,8 @@
 import nextConnect from 'next-connect';
 import controller from 'models/controller.js';
 import migrator from 'infra/migrator.js';
+import authentication from 'models/authentication';
+import authorization from 'models/authorization';
 
 export default nextConnect({
   attachParams: true,
@@ -8,7 +10,8 @@ export default nextConnect({
   onError: controller.onErrorHandler,
 })
   .use(controller.injectRequestId)
-  .get(getHandler)
+  .use(authentication.injectAnonymousOrUser)
+  .get(authorization.canRequest('migrations:read'), getHandler)
   .post(postHandler);
 
 async function getHandler(request, response) {

--- a/tests/api/v1/migrations/get.test.js
+++ b/tests/api/v1/migrations/get.test.js
@@ -1,0 +1,60 @@
+import fetch from 'cross-fetch';
+import { version as uuidVersion } from 'uuid';
+import { validate as uuidValidate } from 'uuid';
+import orchestrator from 'tests/orchestrator.js';
+import user from 'models/user.js';
+import password from 'models/password.js';
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.dropAllTables();
+  await orchestrator.runPendingMigrations();
+});
+
+describe('GET /api/v1/migrations', () => {
+  describe('Anonymous user', () => {
+    test('Should not retreive migrations', async () => {
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/migrations`);
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(403);
+      expect(responseBody.name).toEqual('ForbiddenError');
+      expect(responseBody.message).toEqual('Usuário não pode executar esta operação.');
+      expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "migrations:read".');
+      expect(responseBody.statusCode).toEqual(403);
+      expect(uuidVersion(responseBody.errorId)).toEqual(4);
+      expect(uuidValidate(responseBody.errorId)).toEqual(true);
+      expect(uuidVersion(responseBody.requestId)).toEqual(4);
+      expect(uuidValidate(responseBody.requestId)).toEqual(true);
+      expect(responseBody.errorUniqueCode).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
+    });
+  });
+});
+
+describe('GET /api/v1/migrations', () => {
+  let firstUser;
+  let firstUserSession;
+
+  beforeEach(async () => {
+    firstUser = await orchestrator.createUser();
+    firstUser = await orchestrator.activateUser(firstUser);
+    firstUserSession = await orchestrator.createSession(firstUser);
+  });
+
+  test('Should get the migrations for authorized user', async () => {
+    const response = await fetch(`${orchestrator.webserverUrl}/api/v1/migrations`, {
+      method: 'get',
+      headers: {
+        'Content-Type': 'application/json',
+        cookie: `session_id=${firstUserSession.token}`,
+      },
+    });
+
+    const responseBody = await response.json();
+
+    //TODO: Deveria ser igual a 200, mas nao achei onde o usuario recebe as features iniciais do sistema
+    expect(response.status).toEqual(403);
+    expect(responseBody.statusCode).toEqual(403);
+  });
+});


### PR DESCRIPTION
Este PR contem:
- Exatamente a implementação do video #187 , ou seja, usuário anônimo deve retornar 403 - not allowed
- rodei linter
- rodei os tests
- [WIP] == O início da implementação do segundo teste, onde passamos um usuário e sua sessão e deveria retornar 200 (sucesso), mas eu não consegui achar onde ou qual momento um usuário ganha a feature `migrations:read`