### PR TITLE
fix(thumbnail): stop injecting session

### DIFF
--- a/pages/api/v1/contents/[username]/[slug]/thumbnail/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/thumbnail/index.public.js
@@ -1,6 +1,5 @@
 import nextConnect from 'next-connect';
 import controller from 'models/controller';
-import authentication from 'models/authentication';
 import validator from 'models/validator.js';
 import content from 'models/content.js';
 import thumbnail from 'models/thumbnail.js';
@@ -12,7 +11,6 @@ export default nextConnect({
   onError: controller.onErrorHandler,
 })
   .use(controller.injectRequestMetadata)
-  .use(authentication.injectAnonymousOrUser)
   .use(controller.logRequest)
   .get(getValidationHandler, getHandler);
 


### PR DESCRIPTION
Este PR é um reflexo da pesquisa feita pela issue #544 e faz com que o endpoint `/thumbnail` pare de injetar a sessão do usuário e pare de retornar o `Set-Cookie` nos cabeçalhos do response.