### PR TITLE
fix(content): remove `grid` property of child content tree

### DIFF
--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -115,7 +115,6 @@ function RenderChildrenTree({ childrenList, level }) {
     return (
       <Box
         sx={{
-          display: 'grid',
           maxWidth: '100%',
           borderRadius: '6px',
           borderWidth: 1,


### PR DESCRIPTION
Esse bug foi encontrado pelo Programador BR que me mandou os seguintes prints:

![image](https://user-images.githubusercontent.com/4248081/167215036-8c5a1a1c-c9e8-4185-8e55-d064ce68b069.png)

![image](https://user-images.githubusercontent.com/4248081/167215052-82d60032-e030-4e4f-9f95-afd77f2ac95f.png)

Quando um conteúdo filho continha um bloco de código muito longo, o layout quebrava, e era a propriedade `grid` que estava sendo aplicada somente aos conteúdos filho 👍 