### PR TITLE
feat(contents): only `unstable_revalidate` Home if it's a `root` content

### DIFF
--- a/pages/api/v1/contents/index.public.js
+++ b/pages/api/v1/contents/index.public.js
@@ -106,18 +106,20 @@ async function postHandler(request, response) {
     await notification.sendReplyEmailToParentUser(createdContent);
   }
 
-  const secureOutputValues = authorization.filterOutput(userTryingToCreate, 'read:content', createdContent);
-
-  try {
-    await response.unstable_revalidate(`/`);
-  } catch (error) {
-    const errorObject = new ServiceError({
-      message: error.message,
-      errorUniqueCode: 'CONTROLLER:CONTENTS:POST_HANDLER:REVALIDATE:ERROR',
-      stack: new Error().stack,
-    });
-    logger.error(snakeize({ ...errorObject, stack: error.stack }));
+  if (!createdContent.parent_id) {
+    try {
+      await response.unstable_revalidate(`/`);
+    } catch (error) {
+      const errorObject = new ServiceError({
+        message: error.message,
+        errorUniqueCode: 'CONTROLLER:CONTENTS:POST_HANDLER:REVALIDATE:ERROR',
+        stack: new Error().stack,
+      });
+      logger.error(snakeize({ ...errorObject, stack: error.stack }));
+    }
   }
+
+  const secureOutputValues = authorization.filterOutput(userTryingToCreate, 'read:content', createdContent);
 
   return response.status(201).json(secureOutputValues);
 }


### PR DESCRIPTION
Somente atualiza a Home usando o `unstable_revalidate` se for um conteúdo sem `parent_id`, ou seja, não é uma resposta e é um conteúdo que irá de fato aparecer na Home.