### PR TITLE
fix(content): check if `user` object have `feature` property

### DIFF
--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -154,7 +154,7 @@ export default function Content({ content, mode = 'view', viewFrame = false }) {
             </Box>
             <Box>
               {user &&
-                (user.id === contentObject.owner_id || user.features.includes('update:content:others')) &&
+                (user.id === contentObject.owner_id || user.features?.includes('update:content:others')) &&
                 ViewModeOptionsMenu()}
             </Box>
           </Box>


### PR DESCRIPTION
No PR #424 eu adicionei um commit c761a04de084c2e448f6e27858d733fbc76b69b5 que fazia uma verificação se o objeto `user` possuía a feature `update:content:others` e assumindo que o `user` sempre possui dentro dele um objeto de **usuário** mesmo... mas infelizmente esse não é o caso.

Quando eu criei o hook `useUser` que é o responsável por preencher esse objeto, ao receber um `403` do `/user` ele preenche esse objeto com um objeto de **erro**. Então na verificação acima eu estava cegamente esperando que haveria uma propriedade `.features`, o que não existe no objeto de erro.

Então isso estava fazendo qualquer página de conteúdo quebrar caso o usuário não estivesse logado.

Eu adicionei um `?` para falhar a verificação, mas o `useUser` precisa ser mais semântico nesse caso, principalmente no de verificar se o usuário está logado ou não, pois hoje estamos verificando as propriedades como `id` ou `username` e isso é frágil.