### PR TITLE
fix(content): stops re-rendering `/publicar` page on re-focus

### DIFF
--- a/pages/interface/hooks/useUser/index.js
+++ b/pages/interface/hooks/useUser/index.js
@@ -1,7 +1,10 @@
 import useSWR from 'swr';
 
-export default function useSession() {
-  const { data, isLoading, isValidating, error } = useSWR('/api/v1/user');
+export default function useUser() {
+  const { data, isLoading, isValidating, error } = useSWR('/api/v1/user', {
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+  });
 
   return {
     user: data,

--- a/pages/publicar/index.public.js
+++ b/pages/publicar/index.public.js
@@ -4,7 +4,10 @@ import { Box, Heading, Flash, Link } from '@primer/react';
 
 export default function Post() {
   const { user } = useUser();
-  const { data: contents } = useSWR(user?.username ? `/api/v1/contents/${user.username}` : null);
+  const { data: contents } = useSWR(user?.username ? `/api/v1/contents/${user.username}` : null, {
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+  });
 
   return (
     <DefaultLayout metadata={{ title: 'Publicar novo conteúdo' }}>


### PR DESCRIPTION
Se algum especialista em React puder me ajudar seria show.

O uso dos hooks ali em baixo estavam causando a página `/publicar` a ser "re-renderizada" ao ser "re-focada" e com isso resetar todo o estado do formulário. O problema estava exatamente no `useUser()`, mas ele era usado somente para a url/chave do `swr`. E isso era usado para entender se a mensagem sobre a primeira postagem deveria aparecer ou não.

Mas mesmo que os valores dos hooks acima mudem, não entendo porque todos os componentes estavam sendo renderizados novamente, incluindo o `<Content mode="edit" />`, o que causava perder todos os dados.

Eu já vou fazer o merge desse PR para consertar isso em produção, mas se alguém estiver disponível para me explicar essa mecânica seria show!