### PR TITLE
Nova estratégia para o Pool

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,3 @@
 {
-  "regions": ["iad1"]
+  "regions": ["gru1"]
 }


### PR DESCRIPTION
Para o atual estágio do projeto isso não é necessário, mas implementei algo para testar uma teoria que eu bolei na virada do dia e ver até onde eu consigo entender toda a modelagem de um ambiente serverless. O projeto já está com uma ótima performance, fiz testes com a versão que está na `main` junto com o @gustavodeschamps que está em Blumenau, e a média de tempo de requests fazendo 3 consultas ao banco ficou em torno de `70ms`. **[edit]** com a nova estratégia ficou abaixo de `50ms`

Mas mais importante que isso, é a gente conseguir entender as mecânicas reais de um ambiente serverless, que são **bem mais complicadas** que um ambiente tradicional e de longa vida.

### Em resumo

Nós não temos controle do que as Lambdas vão fazer (quando elas vão ser congeladas ou reaquecidas). Nós de fato não temos controle sobre isso e a AWS (que está por trás da Vercel) pode congelar uma Lambda por qualquer motivo (depois de retornar a request). O que se sabe é que não há requests concorrentes dentro de uma Lambda... é uma request por vez e é por isso que a AWS irá abrir várias Lambdas para paralelizar as requests.

Então dado a não sabermos quando uma Lambda será congelada, é possível que um Pool não consiga fechar conexões pelo lado dele (encerrar clients que foram devolvidos ao Pool), mesmo que ultrapasse o `idleTimeoutMillis`, porque novamente, ele pode estar congelado e os timers internos (que seriam responsáveis por perceber que o `idleTimeoutMillis` foi ultrapassado e que os clients deveriam ser fechados), estarão congelados. Eles só possuem uma chance de voltar a rodar, quando uma nova request entrar naquela Lambda... e quando isso acontece, eles rodam de fato e o Pool tem mais uma chance de trabalhar.

O resultado disso é que se muitas requests em paralelo entram no sistema, a AWS irá rodar várias instâncias da Lambda, criando vários Pools, que irão abrir `1` conexão cada e isso poderá consumir o número de conexões máximas do banco de dados. O problema se agrava quando as Lambdas que foram abertas podem ser congeladas, segurando consigo essa `1` conexão com o banco, sem o Pool ter a chance de encerrar essa conexão.

E porque usar um Pool? Porque enquanto o custo de ida e volta de uma query simples fica entre `1ms` e `2ms`, abrir uma nova conexão com o banco varia entre `15ms` até em alguns casos `150ms`. Então este hit inicial pode ser custoso, ainda mais se for feito em cada query que uma request possa fazer (pegar sessão, renovar sessão, pegar usuário, pegar os dados finais, etc...).

E tudo fica pior quando o sistema recebe uma carga muito grande, porque parece que quanto mais tentativas de conexões, mais custosas e lentas essas tentativas ficam.

Então reaproveitar uma conexão que já foi aberta é muito legal... mas quando o sistema recebe muita carga, dado a tudo que conversamos das Lambdas congelarem os timers, se você infinitamente ficar abrindo Pools, eles irão consumir todas as conexões do sistema e nenhuma nova request que entrar vai ser resolvida.

E esse PR não resolve esse problema de descongelar Lambdas ou fechar conexões... mas a estratégia agora é verificar quantas conexões podem ser de fato utilizadas, quantas conexões estão abertas, e se as conexões abertas ultrapassarem um limite (que por enquanto vou testar, mas está em 70%), dentro do lifecycle dessa mesma request e antes dela ser retornada ao cliente e a Lambda congelada, ela resolve fechar o Pool e as conexões.

### Resumo do resumo
Se uma request saudável, que possui um Pool com um cliente saudável, notar que o sistema está com muitas conexões abertas, ele fecha o Pool dessa atual request para não ficar aumentando a quantidade de clientes congelados. Então ele "auto impõe" uma degradação dos recursos do sistema para não chegar nos limites e entrar num estado irrecuperável porque todas as conexões abertas estão em Lambdas congeladas.

### Não testei ainda
Não sei se a minha modelagem está certa ou se vai ter algum efeito... então esse PR é para isso e eu venho aqui depois editar e confirmar o que aconteceu.

**[edit]**
Os primeiros testes se saíram muito bem, ne sentido da lógica pelo menos. Com uma carga que antes fazia todas as conexões serem consumidas malucamente, agora não, ele segura e mantem o banco sauável. Isso por si só é ótimo, porque em condições normais, o Pool reaproveita a conexão e as requests não tem o primeiro hit. Em breve quero postar comparativos para ver se isso traz resultados reais nos números totais 🤝 