### PR TITLE
feat(contents): [Draft] creates migrations for content entity

### DIFF
--- a/infra/migrations/1649621949432_create-content-table.js
+++ b/infra/migrations/1649621949432_create-content-table.js
@@ -18,15 +18,15 @@ exports.up = async (pgm) => {
     },
 
     slug: {
-      type: 'varchar(60)',
+      type: 'varchar(200)',
     },
 
     title: {
-      type: 'varchar(60)',
+      type: 'varchar(256)',
     },
 
     body: {
-      type: 'text',
+      type: 'varchar(20000)',
       notNull: true,
     },
 
@@ -37,7 +37,7 @@ exports.up = async (pgm) => {
     },
 
     source_url: {
-      type: 'varchar(100)',
+      type: 'varchar(2000)',
       notNull: false,
     },
 
@@ -53,8 +53,23 @@ exports.up = async (pgm) => {
       default: pgm.func("(now() at time zone 'utc')"),
     },
   });
+
+  await pgm.addConstraint(
+    'contents',
+    'contents_owner_id_and_slug_fkey',
+    'UNIQUE ("owner_id", "slug")'
+  );
+
+  await pgm.addConstraint(
+    'contents',
+    'contents_status_check',
+    'CHECK ("status" = ANY (ARRAY[\'draft\', \'published\', \'unpublished\', \'deleted\']))'
+  );
+
 };
 
 exports.down = async (pgm) => {
+  await pgm.dropConstraint('contents', 'contents_status_check');
+  await pgm.dropConstraint('contents', 'contents_owner_id_and_slug_fkey');
   await pgm.dropTable('contents');
 };


### PR DESCRIPTION
Esse pull request começa a atender a **Issue #230** / **#233** (_Só começa mesmo, falta muito!!_)

Esse é um rascunho do rascunho de uma migração para a nova entidade de 'conteúdos'. Eu não estava no começo e não sei se usaram algum framework para gerar os migrations. Mas fui seguindo o padrão do que já estava pronto.

Os valores para as quantidades de caracteres em cada coluna eu realmente fiquei sem referência e coloquei valores que provavelmente vamos alterar. 

A forma de fazer o 'slug' e o 'title' serem não nulos **apenas quando não existe um 'parent_id'** também não sei se é a melhor forma de fazer e nem a forma mais bonita e também não sei se o correto seria um arquivo separado para essa verificação.

De toda forma tentei colocar uma semente e talvez a partir daí a gente pode ter novas ideias e modificar tudo se achar que é necessário,