### PR TITLE
Fix LocalStorage bugs

### DIFF
--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -229,19 +229,19 @@ export default function Content({ content, mode = 'view', viewFrame = false }) {
           } else {
             setBody(contentObject?.body || '');
           }
-        };
+        }
 
-        rendLocalStorageData(data)
+        rendLocalStorageData(data);
 
         function onFocus(event) {
-          const new_data = event.currentTarget.localStorage[localStorageKey]
-          rendLocalStorageData(new_data)
+          const new_data = event.currentTarget.localStorage[localStorageKey];
+          rendLocalStorageData(new_data);
         }
 
-        addEventListener("focus", onFocus);
+        addEventListener('focus', onFocus);
         return () => {
-          removeEventListener("focus", onFocus);
-        }
+          removeEventListener('focus', onFocus);
+        };
       }
     }, [localStorageKey]);
 


### PR DESCRIPTION
Solução de dois problemas relatados aqui https://www.tabnews.com.br/Pryds/c3376f31-85eb-4b2d-92fa-f8c5d2fdcf94

1) Ao clicar em responder e desistir da postagem as caixas de resposta ficam abertas por tempo indeterminado mesmo fechando o navegador. Isso ocorre porque ao verificar a existência da Key daquele post em LocalStorage, mesmo que vazia, é renderizado o modo de edição.
Correção: Ao ler os dados armazenados em LocalStorage para a Key especificada é verificada, além da validade, também a nulidade do do parâmetro body, então a Key é deletada se não for útil.

2) Abrir mais de uma aba pode deixar os dados de LocalStorage com inconsistências como o título de uma aba e o corpo de outra.
Correção: Os dados são atualizados de LocalStorage sempre que a aba do navegador fica em foco. Assim a nova postagem fica consistente mesmo em caso de abertura de abas simultâneas.

Edit: Criado outro PR #361 sem os erros de Lint