### PR TITLE
fix: add a scalable solution for ContentList items

### DIFF
--- a/pages/interface/components/ContentList/index.js
+++ b/pages/interface/components/ContentList/index.js
@@ -7,25 +7,22 @@ import { pt } from 'date-fns/locale';
 export default function ContentList({ contentList, pagination, nextPageBasePath, revalidatePath }) {
   const listNumberOffset = pagination.perPage * (pagination.currentPage - 1);
 
-  const { data: list, isLoading } = useSWR(revalidatePath, { fallbackData: contentList, revalidateOnMount: false });
+  const { data: list } = useSWR(revalidatePath, { fallbackData: contentList, revalidateOnMount: false });
 
   const nextPageUrl = `${nextPageBasePath}/${pagination?.nextPage}`;
-
-  let count = 1;
 
   return (
     <Box
       sx={{
-        display: 'grid',
-        gap: 2,
+        display: 'table',
         width: '100%',
       }}>
       {list.length > 0 ? <RenderItems /> : <RenderEmptyMessage />}
 
       {pagination?.nextPage && (
-        <Box sx={{ display: 'grid', gridTemplateColumns: '30px 1fr' }}>
-          <Box sx={{ mr: 2, textAlign: 'right' }}>◀️</Box>
-          <Box>
+        <Box sx={{ display: 'grid', display: 'table-row' }}>
+          <Box sx={{ display: 'table-cell', pr: 2, textAlign: 'right' }}>◀️</Box>
+          <Box sx={{ display: 'table-cell' }}>
             <Link sx={{ fontSize: 2, color: 'fg.default', fontWeight: 'semibold' }} href={nextPageUrl}>
               Página anterior
             </Link>
@@ -36,15 +33,16 @@ export default function ContentList({ contentList, pagination, nextPageBasePath,
   );
 
   function RenderItems() {
-    return list.map((contentObject) => {
+    return list.map((contentObject, index) => {
+      const itemCount = index + 1 + listNumberOffset;
       return (
-        <Box as="article" key={contentObject.id} sx={{ display: 'grid', gridTemplateColumns: '30px 1fr' }}>
-          <Box sx={{ mr: 2, textAlign: 'right' }}>
+        <Box as="article" key={contentObject.id} sx={{ display: 'table-row' }}>
+          <Box sx={{ display: 'table-cell', pr: 2, textAlign: 'right' }}>
             <Text sx={{ fontSize: 2, color: 'fg.default', fontWeight: 'semibold', textAlign: 'right' }}>
-              {count++ + listNumberOffset}.
+              {itemCount}.
             </Text>
           </Box>
-          <Box>
+          <Box sx={{ display: 'table-cell' }}>
             <Box>
               <Link
                 sx={{ fontSize: 2, color: 'fg.default', fontWeight: 'semibold' }}


### PR DESCRIPTION
## Por que esse PR existe?

Meu primeiro PR aqui foi tentando ajustar isso, mas a solução que propus não seria definitiva e ainda acabou faltando um gap depois de um outro pr 😢 

| Antes | Depois |
| --- | --- |
| <img width="620" alt="image" src="https://user-images.githubusercontent.com/13791385/170808693-2c8d706f-3001-4e16-bdc9-bd529cadb18d.png"> | <img width="612" alt="image" src="https://user-images.githubusercontent.com/13791385/170808677-8e5641e2-cc16-46f0-b637-551da0a1b2c0.png"> |

## Comentário da solução
- Dado o cenário de termos numeros variáveis o display table parece antiquado, mas é exatamente o comportamento que parece que queremos aqui, o que acha @filipedeschamps?