### PR TITLE
Content migration

### DIFF
--- a/infra/migrations/1649621949432_create-content-table.js
+++ b/infra/migrations/1649621949432_create-content-table.js
@@ -5,11 +5,7 @@ exports.up = async (pgm) => {
       default: pgm.func('gen_random_uuid()'),
       notNull: true,
       primaryKey: true,
-    },
-
-    owner_id: {
-      type: 'uuid',
-      notNull: true,
+      unique: true,
     },
 
     parent_id: {
@@ -17,27 +13,39 @@ exports.up = async (pgm) => {
       notNull: false,
     },
 
+    owner_id: {
+      type: 'uuid',
+      notNull: true,
+    },
+
     slug: {
-      type: 'varchar(200)',
+      type: 'varchar',
+      check: 'length(slug) <= 200',
+      notNull: true,
     },
 
     title: {
-      type: 'varchar(256)',
+      type: 'varchar',
+      check: 'length(title) <= 256',
+      notNull: true,
     },
 
     body: {
-      type: 'varchar(20000)',
+      type: 'text',
+      check: 'length(body) <= 20000',
       notNull: true,
     },
 
     status: {
-      type: 'varchar(20)',
+      type: 'varchar',
       default: 'draft',
       notNull: true,
+      check: "status IN ('draft', 'published', 'unpublished', 'deleted')",
     },
 
     source_url: {
-      type: 'varchar(2000)',
+      type: 'varchar',
+      check: 'length(body) <= 2000',
       notNull: false,
     },
 
@@ -54,22 +62,10 @@ exports.up = async (pgm) => {
     },
   });
 
-  await pgm.addConstraint(
-    'contents',
-    'contents_owner_id_and_slug_fkey',
-    'UNIQUE ("owner_id", "slug")'
-  );
-
-  await pgm.addConstraint(
-    'contents',
-    'contents_status_check',
-    'CHECK ("status" = ANY (ARRAY[\'draft\', \'published\', \'unpublished\', \'deleted\']))'
-  );
-
+  await pgm.addConstraint('contents', 'contents_uniqueness_fkey', 'UNIQUE ("owner_id", "slug")');
 };
 
 exports.down = async (pgm) => {
-  await pgm.dropConstraint('contents', 'contents_status_check');
-  await pgm.dropConstraint('contents', 'contents_owner_id_and_slug_fkey');
+  await pgm.dropConstraint('contents', 'contents_uniqueness_fkey');
   await pgm.dropTable('contents');
 };


### PR DESCRIPTION
PR originalmente criado por @inovaprog 

@inovaprog veja se você concorda com as alterações:

## Inline checks

Para correlacionar diretamente a coluna com as regras dele, coloquei uma propriedade `check` com a regra desejada. Então ao invés de:

```js
    title: {
      type: 'varchar(256)',
    },
```

Que gera esse erro:

```
ERROR:  value too long for type character varying(256)
```

Fazer assim:

```js
    title: {
      type: 'varchar',
      check: 'length(title) <= 256',
    },
```

Que gera um erro por `check` e dá um nome exclusivo a ele:

```
ERROR:  new row for relation "contents" violates check constraint "contents_title_check"
```

Basicamente igual aos constraints, mas deixando eles inline. E se fizermos tudo certo, esse erro nunca será exposto para o user, pois isso já deveria ter sido pego por validações externas. Mas mesmo que fure, a camada que faz o handle disso vai retornar um `503` para o user.

## `slug` e `title` serem `required`

Tava pensando aqui, para cada `content` poder ter seu próprio link único e sua própria página (como cada `tweet` do Twitter), nós no mínimo precisamos que todo `content` precise de um `slug`. E no caso de um usuário escrevendo uma resposta (que é um `content` com `parent_id`) a gente poderia assumir como  `slug` o `id` desse content e o title a gente poderia pegar os primeiros `X` caracteres do corpo. Sabendo que se a pessoa quiser, ela pode editar isso (digo, o autor que está escrevendo essa resposta pode mudar o valor para esses campos default, assim como um `content` qualquer).

## Primary key

Essa aqui eu não sei, mas é possível definir duas Primary Keys (no caso adicionei como PK o `owner_id`, `slug` e `parent_id`) e isso automaticamente faz o migrator adicionar isso:

```sql
  CONSTRAINT "contents_pkey" PRIMARY KEY ("owner_id", "slug", "parent_id")
```

E se você não respeitar e duplicar os dados, retorna o seguinte erro:

```
ERROR:  duplicate key value violates unique constraint "contents_pkey"
DETAIL:  Key (owner_id, slug)=(f1f27a63-8a43-4e21-874d-58079ee1198c, artigo-de-nodejs-massa) already exists.
```

Mas daí tirei o Primary Key do `id`. Será que isso é um problema?

## Conclusão do último commit

A ideia era ficar mais simples. Vocês acham que foi dado um passo para frente ou para trás?