### PR TITLE
feat(content): implementado ação do botão de deletar conteúdo

### DIFF
--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -77,6 +77,7 @@ export default function Post({ contentFound: contentFoundFallback, childrenFound
             </Link>
           </Box>
         )}
+
         <Box
           sx={{
             width: '100%',
@@ -90,23 +91,25 @@ export default function Post({ contentFound: contentFoundFallback, childrenFound
           <Content content={contentFound} mode="view" />
         </Box>
 
-        <Box sx={{ width: '100%' }}>
-          <Box
-            sx={{
-              borderRadius: '6px',
-              borderWidth: 1,
-              borderColor: 'border.default',
-              borderStyle: 'solid',
-              mt: 4,
-              mb: 4,
-              p: 4,
-              wordWrap: 'break-word',
-            }}>
-            <Content content={{ parent_id: contentFound.id }} mode="compact" />
-          </Box>
+        {contentFound.status !== 'deleted' && (
+          <Box sx={{ width: '100%' }}>
+            <Box
+              sx={{
+                borderRadius: '6px',
+                borderWidth: 1,
+                borderColor: 'border.default',
+                borderStyle: 'solid',
+                mt: 4,
+                mb: 4,
+                p: 4,
+                wordWrap: 'break-word',
+              }}>
+              <Content content={{ parent_id: contentFound.id }} mode="compact" />
+            </Box>
 
-          <RenderChildrenTree childrenList={children} level={0} />
-        </Box>
+            <RenderChildrenTree childrenList={children} level={0} />
+          </Box>
+        )}
       </DefaultLayout>
     </>
   );


### PR DESCRIPTION
Implementa a ação do botão de deletar conteúdo.

Feedback exibido quando alguém acessa um conteúdo que foi deletado:
![image](https://user-images.githubusercontent.com/16567734/169441225-ab1218c9-60a3-4035-be62-f9fec25d5cca.png)

Além disso, conforme especificado na [issue](https://github.com/filipedeschamps/tabnews.com.br/issues/349), foi comentado temporariamente o botão de `Despublicar`

### Dependência
Esse pull request tem dependência da issue #348 que implementa o backend da atividade



feat #349