### PR TITLE
Fazer o `controller` parar de devolver um `500` quando um método HTTP não é encontrado

### DIFF
--- a/models/controller.js
+++ b/models/controller.js
@@ -44,7 +44,7 @@ async function injectRequestMetadata(request, response, next) {
 }
 
 async function onNoMatchHandler(request, response) {
-  const errorObject = new NotFoundError({ requestId: request.context.requestId });
+  const errorObject = new NotFoundError({ requestId: request.context?.requestId || uuidV4() });
   logger.info(snakeize(errorObject));
   return response.status(errorObject.statusCode).json(snakeize(errorObject));
 }

--- a/tests/integration/api/v1/user/post.test.js
+++ b/tests/integration/api/v1/user/post.test.js
@@ -1,0 +1,35 @@
+import fetch from 'cross-fetch';
+import { version as uuidVersion } from 'uuid';
+import orchestrator from 'tests/orchestrator.js';
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.dropAllTables();
+  await orchestrator.runPendingMigrations();
+});
+
+describe('POST /api/v1/user', () => {
+  describe('Anonymous user', () => {
+    test('With invalid HTTP `method`', async () => {
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/user`, {
+        method: 'POST',
+      });
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(404);
+
+      expect(responseBody).toStrictEqual({
+        name: 'NotFoundError',
+        message: 'Não foi possível encontrar este recurso no sistema.',
+        action: 'Verifique se o caminho (PATH) e o método (GET, POST, PUT, DELETE) estão corretos.',
+        status_code: 404,
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+      });
+
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+    });
+  });
+});


### PR DESCRIPTION
Hoje, caso você realize um `POST` contra `/api/v1/user` será retornado um erro `500` por conta disso:

```
error - (api)/models/controller.js (47:69) @ onNoMatchHandler
error - unhandledRejection: TypeError: Cannot read properties of undefined (reading 'requestId')
    at onNoMatchHandler (webpack-internal:///(api)/./models/controller.js:44:36)
    at file:///workspaces/tabnews.com.br/node_modules/next-connect/dist/index.js:34:32
    at AsyncFunction.handle (file:///workspaces/tabnews.com.br/node_modules/next-connect/dist/index.js:94:14)
    at nc (file:///workspaces/tabnews.com.br/node_modules/next-connect/dist/index.js:28:8)
    at Object.apiResolver (/workspaces/tabnews.com.br/node_modules/next/dist/server/api-utils/node.js:179:15)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async DevServer.runApi (/workspaces/tabnews.com.br/node_modules/next/dist/server/next-server.js:381:9)
    at async Object.fn (/workspaces/tabnews.com.br/node_modules/next/dist/server/base-server.js:500:37)
    at async Router.execute (/workspaces/tabnews.com.br/node_modules/next/dist/server/router.js:213:36)
    at async DevServer.run (/workspaces/tabnews.com.br/node_modules/next/dist/server/base-server.js:619:29)
  45 | 
  46 | async function onNoMatchHandler(request, response) {
> 47 |   const errorObject = new NotFoundError({ requestId: request.context.requestId });
     |                                                                     ^
  48 |   logger.info(snakeize(errorObject));
  49 |   return response.status(errorObject.statusCode).json(snakeize(errorObject));
  50 | }
```

Neste caso em específico, o erro estoura em `request.context.requestId` porque não deu tempo do `.use(controller.injectRequestMetadata)` injetar o contexto e o id da request, e não via ter como, pois o `next-connect` diretamente pula para o callback de erro.

Eu decidi consertar isso agora, pois tem uma pessoa nesse exato momento tentando fazer uma integração em Node.js e batendo com um `POST` na rota `/api/v1/user` e disparando alertas aqui do meu lado sobre erros `500`.