### PR TITLE
`content`: método e endpoint para listar conteúdos filho

### DIFF
--- a/models/authorization.js
+++ b/models/authorization.js
@@ -1,3 +1,4 @@
+import validator from 'models/validator.js';
 import { ValidationError, ForbiddenError } from 'errors/index.js';
 
 const availableFeatures = new Set([
@@ -191,37 +192,17 @@ function filterOutput(user, feature, output) {
   }
 
   if (feature === 'read:content') {
-    filteredOutputValues = {
-      id: output.id,
-      parent_id: output.parent_id,
-      owner_id: output.owner_id,
-      username: output.username,
-      slug: output.slug,
-      title: output.title,
-      body: output.body,
-      status: output.status,
-      source_url: output.source_url,
-      created_at: output.created_at,
-      updated_at: output.updated_at,
-      published_at: output.published_at,
-    };
+    filteredOutputValues = validator(output, {
+      content: 'required',
+    });
   }
 
   if (feature === 'read:content:list') {
-    filteredOutputValues = output.map((output) => ({
-      id: output.id,
-      parent_id: output.parent_id,
-      owner_id: output.owner_id,
-      username: output.username,
-      slug: output.slug,
-      title: output.title,
-      body: output.body,
-      status: output.status,
-      source_url: output.source_url,
-      created_at: output.created_at,
-      updated_at: output.updated_at,
-      published_at: output.published_at,
-    }));
+    filteredOutputValues = output.map((content) => {
+      return validator(content, {
+        content: 'required',
+      });
+    });
   }
 
   // Force the clean up of "undefined" values

--- a/models/validator.js
+++ b/models/validator.js
@@ -300,4 +300,75 @@ const schemas = {
         }),
     });
   },
+
+  created_at: function () {
+    return Joi.object({
+      created_at: Joi.date()
+        .when('$required.created_at', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
+        .messages({
+          'any.required': `"created_at" é um campo obrigatório.`,
+          'string.empty': `"created_at" não pode estar em branco.`,
+          'string.base': `"created_at" deve ser do tipo Date.`,
+        }),
+    });
+  },
+
+  updated_at: function () {
+    return Joi.object({
+      updated_at: Joi.date()
+        .when('$required.updated_at', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
+        .messages({
+          'any.required': `"updated_at" é um campo obrigatório.`,
+          'string.empty': `"updated_at" não pode estar em branco.`,
+          'string.base': `"updated_at" deve ser do tipo Date.`,
+        }),
+    });
+  },
+
+  published_at: function () {
+    return Joi.object({
+      published_at: Joi.date()
+        .allow(null)
+        .when('$required.published_at', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
+        .messages({
+          'any.required': `"published_at" é um campo obrigatório.`,
+          'string.empty': `"published_at" não pode estar em branco.`,
+          'string.base': `"published_at" deve ser do tipo Date.`,
+        }),
+    });
+  },
+
+  content: function () {
+    let contentSchema = Joi.object({
+      children: Joi.array().optional().items(Joi.link('#content')).messages({
+        'array.base': `"children" deve ser do tipo Array.`,
+      }),
+    })
+      .required()
+      .min(1)
+      .messages({
+        'object.base': `Body deve ser do tipo Object.`,
+      })
+      .id('content');
+
+    for (const key of [
+      'id',
+      'owner_id',
+      'parent_id',
+      'slug',
+      'title',
+      'body',
+      'status',
+      'source_url',
+      'created_at',
+      'updated_at',
+      'published_at',
+      'username',
+    ]) {
+      const keyValidationFunction = schemas[key];
+      contentSchema = contentSchema.concat(keyValidationFunction());
+    }
+
+    return contentSchema;
+  },
 };

--- a/pages/api/v1/contents/[username]/[slug]/children/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/children/index.public.js
@@ -1,0 +1,61 @@
+import nextConnect from 'next-connect';
+import controller from 'models/controller.js';
+import authentication from 'models/authentication.js';
+import authorization from 'models/authorization.js';
+import validator from 'models/validator.js';
+import content from 'models/content.js';
+import { NotFoundError } from 'errors/index.js';
+
+export default nextConnect({
+  attachParams: true,
+  onNoMatch: controller.onNoMatchHandler,
+  onError: controller.onErrorHandler,
+})
+  .use(controller.injectRequestId)
+  .use(authentication.injectAnonymousOrUser)
+  .use(controller.logRequest)
+  .get(getValidationHandler, getHandler);
+
+function getValidationHandler(request, response, next) {
+  const cleanValues = validator(request.query, {
+    username: 'required',
+    slug: 'required',
+  });
+
+  request.query = cleanValues;
+
+  next();
+}
+
+// TODO: cache the response
+async function getHandler(request, response) {
+  const userTryingToGet = request.context.user;
+
+  const contentFound = await content.findOne({
+    where: {
+      username: request.query.username,
+      slug: request.query.slug,
+      status: 'published',
+    },
+  });
+
+  if (!contentFound) {
+    throw new NotFoundError({
+      message: `O conteúdo informado não foi encontrado no sistema.`,
+      action: 'Verifique se o "slug" está digitado corretamente.',
+      stack: new Error().stack,
+      errorUniqueCode: 'CONTROLLER:CONTENT:CHILDREN:GET_HANDLER:SLUG_NOT_FOUND',
+      key: 'slug',
+    });
+  }
+
+  const childrenFound = await content.findChildren({
+    where: {
+      parent_id: contentFound.id,
+    },
+  });
+
+  const secureOutputValues = authorization.filterOutput(userTryingToGet, 'read:content:list', childrenFound);
+
+  return response.status(200).json(secureOutputValues);
+}

--- a/tests/integration/api/v1/contents/[username]/[slug]/children/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/children/get.test.js
@@ -1,0 +1,321 @@
+import fetch from 'cross-fetch';
+import { version as uuidVersion } from 'uuid';
+import orchestrator from 'tests/orchestrator.js';
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.dropAllTables();
+  await orchestrator.runPendingMigrations();
+});
+
+describe('GET /api/v1/contents/[username]/[slug]/children', () => {
+  describe('Anonymous user', () => {
+    test('From "root" content with "draft" status', async () => {
+      const defaultUser = await orchestrator.createUser();
+      const rootContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Root content',
+        status: 'draft',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${rootContent.slug}/children`
+      );
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(404);
+      expect(responseBody.status_code).toEqual(404);
+      expect(responseBody.name).toEqual('NotFoundError');
+      expect(responseBody.message).toEqual('O conteúdo informado não foi encontrado no sistema.');
+      expect(responseBody.action).toEqual('Verifique se o "slug" está digitado corretamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('CONTROLLER:CONTENT:CHILDREN:GET_HANDLER:SLUG_NOT_FOUND');
+    });
+
+    test('From "root" content with "published" status with no children', async () => {
+      const defaultUser = await orchestrator.createUser();
+      const rootContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Root content',
+        status: 'published',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${rootContent.slug}/children`
+      );
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(200);
+      expect(responseBody).toEqual([]);
+    });
+
+    test('From "root" content with "published" status with 6 "published" and 1 "draft" children', async () => {
+      const firstUser = await orchestrator.createUser();
+      const secondUser = await orchestrator.createUser();
+
+      const rootBranchLevel0 = await orchestrator.createContent({
+        owner_id: firstUser.id,
+        title: 'root',
+        status: 'published',
+      });
+
+      const childBranchALevel1 = await orchestrator.createContent({
+        parent_id: rootBranchLevel0.id,
+        owner_id: firstUser.id,
+        title: 'Child branch A [Level 1]',
+        status: 'published',
+      });
+
+      const childBranchALevel2 = await orchestrator.createContent({
+        parent_id: childBranchALevel1.id,
+        owner_id: firstUser.id,
+        title: 'Child branch A [Level 2]',
+        status: 'published',
+      });
+
+      const childBranchALevel3 = await orchestrator.createContent({
+        parent_id: childBranchALevel2.id,
+        owner_id: firstUser.id,
+        title: 'Child branch A [Level 3]',
+        status: 'published',
+      });
+
+      const childBranchBLevel1 = await orchestrator.createContent({
+        parent_id: rootBranchLevel0.id,
+        owner_id: firstUser.id,
+        title: 'Child branch B [Level 1]',
+        status: 'published',
+      });
+
+      const childBranchBLevel2Content1 = await orchestrator.createContent({
+        parent_id: childBranchBLevel1.id,
+        owner_id: firstUser.id,
+        title: 'Child branch B [Level 2] #1',
+        status: 'published',
+      });
+
+      const childBranchBLevel2Content2 = await orchestrator.createContent({
+        parent_id: childBranchBLevel1.id,
+        owner_id: secondUser.id,
+        title: 'Child branch B [Level 2] #2',
+        status: 'published',
+      });
+
+      const childBranchBLevel2Content3 = await orchestrator.createContent({
+        parent_id: childBranchBLevel1.id,
+        owner_id: firstUser.id,
+        title: 'Child branch B [Level 2] #3 [Draft]',
+        status: 'draft',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${firstUser.username}/${rootBranchLevel0.slug}/children`
+      );
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(200);
+      expect(responseBody.length).toEqual(2);
+      expect(responseBody).toStrictEqual([
+        {
+          id: responseBody[0].id,
+          owner_id: firstUser.id,
+          parent_id: rootBranchLevel0.id,
+          slug: childBranchALevel1.slug,
+          title: childBranchALevel1.title,
+          body: childBranchALevel1.body,
+          status: childBranchALevel1.status,
+          source_url: childBranchALevel1.source_url,
+          created_at: childBranchALevel1.created_at.toISOString(),
+          updated_at: childBranchALevel1.updated_at.toISOString(),
+          published_at: childBranchALevel1.published_at.toISOString(),
+          username: firstUser.username,
+          children: [
+            {
+              id: childBranchALevel2.id,
+              owner_id: firstUser.id,
+              parent_id: childBranchALevel1.id,
+              slug: childBranchALevel2.slug,
+              title: childBranchALevel2.title,
+              body: childBranchALevel2.body,
+              status: childBranchALevel2.status,
+              source_url: childBranchALevel2.source_url,
+              created_at: childBranchALevel2.created_at.toISOString(),
+              updated_at: childBranchALevel2.updated_at.toISOString(),
+              published_at: childBranchALevel2.published_at.toISOString(),
+              username: firstUser.username,
+              children: [
+                {
+                  id: childBranchALevel3.id,
+                  owner_id: firstUser.id,
+                  parent_id: childBranchALevel2.id,
+                  slug: childBranchALevel3.slug,
+                  title: childBranchALevel3.title,
+                  body: childBranchALevel3.body,
+                  status: childBranchALevel3.status,
+                  source_url: childBranchALevel3.source_url,
+                  created_at: childBranchALevel3.created_at.toISOString(),
+                  updated_at: childBranchALevel3.updated_at.toISOString(),
+                  published_at: childBranchALevel3.published_at.toISOString(),
+                  username: firstUser.username,
+                  children: [],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          id: childBranchBLevel1.id,
+          owner_id: firstUser.id,
+          parent_id: rootBranchLevel0.id,
+          slug: childBranchBLevel1.slug,
+          title: childBranchBLevel1.title,
+          body: childBranchBLevel1.body,
+          status: childBranchBLevel1.status,
+          source_url: childBranchBLevel1.source_url,
+          source_url: childBranchBLevel1.source_url,
+          created_at: childBranchBLevel1.created_at.toISOString(),
+          updated_at: childBranchBLevel1.updated_at.toISOString(),
+          published_at: childBranchBLevel1.published_at.toISOString(),
+          username: firstUser.username,
+          children: [
+            {
+              id: childBranchBLevel2Content1.id,
+              owner_id: firstUser.id,
+              parent_id: childBranchBLevel1.id,
+              slug: childBranchBLevel2Content1.slug,
+              title: childBranchBLevel2Content1.title,
+              body: childBranchBLevel2Content1.body,
+              status: childBranchBLevel2Content1.status,
+              source_url: childBranchBLevel2Content1.source_url,
+              source_url: childBranchBLevel2Content1.source_url,
+              created_at: childBranchBLevel2Content1.created_at.toISOString(),
+              updated_at: childBranchBLevel2Content1.updated_at.toISOString(),
+              published_at: childBranchBLevel2Content1.published_at.toISOString(),
+              username: firstUser.username,
+              children: [],
+            },
+            {
+              id: childBranchBLevel2Content2.id,
+              owner_id: secondUser.id,
+              parent_id: childBranchBLevel1.id,
+              slug: childBranchBLevel2Content2.slug,
+              title: childBranchBLevel2Content2.title,
+              body: childBranchBLevel2Content2.body,
+              status: childBranchBLevel2Content2.status,
+              source_url: childBranchBLevel2Content2.source_url,
+              source_url: childBranchBLevel2Content2.source_url,
+              created_at: childBranchBLevel2Content2.created_at.toISOString(),
+              updated_at: childBranchBLevel2Content2.updated_at.toISOString(),
+              published_at: childBranchBLevel2Content2.published_at.toISOString(),
+              username: secondUser.username,
+              children: [],
+            },
+          ],
+        },
+      ]);
+    });
+
+    test('From "child" content with "published" status with 2 "published" and 1 "draft" children', async () => {
+      const firstUser = await orchestrator.createUser();
+      const secondUser = await orchestrator.createUser();
+
+      const rootBranchLevel0 = await orchestrator.createContent({
+        owner_id: firstUser.id,
+        title: 'root',
+        status: 'published',
+      });
+
+      const childBranchALevel1 = await orchestrator.createContent({
+        parent_id: rootBranchLevel0.id,
+        owner_id: firstUser.id,
+        title: 'Child branch A [Level 1]',
+        status: 'published',
+      });
+
+      const childBranchALevel2 = await orchestrator.createContent({
+        parent_id: childBranchALevel1.id,
+        owner_id: firstUser.id,
+        title: 'Child branch A [Level 2]',
+        status: 'published',
+      });
+
+      const childBranchALevel3 = await orchestrator.createContent({
+        parent_id: childBranchALevel2.id,
+        owner_id: firstUser.id,
+        title: 'Child branch A [Level 3]',
+        status: 'published',
+      });
+
+      const childBranchBLevel1 = await orchestrator.createContent({
+        parent_id: rootBranchLevel0.id,
+        owner_id: firstUser.id,
+        title: 'Child branch B [Level 1]',
+        status: 'published',
+      });
+
+      const childBranchBLevel2Content1 = await orchestrator.createContent({
+        parent_id: childBranchBLevel1.id,
+        owner_id: firstUser.id,
+        title: 'Child branch B [Level 2] #1',
+        status: 'published',
+      });
+
+      const childBranchBLevel2Content2 = await orchestrator.createContent({
+        parent_id: childBranchBLevel1.id,
+        owner_id: secondUser.id,
+        title: 'Child branch B [Level 2] #2',
+        status: 'published',
+      });
+
+      const childBranchBLevel2Content3 = await orchestrator.createContent({
+        parent_id: childBranchBLevel1.id,
+        owner_id: firstUser.id,
+        title: 'Child branch B [Level 2] #3 [Draft]',
+        status: 'draft',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${firstUser.username}/${childBranchBLevel1.slug}/children`
+      );
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(200);
+      expect(responseBody.length).toEqual(2);
+      expect(responseBody).toStrictEqual([
+        {
+          id: childBranchBLevel2Content1.id,
+          owner_id: firstUser.id,
+          parent_id: childBranchBLevel1.id,
+          slug: childBranchBLevel2Content1.slug,
+          title: childBranchBLevel2Content1.title,
+          body: childBranchBLevel2Content1.body,
+          status: childBranchBLevel2Content1.status,
+          source_url: childBranchBLevel2Content1.source_url,
+          source_url: childBranchBLevel2Content1.source_url,
+          created_at: childBranchBLevel2Content1.created_at.toISOString(),
+          updated_at: childBranchBLevel2Content1.updated_at.toISOString(),
+          published_at: childBranchBLevel2Content1.published_at.toISOString(),
+          username: firstUser.username,
+          children: [],
+        },
+        {
+          id: childBranchBLevel2Content2.id,
+          owner_id: secondUser.id,
+          parent_id: childBranchBLevel1.id,
+          slug: childBranchBLevel2Content2.slug,
+          title: childBranchBLevel2Content2.title,
+          body: childBranchBLevel2Content2.body,
+          status: childBranchBLevel2Content2.status,
+          source_url: childBranchBLevel2Content2.source_url,
+          source_url: childBranchBLevel2Content2.source_url,
+          created_at: childBranchBLevel2Content2.created_at.toISOString(),
+          updated_at: childBranchBLevel2Content2.updated_at.toISOString(),
+          published_at: childBranchBLevel2Content2.published_at.toISOString(),
+          username: secondUser.username,
+          children: [],
+        },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
Essa implementação foi **muito massa** fazer e agora acredito ter finalizado todos os métodos e endpoint para conseguirmos nos focar apenas no Frontend daqui pra frente 👍 

Em resumo, o fluxo do que acontece para pegar conteúdos filho é o seguinte:

1. `GET` em `/api/v1/contents/[username]/[slug]/children`
2. Faz as validações tradicionais de entrada.
3. Tenta encontrar o `username` e um conteúdo com `slug` enviado na URL.
4. Se encontrou, chama o **novo método** `findChildren()` do model `content` passando como `parent_id` o `id` do conteúdo raiz que foi encontrado anteriormente, por exemplo:
  ```js
  const childrenFound = await content.findChildren({
      where: {
        parent_id: contentFound.id,
      },
    });
  ```
5. Esse método faz uma query recursiva no Postgres e retorna todos os conteúdos filho desse `parent_id`, inclusive os conteúdos filhos desses conteúdos filhos... recursivamente até não ter mais filhos a serem encontrados.
6. Essa query retorna uma lista flat, que é transformada numa árvore pela função `flatListToTree()` (isso ainda dentro do model `content`).
7. Isso é retornado para o controller em questão, e antes de retornar o resultado ao usuário, os dados passam pelo filtro de output.
8. Como a profundidade da árvore de filhos pode ser variável, não dá para fazer um filtro flat como estava sendo feito para as outras situações, então é feita uma validação recursiva (administrada pelo próprio Joi) onde eu defino o que é um `content` e se ele possui `children` que é um array de outros `content`s, a validação é continuamente aplicada. Tudo isso abstraído no `validator` e na interface pública basta passar `content` como chave.

Com isso, nos podemos usar o `validator` (a gente já podia antes na verdade), para não somente filtrar os dados de saída, mas também para **validar** que eles estão no formato correto. Isso é interessante, pois as vezes alguém pode dar um jeito de corromper a query e conseguir retornar dados malucos do banco de dados dentro de uma propriedade que já existe, como `username` (por exemplo conseguir retornar todos os campos do user, incluindo password, dentro do `username`), mas se isso passar pelo `validator` ele vai parar o retorno e estourar um `400`, porque nesse caso o `username` possui um formato mais travado e não vai aceitar qualquer coisa).

Isso não foi implementado (de usar o `validator` no filtro de saída), mas deveria para garantir que, se estiver saindo algo, está no formato correto.

## Resultado

```GET /api/v1/contents/filipedeschamps/artigo-nodejs/children```

```json
[
  {
    "id": "32de7d8f-d5df-4059-9d71-8aa17dcc0a26",
    "owner_id": "7e8d7d4d-a8b9-4c07-b3b4-db5db2116885",
    "parent_id": "f076c331-92c6-47f3-be23-6f5d962d7eef",
    "slug": "child-branch-a-level-1",
    "title": "Child branch A [Level 1]",
    "body": "Ea voluptas qui quaerat temporibus rerum. Animi et et. Impedit et aut deleniti eaque soluta ad fuga fugiat et. Iusto et repellat nesciunt porro doloribus. Optio neque qui odio impedit. Est et voluptas ipsa blanditiis voluptate quas voluptas.\n \rSit voluptatem quaerat at. Nobis reprehenderit perferendis odit voluptas est aut repudiandae maxime. Suscipit eum ut earum dolores. Omnis dolor ut deleniti eum temporibus mollitia. Enim aut excepturi debitis nisi. Dolorum et pariatur voluptatem molestiae et.\n \rOdit et minima in aut. Nobis exercitationem consequatur. Ipsa quia deleniti in repellat perspiciatis. Molestiae ullam quo esse vel quae maiores voluptas quaerat est. Aspernatur non blanditiis libero.\n \rQui pariatur distinctio. Quo itaque nobis sed rerum. Laudantium quam pariatur quia at.\n \rHic earum est. Magnam officia nobis labore commodi. Deserunt dolor expedita nihil dignissimos corrupti velit non. Blanditiis sint assumenda est consequatur eius et et excepturi cumque. Quis est rerum mollitia earum accusamus rerum maxime et modi. Non officiis velit omnis aut est a.",
    "status": "published",
    "source_url": null,
    "created_at": "2022-04-25T18:19:40.302Z",
    "updated_at": "2022-04-25T18:19:40.302Z",
    "published_at": "2022-04-25T18:19:40.297Z",
    "username": "Jarred84",
    "children": [
      {
        "id": "f27e7b2e-6544-43c8-b4a2-574983996248",
        "owner_id": "7e8d7d4d-a8b9-4c07-b3b4-db5db2116885",
        "parent_id": "32de7d8f-d5df-4059-9d71-8aa17dcc0a26",
        "slug": "child-branch-a-level-2",
        "title": "Child branch A [Level 2]",
        "body": "Voluptates quia nulla eos rerum enim. Sapiente et ratione minus vero ipsam ipsa facere. Eligendi dolor sunt beatae ut qui.\n \rQuas id qui maxime consequuntur officiis incidunt. Eos quia necessitatibus nobis. Est mollitia perferendis rem aut placeat minus. Corrupti dolorem est cum sit rem laudantium. Dolorum sequi ut est. Nesciunt omnis dolor omnis et quis quibusdam nam.\n \rVoluptatem voluptas et. Ipsum et laboriosam dolores sed dolor. Numquam quis eum dolorum sit. Quia veniam dicta id minus sed eos voluptatem. Ex aliquam autem ea sed et ipsum voluptatum. Fugiat eveniet veniam error.\n \rAnimi maxime earum vitae ut fuga dolores magni. Amet voluptates quam sint odio. Consequatur et dolor alias sapiente nobis voluptatem dolorem consequatur. Ullam eos voluptate iure. Ratione repellat est et tempora eum delectus. Delectus odio in odio.\n \rTemporibus sit quis cum quia quo. Iste deleniti totam doloremque eligendi explicabo excepturi molestiae qui. Sit excepturi illum pariatur rerum necessitatibus totam.",
        "status": "published",
        "source_url": null,
        "created_at": "2022-04-25T18:19:40.334Z",
        "updated_at": "2022-04-25T18:19:40.334Z",
        "published_at": "2022-04-25T18:19:40.329Z",
        "username": "Jarred84",
        "children": [
          {
            "id": "044e2d85-3bc5-48b2-afcd-7214cbbb9561",
            "owner_id": "7e8d7d4d-a8b9-4c07-b3b4-db5db2116885",
            "parent_id": "f27e7b2e-6544-43c8-b4a2-574983996248",
            "slug": "child-branch-a-level-3",
            "title": "Child branch A [Level 3]",
            "body": "Quod enim et aut quia eius nihil rem totam labore. Dolorum occaecati quos impedit unde. Et a ipsam hic expedita aut. Dignissimos ea aspernatur est dolores repellat voluptas quisquam reprehenderit veritatis.\n \rHarum rerum quam eius qui ullam. In ad quo similique suscipit non facilis quidem ratione. Consequatur rem veritatis molestias itaque aut beatae ratione sapiente. Ducimus sit similique dicta expedita totam laboriosam recusandae mollitia quas. Et qui rerum. Ipsa exercitationem dolore voluptatibus.\n \rNihil eaque commodi harum dolor. Incidunt neque necessitatibus. Eveniet placeat id excepturi pariatur sapiente a. Saepe occaecati pariatur eum magni est rerum odit libero aut. Et dignissimos enim modi error nihil culpa aut recusandae.\n \rEligendi hic dolorem ullam in repellat voluptatum perferendis quos necessitatibus. Ea quod quod. Quisquam rerum voluptas cupiditate. Repudiandae accusamus deserunt reiciendis et aut dolores veniam. Animi quia sit dignissimos eos sint porro. Nobis fuga quis at cupiditate.\n \rFugiat impedit in quaerat sapiente autem saepe. Et et nesciunt laudantium sunt. Ipsam voluptas ducimus at vitae exercitationem. Eos eum corrupti corporis. Commodi voluptatum rerum repellat sed adipisci rem.",
            "status": "published",
            "source_url": null,
            "created_at": "2022-04-25T18:19:40.361Z",
            "updated_at": "2022-04-25T18:19:40.361Z",
            "published_at": "2022-04-25T18:19:40.356Z",
            "username": "Jarred84",
            "children": [
              
            ]
          }
        ]
      }
    ]
  },
  {
    "id": "0714c439-c8de-4d50-bdca-d8a064c54c27",
    "owner_id": "7e8d7d4d-a8b9-4c07-b3b4-db5db2116885",
    "parent_id": "f076c331-92c6-47f3-be23-6f5d962d7eef",
    "slug": "child-branch-b-level-1",
    "title": "Child branch B [Level 1]",
    "body": "Fuga corporis vel. Reiciendis ut suscipit id earum aut perspiciatis et expedita quia. Et adipisci voluptatem et consectetur. Ut quia voluptas quo.\n \rNemo dolores eos consequuntur. Sit non voluptatem. Blanditiis dolorum in consectetur dolore. Voluptatem iste reiciendis adipisci fugit saepe natus eum maxime.\n \rRatione assumenda velit nesciunt. Sit qui iusto quibusdam placeat aut. Quasi sapiente sed molestiae aliquid et sequi qui maiores et. Recusandae beatae doloremque minus tenetur eius cumque.\n \rEius quae omnis optio ducimus voluptatum explicabo corrupti. Quia voluptatem rerum. Quisquam reprehenderit quam qui. Est suscipit autem sequi sunt a illo.\n \rRepudiandae quos sunt ea tenetur eum ut numquam ut. Ex sunt natus natus beatae dolorem. Et reprehenderit voluptas dolores id qui tempora esse ut occaecati. Odio accusamus et voluptatem sed in mollitia nostrum libero.",
    "status": "published",
    "source_url": null,
    "created_at": "2022-04-25T18:19:40.391Z",
    "updated_at": "2022-04-25T18:19:40.391Z",
    "published_at": "2022-04-25T18:19:40.386Z",
    "username": "Jarred84",
    "children": [
      {
        "id": "c3ed0964-bc4a-44f8-a6fb-cf09a78b68d2",
        "owner_id": "7e8d7d4d-a8b9-4c07-b3b4-db5db2116885",
        "parent_id": "0714c439-c8de-4d50-bdca-d8a064c54c27",
        "slug": "child-branch-b-level-2-1",
        "title": "Child branch B [Level 2] #1",
        "body": "Voluptatem quis consequatur. Quia fuga in et voluptatem et modi eum aut minus. Vel neque praesentium quos. Minus dolorum sit.\n \rConsequuntur incidunt dolor voluptatem in nostrum odio recusandae aut ad. Et illo id consequatur nobis. Incidunt ullam modi eos omnis. Quia quisquam qui impedit aspernatur at earum incidunt vero nostrum. Assumenda non qui praesentium eveniet fuga est nihil est.\n \rAdipisci consequatur quis. Ut sunt molestiae nisi earum dolor tempore error. Ut ea magni aut a consectetur omnis.\n \rVoluptatibus et excepturi odit quia. Necessitatibus ab earum sequi non autem ut rerum et rerum. Quibusdam voluptate est sed consequatur beatae rerum cumque blanditiis. Autem perferendis corporis modi ipsum. Dolores ea reiciendis omnis accusamus sit. Omnis atque alias repudiandae aliquid possimus itaque.\n \rSed qui error aut ea magnam ut. Sed vitae totam sed iure aliquam. Libero omnis voluptates. Qui nostrum et explicabo possimus rerum.",
        "status": "published",
        "source_url": null,
        "created_at": "2022-04-25T18:19:40.417Z",
        "updated_at": "2022-04-25T18:19:40.417Z",
        "published_at": "2022-04-25T18:19:40.412Z",
        "username": "Jarred84",
        "children": [
          
        ]
      },
      {
        "id": "e79affd7-8a87-4f01-a7cc-d75ff7be8bf7",
        "owner_id": "ab5e71b0-889c-4160-978d-34d85f68737a",
        "parent_id": "0714c439-c8de-4d50-bdca-d8a064c54c27",
        "slug": "child-branch-b-level-2-2",
        "title": "Child branch B [Level 2] #2",
        "body": "Rerum quos quaerat ad natus voluptatem qui sint id. Molestiae qui voluptates iure molestiae aut qui illo vel voluptatem. Quia voluptatem inventore qui modi aut dolorem. Quis nulla dicta modi aliquid eaque. Reprehenderit magnam quisquam saepe est hic. Quod inventore cumque beatae.\n \rAdipisci nihil ducimus eaque. Dolores in assumenda illo sint repudiandae aut commodi sed. Corporis debitis laudantium culpa expedita aut.\n \rNon eligendi quo rerum delectus labore nisi. Cum deserunt velit quo soluta et nostrum consequuntur adipisci. Quo nihil iste et eos fuga natus unde voluptate. Accusantium dolorem molestiae debitis animi autem praesentium sint quae quo.\n \rAut aut autem quia in necessitatibus voluptatum alias harum. Quis aut animi necessitatibus eos voluptatem magni quia. Temporibus repellat autem nobis a dolores quia corporis qui.\n \rRem cupiditate cupiditate voluptatum qui aut adipisci odio debitis a. Quo velit et corrupti quasi delectus. Corrupti dignissimos repellat quia rerum aut illum aut. Praesentium modi officia consequatur qui ipsam consequatur. Molestias ducimus qui et et. Exercitationem minima doloribus saepe et corporis qui.",
        "status": "published",
        "source_url": null,
        "created_at": "2022-04-25T18:19:40.445Z",
        "updated_at": "2022-04-25T18:19:40.445Z",
        "published_at": "2022-04-25T18:19:40.440Z",
        "username": "Nia28",
        "children": [
          
        ]
      }
    ]
  }
]
```