### PR TITLE
fix(editor): fix `height` property

### DIFF
--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -386,9 +386,7 @@ export default function Content({ content, mode = 'view', viewFrame = false }) {
 
         <style global jsx>{`
           .bytemd {
-            height: {
-              mode==='edit'?'calc(100vh - 350px)': 'calc(100vh - 100px)';
-            }
+            height: ${mode === 'edit' ? 'calc(100vh - 350px)' : 'calc(100vh - 600px)'};
             min-height: 200px;
             border-radius: 6px;
           }


### PR DESCRIPTION
Eu fiz alguma besteira no CSS do editor e só notei agora: a propriedade `height` estava 100% quebrada.

Agora quando você está criando um post novo, tem praticamente toda a altura da tela para escrever. E quando está respondendo a algum outro conteúdo, a altura reage de acordo com o ambiente (o espaço do corpo fica um pouco menor).