### PR TITLE
ci(actions): implement test matrix using `macos`, `ubuntu` and `windows`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,12 @@ concurrency:
 
 jobs:
   tests:
+    strategy:
+      matrix:
+        node: [16]
+        os: [ubuntu-latest, windows-2019]
     name: Tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
 
@@ -25,7 +29,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: ${{ matrix.node }}
           cache: 'npm'
       - run: npm ci
       - run: npm run dev & npx jest --runInBand

--- a/infra/docker-compose.development.yml
+++ b/infra/docker-compose.development.yml
@@ -2,7 +2,7 @@ version: '2.4'
 services:
   postgres_dev:
     container_name: 'postgres-dev'
-    image: 'postgres:14.1-alpine'
+    image: 'postgres:9.5.2'
     env_file:
       - ../.env
     ports:


### PR DESCRIPTION
Conforme o que está sendo discutido no PR #592, o @CarlosZiegler trouxe uma idéia **sensacional** sobre como testar se o ambiente de desenvolvimento está funcionando no Windows que é utilizando a matriz de teste disponível no GitHub Actions.

Ele colocou [nesse comentário](https://github.com/filipedeschamps/tabnews.com.br/pull/592#issuecomment-1198217857) o código e estou repassando isso para esse PR e a idéia é testar em estágios:

1. Enviar esse PR testando a matriz com Windows e se certificando que irá quebrar porque o script que roda o `npm test` não está funcionando em ambientes Windows.
2. Se quebrar, trazer do PR #592 o ajuste que faz consertar o `npm test` em ambientes Windows.
3. Se certificar que o ajuste funciona.
4. Fazer merge 👍 