### PR TITLE
refactor(content): refactor `amountToDebit` to use absolute value

### DIFF
--- a/models/content.js
+++ b/models/content.js
@@ -494,16 +494,16 @@ async function creditOrDebitTabCoins(oldContent, newContent, options = {}) {
     let amountToDebit;
 
     if (oldContent.tabcoins > 0) {
-      amountToDebit = (oldContent.tabcoins - contentDefaultEarnings + userDefaultEarnings) * -1;
+      amountToDebit = oldContent.tabcoins - contentDefaultEarnings + userDefaultEarnings;
     } else {
-      amountToDebit = userDefaultEarnings * -1;
+      amountToDebit = userDefaultEarnings;
     }
 
     await balance.create(
       {
         balanceType: 'user:tabcoin',
         recipientId: newContent.owner_id,
-        amount: amountToDebit,
+        amount: amountToDebit * -1,
         originatorType: options.eventId ? 'event' : 'content',
         originatorId: options.eventId ? options.eventId : newContent.id,
       },


### PR DESCRIPTION
No model de `content`, o valor `amountToDebit` estava negativo, e após [esse comentário](https://github.com/filipedeschamps/tabnews.com.br/pull/649#issuecomment-1214967434) do @aprendendofelipe fez total sentido trabalhar com ele de forma positiva e só após no final deixar ele negativo.

Bom, ao menos eu espero que era isso que o @aprendendofelipe sugeriu 🤝 👍 