### PR TITLE
Nova proposta para Links da Paginação

### DIFF
--- a/pages/[username]/index.public.js
+++ b/pages/[username]/index.public.js
@@ -12,7 +12,7 @@ export default function Home({ contentListFound, pagination, username }) {
         <ContentList
           contentList={contentListFound}
           pagination={pagination}
-          nextPageBasePath={`/${username}/pagina`}
+          paginationBasePath={`/${username}/pagina`}
           revalidatePath={`/api/v1/contents/${username}`}
         />
       </DefaultLayout>

--- a/pages/[username]/pagina/[page]/index.public.js
+++ b/pages/[username]/pagina/[page]/index.public.js
@@ -12,7 +12,7 @@ export default function Home({ contentListFound, pagination, username }) {
         <ContentList
           contentList={contentListFound}
           pagination={pagination}
-          nextPageBasePath={`/${username}/pagina`}
+          paginationBasePath={`/${username}/pagina`}
           revalidatePath={`/api/v1/contents/${username}?page=${pagination.currentPage}`}
         />
       </DefaultLayout>

--- a/pages/index.public.js
+++ b/pages/index.public.js
@@ -11,7 +11,7 @@ export default function Home({ contentListFound, pagination }) {
         <ContentList
           contentList={contentListFound}
           pagination={pagination}
-          nextPageBasePath="/pagina"
+          paginationBasePath="/pagina"
           revalidatePath="/api/v1/contents"
         />
       </DefaultLayout>

--- a/pages/interface/components/ContentList/index.js
+++ b/pages/interface/components/ContentList/index.js
@@ -1,33 +1,60 @@
 import useSWR from 'swr';
 import { Box, Link, Text } from '@primer/react';
+import { ChevronLeftIcon, ChevronRightIcon } from '@primer/octicons-react';
+
 import PublishedSince from 'pages/interface/components/PublishedSince';
 
-export default function ContentList({ contentList, pagination, nextPageBasePath, revalidatePath }) {
+export default function ContentList({ contentList, pagination, paginationBasePath, revalidatePath }) {
   const listNumberOffset = pagination.perPage * (pagination.currentPage - 1);
 
   const { data: list } = useSWR(revalidatePath, { fallbackData: contentList, revalidateOnMount: false });
 
-  const nextPageUrl = `${nextPageBasePath}/${pagination?.nextPage}`;
+  const previousPageUrl = `${paginationBasePath}/${pagination?.previousPage}`;
+  const nextPageUrl = `${paginationBasePath}/${pagination?.nextPage}`;
 
   return (
-    <Box
-      sx={{
-        display: 'table',
-        borderSpacing: '0 0.5rem',
-      }}>
-      {list.length > 0 ? <RenderItems /> : <RenderEmptyMessage />}
+    <>
+      <Box
+        sx={{
+          display: 'table',
+          borderSpacing: '0 0.5rem',
+        }}>
+        {list.length > 0 ? <RenderItems /> : <RenderEmptyMessage />}
+      </Box>
 
-      {pagination?.nextPage && (
-        <Box sx={{ display: 'grid', display: 'table-row' }}>
-          <Box sx={{ display: 'table-cell', pr: 2, textAlign: 'right' }}>◀️</Box>
-          <Box sx={{ display: 'table-cell' }}>
-            <Link sx={{ fontSize: 2, color: 'fg.default', fontWeight: 'semibold' }} href={nextPageUrl}>
-              Página anterior
-            </Link>
-          </Box>
-        </Box>
-      )}
-    </Box>
+      <Box
+        sx={{
+          display: 'flex',
+          width: '100%',
+          justifyContent: 'center',
+          gap: 4,
+          m: 4,
+        }}>
+        {pagination.previousPage ? (
+          <Link href={previousPageUrl}>
+            <ChevronLeftIcon size={16} />
+            Anterior
+          </Link>
+        ) : (
+          <Text color="fg.muted">
+            <ChevronLeftIcon size={16} />
+            Anterior
+          </Text>
+        )}
+
+        {pagination.nextPage ? (
+          <Link href={nextPageUrl}>
+            Próximo
+            <ChevronRightIcon size={16} />
+          </Link>
+        ) : (
+          <Text color="fg.muted">
+            Próximo
+            <ChevronRightIcon size={16} />
+          </Text>
+        )}
+      </Box>
+    </>
   );
 
   function RenderItems() {

--- a/pages/pagina/[page]/index.public.js
+++ b/pages/pagina/[page]/index.public.js
@@ -11,7 +11,7 @@ export default function Home({ contentListFound, pagination }) {
         <ContentList
           contentList={contentListFound}
           pagination={pagination}
-          nextPageBasePath="/pagina"
+          paginationBasePath="/pagina"
           revalidatePath={`/api/v1/contents?page=${pagination.currentPage}`}
         />
       </DefaultLayout>


### PR DESCRIPTION
Após feedback da comunidade, ficou evidente que eu tinha implementado os links da paginação ao contrário. Então iniciei a implementação usando o componente oficial de paginação do Primer, mas ele não possui tradução, então os links ficariam  algo como `< Previous | Next >`. Mas sem problemas, refiz uma implementação do modo mais simples da navegação deles (e usando as flechas do pacote oficial de ícones deles) e que reage a existência ou não de uma página:

<img width="207" alt="image" src="https://user-images.githubusercontent.com/4248081/171024620-5c1942c5-6b27-4139-8208-4d8a6022776f.png">

<img width="207" alt="image" src="https://user-images.githubusercontent.com/4248081/171024708-e2f07165-6a74-424b-b161-8bf3cb5c6ac6.png">

<img width="207" alt="image" src="https://user-images.githubusercontent.com/4248081/171024761-6d3f3bc0-55b2-434e-93eb-8a9fb4ce063a.png">

E dado que agora não possui somente mais um link para a próxima página, refatorei o parâmetro `nextPageBasePath` para `paginationBasePath`.