### PR TITLE
fix(content): word-wrap on content box

### DIFF
--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -85,6 +85,7 @@ export default function Post({ contentFound: contentFoundFallback, childrenFound
             borderColor: 'border.default',
             borderStyle: 'solid',
             padding: 4,
+            wordWrap: 'break-word',
           }}>
           <Content content={contentFound} mode="view" />
         </Box>


### PR DESCRIPTION
Hoje estava lendo um post do tabnews no celular, acabei reparando em um bug de quebra do conteúdo conforme imagem abaixo:
![Captura de tela em 2022-05-14 23-55-05](https://user-images.githubusercontent.com/5334261/168455108-5cc13ece-c7ab-4135-b536-f5af6ce090d1.png)

Resolvi adicionando o style wordWrap: 'break-word',