### PR TITLE
[Bug Fix] Girar a tela do celular (vertical <-> horizontal) logo após publicar uma resposta gera mensagem de erro

### DIFF
--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -43,7 +43,9 @@ export default function Content({ content, mode = 'view', viewFrame = false }) {
   }, [mode]);
 
   useEffect(() => {
-    setContentObject(content);
+    setContentObject((contentObject) => {
+      return { ...contentObject, ...content };
+    });
   }, [content]);
 
   const localStorageKey = useMemo(() => {


### PR DESCRIPTION
Buscando entender comportamentos que ocorrem de maneiras diferentes no computador e no celular, encontrei mais esse bug.

Pelo que vi nos deploys antigos, o bug já está presente há bastante tempo, mas como ocorre em uma situação bem específica, não deve ser considerado urgente. Se bem que a solução é bem simples.

### Como ocorre o problema

Ao clicar em responder, o componente `Content` que inicialmente estava renderizado em `CompactMode` passa para `EditMode`.

Inicialmente o `contentObject` só tem o id do conteúdo pai.

Após submeter a resposta, o `contentObject` é atualizado com os dados da resposta e o componente muda para `ViewMode`.

Acontece que ao mudar a disposição da tela, quase tudo é renderizado novamente e alguns estados são mantidos, mas outros são perdidos.

O componente recebe novamente o `content`, o que acaba zerando o `contentObject`, ficando novamente apenas com o id do conteúdo pai, mas continua renderizado em `ViewMode`, o que causa o erro.

### Solução proposta

Usar a sintaxe de espalhamento no `setContentObject` para não perder os dados atuais no `contentObject` e apenas atualizar o que vier diferente no `content`.