### PR TITLE
test(content): add `await` to one of the `orchestrator` update method

### DIFF
--- a/tests/integration/api/v1/contents/[username]/[slug]/children/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/children/get.test.js
@@ -41,7 +41,7 @@ describe('GET /api/v1/contents/[username]/[slug]/children', () => {
         status: 'published',
       });
 
-      orchestrator.updateContent(rootContent.id, { status: 'deleted' });
+      await orchestrator.updateContent(rootContent.id, { status: 'deleted' });
 
       const response = await fetch(
         `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${rootContent.slug}/children`


### PR DESCRIPTION
Havia uma intermitência nos testes de integração causada pela falta de um `await` na frente de um comando de atualização do `orchestrator`.

Isso foi revelado no PR #440 do @aprendendofelipe , um PR que não mexia em nada no backend.

E eu vou fazer os testes desse PR rodarem várias vezes para entender se o comportamento deixou de ser intermitente 🤝 