### PR TITLE
feat(status): adds `webserver` dependency

### DIFF
--- a/infra/database.js
+++ b/infra/database.js
@@ -42,6 +42,7 @@ async function query(query, params) {
       errorUniqueCode: 'INFRA:DATABASE:QUERY',
       stack: new Error().stack,
     });
+    console.error(errorObject);
     throw errorObject;
   } finally {
     if (client) {

--- a/models/health.js
+++ b/models/health.js
@@ -7,6 +7,10 @@ async function getDependencies() {
       name: 'database',
       handler: checkDatabaseDependency,
     },
+    {
+      name: 'webserver',
+      handler: checkWebserverDependency,
+    },
   ];
 
   const promises = dependenciesHandlersToCheck.map(async ({ name, handler }) => {
@@ -32,10 +36,7 @@ async function checkDatabaseDependency() {
   let result;
   try {
     const startTimer = performance.now();
-    const maxConnectionsResult = await database.query(
-      'SELECT rolconnlimit as max_connections FROM pg_roles WHERE rolname = $1;',
-      [process.env.POSTGRES_USER]
-    );
+    const maxConnectionsResult = await database.query('SHOW max_connections;');
     const timerDuration = performance.now() - startTimer;
     const maxConnectionsValue = maxConnectionsResult.rows[0].max_connections;
 
@@ -59,6 +60,20 @@ async function checkDatabaseDependency() {
   }
 
   return result;
+}
+
+async function checkWebserverDependency() {
+  return {
+    status: 'healthy',
+    provider: process.env.VERCEL ? 'vercel' : 'local',
+    environment: process.env.VERCEL_ENV ? process.env.VERCEL_ENV : 'local',
+    aws_region: process.env.AWS_REGION,
+    vercel_region: process.env.VERCEL_REGION,
+    timezone: process.env.TZ,
+    last_commit_author: process.env.VERCEL_GIT_COMMIT_AUTHOR_LOGIN,
+    last_commit_message: process.env.VERCEL_GIT_COMMIT_MESSAGE,
+    last_commit_message_sha: process.env.VERCEL_GIT_COMMIT_SHA,
+  };
 }
 
 export default Object.freeze({

--- a/pages/api/v1/status/index.test.js
+++ b/pages/api/v1/status/index.test.js
@@ -18,6 +18,10 @@ describe('[e2e] do a GET request to /api/v1/status', () => {
     expect(serverStatusBody.dependencies.database.status).toEqual('healthy');
     expect(serverStatusBody.dependencies.database.opened_connections).toBeGreaterThan(0);
     expect(serverStatusBody.dependencies.database.latency).toBeGreaterThan(0);
+
+    expect(serverStatusBody.dependencies.webserver.status).toEqual('healthy');
+    expect(serverStatusBody.dependencies.webserver.provider).toEqual('local');
+    expect(serverStatusBody.dependencies.webserver.environment).toEqual('local');
   });
 });
 


### PR DESCRIPTION
Eu estou usando Terraform igual a um doido e estou preparando o ambiente de staging para realizar uns testes em breve e conseguir monitorar melhor o que está acontecendo. Pra isso, nesse PR eu adiciono uma dependência no `/status` para mostrar algumas informações adicionais do servidor web e o ambiente que está deployado.