### PR TITLE
fix(head): remove canonical url

### DIFF
--- a/pages/interface/components/BaseLayout/index.js
+++ b/pages/interface/components/BaseLayout/index.js
@@ -3,8 +3,6 @@ import Head from 'next/head';
 // TODO: remove `content` from the props and only work with `metadata`
 export default function DefaultLayout({ children, metadata = {}, content }) {
   let title = 'TabNews';
-  let baseUrl = process.env.NEXT_PUBLIC_VERCEL_URL || 'www.tabnews.com.br';
-  let canonicalUrl;
 
   if (content) {
     if (content.title) {
@@ -12,7 +10,6 @@ export default function DefaultLayout({ children, metadata = {}, content }) {
     } else {
       title = `${content.username}/${content.slug} · TabNews`;
     }
-    canonicalUrl = `https://${baseUrl}/${content.username}/${content.slug}`;
   }
 
   if (metadata.title) {
@@ -24,12 +21,6 @@ export default function DefaultLayout({ children, metadata = {}, content }) {
       <Head>
         <title>{title}</title>
         <meta property="og:title" content={title} key="title" />
-        {canonicalUrl && (
-          <>
-            <meta property="og:url" content={canonicalUrl} key="url" />
-            <link rel="canonical" href={canonicalUrl} />
-          </>
-        )}
         <meta property="og:site_name" content="TabNews" />
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
         <link rel="icon" href="/favicon.png" type="image/png" />


### PR DESCRIPTION
Estou por hora removendo o `canonical url` do layout base, pois está fazendo mais ruim do que bom no momento. Isso porque do jeito que eu fiz, a base da URL é construída de forma dinâmica, mas de um jeito que pega a "url do build" lá na Vercel. Isso é ótimo para ambiente de Preview, mas em produção não, olha com que estava:

**Url de referência:**
```
https://www.tabnews.com.br/filipedeschamps/tentando-construir-um-pedaco-de-internet-mais-massa
```

**Tag gerada:**
```
<link rel="canonical" href="https://tabnews-3ri8e23d7-tabnews.vercel.app/filipedeschamps/tentando-construir-um-pedaco-de-internet-mais-massa"/>
```