### PR TITLE
fix(status): fix chart y axis error

### DIFF
--- a/pages/api/v1/analytics/child-content-published/index.public.js
+++ b/pages/api/v1/analytics/child-content-published/index.public.js
@@ -31,7 +31,7 @@ async function getHandler(request, response) {
   )
 
   SELECT TO_CHAR(day_range.date :: DATE, 'dd/mm') as date,
-         daily_counts.ct as respostas
+         daily_counts.ct::INTEGER as respostas
   FROM day_range
   LEFT OUTER JOIN daily_counts on day_range.date = daily_counts.date;
   `);

--- a/pages/api/v1/analytics/root-content-published/index.public.js
+++ b/pages/api/v1/analytics/root-content-published/index.public.js
@@ -31,7 +31,7 @@ async function getHandler(request, response) {
   )
 
   SELECT TO_CHAR(day_range.date :: DATE, 'dd/mm') as date,
-         daily_counts.ct as conteudos
+         daily_counts.ct::INTEGER as conteudos
   FROM day_range
   LEFT OUTER JOIN daily_counts on day_range.date = daily_counts.date;
   `);

--- a/pages/api/v1/analytics/users-created/index.public.js
+++ b/pages/api/v1/analytics/users-created/index.public.js
@@ -31,7 +31,7 @@ async function getHandler(request, response) {
   )
 
   SELECT TO_CHAR(day_range.date :: DATE, 'dd/mm') as date,
-         daily_counts.ct as cadastros
+         daily_counts.ct::INTEGER as cadastros
   FROM day_range
   LEFT OUTER JOIN daily_counts on day_range.date = daily_counts.date;
   `);


### PR DESCRIPTION
Encontrei o problema na página `/status` dos gráficos não representarem corretamente a altura dos valores... eles estavam vindo como `String` e agora vem como `Number`.

De qualquer forma, essa query tem que ser jogada fora e refeita do zero, tem formas muito mais simples.