### PR TITLE
Aceitar URL com TLDs maiores

### DIFF
--- a/models/validator.js
+++ b/models/validator.js
@@ -332,7 +332,7 @@ const schemas = {
         .allow(null)
         .trim()
         .max(2000)
-        .pattern(/^(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/)
+        .pattern(/^(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,18}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/)
         .when('$required.source_url', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
           'any.required': `"source_url" é um campo obrigatório.`,

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -897,6 +897,76 @@ describe('POST /api/v1/contents', () => {
       expect(responseBody.published_at).toEqual(null);
     });
 
+    test('Content with "source_url" containing a valid long TLD', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
+        method: 'post',
+        headers: {
+          'Content-Type': 'application/json',
+          cookie: `session_id=${sessionObject.token}`,
+        },
+        body: JSON.stringify({
+          title: 'Um baita de um Top-Level Domain',
+          body: 'O maior TLD que foi encontrado no dia do commit possuía 18 caracteres',
+          source_url: 'https://nic.northwesternmutual/',
+        }),
+      });
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(201);
+      expect(uuidVersion(responseBody.id)).toEqual(4);
+      expect(responseBody.owner_id).toEqual(defaultUser.id);
+      expect(responseBody.username).toEqual(defaultUser.username);
+      expect(responseBody.parent_id).toEqual(null);
+      expect(responseBody.parent_title).toEqual(null);
+      expect(responseBody.parent_slug).toEqual(null);
+      expect(responseBody.parent_username).toEqual(null);
+      expect(responseBody.slug).toEqual('um-baita-de-um-top-level-domain');
+      expect(responseBody.title).toEqual('Um baita de um Top-Level Domain');
+      expect(responseBody.body).toEqual('O maior TLD que foi encontrado no dia do commit possuía 18 caracteres');
+      expect(responseBody.status).toEqual('draft');
+      expect(responseBody.source_url).toEqual('https://nic.northwesternmutual/');
+      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(responseBody.published_at).toEqual(null);
+    });
+
+    test('Content with "source_url" containing a invalid long TLD', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
+        method: 'post',
+        headers: {
+          'Content-Type': 'application/json',
+          cookie: `session_id=${sessionObject.token}`,
+        },
+        body: JSON.stringify({
+          title: 'Um Top-Level Domain maior que o permitido',
+          body: 'O maior TLD que foi encontrado no dia do commit possuía 18 caracteres',
+          source_url: 'https://tldco.mdezenovecaracteres',
+        }),
+      });
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual(
+        '"source_url" deve possuir uma URL válida e utilizando os protocolos HTTP ou HTTPS.'
+      );
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_unique_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+    });
+
     test('Content with "source_url" containing a not accepted Protocol', async () => {
       const defaultUser = await orchestrator.createUser();
       await orchestrator.activateUser(defaultUser);


### PR DESCRIPTION
Hoje só é considerada uma URL válida se o TLD tiver entre 2 e 6 caracteres.
Proponho aceitar até 18 caracteres para não barrar, por exemplo:
https://nic.northwesternmutual/

ou como citado em https://github.com/filipedeschamps/tabnews.com.br/issues/409#issue-1251934882
https://www.portaldev.digital/posts/o-que-e-html