### PR TITLE
feat(recoveryPassword): Invalidando as sessões do usuário ao resetar a senha

### DIFF
--- a/models/recovery.js
+++ b/models/recovery.js
@@ -10,7 +10,7 @@ async function createAndSendRecoveryEmail(secureInputValues) {
   const tokenObject = await create(userFound);
   await sendEmailToUser(userFound, tokenObject.id);
 
-  return tokenObject; 
+  return tokenObject;
 }
 
 async function findUserByUsernameOrEmail({ username, email }) {
@@ -78,7 +78,7 @@ async function resetUserPassword(secureInputValues) {
 
   if (!tokenObject.used) {
     const userToken = await markTokenAsUsed(tokenObject.id);
-    await session.expireAllFromUser(tokenObject.user_id)
+    await session.expireAllFromUserId(tokenObject.user_id)
     await updateUserPassword(tokenObject.user_id, secureInputValues.password);
     return userToken;
   }

--- a/models/session.js
+++ b/models/session.js
@@ -48,7 +48,7 @@ async function expireById(id) {
   return results.rows[0];
 }
 
-async function expireAllFromUser(userId) {
+async function expireAllFromUserId(userId) {
   const query = {
     text: `
       UPDATE
@@ -159,7 +159,7 @@ export default Object.freeze({
   create,
   setSessionIdCookieInResponse,
   expireById,
-  expireAllFromUser,
+  expireAllFromUserId,
   clearSessionIdCookie,
   findOneValidByToken,
   findOneById,


### PR DESCRIPTION
Foi adicionado uma função `expireAllFromUser` no `model Session` que recebe um id de usuário e invalida todas as sessões relacionadas a esse id.
Paralelamente foi adicionado a importação do `model session` dentro do `model recovery` e, na função `resetUserPassword` foi adicionada a chamada para essa função passando o `tokenObject.user_id`

Issue: [384](https://github.com/filipedeschamps/tabnews.com.br/issues/384)