### PR TITLE
build(postgres): upgrades to 14.1 and removes the uuid ossp extension

### DIFF
--- a/infra/docker-compose.development.yml
+++ b/infra/docker-compose.development.yml
@@ -2,7 +2,7 @@ version: '2.4'
 services:
   postgres_dev:
     container_name: 'postgres-dev'
-    image: 'postgres:13.3-alpine'
+    image: 'postgres:14.1-alpine'
     env_file:
       - ../.env
     ports:

--- a/infra/migrations/1631027616537_install-uuid-ossp-extension.js
+++ b/infra/migrations/1631027616537_install-uuid-ossp-extension.js
@@ -1,8 +1,0 @@
-exports.up = (pgm) => {
-  pgm.createExtension('uuid-ossp', {
-    ifNotExists: true,
-    schema: 'public',
-  });
-};
-
-exports.down = (pgm) => {};

--- a/infra/migrations/1632278997051_create-user-table.js
+++ b/infra/migrations/1632278997051_create-user-table.js
@@ -2,7 +2,7 @@ exports.up = (pgm) => {
   pgm.createTable('users', {
     id: {
       type: 'uuid',
-      default: pgm.func('uuid_generate_v4()'),
+      default: pgm.func('gen_random_uuid()'),
       notNull: true,
       primaryKey: true,
     },

--- a/infra/migrations/1643395493467_create-activate-account-tokens-table.js
+++ b/infra/migrations/1643395493467_create-activate-account-tokens-table.js
@@ -2,7 +2,7 @@ exports.up = (pgm) => {
   pgm.createTable('activate_account_tokens', {
     id: {
       type: 'uuid',
-      default: pgm.func('uuid_generate_v4()'),
+      default: pgm.func('gen_random_uuid()'),
       notNull: true,
       primaryKey: true,
     },

--- a/infra/migrations/1643506329419_create-session-table.js
+++ b/infra/migrations/1643506329419_create-session-table.js
@@ -2,7 +2,7 @@ exports.up = (pgm) => {
   pgm.createTable('sessions', {
     id: {
       type: 'uuid',
-      default: pgm.func('uuid_generate_v4()'),
+      default: pgm.func('gen_random_uuid()'),
       notNull: true,
       primaryKey: true,
     },


### PR DESCRIPTION
# Atenção

Caso você puxe esse PR, é bastante provável que você precise deletar o container local do banco do tabnews. Ao menos, aqui do meu lado ele reclamava que já existia um banco de dados e não subia o novo container com a nova versão. Tive que apagar.

# Motivo

Estou na trilha de configurar os bancos finais de Staging e Production e por hora vamos usar a versão 14.1 do Postgres e nas pesquisas notei que podemos remover uma das migrations, aquela primeira que instalava uma extensão para gerar `uuid`.

Então com essa versão do Postgres (e acho que na 13.x também já tinha isso), é só questão de chamar:

```js
default: pgm.func('gen_random_uuid()')
```

Ao invés de ter que instalar a extensão e chamar:

```js
default: pgm.func('uuid_generate_v4()')
```

Pelos testes, todos os uuids gerados foram validados, inclusive na versão 4 👍 