### PR TITLE
A configuração experimental nftTracing não é mais necessária

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,9 +3,6 @@ module.exports = {
   eslint: {
     ignoreDuringBuilds: true,
   },
-  experimental: {
-    nftTracing: true,
-  },
   compiler: {
     styledComponents: true,
   },


### PR DESCRIPTION
Não necessitamos mais do parâmetro experimental `nftTracing`, pois em 28 de julho migramos o TabNews do Next.js v12.1.6 para v12.2.3, o que engloba as alterações abaixo:

* 21/09/21 - o parâmetro experimental `nftTracing` foi renomeado para `outputFileTracing` (https://github.com/vercel/next.js/commit/9c86953745039738fb8890a4aeebdbceab984989);
* 23/10/21 - o `outputFileTracing` passa a ser `true` por padrão (https://github.com/vercel/next.js/pull/30202/commits/1c78e612639cd8be881510fcb49bed1e9aca5bf9);
* 26/10/21 - o `outputFileTracing` deixa de ser experimental (https://github.com/vercel/next.js/pull/30295/commits/20898f786a838bde5bb089ce3d6235190db184a5).