### PR TITLE
refactor(Content): and minor fixes in localStorage

### DIFF
--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useRouter } from 'next/router';
 
 import {
@@ -36,6 +36,7 @@ import 'github-markdown-css/github-markdown-light.css';
 export default function Content({ content, mode = 'view', viewFrame = false }) {
   const [componentMode, setComponentMode] = useState(mode);
   const [contentObject, setContentObject] = useState(content);
+  const { user, isLoading } = useUser();
 
   useEffect(() => {
     setComponentMode(mode);
@@ -60,7 +61,6 @@ export default function Content({ content, mode = 'view', viewFrame = false }) {
   }
 
   function ViewMode() {
-    const { user, isLoading } = useUser();
     const [publishedSinceText, setPublishedSinceText] = useState();
 
     useEffect(() => {
@@ -166,8 +166,6 @@ export default function Content({ content, mode = 'view', viewFrame = false }) {
 
   function EditMode() {
     const router = useRouter();
-    const { user, isLoading } = useUser();
-
     useEffect(() => {
       if (!isLoading && !user.username) {
         // TODO: re-implement this after local changes
@@ -178,64 +176,49 @@ export default function Content({ content, mode = 'view', viewFrame = false }) {
       } else {
         clearErrors();
       }
-    }, [user, isLoading]);
+    }, []);
 
     const [globalErrorMessage, setGlobalErrorMessage] = useState(false);
     const [isPosting, setIsPosting] = useState(false);
     const [errorObject, setErrorObject] = useState(undefined);
-    const [body, setBody] = useState('');
-    const [titleDefaultValue, setTitleDefaultValue] = useState('');
-    const [sourceUrlDefaultValue, setSourceUrlDefaultValue] = useState('');
-    const titleRef = useRef('');
-    const sourceUrlRef = useRef('');
+    const [newData, setNewData] = useState({
+      title: contentObject?.title || '',
+      body: contentObject?.body || '',
+      source_url: contentObject?.source_url || '',
+    });
 
     const localStorageKey = useMemo(() => {
-      if (contentObject?.parent_id) {
-        return `content-edit-child-${contentObject.parent_id}`;
-      } else if (contentObject?.parent_id && contentObject?.id) {
-        return `content-edit-child-${contentObject.parent_id}-${contentObject.id}`;
-      } else if (contentObject?.id) {
+      if (contentObject?.id) {
         return `content-edit-${contentObject.id}`;
+      } else if (contentObject?.parent_id) {
+        return `content-new-parent-${contentObject.parent_id}`;
       } else {
         return `content-new`;
       }
     }, []);
 
-    useEffect(() => {
-      if (componentMode === 'edit') {
-        if (!contentObject && !contentObject?.parent_id) {
-          titleRef?.current.focus();
-        }
+    function loadLocalStorage(oldData) {
+      const data = localStorage.getItem(localStorageKey);
 
-        let data = localStorage.getItem(localStorageKey);
-
-        if (contentObject && !contentObject?.parent_id && !isValidJsonString(data)) {
-          localStorage.setItem(
-            localStorageKey,
-            JSON.stringify({
-              title: contentObject?.title || '',
-              source_url: contentObject?.source_url || '',
-              body: contentObject?.body || '',
-            })
-          );
-        }
-
-        data = localStorage.getItem(localStorageKey);
-
-        if (isValidJsonString(data)) {
-          const parsedData = JSON.parse(data);
-
-          setBody(parsedData?.body || '');
-
-          if (!contentObject?.parent_id) {
-            setTitleDefaultValue(parsedData?.title || '');
-            setSourceUrlDefaultValue(parsedData?.source_url || '');
-          }
-        } else {
-          setBody(contentObject?.body || '');
-        }
+      if (!isValidJsonString(data)) {
+        localStorage.removeItem(localStorageKey);
+        return oldData;
       }
-    }, [localStorageKey]);
+
+      return JSON.parse(data);
+    }
+
+    useEffect(() => {
+      setNewData(loadLocalStorage(newData));
+
+      function onFocus() {
+        setNewData((oldData) => loadLocalStorage(oldData));
+      }
+
+      addEventListener('focus', onFocus);
+      return () => removeEventListener('focus', onFocus);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     function clearErrors() {
       setErrorObject(undefined);
@@ -246,8 +229,9 @@ export default function Content({ content, mode = 'view', viewFrame = false }) {
       setIsPosting(true);
       setErrorObject(undefined);
 
-      const title = titleRef.current.value;
-      const sourceUrl = sourceUrlRef.current.value;
+      const title = newData.title;
+      const body = newData.body;
+      const sourceUrl = newData.source_url;
 
       const requestMethod = contentObject?.id ? 'PATCH' : 'POST';
       const requestUrl = contentObject?.id
@@ -288,31 +272,22 @@ export default function Content({ content, mode = 'view', viewFrame = false }) {
         const responseBody = await response.json();
 
         if (response.status === 200) {
-          setContentObject(responseBody);
-
           localStorage.removeItem(localStorageKey);
-
+          setContentObject(responseBody);
           setComponentMode('view');
-
           return;
         }
 
         if (response.status === 201) {
+          localStorage.removeItem(localStorageKey);
           if (!responseBody.parent_id) {
             localStorage.setItem('justPublishedNewRootContent', true);
-
-            localStorage.removeItem(localStorageKey);
-
             router.push(`/${responseBody.username}/${responseBody.slug}`);
             return;
           }
 
           setContentObject(responseBody);
-
-          localStorage.removeItem(localStorageKey);
-
           setComponentMode('view');
-
           return;
         }
 
@@ -344,34 +319,26 @@ export default function Content({ content, mode = 'view', viewFrame = false }) {
       }
     }
 
-    const handleChange = useCallback(
-      (event) => {
-        const data = localStorage.getItem(localStorageKey);
-        if (isValidJsonString(data)) {
-          const parsedData = JSON.parse(data);
+    const handleChange = (event) => {
+      clearErrors();
+      setNewData((oldData) => {
+        const newData = { ...oldData, [event.target?.name || 'body']: event.target?.value ?? event };
+        localStorage.setItem(localStorageKey, JSON.stringify(newData));
+        return newData;
+      });
+    };
 
-          parsedData[event.target.name] = event.target.value;
-
-          localStorage.setItem(localStorageKey, JSON.stringify(parsedData));
-        } else {
-          const parsedData = {};
-          parsedData[event.target.name] = event.target.value;
-          localStorage.setItem(localStorageKey, JSON.stringify(parsedData));
-        }
-      },
-      [localStorageKey]
-    );
-
-    useEffect(() => {
-      if (body !== '') {
-        handleChange({
-          target: {
-            name: 'body',
-            value: body,
-          },
-        });
-      }
-    }, [handleChange, body]);
+    function handleCancel() {
+      if (
+        newData.body &&
+        !window.confirm('Tem certeza que deseja sair da edição?\n Os dados não salvos serão perdidos.')
+      )
+        return;
+      clearErrors();
+      localStorage.removeItem(localStorageKey);
+      const isPublished = contentObject?.status === 'published';
+      setComponentMode(isPublished ? 'view' : 'compact');
+    }
 
     return (
       <Box sx={{ mb: 4, width: '100%' }}>
@@ -383,11 +350,7 @@ export default function Content({ content, mode = 'view', viewFrame = false }) {
               <FormControl id="title">
                 <FormControl.Label visuallyHidden>Título</FormControl.Label>
                 <TextInput
-                  ref={titleRef}
-                  onChange={(event) => {
-                    clearErrors();
-                    setTitleDefaultValue(event.target.value);
-                  }}
+                  onChange={handleChange}
                   name="title"
                   size="large"
                   autoCorrect="off"
@@ -395,8 +358,11 @@ export default function Content({ content, mode = 'view', viewFrame = false }) {
                   spellCheck={false}
                   placeholder="Título"
                   aria-label="Título"
-                  onKeyUp={handleChange}
-                  value={titleDefaultValue}
+                  // Autofocus: na prática já estava implementado
+                  // através da referência do input no useEffect
+                  // eslint-disable-next-line jsx-a11y/no-autofocus
+                  autoFocus={true}
+                  value={newData.title}
                 />
 
                 {errorObject?.key === 'title' && (
@@ -409,15 +375,7 @@ export default function Content({ content, mode = 'view', viewFrame = false }) {
             <FormControl id="body">
               <FormControl.Label visuallyHidden>Corpo</FormControl.Label>
               <Box className={errorObject?.key === 'body' ? 'is-invalid' : ''}>
-                <Editor
-                  value={body}
-                  plugins={bytemdPluginList}
-                  onChange={(newBody) => {
-                    clearErrors();
-                    setBody(newBody);
-                  }}
-                  mode="tab"
-                />
+                <Editor value={newData.body} plugins={bytemdPluginList} onChange={handleChange} mode="tab" />
               </Box>
 
               {errorObject?.key === 'body' && (
@@ -429,11 +387,7 @@ export default function Content({ content, mode = 'view', viewFrame = false }) {
               <FormControl id="source_url">
                 <FormControl.Label visuallyHidden>Fonte (opcional)</FormControl.Label>
                 <TextInput
-                  ref={sourceUrlRef}
-                  onChange={(event) => {
-                    clearErrors();
-                    setSourceUrlDefaultValue(event.target.value);
-                  }}
+                  onChange={handleChange}
                   name="source_url"
                   size="large"
                   autoCorrect="off"
@@ -441,8 +395,7 @@ export default function Content({ content, mode = 'view', viewFrame = false }) {
                   spellCheck={false}
                   placeholder="Fonte (opcional)"
                   aria-label="Fonte (opcional)"
-                  onKeyUp={handleChange}
-                  value={sourceUrlDefaultValue}
+                  value={newData.source_url}
                 />
 
                 {errorObject?.key === 'source_url' && (
@@ -452,25 +405,11 @@ export default function Content({ content, mode = 'view', viewFrame = false }) {
             )}
 
             <Box sx={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center' }}>
-              {contentObject && contentObject.id && (
+              {contentObject && (
                 <Link
                   sx={{ marginRight: 3, fontSize: 1, cursor: 'pointer', color: 'fg.muted' }}
                   aria-label="Cancelar alteração"
-                  onClick={(event) => {
-                    setComponentMode('view');
-                    localStorage.removeItem(localStorageKey);
-                  }}>
-                  Cancelar
-                </Link>
-              )}
-              {contentObject && contentObject.parent_id && !contentObject.id && (
-                <Link
-                  sx={{ marginRight: 3, fontSize: 1, cursor: 'pointer', color: 'fg.muted' }}
-                  aria-label="Cancelar"
-                  onClick={(event) => {
-                    setComponentMode('compact');
-                    localStorage.removeItem(localStorageKey);
-                  }}>
+                  onClick={handleCancel}>
                   Cancelar
                 </Link>
               )}
@@ -526,35 +465,7 @@ export default function Content({ content, mode = 'view', viewFrame = false }) {
   }
 
   function CompactMode() {
-    const { user, isLoading } = useUser();
     const router = useRouter();
-
-    const localStorageKey = useMemo(() => {
-      if (contentObject?.parent_id) {
-        return `content-edit-child-${contentObject.parent_id}`;
-      } else if (contentObject?.parent_id && contentObject?.id) {
-        return `content-edit-child-${contentObject.parent_id}-${contentObject.id}`;
-      } else if (contentObject?.id) {
-        return `content-edit-${contentObject.id}`;
-      } else {
-        return `content-new`;
-      }
-    }, []);
-
-    useEffect(() => {
-      if (user && !isLoading) {
-        const data = localStorage.getItem(localStorageKey);
-        if (isValidJsonString(data)) {
-          const parsedData = JSON.parse(data);
-
-          if (parsedData?.body) {
-            setComponentMode('edit');
-          } else {
-            localStorage.removeItem(localStorageKey);
-          }
-        }
-      }
-    }, [localStorageKey, user, isLoading]);
 
     const handleClick = useCallback(() => {
       if (user?.username && !isLoading) {
@@ -562,16 +473,14 @@ export default function Content({ content, mode = 'view', viewFrame = false }) {
       } else {
         router.push(`/login?redirect=${router.asPath}`);
       }
-    }, [user, isLoading, router]);
+    }, [router]);
 
     return (
       <Button
         sx={{
           maxWidth: 'fit-content',
         }}
-        onClick={() => {
-          handleClick();
-        }}>
+        onClick={handleClick}>
         Responder
       </Button>
     );


### PR DESCRIPTION
Considerando qua ainda haviam alguns problemas menores relacionados com o localStorage, aproveitei para fazer uma refatoração no componente Content.
Lembrando que esse componente é renderizado para cada post na tela, portanto, qualquer problema de performance nele é multiplicado pelo número de mensagens na página. Com isso em mente, foram eliminadas as leituras excessivas ao localStorage.
Também foi resolvido um bug que ocorria ao fazer edição de um post root em diferentes abas deixando o dado em localStorage inconsistente.
Dessa forma, estou publicando a PR para que seja **avaliada com calma**, pois realmente não contém nada urgente.

As mudanças estão relatadas abaixo:

### Refatoração

#### 1) Remoção de código duplicado e mudança de escopo:
 - `useUser` (agora está só no componente pai Content)
 - `localStorageKey` (agora está só no componente `EditMode`)

#### 2) Troca de `useRef` por `useState` e reformulação dos que já usavam `useState` dentro do componente `EditMode`.

**Saem**: 
- `titleDefaultValue` e `setTitleDefaultValue`,
- `sourceUrlDefaultValue` e `setSourceUrlDefaultValue`,
- `body` e `setBody`,
- `titleRef`
- `sourceUrlRef`

**Entram**:
-  `newData` e `setNewData`

#### 3) `handleChange`:
- Não estava muito clara a maneira como eram atualizadas as variáveis e o localStorage no modo de edição. Isso estava dificultando entender os BUGs que apareceram anteriormente.
- Agora ocorre tudo dentro da  nova função `handleChange`, que até ficou mais simples que a antiga. 
- Também não há mais necessidade do `useEffect` monitorando alterações em `handleChange` e `body`.

#### 4) `handleSubmit`:
- Alteradas variáveis `title`, `boby` e `sourceUrl` que agora puxam os dados de `newData` ao invés de `useRef`.
- Mudança na ordem em que o item postado com sucesso é removido de `localStorage`.

#### 5) `handleCancel` - Centralizada em uma função as ações necessárias ao cancelar uma edição de conteúdo:
- Mensagem de confirmação avisando sobre a perda de dados não salvos.
- Limpeza dos erros
- Limpeza do `localStorage`
- Mudança do modo do componente para `'view'` ou `'compact'` de acordo com o caso.

#### 6)  O autofoco do título ao abrir edição em conteúdo root:
- Era feito através de `useRef` e foi mudado para a propriedade `autoFocus={true}` no input.
- Executa exatamente a mesma função, mas agora de maneira mais simples e transparente.
- Obriga a deixar o aviso do lint lembrando que em alguns casos isso pode atrapalhar a acessibilidade. Informação importante que ficava mascarada da outra forma.

#### 7) `onChange={handleChange}`:
- Alterações em quaisquer inputs chamam essa única função, facilitando a análise do código.

### Mudanças na lógica do localStorage

#### 1) `localStorageKey` - Definição da variável
- Foi invertida a ordem dos condicionais para priorizar usar o id antes de parent_id (se a postagem já existir, irá utilizar o próprio id e não o do pai). Da forma como estava, iria gerar a mesma Key para a edição de dois filhos diferentes, pois usaria o id do pai.
- Além disso, da maneira como estava, nunca entraria na condição abaixo que era mais restrita que a primeira. Na verdade essa condição nem é necessária:
        ```else if (contentObject?.parent_id && contentObject?.id) {
                return `content-edit-child-${contentObject.parent_id}-${[contentObject.id](http://contentobject.id/)}`;
         }```
- Se a Key é baseada no id é porque é uma edição de conteúdo já existente, seja pai ou filho não faz diferença, então faz sentido o padrão `content-edit-${contentObject.id}`
- Se a Key for baseada no `parent_id` é porque é um novo conteúdo filho, então faz mais sentido usar "content-new" e não "content-edit": `content-new-parent-${contentObject.parent_id}`
- E por fim será usada a Key `content-new` se for um novo conteúdo root.

#### 2) localStorage - Leituras e gravações
- Agora só é lido na função `loadLocalStorage` que só executa uma vez quando o conteúdo é renderizado no modo de edição e, se estiver nesse modo, a cada vez que a aba do navegador entrar em foco (para atualizar caso ocorra edição em mais de uma aba ao mesmo tempo). Antes era acessado também em cada conteúdo no modo compacto, ou seja, em cada conteúdo renderizado. Era lido também em algumas outras situações ao invés de ler diretamente das variáveis de estado.
- Não é lido mais no modo compacto, então não irá abrir o modo de edição automaticamente caso tenha sido fechado o navegador sem submeter o conteúdo, mas caso se tente fazer nova postagem, o rascunho será recuperado. Obs. Acho interessante o conteúdo salvo em localStorage, e pendente de submissão, ser renderizado já no modo de edição caso seja aberta nova aba ou reinicializado o navegador, mas essa verificação do localStorage pode ser feita uma única vez em um componente superior ao invés de a cada conteúdo renderizado. Então o componente superior já aciona o Content com o modo edit selecionado, ou seja, é uma alteração para ser feita em outro escopo.
- Para sincronizar as alterações em diferentes abas é utilizado um EventListener('focus') dentro de apenas conteúdos que estão sendo editados. O listener sempre é descartado ao desmontar o componente de edição. Esse listener evita que o conteúdo em localStorage fique inconsistente em caso de alterações parciais em cada aba (pode ficar com o título de uma e o corpo de outra aba, por exemplo).
- A gravação em localStorage agora ocorre dentro da função `handleChange` e sem necessitar de uma leitura antes de gravar.