### PR TITLE
Conserta validação do `rss` sobre `guid` e `charset`

### DIFF
--- a/models/rss.js
+++ b/models/rss.js
@@ -38,7 +38,7 @@ function generateRss2(contentList) {
 
     feed.addItem({
       title: contentObject.title,
-      id: contentObject.id,
+      id: contentUrl,
       link: contentUrl,
       description: removeMarkdown(contentObject.body).replace(/\s+/g, ' ').substring(0, 190) + '...',
       content: renderToStaticMarkup(<Viewer value={contentObject.body} plugins={bytemdPluginList} />).replace(

--- a/pages/api/v1/contents/rss/index.public.js
+++ b/pages/api/v1/contents/rss/index.public.js
@@ -32,7 +32,7 @@ async function handleRequest(request, response) {
   const secureContentListFound = authorization.filterOutput(userTryingToList, 'read:content:list', contentListFound);
   const rss2 = rss.generateRss2(secureContentListFound);
 
-  response.setHeader('Content-Type', 'text/xml');
+  response.setHeader('Content-Type', 'text/xml; charset=utf-8');
   response.setHeader('Cache-Control', 'public, s-maxage=60, stale-while-revalidate');
   response.status(200).send(rss2);
 }

--- a/tests/integration/api/v1/contents/rss/get.test.js
+++ b/tests/integration/api/v1/contents/rss/get.test.js
@@ -96,7 +96,7 @@ describe('GET /recentes/rss', () => {
         <item>
             <title><![CDATA[Conteúdo #2 (mais novo)]]></title>
             <link>http://localhost:3000/${secondRootContent.owner_username}/${secondRootContent.slug}</link>
-            <guid>${secondRootContent.id}</guid>
+            <guid>http://localhost:3000/${secondRootContent.owner_username}/${secondRootContent.slug}</guid>
             <pubDate>${new Date(secondRootContent.published_at).toUTCString()}</pubDate>
             <description><![CDATA[Este é um corpo bastante longo, vamos ver como que a propriedade description irá reagir, pois por padrão ela deverá cortar após um número X de caracteres. Não vou tomar nota aqui da quantida...]]></description>
             <content:encoded><![CDATA[<div class="markdown-body"><p>Este é um corpo bastante longo, vamos ver como que a propriedade description irá reagir, pois por padrão ela deverá cortar após um número X de caracteres. Não vou tomar nota aqui da quantidade exata de caracteres, pois isso pode mudar ao longo do tempo.</p></div>]]></content:encoded>
@@ -104,7 +104,7 @@ describe('GET /recentes/rss', () => {
         <item>
             <title><![CDATA[Conteúdo #1 (mais antigo)]]></title>
             <link>http://localhost:3000/${firstRootContent.owner_username}/${firstRootContent.slug}</link>
-            <guid>${firstRootContent.id}</guid>
+            <guid>http://localhost:3000/${firstRootContent.owner_username}/${firstRootContent.slug}</guid>
             <pubDate>${new Date(firstRootContent.published_at).toUTCString()}</pubDate>
             <description><![CDATA[Corpo com HTML É importante lidar corretamente com o HTML, incluindo estilos especiais do GFM....]]></description>
             <content:encoded><![CDATA[<div class="markdown-body"><h1>Corpo com HTML</h1><p>É <strong>importante</strong> lidar corretamente com o <code>HTML</code>, incluindo estilos <del>especiais</del> do <code>GFM</code>.</p></div>]]></content:encoded>


### PR DESCRIPTION
Este PR faz a tag `<guid>` conter a URL absoluta da publicação ao invés do `id` do `content`, isso por conta de não estar passando [nesta validação](https://www.rssboard.org/rss-validator/check.cgi?url=https%3A%2F%2Fwww.tabnews.com.br%2Frecentes%2Frss):

<img width="1278" alt="image" src="https://user-images.githubusercontent.com/4248081/183718597-d4d2b930-16b7-4380-b05c-170794a152ac.png">

Ele também conserta o erro de `charset`:

<img width="1074" alt="image" src="https://user-images.githubusercontent.com/4248081/183721762-68b8b18c-0f16-4908-9c8f-7f637406be9b.png">
