### PR TITLE
feat(content): redirect home when cancel new root content

### DIFF
--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -406,8 +406,15 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
     setErrorObject(undefined);
     localStorage.removeItem(localStorageKey);
     const isPublished = contentObject?.status === 'published';
-    setComponentMode(isPublished ? 'view' : 'compact');
-  }, [confirm, contentObject?.status, localStorageKey, newData, setComponentMode]);
+    const isChild = !!contentObject?.parent_id;
+    if (isPublished) {
+      setComponentMode('view');
+    } else if (isChild) {
+      setComponentMode('compact');
+    } else if (router) {
+      router.push('/');
+    }
+  }, [confirm, contentObject, localStorageKey, newData, router, setComponentMode]);
 
   const onKeyDown = useCallback(
     (event) => {


### PR DESCRIPTION
Resolvendo a situação relatada em #633... 

Ao cancelar a publicação de um novo conteúdo `root`, após limpar o rascunho do `localStorage`, agora ocorre a navegação para a `home`.