### PR TITLE
feat(use-user): cache user state to `localStorage`

### DIFF
--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -192,8 +192,7 @@ export default function Content({ content, mode = 'view', viewFrame = false }) {
               </Tooltip>
             </Box>
             <Box>
-              {user &&
-                (user.id === contentObject.owner_id || user.features?.includes('update:content:others')) &&
+              {(user?.id === contentObject.owner_id || user?.features?.includes('update:content:others')) &&
                 ViewModeOptionsMenu()}
             </Box>
           </Box>
@@ -254,7 +253,7 @@ export default function Content({ content, mode = 'view', viewFrame = false }) {
     const handleSubmit = useCallback(
       async (event) => {
         event.preventDefault();
-        if (!user.username) {
+        if (!user?.username) {
           router.push('/login');
           return;
         }

--- a/pages/interface/components/Header/index.js
+++ b/pages/interface/components/Header/index.js
@@ -1,11 +1,9 @@
-import { useRouter } from 'next/router';
-import { Header, Box, Button, ActionMenu, ActionList } from '@primer/react';
+import { Header, Box, ActionMenu, ActionList } from '@primer/react';
 import { CgTab } from 'react-icons/cg';
 import { useUser } from 'pages/interface/index.js';
 
 export default function HeaderComponent() {
-  const router = useRouter();
-  const { user, isLoading, loginStatus } = useUser();
+  const { user, isLoading } = useUser();
 
   return (
     <Header>
@@ -22,7 +20,7 @@ export default function HeaderComponent() {
         </Header.Link>
       </Header.Item>
 
-      {loginStatus === 'logged-out' && (
+      {!isLoading && !user?.username && (
         <>
           <Header.Item>
             <Header.Link href="/login" fontSize={2}>
@@ -37,7 +35,7 @@ export default function HeaderComponent() {
         </>
       )}
 
-      {loginStatus === 'logged-in' && (
+      {user?.username && (
         <>
           <Header.Item>
             <ActionMenu>

--- a/pages/login/index.public.js
+++ b/pages/login/index.public.js
@@ -62,17 +62,6 @@ function LoginForm() {
       const responseBody = await response.json();
 
       if (response.status === 201) {
-        const userResponse = await fetch(`/api/v1/user`, {
-          method: 'GET',
-          headers: {
-            Accept: 'application/json',
-            'Content-Type': 'application/json',
-          },
-        });
-
-        const userResponseBody = await userResponse.json();
-        localStorage.setItem('user', JSON.stringify(userResponseBody));
-
         if (router.query?.redirect) {
           router.push(router.query.redirect);
         } else {


### PR DESCRIPTION
Este PR faz par com o PR #440 do @aprendendofelipe e a tentativa aqui foi fazer a mesma coisa proposta por ele, mas usando o `swr`. Não trouxe para cá todas as implementações do PR dele, queria apenas rabiscar algo para ele ver.

Então as características são:

1. Componente começa com o `loginStatus` como `"loading"` e que pode resolver para `"logged-in"` ou `"logged-out"`.
2. Com isso, na interface posso escolher não renderizar nenhum item no menu enquanto não resolver para algum dos dois status acima.
3. Se resolver para `"logged-out"` aparece o menu de `Login / Cadastrar`.
4. Se resolver para `"logged-in"` aparece o dropdown menu com o `username`.
6. Decidir estar logado ou não é resolvido através da existência ou não do item `user` no `localStorage`.
7. Se existir esse item, ele é injetado como `fallbackData` no `swr` para que independente da revalidação que ele esteja fazendo contra o endpoint real, o `user` será retornado instantaneamente.
8. Se o `swr` conseguir revalidar, o `user` é atualizado.
9. Se não conseguir revalidar pelo fato do endpoint `/user` retornar `401` ou `403`, o item `user` é deletado do `localStorage` e o `loginStatus` é setado como `"logged-out"`.
10. A variável `shouldRevalidate` controla se o `swr` deve fazer uma tentativa de bater no endpoint `/user` e essa variável é apenas `true` se `loginStatus` estiver setado como `"logged-in"`. Se estiver como `false`, o `swr` não tenta bater na rota.
11. Na atual implementação, usuários precisarão se logar novamente, mas a ideia seria fazer um deploy intermediário que vai populando por um tempo o `localStorage` do pessoal, até que decidirmos virar a chave.
12. Url de teste: https://tabnews-ffuzi3g7w-tabnews.vercel.app/