### PR TITLE
fix: gap between number and item in ContentList

### DIFF
--- a/pages/interface/components/ContentList/index.js
+++ b/pages/interface/components/ContentList/index.js
@@ -23,7 +23,7 @@ export default function ContentList({ contentList, path }) {
     return list.map((contentObject) => {
       return (
         <Box key={contentObject.id} sx={{ display: 'flex' }}>
-          <Box sx={{ mr: 2, width: '20px', textAlign: 'right' }}>
+          <Box sx={{ mr: 2, width: '30px', textAlign: 'right' }}>
             <Text sx={{ fontSize: 2, color: 'fg.default', fontWeight: 'semibold' }}>{count++}.</Text>
           </Box>
           <Box>


### PR DESCRIPTION
## 🤔 Por que você está abrindo esse Pull Request?
- Eu estou resolvendo um problema visual do gap entre o numero e o titulo do conteúdo na ContentList que fica na home.

## 🧐 Descreva sua solução:
- Eu aumentei o gap, mas acredito que poderíamos ter uma solução melhor para isso no futuro, em breve vamos ter mais posts e essa solução não vai escalar.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/13791385/170561867-3a1c5eda-c20f-4d74-a3fb-fc64c02fbe4e.png) | ![image](https://user-images.githubusercontent.com/13791385/170562081-3c08fcff-bb31-4041-bdc8-5bc6654ba046.png) |