### PR TITLE
fix(thumbinal): `FIXED` surplus characters

### DIFF
--- a/models/thumbnail.js
+++ b/models/thumbnail.js
@@ -48,7 +48,7 @@ export function parseContent(content) {
     parent_title = (parent_title ?? content.parent_username).substring(0, 60);
   }
 
-  parent_title = parent_title?.length > 50 ? parent_title.substring(0, 50) + '...' : parent_title;
+  parent_title = parent_title?.length > 36 ? parent_title.substring(0, 36) + '...' : parent_title;
 
   const date = new Date(content.published_at).toLocaleDateString('pt-BR');
 


### PR DESCRIPTION
Commit para `fixação da excedência de caracteres na thumbnail de respostas`

Essa é uma pull request para fixação de um `bug` da thumbnail de respostas, veja a seguir o erro:

![thumbnail](https://www.tabnews.com.br/api/v1/contents/filipedeschamps/2a1f8451-dc1e-4a33-8ce8-aaac4f59cf2f/thumbnail)

Como pode-se perceber os caracteres excederam o limite da área permitida, isso acontece pois o limite permitido é 50, no entanto, ele excede em 14 caracteres por causa do array de caracteres: `Em resposta a `, que não é levado em consideração pela linha de comando que será alterada nessa pull request.

Desse modo, foi reparado para margem de erro limite permitida.
