### PR TITLE
feat(scripts): run migrations on `npm run dev`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Para rodar o projeto localmente, basta rodar o comando abaixo:
 npm run dev
 ```
 
-Isto irá automaticamente rodar serviços como Banco de dados, Servidor de Email e irá expor um Serviço Web (Frontend e API) no seguinte endereço:
+Isto irá automaticamente rodar serviços como Banco de dados (incluindo as Migrations), Servidor de Email e irá expor um Serviço Web (Frontend e API) no seguinte endereço:
 
 ```bash
 http://localhost:3000/
@@ -45,7 +45,7 @@ Observações:
 - Para derrubar todos os serviços, basta utilizar as teclas `CTRL+C`, que é o padrão dos terminais para matar processos.
 - Você pode conferir o endereço dos outros serviços dentro do arquivo `.env` encontrado na raiz do projeto, como por exemplo o endereço e credenciais do Banco de Dados local ou o Frontend do Serviço de Email.
 
-### Rodar os testes
+## Rodar os testes
 
 Há várias formas de rodar os testes dependendo do que você deseja fazer, mas o primeiro passo antes de fazer qualquer alteração no projeto é rodar os testes de forma geral para se certificar que tudo está passando como esperado. O comando abaixo irá rodar todos os serviços necessários, rodar os testes e em seguida derrubar todos os serviços.
 
@@ -87,7 +87,7 @@ Observações:
 - A forma como é tratado o caminho dos arquivos pode mudar dependendo do seu sistema operacional.
 - A forma como o seu terminal interpreta caracteres especiais como `/` ou `[` pode mudar, mas você poderá fazer o _escape_ deles adicionando o caractere `\` na frente, por exemplo: `\[`.
 
-### Commit das alterações
+## Commit das alterações
 
 Após finalizar suas alterações e se certificar que todos os testes estão passando com o comando geral `npm test`, chegou a hora de fazer o commit das suas alterações.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7586,6 +7586,12 @@
         "trouter": "^3.2.0"
       }
     },
+    "node-getopt": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/node-getopt/-/node-getopt-0.3.2.tgz",
+      "integrity": "sha512-yqkmYrMbK1wPrfz7mgeYvA4tBperLg9FQ4S3Sau3nSAkpOA0x0zC8nQ1siBwozy1f4SE8vq2n1WKv99r+PCa1Q==",
+      "dev": true
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -8555,6 +8561,17 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
+    },
+    "retry-cli": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/retry-cli/-/retry-cli-0.7.0.tgz",
+      "integrity": "sha512-VSWsAZFV4AxAsxH2/r+TDQGTS4cTory266mmpI5KiZUZB/8VjqksCZ/kOGMLQ7XZFVNwzVdQ54pEJu6jnLbSVw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.3",
+        "node-getopt": "^0.3.2",
+        "retry": "^0.13.1"
+      }
     },
     "reusify": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -47,10 +47,11 @@
     "eslint-plugin-primer-react": "0.7.4",
     "jest": "28.0.2",
     "kill-port": "1.6.1",
-    "prettier": "2.6.2"
+    "prettier": "2.6.2",
+    "retry-cli": "0.7.0"
   },
   "scripts": {
-    "dev": "kill-port 3000 && npm run services:up && npm run next && npm run services:stop",
+    "dev": "kill-port 3000 && npm run services:up && npx retry -- npm run migration:run 2>/dev/null && npm run next && npm run services:stop",
     "next": "next dev",
     "services:up": "docker-compose -f infra/docker-compose.development.yml up -d",
     "services:stop": "docker-compose -f infra/docker-compose.development.yml stop",


### PR DESCRIPTION
Relacionado a issue #297 

Foi adicionado uma lógica de "retry" para rodar as migrations e enquanto o banco não termina de levantar, o script de rodar as migrações fica retornando erro, mas isso é silenciado pelo comando `2>/dev/null` (o `2` filtra apenas o `stderr` e joga ele no limbo).

Mas não sei como isso vai se comportar no Windows, porque pelo que vi aqui, nele o comando é `2> nul`. Como fazer algo que rode nos dois ambientes?