### PR TITLE
perf(content): embed findChildrenCount() query inside findAll() method

### DIFF
--- a/tests/integration/api/v1/contents/get.test.js
+++ b/tests/integration/api/v1/contents/get.test.js
@@ -272,7 +272,7 @@ describe('GET /api/v1/contents', () => {
       expect(responseBody[1].published_at > responseBody[0].published_at).toEqual(true);
     });
 
-    test('With 3 children 3 level deep and strategy', async () => {
+    test('With 3 children 3 level deep and default strategy', async () => {
       const defaultUser = await orchestrator.createUser();
 
       const rootContent = await orchestrator.createContent({


### PR DESCRIPTION
Usando a mesma estratégia de subquery aplicada no PR #667 para o método `findRootContent()`, o método `findAll()` agora também busca a quantidade de conteúdos filho em uma ida ao banco de dados. Antes, uma busca ao banco de dados  por uma lista de conteúdos sempre fazia o dobro de buscas do valor encontrado na paginação para pegar todos os filhos dos conteúdos.

Em alguns minutos envio aqui os testes de performance para entender o que aconteceu no ambiente de homologação.