### PR TITLE
`content`: implementa primeira versão do `PATCH`

### DIFF
--- a/infra/migrations/1649621949432_create-content-table.js
+++ b/infra/migrations/1649621949432_create-content-table.js
@@ -40,7 +40,7 @@ exports.up = async (pgm) => {
       type: 'varchar',
       default: 'draft',
       notNull: true,
-      check: "status IN ('draft', 'published', 'unpublished', 'deleted')",
+      check: "status IN ('draft', 'published')",
     },
 
     source_url: {

--- a/models/activation.js
+++ b/models/activation.js
@@ -117,6 +117,7 @@ async function activateUserByUserId(userId) {
     'create:content',
     'create:content:text_root',
     'create:content:text_child',
+    'update:content',
     'update:user',
   ]);
 }

--- a/models/authorization.js
+++ b/models/authorization.js
@@ -20,6 +20,7 @@ const availableFeatures = new Set([
 
   // CONTENT
   'read:content',
+  'update:content',
   'create:content',
   'create:content:text_root',
   'create:content:text_child',
@@ -41,6 +42,14 @@ function can(user, feature, resource) {
     authorized = false;
 
     if (user.id === resource.id) {
+      authorized = true;
+    }
+  }
+
+  if (feature === 'update:content' && resource) {
+    authorized = false;
+
+    if (user.id === resource.owner_id) {
       authorized = true;
     }
   }
@@ -105,7 +114,19 @@ function filterInput(user, feature, input) {
     };
   }
 
-  return filteredInputValues;
+  if (feature === 'update:content' && can(user, feature)) {
+    filteredInputValues = {
+      parent_id: input.parent_id,
+      slug: input.slug,
+      title: input.title,
+      body: input.body,
+      status: input.status,
+      source_url: input.source_url,
+    };
+  }
+
+  // Force the clean up of "undefined" values
+  return JSON.parse(JSON.stringify(filteredInputValues));
 }
 
 function filterOutput(user, feature, output) {
@@ -203,7 +224,8 @@ function filterOutput(user, feature, output) {
     }));
   }
 
-  return filteredOutputValues;
+  // Force the clean up of "undefined" values
+  return JSON.parse(JSON.stringify(filteredOutputValues));
 }
 
 function validateUser(user) {

--- a/models/controller.js
+++ b/models/controller.js
@@ -44,7 +44,9 @@ function onErrorHandler(error, request, response) {
     errorUniqueCode: error.errorUniqueCode,
   });
 
-  logger.error(snakeize(errorObject));
+  // TODO: Understand why `sanaize` is not logging the
+  // `stack` property of the error object.
+  logger.error(snakeize({ ...errorObject, stack: error.stack }));
 
   return response.status(errorObject.statusCode).json(snakeize(errorObject));
 }

--- a/models/validator.js
+++ b/models/validator.js
@@ -144,6 +144,7 @@ const schemas = {
   parent_id: function () {
     return Joi.object({
       parent_id: Joi.string()
+        .allow(null)
         .trim()
         .guid({ version: 'uuidv4' })
         .when('$required.parent_id', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
@@ -195,10 +196,10 @@ const schemas = {
   title: function () {
     return Joi.object({
       title: Joi.string()
+        .allow(null)
         .min(1)
         .max(256)
         .trim()
-        .invalid(null)
         .when('$required.title', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
           'any.required': `"title" é um campo obrigatório.`,
@@ -234,7 +235,7 @@ const schemas = {
     return Joi.object({
       status: Joi.string()
         .trim()
-        .valid('draft', 'published', 'deleted')
+        .valid('draft', 'published')
         .invalid(null)
         .when('$required.status', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
@@ -244,7 +245,7 @@ const schemas = {
           'string.min': `"status" deve conter no mínimo {#limit} caracteres.`,
           'string.max': `"status" deve conter no máximo {#limit} caracteres.`,
           'any.invalid': `"status" possui o valor inválido "null".`,
-          'any.only': `"status" deve possuir um dos seguintes valores: "draft", "published" ou "deleted".`,
+          'any.only': `"status" deve possuir um dos seguintes valores: "draft" ou "published".`,
         }),
     });
   },
@@ -252,9 +253,9 @@ const schemas = {
   source_url: function () {
     return Joi.object({
       source_url: Joi.string()
+        .allow(null)
         .trim()
         .max(2000)
-        .invalid(null)
         .pattern(/^(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/)
         .when('$required.source_url', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({

--- a/pages/api/v1/contents/[username]/[slug]/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/index.public.js
@@ -1,0 +1,96 @@
+import nextConnect from 'next-connect';
+import controller from 'models/controller.js';
+import authentication from 'models/authentication.js';
+import authorization from 'models/authorization.js';
+import validator from 'models/validator.js';
+import content from 'models/content.js';
+import { ForbiddenError } from 'errors/index.js';
+
+export default nextConnect({
+  attachParams: true,
+  onNoMatch: controller.onNoMatchHandler,
+  onError: controller.onErrorHandler,
+})
+  .use(controller.injectRequestId)
+  .use(authentication.injectAnonymousOrUser)
+  .use(controller.logRequest)
+  // .get(getHandler)
+  .patch(patchValidationHandler, authorization.canRequest('update:content'), patchHandler);
+
+// TODO: cache the response
+// async function getHandler(request, response) {
+//   const userTryingToGet = request.context.user;
+//   const contentList = await content.findAll();
+
+//   const secureOutputValues = authorization.filterOutput(userTryingToGet, 'read:content', contentList);
+
+//   return response.status(200).json(secureOutputValues);
+// }
+
+function patchValidationHandler(request, response, next) {
+  const cleanQueryValues = validator(request.query, {
+    username: 'required',
+    slug: 'required',
+  });
+
+  request.query = cleanQueryValues;
+
+  const cleanBodyValues = validator(request.body, {
+    parent_id: 'optional',
+    slug: 'optional',
+    title: 'optional',
+    body: 'optional',
+    status: 'optional',
+    source_url: 'optional',
+  });
+
+  request.body = cleanBodyValues;
+
+  next();
+}
+
+async function patchHandler(request, response) {
+  const userTryingToPatch = request.context.user;
+  const unfilteredBodyValues = request.body;
+  const contentToBeUpdated = await content.findOneByUsernameAndSlug(request.query.username, request.query.slug);
+
+  if (!authorization.can(userTryingToPatch, 'update:content', contentToBeUpdated)) {
+    throw new ForbiddenError({
+      message: 'Você não possui permissão para atualizar o conteúdo de outro usuário.',
+      action: 'Verifique se você possui a feature "update:content:others".',
+      errorUniqueCode: 'CONTROLLER:CONTENTS:PATCH:USER_CANT_UPDATE_CONTENT_FROM_OTHER_USER',
+    });
+  }
+
+  let filteredBodyValues;
+
+  if (!unfilteredBodyValues.parent_id) {
+    if (!authorization.can(userTryingToPatch, 'create:content:text_root', unfilteredBodyValues)) {
+      throw new ForbiddenError({
+        message: 'Você não possui permissão para editar conteúdos na raiz do site.',
+        action: 'Verifique se você possui a feature "create:content:text_root".',
+        errorUniqueCode: 'CONTROLLER:CONTENT:PATCH_HANDLER:CREATE:CONTENT:TEXT_ROOT:FEATURE_NOT_FOUND',
+      });
+    }
+
+    filteredBodyValues = authorization.filterInput(userTryingToPatch, 'update:content', unfilteredBodyValues);
+  }
+
+  if (unfilteredBodyValues.parent_id) {
+    if (!authorization.can(userTryingToPatch, 'create:content:text_child', unfilteredBodyValues)) {
+      throw new ForbiddenError({
+        message: 'Você não possui permissão para editar conteúdos dentro de outros conteúdos.',
+        action: 'Verifique se você possui a feature "create:content:text_child".',
+        errorUniqueCode: 'CONTROLLER:CONTENT:PATCH_HANDLER:CREATE:CONTENT:TEXT_CHILD:FEATURE_NOT_FOUND',
+      });
+    }
+
+    filteredBodyValues = authorization.filterInput(userTryingToPatch, 'update:content', unfilteredBodyValues);
+  }
+
+  const updatedContent = await content.update(contentToBeUpdated.id, filteredBodyValues);
+
+  const secureOutputValues = authorization.filterOutput(userTryingToPatch, 'read:content', updatedContent);
+
+  return response.status(200).json(secureOutputValues);
+}

--- a/tests/integration/api/v1/_use-cases/registration-flow.test.js
+++ b/tests/integration/api/v1/_use-cases/registration-flow.test.js
@@ -96,6 +96,7 @@ describe('Use case: Registration Flow (all successfully)', () => {
       'create:content',
       'create:content:text_root',
       'create:content:text_child',
+      'update:content',
       'update:user',
     ]);
   });

--- a/tests/integration/api/v1/contents/patch.test.js
+++ b/tests/integration/api/v1/contents/patch.test.js
@@ -1,0 +1,2004 @@
+import fetch from 'cross-fetch';
+import { version as uuidVersion } from 'uuid';
+import orchestrator from 'tests/orchestrator.js';
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.dropAllTables();
+  await orchestrator.runPendingMigrations();
+});
+
+describe('PATCH /api/v1/contents/[username]/[slug]', () => {
+  describe('Anonymous user', () => {
+    test('Content with minimum valid data', async () => {
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents/username/slug`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          title: 'Anônimo tentando atualizar um conteúdo existente',
+          body: 'Não deveria conseguir.',
+        }),
+      });
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(403);
+      expect(responseBody.status_code).toEqual(403);
+      expect(responseBody.name).toEqual('ForbiddenError');
+      expect(responseBody.message).toEqual('Usuário não pode executar esta operação.');
+      expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "update:content".');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
+    });
+  });
+
+  describe('User without "update:content" feature', () => {
+    test('"root" content with valid data', async () => {
+      const userWithoutFeature = await orchestrator.createUser();
+      await orchestrator.activateUser(userWithoutFeature);
+      await orchestrator.removeFeaturesFromUser(userWithoutFeature, ['update:content']);
+      const sessionObject = await orchestrator.createSession(userWithoutFeature);
+
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents/username/slug`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          cookie: `session_id=${sessionObject.token}`,
+        },
+        body: JSON.stringify({
+          title: 'Usuário válido, tentando atualizar conteúdo na raiz do site.',
+          body: 'Não deveria conseguir, pois não possui a feature "update:content".',
+        }),
+      });
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(403);
+      expect(responseBody.status_code).toEqual(403);
+      expect(responseBody.name).toEqual('ForbiddenError');
+      expect(responseBody.message).toEqual('Usuário não pode executar esta operação.');
+      expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "update:content".');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
+    });
+
+    test('"child" content with valid data', async () => {
+      const userWithoutFeature = await orchestrator.createUser();
+      await orchestrator.activateUser(userWithoutFeature);
+      await orchestrator.removeFeaturesFromUser(userWithoutFeature, ['update:content']);
+      const sessionObject = await orchestrator.createSession(userWithoutFeature);
+
+      const rootContent = await orchestrator.createContent({
+        owner_id: userWithoutFeature.id,
+        title: 'Root content title',
+        body: 'Root content body',
+      });
+
+      const childContent = await orchestrator.createContent({
+        owner_id: userWithoutFeature.id,
+        title: 'Child content title',
+        body: 'Child content body',
+        parent_id: rootContent.id,
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${userWithoutFeature.username}/${childContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            title: 'Usuário válido, tentando atualizar conteúdo "child".',
+            body: 'Não deveria conseguir, pois não possui a feature "update:content".',
+          }),
+        }
+      );
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(403);
+      expect(responseBody.status_code).toEqual(403);
+      expect(responseBody.name).toEqual('ForbiddenError');
+      expect(responseBody.message).toEqual('Usuário não pode executar esta operação.');
+      expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "update:content".');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
+    });
+  });
+
+  describe('Default user', () => {
+    test('Content without PATCH Body and "Content-Type"', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents/username/slug`, {
+        method: 'PATCH',
+        headers: {
+          cookie: `session_id=${sessionObject.token}`,
+        },
+      });
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual('Body enviado deve ser do tipo Object.');
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+    });
+
+    test('Content with PATCH Body containing an invalid JSON string', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents/username/slug`, {
+        method: 'PATCH',
+        headers: {
+          cookie: `session_id=${sessionObject.token}`,
+        },
+        body: 'Texto corrido no lugar de um JSON',
+      });
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual('Body enviado deve ser do tipo Object.');
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+    });
+
+    test('Content with PATCH Body containing an empty Object', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents/username/slug`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          cookie: `session_id=${sessionObject.token}`,
+        },
+        body: JSON.stringify({}),
+      });
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual('Objeto enviado deve ter no mínimo uma chave.');
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+    });
+
+    test('Content with invalid "username" in the URL', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents/invalid-username/slug`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          cookie: `session_id=${sessionObject.token}`,
+        },
+        body: JSON.stringify({}),
+      });
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual('"username" deve conter apenas caracteres alfanuméricos.');
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+    });
+
+    test('Content with invalid "slug" in the URL', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/username/%3Cscript%3Ealert%28%29%3Cscript%3E`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({}),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual('"slug" está no formato errado.');
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+    });
+
+    test('Content with "username" non-existent', async () => {
+      const firstUser = await orchestrator.createUser();
+      await orchestrator.activateUser(firstUser);
+      const firstUserSessionObject = await orchestrator.createSession(firstUser);
+
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents/ThisUserDoesNotExists/slug`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          cookie: `session_id=${firstUserSessionObject.token}`,
+        },
+        body: JSON.stringify({
+          title: 'Primeiro usuário tentando atualizar o conteúdo do Segundo usuário',
+          body: 'Não deveria conseguir',
+        }),
+      });
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(404);
+      expect(responseBody.status_code).toEqual(404);
+      expect(responseBody.name).toEqual('NotFoundError');
+      expect(responseBody.message).toEqual('O "username" informado não foi encontrado no sistema.');
+      expect(responseBody.action).toEqual('Verifique se o "username" está digitado corretamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('MODEL:USER:FIND_ONE_BY_USERNAME:NOT_FOUND');
+    });
+
+    test('Content with "username" existent, but "slug" non-existent', async () => {
+      const firstUser = await orchestrator.createUser();
+      await orchestrator.activateUser(firstUser);
+      const firstUserSessionObject = await orchestrator.createSession(firstUser);
+
+      const firstUserContent = await orchestrator.createContent({
+        owner_id: firstUser.id,
+        title: 'Conteúdo do primeiro usuário',
+        status: 'published',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${firstUser.username}/esse-slug-nao-existe`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${firstUserSessionObject.token}`,
+          },
+          body: JSON.stringify({
+            title: 'Tentando atualizar um conteúdo próprio, mas errando o slug',
+            body: 'Não deveria conseguir',
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(404);
+      expect(responseBody.status_code).toEqual(404);
+      expect(responseBody.name).toEqual('NotFoundError');
+      expect(responseBody.message).toEqual('O conteúdo informado não foi encontrado no sistema.');
+      expect(responseBody.action).toEqual('Verifique se o "slug" está digitado corretamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('MODEL:CONTENT:FIND_ONE_BY_USERNAME_AND_SLUG:CONTENT_NOT_FOUND');
+    });
+
+    test('Content with "username" and "slug" pointing to content from another user', async () => {
+      const firstUser = await orchestrator.createUser();
+      await orchestrator.activateUser(firstUser);
+      const firstUserSessionObject = await orchestrator.createSession(firstUser);
+
+      const secondUser = await orchestrator.createUser();
+
+      const secondUserContent = await orchestrator.createContent({
+        owner_id: secondUser.id,
+        title: 'Conteúdo do segundo usuário',
+        status: 'published',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${secondUser.username}/${secondUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${firstUserSessionObject.token}`,
+          },
+          body: JSON.stringify({
+            title: 'Primeiro usuário tentando atualizar o conteúdo do Segundo usuário',
+            body: 'Não deveria conseguir',
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(403);
+      expect(responseBody.status_code).toEqual(403);
+      expect(responseBody.name).toEqual('ForbiddenError');
+      expect(responseBody.message).toEqual('Você não possui permissão para atualizar o conteúdo de outro usuário.');
+      expect(responseBody.action).toEqual('Verifique se você possui a feature "update:content:others".');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual(
+        'CONTROLLER:CONTENTS:PATCH:USER_CANT_UPDATE_CONTENT_FROM_OTHER_USER'
+      );
+    });
+
+    test('Content with "owner_id" pointing to another user', async () => {
+      const firstUser = await orchestrator.createUser();
+      await orchestrator.activateUser(firstUser);
+      const firstUserSessionObject = await orchestrator.createSession(firstUser);
+      const secondUser = await orchestrator.createUser();
+
+      const firstUserContent = await orchestrator.createContent({
+        owner_id: firstUser.id,
+        title: 'Conteúdo do Primeiro Usuário antes do patch!',
+        body: 'Body antes do patch!',
+        status: 'published',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${firstUser.username}/${firstUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${firstUserSessionObject.token}`,
+          },
+          body: JSON.stringify({
+            title: 'Tentando atualizar o dono do conteúdo.',
+            body: 'Campo "owner_id" da request deveria ser ignorado e pego através da sessão.',
+            owner_id: secondUser.id,
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(200);
+      expect(uuidVersion(responseBody.id)).toEqual(4);
+      expect(responseBody.id).toEqual(firstUserContent.id);
+      expect(responseBody.owner_id).toEqual(firstUser.id);
+      expect(responseBody.username).toEqual(firstUser.username);
+      expect(responseBody.owner_id).not.toEqual(secondUser.id);
+      expect(responseBody.username).not.toEqual(secondUser.username);
+      expect(responseBody.parent_id).toEqual(null);
+      expect(responseBody.slug).toEqual('conteudo-do-primeiro-usuario-antes-do-patch');
+      expect(responseBody.title).toEqual('Tentando atualizar o dono do conteúdo.');
+      expect(responseBody.body).toEqual('Campo "owner_id" da request deveria ser ignorado e pego através da sessão.');
+      expect(responseBody.status).toEqual('published');
+      expect(responseBody.source_url).toEqual(null);
+      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(responseBody.published_at).toEqual(firstUserContent.published_at.toISOString());
+      expect(responseBody.updated_at > firstUserContent.updated_at.toISOString()).toEqual(true);
+    });
+
+    test('Content with "body" declared solely', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            body: 'Body novo',
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(200);
+      expect(uuidVersion(responseBody.id)).toEqual(4);
+      expect(responseBody.owner_id).toEqual(defaultUser.id);
+      expect(responseBody.username).toEqual(defaultUser.username);
+      expect(responseBody.parent_id).toEqual(null);
+      expect(responseBody.slug).toEqual('titulo-velho');
+      expect(responseBody.title).toEqual('Título velho');
+      expect(responseBody.body).toEqual('Body novo');
+      expect(responseBody.status).toEqual('draft');
+      expect(responseBody.source_url).toEqual(null);
+      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(responseBody.published_at).toEqual(null);
+      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toEqual(true);
+    });
+
+    test('Content with "body" containing blank String', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            body: '',
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual('"body" não pode estar em branco.');
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+    });
+
+    test('Content with "body" containing more than 20.000 characters', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            body: 'A'.repeat(20001),
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual('"body" deve conter no máximo 20000 caracteres.');
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+    });
+
+    test('Content with "body" containing untrimmed values', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            body: ' Espaço no início e no fim ',
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(200);
+      expect(uuidVersion(responseBody.id)).toEqual(4);
+      expect(responseBody.owner_id).toEqual(defaultUser.id);
+      expect(responseBody.username).toEqual(defaultUser.username);
+      expect(responseBody.parent_id).toEqual(null);
+      expect(responseBody.slug).toEqual('titulo-velho');
+      expect(responseBody.title).toEqual('Título velho');
+      expect(responseBody.body).toEqual('Espaço no início e no fim');
+      expect(responseBody.status).toEqual('draft');
+      expect(responseBody.source_url).toEqual(null);
+      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(responseBody.published_at).toEqual(null);
+      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toEqual(true);
+    });
+
+    test('Content with "body" containing Null value', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            body: null,
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual('"body" possui o valor inválido "null".');
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+    });
+
+    test('Content with "slug" declared solely', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+        slug: 'slug-velho',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            slug: 'slug-novo',
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(200);
+      expect(uuidVersion(responseBody.id)).toEqual(4);
+      expect(responseBody.owner_id).toEqual(defaultUser.id);
+      expect(responseBody.username).toEqual(defaultUser.username);
+      expect(responseBody.parent_id).toEqual(null);
+      expect(responseBody.slug).toEqual('slug-novo');
+      expect(responseBody.title).toEqual('Título velho');
+      expect(responseBody.body).toEqual('Body velho');
+      expect(responseBody.status).toEqual('draft');
+      expect(responseBody.source_url).toEqual(null);
+      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(responseBody.published_at).toEqual(null);
+      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toEqual(true);
+    });
+
+    test('Content with "slug" containing a blank String', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            slug: '',
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual('"slug" não pode estar em branco.');
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+    });
+
+    test('Content with "slug" containing more than 256 characters', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            slug: 'this-slug-is-to-257-characterssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss',
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual('"slug" deve conter no máximo 256 caracteres.');
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+    });
+
+    test('Content with "slug" containing special characters', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            slug: 'slug-não-pode-ter-caracteres-especiais',
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual('"slug" está no formato errado.');
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+    });
+
+    test('Content with "slug" containing Null value', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            slug: null,
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual('"slug" possui o valor inválido "null".');
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+    });
+
+    test('Content with "title" declared solely', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            title: 'Título novo',
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(200);
+      expect(uuidVersion(responseBody.id)).toEqual(4);
+      expect(responseBody.owner_id).toEqual(defaultUser.id);
+      expect(responseBody.username).toEqual(defaultUser.username);
+      expect(responseBody.parent_id).toEqual(null);
+      expect(responseBody.slug).toEqual('titulo-velho');
+      expect(responseBody.title).toEqual('Título novo');
+      expect(responseBody.body).toEqual('Body velho');
+      expect(responseBody.status).toEqual('draft');
+      expect(responseBody.source_url).toEqual(null);
+      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(responseBody.published_at).toEqual(null);
+      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toEqual(true);
+    });
+
+    test('Content with "title" containing a blank String', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            title: '',
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual('"title" não pode estar em branco.');
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+    });
+
+    test('Content with "title" containing more than 256 characters', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            title:
+              'Este título possui 257 caracteresssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss',
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual('"title" deve conter no máximo 256 caracteres.');
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+    });
+
+    test('Content with "title" containing Null value in "root" content', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            title: null,
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual('"title" é um campo obrigatório para conteúdos raiz.');
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('MODEL:CONTENT:CHECK_ROOT_CONTENT_TITLE:MISSING_TITLE');
+    });
+
+    test('Content with "title" containing Null value in "child" content', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const rootContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Root old title',
+        body: 'Root old body',
+      });
+
+      const childContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        parent_id: rootContent.id,
+        title: 'Child old title',
+        body: 'Child old body',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${childContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            title: null,
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(200);
+      expect(uuidVersion(responseBody.id)).toEqual(4);
+      expect(responseBody.id).toEqual(childContent.id);
+      expect(responseBody.owner_id).toEqual(defaultUser.id);
+      expect(responseBody.username).toEqual(defaultUser.username);
+      expect(responseBody.parent_id).toEqual(rootContent.id);
+      expect(responseBody.slug).toEqual('child-old-title');
+      expect(responseBody.title).toEqual(null);
+      expect(responseBody.body).toEqual('Child old body');
+      expect(responseBody.status).toEqual('draft');
+      expect(responseBody.source_url).toEqual(null);
+      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(responseBody.published_at).toEqual(null);
+      expect(responseBody.updated_at > childContent.updated_at.toISOString()).toEqual(true);
+    });
+
+    test('Content with "title" containing untrimmed values', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            title: ' Título válido, mas com espaços em branco no início e no fim ',
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(200);
+      expect(uuidVersion(responseBody.id)).toEqual(4);
+      expect(responseBody.owner_id).toEqual(defaultUser.id);
+      expect(responseBody.username).toEqual(defaultUser.username);
+      expect(responseBody.parent_id).toEqual(null);
+      expect(responseBody.slug).toEqual('titulo-velho');
+      expect(responseBody.title).toEqual('Título válido, mas com espaços em branco no início e no fim');
+      expect(responseBody.body).toEqual('Body velho');
+      expect(responseBody.status).toEqual('draft');
+      expect(responseBody.source_url).toEqual(null);
+      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(responseBody.published_at).toEqual(null);
+      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toEqual(true);
+    });
+
+    test('Content with "title" containing unescaped characters', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            title: `Tab & News | Conteúdos com \n valor <strong>concreto</strong> e "massa"> participe! '\o/'`,
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(200);
+      expect(uuidVersion(responseBody.id)).toEqual(4);
+      expect(responseBody.owner_id).toEqual(defaultUser.id);
+      expect(responseBody.username).toEqual(defaultUser.username);
+      expect(responseBody.parent_id).toEqual(null);
+      expect(responseBody.slug).toEqual('titulo-velho');
+      expect(responseBody.title).toEqual(
+        `Tab & News | Conteúdos com \n valor <strong>concreto</strong> e "massa"> participe! '\o/'`
+      );
+      expect(responseBody.body).toEqual('Body velho');
+      expect(responseBody.status).toEqual('draft');
+      expect(responseBody.source_url).toEqual(null);
+      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(responseBody.published_at).toEqual(null);
+      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toEqual(true);
+    });
+
+    test('Content with "status" "draft" set to "draft"', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            status: 'draft',
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(200);
+      expect(uuidVersion(responseBody.id)).toEqual(4);
+      expect(responseBody.owner_id).toEqual(defaultUser.id);
+      expect(responseBody.username).toEqual(defaultUser.username);
+      expect(responseBody.parent_id).toEqual(null);
+      expect(responseBody.slug).toEqual('titulo-velho');
+      expect(responseBody.title).toEqual('Título velho');
+      expect(responseBody.body).toEqual('Body velho');
+      expect(responseBody.status).toEqual('draft');
+      expect(responseBody.source_url).toEqual(null);
+      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(responseBody.published_at).toEqual(null);
+      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toEqual(true);
+    });
+
+    test('Content with "status" "draft" set to "published"', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+        status: 'draft',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            status: 'published',
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(200);
+      expect(uuidVersion(responseBody.id)).toEqual(4);
+      expect(responseBody.owner_id).toEqual(defaultUser.id);
+      expect(responseBody.username).toEqual(defaultUser.username);
+      expect(responseBody.parent_id).toEqual(null);
+      expect(responseBody.slug).toEqual('titulo-velho');
+      expect(responseBody.title).toEqual('Título velho');
+      expect(responseBody.body).toEqual('Body velho');
+      expect(responseBody.status).toEqual('published');
+      expect(responseBody.source_url).toEqual(null);
+      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.published_at)).not.toEqual(NaN);
+      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toEqual(true);
+    });
+
+    test('Content with "status" "published" set to "draft"', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+        status: 'published',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            status: 'draft',
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(200);
+      expect(uuidVersion(responseBody.id)).toEqual(4);
+      expect(responseBody.owner_id).toEqual(defaultUser.id);
+      expect(responseBody.username).toEqual(defaultUser.username);
+      expect(responseBody.parent_id).toEqual(null);
+      expect(responseBody.slug).toEqual('titulo-velho');
+      expect(responseBody.title).toEqual('Título velho');
+      expect(responseBody.body).toEqual('Body velho');
+      expect(responseBody.status).toEqual('draft');
+      expect(responseBody.source_url).toEqual(null);
+      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.published_at)).not.toEqual(NaN);
+      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toEqual(true);
+    });
+
+    test('Content with "status" "published" set to "draft", than "published"', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const originalContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+        status: 'published',
+      });
+
+      const draftResponse = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${originalContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            status: 'draft',
+          }),
+        }
+      );
+
+      const draftResponseBody = await draftResponse.json();
+
+      const republishedResponse = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${originalContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            status: 'published',
+          }),
+        }
+      );
+
+      const republishedResponseBody = await republishedResponse.json();
+
+      expect(republishedResponse.status).toEqual(200);
+      expect(uuidVersion(republishedResponseBody.id)).toEqual(4);
+      expect(republishedResponseBody.owner_id).toEqual(defaultUser.id);
+      expect(republishedResponseBody.username).toEqual(defaultUser.username);
+      expect(republishedResponseBody.parent_id).toEqual(null);
+      expect(republishedResponseBody.slug).toEqual('titulo-velho');
+      expect(republishedResponseBody.title).toEqual('Título velho');
+      expect(republishedResponseBody.body).toEqual('Body velho');
+      expect(republishedResponseBody.status).toEqual('published');
+      expect(republishedResponseBody.source_url).toEqual(null);
+      expect(Date.parse(republishedResponseBody.created_at)).not.toEqual(NaN);
+      expect(Date.parse(republishedResponseBody.updated_at)).not.toEqual(NaN);
+      expect(Date.parse(republishedResponseBody.published_at)).not.toEqual(NaN);
+      expect(draftResponseBody.published_at).toEqual(originalContent.published_at.toISOString());
+      expect(draftResponseBody.published_at).toEqual(republishedResponseBody.published_at);
+      expect(draftResponseBody.updated_at > originalContent.updated_at.toISOString()).toEqual(true);
+      expect(republishedResponseBody.updated_at > draftResponseBody.updated_at).toEqual(true);
+    });
+
+    test('Content with "status" set to "non_existent_status"', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            status: 'inexisting_status',
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual('"status" deve possuir um dos seguintes valores: "draft" ou "published".');
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+    });
+
+    test('Content with "status" set to Null', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            status: null,
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual('"status" deve possuir um dos seguintes valores: "draft" ou "published".');
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+    });
+
+    test('Content with "status" set a blank String', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            status: '',
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual('"status" deve possuir um dos seguintes valores: "draft" ou "published".');
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+    });
+
+    test('Content with "source_url" containing a valid HTTP URL', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            source_url: 'http://www.tabnews.com.br/',
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(200);
+      expect(uuidVersion(responseBody.id)).toEqual(4);
+      expect(responseBody.owner_id).toEqual(defaultUser.id);
+      expect(responseBody.username).toEqual(defaultUser.username);
+      expect(responseBody.parent_id).toEqual(null);
+      expect(responseBody.slug).toEqual('titulo-velho');
+      expect(responseBody.title).toEqual('Título velho');
+      expect(responseBody.body).toEqual('Body velho');
+      expect(responseBody.status).toEqual('draft');
+      expect(responseBody.source_url).toEqual('http://www.tabnews.com.br/');
+      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(responseBody.published_at).toEqual(null);
+      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toEqual(true);
+    });
+
+    test('Content with "source_url" containing a valid HTTPS URL', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            source_url: 'https://www.tabnews.com.br/museu',
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(200);
+      expect(uuidVersion(responseBody.id)).toEqual(4);
+      expect(responseBody.owner_id).toEqual(defaultUser.id);
+      expect(responseBody.username).toEqual(defaultUser.username);
+      expect(responseBody.parent_id).toEqual(null);
+      expect(responseBody.slug).toEqual('titulo-velho');
+      expect(responseBody.title).toEqual('Título velho');
+      expect(responseBody.body).toEqual('Body velho');
+      expect(responseBody.status).toEqual('draft');
+      expect(responseBody.source_url).toEqual('https://www.tabnews.com.br/museu');
+      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(responseBody.published_at).toEqual(null);
+      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toEqual(true);
+    });
+
+    test('Content with "source_url" containing a not accepted Protocol', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            source_url: 'ftp://www.tabnews.com.br',
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual(
+        '"source_url" deve possuir uma URL válida e utilizando os protocolos HTTP ou HTTPS.'
+      );
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+    });
+
+    test('Content with "source_url" containing an incomplete URL', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            source_url: 'https://lol.',
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual(
+        '"source_url" deve possuir uma URL válida e utilizando os protocolos HTTP ou HTTPS.'
+      );
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+    });
+
+    test('Content with "source_url" containing query parameters', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            source_url: 'https://www.tabnews.com.br/api/v1/contents?strategy=ascending',
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(200);
+      expect(uuidVersion(responseBody.id)).toEqual(4);
+      expect(responseBody.owner_id).toEqual(defaultUser.id);
+      expect(responseBody.username).toEqual(defaultUser.username);
+      expect(responseBody.parent_id).toEqual(null);
+      expect(responseBody.slug).toEqual('titulo-velho');
+      expect(responseBody.title).toEqual('Título velho');
+      expect(responseBody.body).toEqual('Body velho');
+      expect(responseBody.status).toEqual('draft');
+      expect(responseBody.source_url).toEqual('https://www.tabnews.com.br/api/v1/contents?strategy=ascending');
+      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(responseBody.published_at).toEqual(null);
+      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toEqual(true);
+    });
+
+    test('Content with "source_url" containing an empty String', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            source_url: '',
+          }),
+        }
+      );
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual('"source_url" não pode estar em branco.');
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+    });
+
+    test('Content with "source_url" containing a Null value', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+        source_url: 'https://www.tabnews.com.br',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            source_url: null,
+          }),
+        }
+      );
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(200);
+      expect(uuidVersion(responseBody.id)).toEqual(4);
+      expect(responseBody.owner_id).toEqual(defaultUser.id);
+      expect(responseBody.username).toEqual(defaultUser.username);
+      expect(responseBody.parent_id).toEqual(null);
+      expect(responseBody.slug).toEqual('titulo-velho');
+      expect(responseBody.title).toEqual('Título velho');
+      expect(responseBody.body).toEqual('Body velho');
+      expect(responseBody.status).toEqual('draft');
+      expect(responseBody.source_url).toEqual(null);
+      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(responseBody.published_at).toEqual(null);
+      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toEqual(true);
+    });
+
+    test('Content with "parent_id" declared solely', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const rootContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Root content title',
+        body: 'Root content body',
+      });
+
+      const childContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Child content title',
+        body: 'Child content body',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${childContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            parent_id: rootContent.id,
+          }),
+        }
+      );
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(200);
+      expect(uuidVersion(responseBody.id)).toEqual(4);
+      expect(responseBody.owner_id).toEqual(defaultUser.id);
+      expect(responseBody.username).toEqual(defaultUser.username);
+      expect(responseBody.parent_id).toEqual(rootContent.id);
+      expect(responseBody.slug).toEqual('child-content-title');
+      expect(responseBody.title).toEqual('Child content title');
+      expect(responseBody.body).toEqual('Child content body');
+      expect(responseBody.status).toEqual('draft');
+      expect(responseBody.source_url).toEqual(null);
+      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(responseBody.published_at).toEqual(null);
+      expect(responseBody.updated_at > childContent.updated_at.toISOString()).toEqual(true);
+    });
+
+    test('Content with "title" and "parent_id" set to Null', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const rootContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Root content title',
+        body: 'Root content body',
+      });
+
+      const childContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Child content title',
+        body: 'Child content body',
+        parent_id: rootContent.id,
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${childContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            parent_id: null,
+          }),
+        }
+      );
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(200);
+      expect(uuidVersion(responseBody.id)).toEqual(4);
+      expect(responseBody.owner_id).toEqual(defaultUser.id);
+      expect(responseBody.username).toEqual(defaultUser.username);
+      expect(responseBody.parent_id).toEqual(null);
+      expect(responseBody.slug).toEqual('child-content-title');
+      expect(responseBody.title).toEqual('Child content title');
+      expect(responseBody.body).toEqual('Child content body');
+      expect(responseBody.status).toEqual('draft');
+      expect(responseBody.source_url).toEqual(null);
+      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(responseBody.published_at).toEqual(null);
+      expect(responseBody.updated_at > childContent.updated_at.toISOString()).toEqual(true);
+    });
+
+    test('Content without "title" and "parent_id" set to Null', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const rootContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Root content title',
+        body: 'Root content body',
+      });
+
+      const childContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Child content title',
+        body: 'Child content body',
+        parent_id: rootContent.id,
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${childContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            title: null,
+            parent_id: null,
+          }),
+        }
+      );
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual('"title" é um campo obrigatório para conteúdos raiz.');
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('MODEL:CONTENT:CHECK_ROOT_CONTENT_TITLE:MISSING_TITLE');
+    });
+
+    test('Content with "parent_id" set to itself', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const rootContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Root content title',
+        body: 'Root content body',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${rootContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            parent_id: rootContent.id,
+          }),
+        }
+      );
+      const responseBody = await response.json();
+
+      expect(responseBody.status_code).toEqual(422);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual('"parent_id" não deve apontar para o próprio conteúdo.');
+      expect(responseBody.action).toEqual('Utilize um "parent_id" diferente do "id" do mesmo conteúdo.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('MODEL:CONTENT:CHECK_FOR_PARENT_ID_RECURSION:RECURSION_FOUND');
+    });
+
+    test('Content with "parent_id" containing a Number', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            parent_id: 123456,
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual('"parent_id" deve ser do tipo String.');
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+    });
+
+    test('Content with "parent_id" containing a blank string', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            parent_id: '',
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual('"parent_id" não pode estar em branco.');
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+    });
+
+    test('Content with "parent_id" containing a malformatted UUIDV4', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            parent_id: 'isso não é um UUID válido',
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual('"parent_id" deve possuir um token UUID na versão 4.');
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+    });
+
+    test('Content with "parent_id" that does not exists', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            parent_id: 'fe2e20f5-9296-45ea-9a0f-401866819b9e',
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(422);
+      expect(responseBody.status_code).toEqual(422);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual(
+        'Você está tentando criar ou atualizar um sub-conteúdo para um conteúdo que não existe.'
+      );
+      expect(responseBody.action).toEqual('Utilize um "parent_id" que aponte para um conteúdo que existe.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('MODEL:CONTENT:CHECK_IF_PARENT_ID_EXISTS:NOT_FOUND');
+    });
+  });
+});

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -564,35 +564,6 @@ describe('POST /api/v1/contents', () => {
       expect(responseBody.error_unique_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
-    test('Content with "title" containing Null value', async () => {
-      const defaultUser = await orchestrator.createUser();
-      await orchestrator.activateUser(defaultUser);
-      const sessionObject = await orchestrator.createSession(defaultUser);
-
-      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
-        method: 'post',
-        headers: {
-          'Content-Type': 'application/json',
-          cookie: `session_id=${sessionObject.token}`,
-        },
-        body: JSON.stringify({
-          title: null,
-          body: 'Qualquer coisa.',
-        }),
-      });
-
-      const responseBody = await response.json();
-
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"title" possui o valor inválido "null".');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_unique_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-    });
-
     test('Content with "title" containing untrimmed values', async () => {
       const defaultUser = await orchestrator.createUser();
       await orchestrator.activateUser(defaultUser);
@@ -733,38 +704,6 @@ describe('POST /api/v1/contents', () => {
       expect(Date.parse(responseBody.published_at)).not.toEqual(NaN);
     });
 
-    test('Content with "status" set to "deleted"', async () => {
-      const defaultUser = await orchestrator.createUser();
-      await orchestrator.activateUser(defaultUser);
-      const sessionObject = await orchestrator.createSession(defaultUser);
-
-      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
-        method: 'post',
-        headers: {
-          'Content-Type': 'application/json',
-          cookie: `session_id=${sessionObject.token}`,
-        },
-        body: JSON.stringify({
-          title: 'Deveria negar criar conteúdos diretamente com status "deleted".',
-          body: 'Qualquer coisa.',
-          status: 'deleted',
-        }),
-      });
-
-      const responseBody = await response.json();
-
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('Não é possível criar um conteúdo diretamente com status "deleted".');
-      expect(responseBody.action).toEqual(
-        'Você pode apenas criar conteúdos com "status" igual a "draft" ou "published".'
-      );
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_unique_code).toEqual('MODEL:CONTENT:VALIDATE_CREATE_SCHEMA:INVALID_STATUS:DELETED');
-    });
-
     test('Content with "status" set to "non_existent_status"', async () => {
       const defaultUser = await orchestrator.createUser();
       await orchestrator.activateUser(defaultUser);
@@ -788,9 +727,7 @@ describe('POST /api/v1/contents', () => {
       expect(response.status).toEqual(400);
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual(
-        '"status" deve possuir um dos seguintes valores: "draft", "published" ou "deleted".'
-      );
+      expect(responseBody.message).toEqual('"status" deve possuir um dos seguintes valores: "draft" ou "published".');
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
@@ -820,9 +757,7 @@ describe('POST /api/v1/contents', () => {
       expect(response.status).toEqual(400);
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual(
-        '"status" deve possuir um dos seguintes valores: "draft", "published" ou "deleted".'
-      );
+      expect(responseBody.message).toEqual('"status" deve possuir um dos seguintes valores: "draft" ou "published".');
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
@@ -852,9 +787,7 @@ describe('POST /api/v1/contents', () => {
       expect(response.status).toEqual(400);
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual(
-        '"status" deve possuir um dos seguintes valores: "draft", "published" ou "deleted".'
-      );
+      expect(responseBody.message).toEqual('"status" deve possuir um dos seguintes valores: "draft" ou "published".');
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
@@ -1049,6 +982,7 @@ describe('POST /api/v1/contents', () => {
           source_url: '',
         }),
       });
+
       const responseBody = await response.json();
 
       expect(response.status).toEqual(400);
@@ -1078,16 +1012,22 @@ describe('POST /api/v1/contents', () => {
           source_url: null,
         }),
       });
+
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"source_url" possui o valor inválido "null".');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_unique_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toEqual(201);
+      expect(uuidVersion(responseBody.id)).toEqual(4);
+      expect(responseBody.owner_id).toEqual(defaultUser.id);
+      expect(responseBody.username).toEqual(defaultUser.username);
+      expect(responseBody.parent_id).toEqual(null);
+      expect(responseBody.slug).toEqual('titulo');
+      expect(responseBody.title).toEqual('Titulo');
+      expect(responseBody.body).toEqual('Corpo');
+      expect(responseBody.status).toEqual('draft');
+      expect(responseBody.source_url).toEqual(null);
+      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(responseBody.published_at).toEqual(null);
     });
 
     test('"root" content with minimum valid data', async () => {
@@ -1107,6 +1047,7 @@ describe('POST /api/v1/contents', () => {
           body: 'Deveria conseguir, pois atualmente todos os usuários recebem todas as features relacionadas a "content".',
         }),
       });
+
       const responseBody = await response.json();
 
       expect(response.status).toEqual(201);
@@ -1145,6 +1086,7 @@ describe('POST /api/v1/contents', () => {
           body: 'Não deveria conseguir, falta o "title".',
         }),
       });
+
       const responseBody = await response.json();
 
       expect(response.status).toEqual(400);
@@ -1154,9 +1096,36 @@ describe('POST /api/v1/contents', () => {
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_unique_code).toEqual(
-        'MODEL:CONTENT:VALIDATE_CREATE_SCHEMA:MISSING_TITLE_WITHOUT_PARENT_ID'
-      );
+      expect(responseBody.error_unique_code).toEqual('MODEL:CONTENT:CHECK_ROOT_CONTENT_TITLE:MISSING_TITLE');
+    });
+
+    test('"root" content with "title" containing Null value', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
+        method: 'post',
+        headers: {
+          'Content-Type': 'application/json',
+          cookie: `session_id=${sessionObject.token}`,
+        },
+        body: JSON.stringify({
+          title: null,
+          body: 'Não deveria conseguir, falta o "title".',
+        }),
+      });
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual('"title" é um campo obrigatório para conteúdos raiz.');
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('MODEL:CONTENT:CHECK_ROOT_CONTENT_TITLE:MISSING_TITLE');
     });
 
     test('"child" content with minimum valid data', async () => {
@@ -1181,6 +1150,7 @@ describe('POST /api/v1/contents', () => {
           parent_id: rootContent.id,
         }),
       });
+
       const responseBody = await response.json();
 
       expect(response.status).toEqual(201);
@@ -1198,6 +1168,48 @@ describe('POST /api/v1/contents', () => {
       expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
       expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
       expect(responseBody.published_at).toEqual(null);
+    });
+
+    test('"child" content with "title" containing Null value', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const rootContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Conteúdo raiz',
+        status: 'published',
+      });
+
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
+        method: 'post',
+        headers: {
+          'Content-Type': 'application/json',
+          cookie: `session_id=${sessionObject.token}`,
+        },
+        body: JSON.stringify({
+          title: null,
+          body: 'Deveria criar um slug com UUID V4',
+          parent_id: rootContent.id,
+          status: 'published',
+        }),
+      });
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(201);
+      expect(uuidVersion(responseBody.id)).toEqual(4);
+      expect(responseBody.owner_id).toEqual(defaultUser.id);
+      expect(responseBody.username).toEqual(defaultUser.username);
+      expect(responseBody.parent_id).toEqual(rootContent.id);
+      expect(uuidVersion(responseBody.slug)).toEqual(4);
+      expect(responseBody.title).toEqual(null);
+      expect(responseBody.body).toEqual('Deveria criar um slug com UUID V4');
+      expect(responseBody.status).toEqual('published');
+      expect(responseBody.source_url).toEqual(null);
+      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.published_at)).not.toEqual(NaN);
     });
 
     test('"child" content with "title"', async () => {
@@ -1224,6 +1236,7 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         }),
       });
+
       const responseBody = await response.json();
 
       expect(response.status).toEqual(201);
@@ -1350,7 +1363,9 @@ describe('POST /api/v1/contents', () => {
       expect(response.status).toEqual(422);
       expect(responseBody.status_code).toEqual(422);
       expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('Você está tentando criar um sub-conteúdo para um conteúdo que não existe.');
+      expect(responseBody.message).toEqual(
+        'Você está tentando criar ou atualizar um sub-conteúdo para um conteúdo que não existe.'
+      );
       expect(responseBody.action).toEqual('Utilize um "parent_id" que aponte para um conteúdo que existe.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);


### PR DESCRIPTION
Esse PR implementa a possibilidade de atualizar conteúdos pela API. A quantidade de combinações da interface pública desse endpoint me surpreendeu, incluindo detalhes como: não deixar que um conteúdo seja atualizado com `parent_id` que **aponte para ele mesmo**. Isso e várias coisas legais eu consegui visualizar fazendo um "sparring" com os testes:

<img width="768" alt="image" src="https://user-images.githubusercontent.com/4248081/164604633-1d3f3d8a-3d96-4eeb-bc52-c85e68f8943e.png">

E com certeza devem ter muitas outras condições, uma que por exemplo impactou numa implementação nesse PR mas que vai ser finalizada em outro que é sobre o `DELETE` de conteúdos. Eu pessoalmente não estou muito feliz, mas nessa versão ao deletar um conteúdo, ao invés dele ter o status alterado para `deleted`, vamos precisar de fato deletar a linha. O motivo é que se não deletarmos, o `slug` desse conteúdo `deleted` pode começar a dar conflito com outros conteúdos que o usuário esteja tentando criar em `draft` e `published`.

Eu tinha inclusive programado tudo relacionado a isso, de não poder postar conteúdos diretamente com status `deleted`, de uma vez em status `deleted` não poder mais voltar para outro status, etc. mas depois que me dei conta do conflito de `slug` e que o nosso banco inteiro hoje está num modo **mutável**, assumi que o `DELETE` vai ser a solução cabível para o atual estágio. E caso algum dado muito importante seja perdido, tanto por `UPDATE` ou `DELETE`, a gente pode recuperar nos backups ou logs.

E mais para frente podemos fazer um grande refactor para que o banco de dados seja apenas `INSERT ONLY`. Seria bem show estudar sobre isso 👍 (mas não agora).