### PR TITLE
fix(header): return header overflow to visible

### DIFF
--- a/pages/interface/components/Header/index.js
+++ b/pages/interface/components/Header/index.js
@@ -7,7 +7,7 @@ export default function HeaderComponent() {
   const { user, isLoading } = useUser();
 
   return (
-    <Header sx={{ overflow: 'auto' }}>
+    <Header>
       <Header.Item>
         <Header.Link href="/" fontSize={2}>
           <CgTab size={32} />


### PR DESCRIPTION
Infelizmente encontrei outro bug do PR dos overflows... Na época que comecei esse PR, ainda não existiam as TabCoins, então não tinha esse problema onde o `Tooltip` extrapola o tamanho do `Header`.

Para o Header em telas pequenas vamos direto para a adoção de um Menu Sidebar mesmo. Ou outra solução.

Sorry! 😳