### PR TITLE
fix(ContentList): lineHeight changed from `'1.25rem'` to `1.5`

### DIFF
--- a/pages/interface/components/ContentList/index.js
+++ b/pages/interface/components/ContentList/index.js
@@ -70,12 +70,12 @@ export default function ContentList({ contentList, pagination, paginationBasePat
     return list.map((contentObject, index) => {
       const itemCount = index + 1 + listNumberOffset;
       return [
-        <Box key={itemCount} sx={{ lineHeight: '1.25rem', textAlign: 'right' }}>
+        <Box key={itemCount} sx={{ textAlign: 'right' }}>
           <Text sx={{ fontSize: 2, color: 'fg.default', fontWeight: 'semibold', textAlign: 'right' }}>
             {itemCount}.
           </Text>
         </Box>,
-        <Box as="article" key={contentObject.id} sx={{ lineHeight: '1.25rem', overflow: 'auto' }}>
+        <Box as="article" key={contentObject.id} sx={{ overflow: 'auto' }}>
           <Box sx={{ overflow: 'auto' }}>
             <Link
               sx={{ fontSize: 2, color: 'fg.default', fontWeight: 'semibold', wordWrap: 'break-word' }}


### PR DESCRIPTION
No PR #425 deixei o `lineHeight` com unidade `rem`, porém isso está causando problemas quando se usa o zoom do navegador com alguns valores diferentes de 100%. E nessas condições aparece a barra de rolagem.

Para corrigir isso, deixei o `lineHeight` para ser sempre relativo ao tamanho da fonte real e não levar em consideração o tamanho da fonte padrão do navegador.

Edit: 1.5 já é o padrão utilizado no `BaseStyles` do Primer React, então só removi os `lineHeight`