### PR TITLE
Adiciona estratégia `relevant`

### DIFF
--- a/models/validator.js
+++ b/models/validator.js
@@ -502,8 +502,9 @@ const schemas = {
     return Joi.object({
       strategy: Joi.string()
         .trim()
-        .valid('new', 'old', 'best')
-        .default('best')
+        // TODO: remove 'best' strategy in the near future
+        .valid('new', 'old', 'best', 'relevant')
+        .default('relevant')
         .invalid(null)
         .when('$required.strategy', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
@@ -511,7 +512,7 @@ const schemas = {
           'string.empty': `"strategy" não pode estar em branco.`,
           'string.base': `"strategy" deve ser do tipo String.`,
           'any.invalid': `"strategy" possui o valor inválido "null".`,
-          'any.only': `"strategy" deve possuir um dos seguintes valores: "new", "old" ou "best".`,
+          'any.only': `"strategy" deve possuir um dos seguintes valores: "new", "old" ou "relevant".`,
         }),
     });
   },

--- a/pages/index.public.js
+++ b/pages/index.public.js
@@ -12,7 +12,7 @@ export default function Home({ contentListFound, pagination }) {
           contentList={contentListFound}
           pagination={pagination}
           paginationBasePath="/pagina"
-          revalidatePath="/api/v1/contents?strategy=best"
+          revalidatePath="/api/v1/contents?strategy=relevant"
         />
       </DefaultLayout>
     </>
@@ -37,7 +37,7 @@ export async function getStaticProps(context) {
   }
 
   const results = await content.findWithStrategy({
-    strategy: 'best',
+    strategy: 'relevant',
     where: {
       parent_id: null,
       status: 'published',

--- a/pages/pagina/[page]/index.public.js
+++ b/pages/pagina/[page]/index.public.js
@@ -12,7 +12,7 @@ export default function Home({ contentListFound, pagination }) {
           contentList={contentListFound}
           pagination={pagination}
           paginationBasePath="/pagina"
-          revalidatePath={`/api/v1/contents?strategy=best&page=${pagination.currentPage}`}
+          revalidatePath={`/api/v1/contents?strategy=relevant&page=${pagination.currentPage}`}
         />
       </DefaultLayout>
     </>
@@ -44,7 +44,7 @@ export async function getStaticProps(context) {
   }
 
   const results = await content.findWithStrategy({
-    strategy: 'best',
+    strategy: 'relevant',
     where: {
       parent_id: null,
       status: 'published',

--- a/tests/integration/api/v1/contents/get.test.js
+++ b/tests/integration/api/v1/contents/get.test.js
@@ -39,7 +39,7 @@ describe('GET /api/v1/contents', () => {
         'access-control-allow-headers': [
           'X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version',
         ],
-        link: ['<http://localhost:3000/api/v1/contents?strategy=best&page=1&per_page=30>; rel="first"'],
+        link: ['<http://localhost:3000/api/v1/contents?strategy=relevant&page=1&per_page=30>; rel="first"'],
         'x-pagination-total-rows': ['0'],
         'content-type': ['application/json; charset=utf-8'],
         etag: responseHeaders.etag,
@@ -66,7 +66,7 @@ describe('GET /api/v1/contents', () => {
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
-        message: '"strategy" deve possuir um dos seguintes valores: "new", "old" ou "best".',
+        message: '"strategy" deve possuir um dos seguintes valores: "new", "old" ou "relevant".',
         action: 'Ajuste os dados enviados e tente novamente.',
         status_code: 400,
         error_id: responseBody.error_id,
@@ -388,7 +388,7 @@ describe('GET /api/v1/contents', () => {
       expect(responseBody[29].title).toEqual('Conteúdo #31');
     });
 
-    test('With 60 entries, default "page", "per_page" and strategy "best" (default)', async () => {
+    test('With 60 entries, default "page", "per_page" and strategy "relevant" (default)', async () => {
       const defaultUser = await orchestrator.createUser();
 
       const numberOfContents = 60;
@@ -447,22 +447,22 @@ describe('GET /api/v1/contents', () => {
           page: '1',
           per_page: '30',
           rel: 'first',
-          strategy: 'best',
-          url: 'http://localhost:3000/api/v1/contents?strategy=best&page=1&per_page=30',
+          strategy: 'relevant',
+          url: 'http://localhost:3000/api/v1/contents?strategy=relevant&page=1&per_page=30',
         },
         next: {
           page: '2',
           per_page: '30',
           rel: 'next',
-          strategy: 'best',
-          url: 'http://localhost:3000/api/v1/contents?strategy=best&page=2&per_page=30',
+          strategy: 'relevant',
+          url: 'http://localhost:3000/api/v1/contents?strategy=relevant&page=2&per_page=30',
         },
         last: {
           page: '2',
           per_page: '30',
           rel: 'last',
-          strategy: 'best',
-          url: 'http://localhost:3000/api/v1/contents?strategy=best&page=2&per_page=30',
+          strategy: 'relevant',
+          url: 'http://localhost:3000/api/v1/contents?strategy=relevant&page=2&per_page=30',
         },
       });
 


### PR DESCRIPTION
Seguindo o que foi explicado nessa issue #658 estou fazendo uma cópia da `strategy` `best` e colocando como nome `relevant`. Por enquanto elas irão rodar juntas, mas depois iremos fazer uma breaking change para por enquanto só manter a `relevant`.