### PR TITLE
Implementa Rate Limit na API: Rotas com `POST`, `PATCH` e `DELETE`

### DIFF
--- a/infra/rate-limit.js
+++ b/infra/rate-limit.js
@@ -59,7 +59,31 @@ function getLimit(method, path, ip) {
       requests: 1000,
       window: '5 m',
     },
+    'PATCH /api/v1/activation': {
+      requests: 50,
+      window: '30 m',
+    },
+    'POST /api/v1/contents': {
+      requests: 50,
+      window: '30 m',
+    },
+    'POST /api/v1/recovery': {
+      requests: 50,
+      window: '30 m',
+    },
+    'PATCH /api/v1/recovery': {
+      requests: 50,
+      window: '30 m',
+    },
+    'DELETE /api/v1/sessions': {
+      requests: 50,
+      window: '30 m',
+    },
     'POST /api/v1/sessions': {
+      requests: 50,
+      window: '30 m',
+    },
+    'POST /api/v1/users': {
       requests: 50,
       window: '30 m',
     },

--- a/middleware.public.js
+++ b/middleware.public.js
@@ -2,8 +2,11 @@ import { NextResponse } from 'next/server';
 import rateLimit from 'infra/rate-limit.js';
 import snakeize from 'snakeize';
 
+// TODO: Add `/api/v1/contents` when Next.js fix this:
+// https://github.com/vercel/next.js/issues/39262
+// Actually, configure matcher to `/api/:path*` after they fix this bug.
 export const config = {
-  matcher: ['/api/v1/sessions'],
+  matcher: ['/api/v1/activation', '/api/v1/recovery', '/api/v1/sessions', '/api/v1/users', '/api/v1/user'],
 };
 
 export async function middleware(request) {


### PR DESCRIPTION
Neste PR vou continuar a inserção de rate-limit nas rotas da API, dando preferência para rotas com `POST`, `PATCH` e `DELETE`.

65fe7602aa7749a2268ad09e2f93540b45339a77
* **Mas antes de adicionar as outras rotas**, notei que ficaria um saco gerenciar a estrutura de dados que configura os limites, tanto no código quanto nas variáveis de ambiente, então refatorei tudo.
* Agora as configurações que estão registradas no código e nas variáveis de ambiente não se substituem, elas se **mesclam**.
* Fora isso, cada configuração de rota não possui mais um nome próprio, como `postSessions` e agora isso é deduzido pela request para automaticamente formar a chave de configuração, como `"POST /api/v1/sessions"`.
* Isso significa que **não é mais necessário alterar o código** para criar limites específicos para as rotas, basta alterar a variável de ambiente. Então não precisamos mais declarar algo como `if (method === 'POST' && path === '/api/v1/sessions')` para cada rota que quisermos controlar um limite específico.
* Por último, estou me incomodando muito com o `snakeize` e tive que fazer uma gambiarra no log do middleware para ele logar o `message` quando é um erro padrão do JavaScript. Um exemplo é logar um erro jogado pelo `JSON.parse()`. Sem essa gambiarra, o que aparecia no log era o seguinte: `{}`.

Mais para frente vou incluir no `defaultLimits` outras rotas.