### PR TITLE
feat(status): adds `latency` measurement

### DIFF
--- a/pages/api/v1/status/index.test.js
+++ b/pages/api/v1/status/index.test.js
@@ -17,6 +17,7 @@ describe('[e2e] do a GET request to /api/v1/status', () => {
     expect(serverStatusBody.updated_at).toBeDefined();
     expect(serverStatusBody.dependencies.database.status).toEqual('healthy');
     expect(serverStatusBody.dependencies.database.opened_connections).toBeGreaterThan(0);
+    expect(serverStatusBody.dependencies.database.latency).toBeGreaterThan(0);
   });
 });
 


### PR DESCRIPTION
Uma pequena feature que vai ajudar a monitorar a latência do banco de dados, principalmente quando a gente fizer os testes entre regiões de deploy das lambdas e instância do banco 👍 