### PR TITLE
fix(migrations): use `retry-cli` to run the migration script on `npm run dev`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7646,6 +7646,12 @@
         "trouter": "^3.2.0"
       }
     },
+    "node-getopt": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/node-getopt/-/node-getopt-0.3.2.tgz",
+      "integrity": "sha512-yqkmYrMbK1wPrfz7mgeYvA4tBperLg9FQ4S3Sau3nSAkpOA0x0zC8nQ1siBwozy1f4SE8vq2n1WKv99r+PCa1Q==",
+      "dev": true
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -8615,6 +8621,17 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
+    },
+    "retry-cli": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/retry-cli/-/retry-cli-0.7.0.tgz",
+      "integrity": "sha512-VSWsAZFV4AxAsxH2/r+TDQGTS4cTory266mmpI5KiZUZB/8VjqksCZ/kOGMLQ7XZFVNwzVdQ54pEJu6jnLbSVw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.3",
+        "node-getopt": "^0.3.2",
+        "retry": "^0.13.1"
+      }
     },
     "reusify": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "eslint-plugin-primer-react": "0.7.4",
     "jest": "28.1.0",
     "kill-port": "1.6.1",
-    "prettier": "2.6.2"
+    "prettier": "2.6.2",
+    "retry-cli": "0.7.0"
   },
   "scripts": {
     "dev": "kill-port 3000 && npm run services:up && npm run migration:run && npm run next && npm run services:stop",
@@ -65,7 +66,7 @@
     "lint:fix": "eslint --fix && prettier --write '**/*.{json,js,jsx,ts,tsx}'",
     "commit": "cz",
     "migration:create": "node-pg-migrate create",
-    "migration:run": "while ! docker-compose  -f  infra/docker-compose.development.yml logs | grep 'accept connections' ; do sleep 1; echo 'Aguardando Postgres aceitar conexões'; done && node-pg-migrate up --envPath ./.env -m infra/migrations/"
+    "migration:run": "npx retry -- node-pg-migrate up --envPath ./.env -m infra/migrations/ 2>migrations.log"
   },
   "name": "tabnews.com.br",
   "description": "Conteúdos para quem vive de programação e tecnologia.",


### PR DESCRIPTION
Sobre o problema [reportado aqui](https://github.com/filipedeschamps/tabnews.com.br/pull/306#issuecomment-1123916585) e relacionado a issue #297

Vou ficar rodando os testes várias vezes aqui no CI para ver o comportamento.

E diferente da primeira implementação que enviava os logs de erro para o `/dev/null` agora eles são enviados para `migrations.log` e isso faz ficar compatível com todos os sistemas operacionais.