### PR TITLE
fix(errors): handle validation error on `getStaticProp()`

### DIFF
--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -149,10 +149,16 @@ export async function getStaticPaths() {
 export async function getStaticProps(context) {
   const userTryingToGet = user.createAnonymous();
 
-  context.params = validator(context.params, {
-    username: 'required',
-    slug: 'required',
-  });
+  try {
+    context.params = validator(context.params, {
+      username: 'required',
+      slug: 'required',
+    });
+  } catch (error) {
+    return {
+      notFound: true,
+    };
+  }
 
   let contentFound;
 

--- a/pages/[username]/index.public.js
+++ b/pages/[username]/index.public.js
@@ -26,9 +26,15 @@ export async function getStaticPaths() {
 export async function getStaticProps(context) {
   const userTryingToGet = user.createAnonymous();
 
-  context.params = validator(context.params, {
-    username: 'required',
-  });
+  try {
+    context.params = validator(context.params, {
+      username: 'required',
+    });
+  } catch (error) {
+    return {
+      notFound: true,
+    };
+  }
 
   let contentListFound;
 


### PR DESCRIPTION
Eu estava analisando os logs para ver se tudo estava ok, e comecei a notar uns erros `500` para URLs como essa:

https://www.tabnews.com.br/nao-existe.jpg

<img width="269" alt="image" src="https://user-images.githubusercontent.com/4248081/167544133-2ed4028c-3b8f-41bd-8692-809e79a2c59a.png">

E lembrei que nas páginas estáticas, antes delas serem geradas, é feita a validação **também**, porém não estava sendo feito o handling caso a validação não passasse.

Então no caso da URL acima, ela estava caindo na validação de username:

`https://www.tabnews.com.br/[username]`

E o `username` só aceita caracteres alfanuméricos.

A mesma coisa para o slug:

`https://www.tabnews.com.br/[username]/[slug]`

E isso era ativado quando alguém tentou acessar a url:

`https://www.tabnews.com.br/.well-known/traffic-advice`

Esse PR pretende consertar isso e retornar `404` (não encontrei como ser possível retornar outro status code de dentro de um `getStaticProp`)