### PR TITLE
feat(migrations): seed initial users

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,24 @@ Observações:
 - Para derrubar todos os serviços, basta utilizar as teclas `CTRL+C`, que é o padrão dos terminais para matar processos.
 - Você pode conferir o endereço dos outros serviços dentro do arquivo `.env` encontrado na raiz do projeto, como por exemplo o endereço e credenciais do Banco de Dados local ou o Frontend do Serviço de Email.
 
-### Criar seu primeiro usuário
+### Cadastro e Login de usuários
+
+No ambiente de desenvolvimento você poderá tanto criar usuários manualmente (inclusive para receber e testar o email de ativação), quanto utilizar usuários pré-cadastrados e que já foram ativados para sua conveniência.
+
+#### Manualmente criar um usuário
 
 1. Após subir os serviços, acesse http://localhost:3000/cadastro
 2. Preencha os dados e utilize **qualquer email** com formato válido, mesmo que este email não exista, por exemplo: `teste@teste.com`
 3. O backend irá enviar um email para o servidor **local** de emails e que pode ser acessado pelo endereço http://localhost:1080/
 4. Abra o email de Ativação e acesse o link para ativar sua conta de fato.
 5. Com a conta ativa, realize o login: http://localhost:3000/login
+
+#### Utilizar usuários pré-cadastrados
+
+Por padrão, ao rodar o comando `npm run dev` será injetado dois usuários ativados, um com features padrões e outro com features administrativas como a habilidade de rodar as Migrations usando a API ou alterar o conteúdo de outros usuários. Segue abaixo as credenciais destes dois usuários (`"email"` + `"senha"`):
+
+- **Usuário Admin**: `"admin@admin.com"` + `"password"`
+- **Usuário padrão**: `"user@user.com"` + `"password"`
 
 ## Rodar os testes
 

--- a/infra/scripts/seed-database.js
+++ b/infra/scripts/seed-database.js
@@ -1,0 +1,65 @@
+const { Client } = require('pg');
+const client = new Client({
+  connectionString: 'postgres://local_user:local_password@localhost:54320/tabnews',
+  connectionTimeoutMillis: 5000,
+  idleTimeoutMillis: 30000,
+  allowExitOnIdle: false,
+});
+
+seedDatabase();
+
+async function seedDatabase() {
+  console.log('> Seeding database...');
+
+  await client.connect();
+  await seedDevelopmentUsers();
+  await client.end();
+
+  console.log('> Database seeded!');
+}
+
+async function seedDevelopmentUsers() {
+  await insertUser('admin', 'admin@admin.com', '$2a$04$v0hvAu/y6pJ17LzeCfcKG.rDStO9x5ficm2HTLZIfeDBG8oR/uQXi', [
+    'create:session',
+    'read:session',
+    'create:content',
+    'create:content:text_root',
+    'create:content:text_child',
+    'update:content',
+    'update:user',
+    'read:migration',
+    'create:migration',
+    'update:content:others',
+  ]);
+  await insertUser('user', 'user@user.com', '$2a$04$v0hvAu/y6pJ17LzeCfcKG.rDStO9x5ficm2HTLZIfeDBG8oR/uQXi', [
+    'create:session',
+    'read:session',
+    'create:content',
+    'create:content:text_root',
+    'create:content:text_child',
+    'update:content',
+    'update:user',
+  ]);
+
+  console.log('------------------------------');
+  console.log('> You can now Login to TabNews using the following credentials:');
+  console.log('> "admin@admin.com" + "password"');
+  console.log('> "user@user.com" + "password"');
+  console.log('------------------------------');
+
+  async function insertUser(username, email, passwordHash, features) {
+    try {
+      const query = {
+        text: 'INSERT INTO users (username, email, password, features) VALUES($1, $2, $3, $4) RETURNING *;',
+        values: [username, email, passwordHash, features],
+      };
+
+      await client.query(query);
+    } catch (error) {
+      // Probably there's a better way to do this
+      if (!error.detail.includes('already exists')) {
+        throw error;
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "retry-cli": "0.7.0"
   },
   "scripts": {
-    "dev": "kill-port 3000 && npm run services:up && npm run migration:run && npm run next && npm run services:stop",
+    "dev": "kill-port 3000 && npm run services:up && npm run migration:run && npm run migration:seed && npm run next && npm run services:stop",
     "next": "next dev",
     "services:up": "docker-compose -f infra/docker-compose.development.yml up -d",
     "services:stop": "docker-compose -f infra/docker-compose.development.yml stop",
@@ -68,7 +68,8 @@
     "lint:fix": "eslint --fix && prettier --write '**/*.{json,js,jsx,ts,tsx}'",
     "commit": "cz",
     "migration:create": "node-pg-migrate create",
-    "migration:run": "node infra/scripts/wait-for-db-connection-ready.js && node-pg-migrate up --envPath ./.env -m infra/migrations/ 2>migrations.log"
+    "migration:run": "node infra/scripts/wait-for-db-connection-ready.js && node-pg-migrate up --envPath ./.env -m infra/migrations/ 2>migrations.log",
+    "migration:seed": "node infra/scripts/seed-database.js"
   },
   "engines": {
     "node": "^16"


### PR DESCRIPTION
Estou trabalhando na migration para a issue #348 e estou sofrendo alguns comportamentos estranhos do módulo de migração que usamos, tanto que no repositório dele encontrei [essa issue sobre problemas ao usar o Node.js `16`](https://github.com/salsita/node-pg-migrate/issues/887). E notei que estava perdendo **muito tempo** criando usuários em desenvolvimento, principalmente para testar a diferença entre rodar as migrações pelo `cli` ou pelo endpoint da API.

Então para facilitar esse debug e seguir uma sugestão do @tembra (se eu não me engano, foi ele ou outra pessoa), criei um script intermediário dentro do `npm run dev` para injetar dois usuários, um com features padrões, e outro com features de admin.

Deve existir formas melhores de fazer o que foi feito, principalmente na parte que ignora o erro do insert se já existir esses usuários na base 🤝 