### PR TITLE
Problemas de overflow

### DIFF
--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -210,9 +210,13 @@ function ViewMode({ setComponentMode, contentObject, viewFrame }) {
           </Box>
         </Box>
 
-        {!contentObject?.parent_id && contentObject?.title && <Heading as="h1">{contentObject.title}</Heading>}
+        {!contentObject?.parent_id && contentObject?.title && (
+          <Heading sx={{ overflow: 'auto', wordWrap: 'break-word' }} as="h1">
+            {contentObject.title}
+          </Heading>
+        )}
       </Box>
-      <Box>
+      <Box sx={{ overflow: 'auto' }}>
         <Viewer value={contentObject.body} plugins={bytemdPluginList} />
       </Box>
       {contentObject.source_url && (

--- a/pages/interface/components/ContentList/index.js
+++ b/pages/interface/components/ContentList/index.js
@@ -16,8 +16,9 @@ export default function ContentList({ contentList, pagination, paginationBasePat
     <>
       <Box
         sx={{
-          display: 'table',
-          borderSpacing: '0 0.5rem',
+          display: 'grid',
+          gap: '0.5rem',
+          gridTemplateColumns: 'auto 1fr',
         }}>
         {list.length > 0 ? <RenderItems /> : <RenderEmptyMessage />}
       </Box>
@@ -68,41 +69,39 @@ export default function ContentList({ contentList, pagination, paginationBasePat
 
     return list.map((contentObject, index) => {
       const itemCount = index + 1 + listNumberOffset;
-      return (
-        <Box as="article" key={contentObject.id} sx={{ display: 'table-row' }}>
-          <Box sx={{ display: 'table-cell', pr: 2, textAlign: 'right' }}>
-            <Text sx={{ fontSize: 2, color: 'fg.default', fontWeight: 'semibold', textAlign: 'right' }}>
-              {itemCount}.
+      return [
+        <Box key={itemCount} sx={{ lineHeight: '1.25rem', textAlign: 'right' }}>
+          <Text sx={{ fontSize: 2, color: 'fg.default', fontWeight: 'semibold', textAlign: 'right' }}>
+            {itemCount}.
+          </Text>
+        </Box>,
+        <Box as="article" key={contentObject.id} sx={{ lineHeight: '1.25rem', overflow: 'auto' }}>
+          <Box sx={{ overflow: 'auto' }}>
+            <Link
+              sx={{ fontSize: 2, color: 'fg.default', fontWeight: 'semibold', wordWrap: 'break-word' }}
+              href={`/${contentObject.username}/${contentObject.slug}`}>
+              {contentObject.title}
+            </Link>
+          </Box>
+          <Box sx={{ fontSize: 0, color: 'neutral.emphasis' }}>
+            <Text>
+              <TabCoinsText count={contentObject.tabcoins} />
+            </Text>
+            {' · '}
+            <Text>
+              <ChildrenDeepCountText count={contentObject.children_deep_count} />
+            </Text>
+            {' · '}
+            <Link sx={{ color: 'neutral.emphasis' }} href={`/${contentObject.username}`}>
+              {contentObject.username}
+            </Link>
+            {' · '}
+            <Text>
+              <PublishedSince date={contentObject.published_at} />
             </Text>
           </Box>
-          <Box sx={{ display: 'table-cell', lineHeight: '20px' }}>
-            <Box>
-              <Link
-                sx={{ fontSize: 2, color: 'fg.default', fontWeight: 'semibold' }}
-                href={`/${contentObject.username}/${contentObject.slug}`}>
-                {contentObject.title}
-              </Link>
-            </Box>
-            <Box sx={{ fontSize: 0, color: 'neutral.emphasis' }}>
-              <Text>
-                <TabCoinsText count={contentObject.tabcoins} />
-              </Text>
-              {' · '}
-              <Text>
-                <ChildrenDeepCountText count={contentObject.children_deep_count} />
-              </Text>
-              {' · '}
-              <Link sx={{ color: 'neutral.emphasis' }} href={`/${contentObject.username}`}>
-                {contentObject.username}
-              </Link>
-              {' · '}
-              <Text>
-                <PublishedSince date={contentObject.published_at} />
-              </Text>
-            </Box>
-          </Box>
-        </Box>
-      );
+        </Box>,
+      ];
     });
   }
 

--- a/pages/interface/components/Header/index.js
+++ b/pages/interface/components/Header/index.js
@@ -7,7 +7,7 @@ export default function HeaderComponent() {
   const { user, isLoading } = useUser();
 
   return (
-    <Header>
+    <Header sx={{ overflow: 'auto' }}>
       <Header.Item>
         <Header.Link href="/" fontSize={2}>
           <CgTab size={32} />


### PR DESCRIPTION
Corrige alguns problemas de responsividade, entre eles os relatados abaixo:
Responsividade em mobile. https://github.com/filipedeschamps/tabnews.com.br/issues/379
Falha no layout ao usar textos zalgo https://github.com/filipedeschamps/tabnews.com.br/issues/400
Bug ao dar hover nas labels da página "Status" https://github.com/filipedeschamps/tabnews.com.br/issues/417

Para as soluções adotadas houve alguma alteração de layout, como no encadeamento de respostas com menos espaçamento, então já aproveitei para propor a fixação do Header (alteração facilmente reversível).

@omariosouto tive que retirar a `table` do ContentList, pois limitava algumas correções necessárias para impedir o estouro de textos grandes sem espaço ou zalgo.

@filipedeschamps vi o PR #418, mas fiz uma mudança que não desconfigura a página se surgir algum novo commit com texto muito longo. No máximo o texto vai ficar cortado, mas vai aparecer completo pelo atributo `title` se mantiver o mouse sobre o texto. Em mobile simplesmente irá cortar o que sair da tela. Fiz o mesmo para o Autor e SHA, pois dependendo da tela também poderia dar problema.

Vejam se estão de acordo. 🤝