### PR TITLE
feat(content): decrease overall padding on mobile

### DIFF
--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -83,7 +83,7 @@ export default function Post({
           }}>
           <Box
             sx={{
-              pr: 2,
+              pr: [0, null, null, 2],
               display: 'flex',
               flexDirection: 'column',
               justifyContent: 'center',
@@ -101,8 +101,7 @@ export default function Post({
             />
           </Box>
 
-          {/* 36px is the size of the TabCoin column */}
-          <Box sx={{ width: 'calc(100% - 36px)' }}>
+          <Box sx={{ width: '100%', overflow: 'auto' }}>
             <Content content={contentFound} mode="view" />
           </Box>
         </Box>
@@ -137,7 +136,12 @@ function InReplyToLinks({ content, parentContent, rootContent }) {
       */}
       {content.parent_id && parentContent.id === rootContent.id && (
         <Box sx={{ fontSize: 1, mb: 3, display: 'flex', flexDirection: 'row' }}>
-          <Box sx={{ pl: '6px', pr: '14px' }}>
+          <Box
+            sx={{
+              textAlign: 'center',
+              pl: ['6px', null, null, '6px'],
+              pr: ['6px', null, null, '13px'],
+            }}>
             <CommentIcon verticalAlign="middle" size="small" />
           </Box>
           <Box>
@@ -164,7 +168,12 @@ function InReplyToLinks({ content, parentContent, rootContent }) {
       */}
       {content.parent_id && parentContent.id !== rootContent.id && (
         <Box sx={{ fontSize: 1, mb: 3, display: 'flex', flexDirection: 'row' }}>
-          <Box sx={{ pl: '7px', pr: '13px' }}>
+          <Box
+            sx={{
+              textAlign: 'center',
+              pl: ['6px', null, null, '6px'],
+              pr: ['6px', null, null, '13px'],
+            }}>
             <CommentDiscussionIcon verticalAlign="middle" size="small" />
           </Box>
           <Box>
@@ -216,7 +225,7 @@ function RenderChildrenTree({ childrenList, level }) {
         key={child.id}>
         <Box
           sx={{
-            pr: 2,
+            pr: [0, null, null, 2],
             display: 'flex',
             flexDirection: 'column',
             justifyContent: 'center',
@@ -234,8 +243,7 @@ function RenderChildrenTree({ childrenList, level }) {
           />
         </Box>
 
-        {/* 36px is the size of the TabCoin column */}
-        <Box sx={{ width: 'calc(100% - 36px)' }}>
+        <Box sx={{ width: '100%', overflow: 'auto' }}>
           <Content content={child} mode="view" />
 
           <Box sx={{ mt: 4 }}>

--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -194,7 +194,7 @@ function ViewMode({ setComponentMode, contentObject, viewFrame }) {
         )}
 
         <Box sx={{ display: 'flex', alignItems: 'flex-start' }}>
-          <Box sx={{ flex: 'auto' }}>
+          <Box sx={{ flex: 'auto', overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }}>
             <BranchName sx={{ mr: 2 }} href={`/${contentObject.owner_username}`}>
               {contentObject.owner_username}
             </BranchName>

--- a/pages/interface/components/DefaultLayout/index.js
+++ b/pages/interface/components/DefaultLayout/index.js
@@ -12,7 +12,8 @@ export default function DefaultLayout({ children, containerWidth = 'large', meta
           marginX: 'auto',
           display: 'flex',
           flexWrap: 'wrap',
-          padding: [3, null, null, 4],
+          padding: [2, null, null, 4],
+          paddingTop: [3, null, null, 4],
         }}>
         {children}
       </Box>

--- a/pages/interface/components/Header/index.js
+++ b/pages/interface/components/Header/index.js
@@ -14,7 +14,11 @@ export default function HeaderComponent() {
   };
 
   return (
-    <Header>
+    <Header
+      sx={{
+        pl: [2, null, null, 3],
+        pr: [2, null, null, 3],
+      }}>
       <Header.Item>
         <Header.Link href="/" fontSize={2} sx={(pathname === '/' || pathname.startsWith('/pagina')) && activeLinkStyle}>
           <CgTab size={32} />

--- a/pages/interface/components/TabCoinButtons/index.js
+++ b/pages/interface/components/TabCoinButtons/index.js
@@ -85,7 +85,7 @@ export default function TabCoinButtons({ content }) {
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
-        mt: contentObject.title ? '8px' : '0px',
+        mt: contentObject.title ? '7px' : '0px',
       }}>
       <Box>
         <IconButton
@@ -93,7 +93,7 @@ export default function TabCoinButtons({ content }) {
           aria-label="Creditar TabCoin"
           icon={ChevronUpIcon}
           size="small"
-          sx={{ color: 'fg.subtle' }}
+          sx={{ color: 'fg.subtle', lineHeight: '18px' }}
           onClick={() => {
             transactTabCoin('credit');
           }}
@@ -117,7 +117,7 @@ export default function TabCoinButtons({ content }) {
           aria-label="Debitar TabCoin"
           icon={ChevronDownIcon}
           size="small"
-          sx={{ color: 'fg.subtle' }}
+          sx={{ color: 'fg.subtle', lineHeight: '18px' }}
           onClick={() => {
             transactTabCoin('debit');
           }}


### PR DESCRIPTION
Uma das tarefas desta Milestone era melhorar o espaçamento quando a página era aberta em aparelhos com telas pequenas, uma vez que o mesmo espaçamento para Desktop estava sendo usado para Mobile em algumas situações.

A tentativa desse PR é manter o layout agradável de ler, mas contrair o máximo que der o espaçamento entre algumas áreas importantes como, por exemplo, o espaçamento global nas bordas da página e o espaçamento entre os botões das TabCoins e o Conteúdo que, a cada nível de resposta, este espaçamento é adicionado. Então por exemplo, o espaçamento padrão nesta área estava em `2` pixels, e numa árvore de `5` respostas, era ocupado `10` pixels. Isso numa tela pequena pode representar bastante coisa.

E @aprendendofelipe esse PR também remove aquela regra de `calc` do CSS com a sua técnica do `overflow`, isso foi fundamental para conseguir fazer os espaçamentos responsivos 🤝 

## Testes

Os prints abaixo foram feitos simulando um `iPhone SE` que é um dos menores que existem e com estas duas branches:

* Antes: https://tabnews-git-remove-best-strategy-tabnews.vercel.app
* Depois: https://tabnews-git-compact-tabcoins-space-tabnews.vercel.app

## Home

Mesmos conteúdos, coube até mais `1,5` itens na tela.

| Antes | Depois |
|:-:|:-:|
|<img width="383" alt="image" src="https://user-images.githubusercontent.com/4248081/186553881-07f5abb3-67ae-4bbe-bd82-1f5c73a940dc.png">|<img width="383" alt="image" src="https://user-images.githubusercontent.com/4248081/186553895-3d5c5503-7a03-4718-9daf-f28f835ecb35.png">|

## Conteúdo (topo)

Aqui apesar do modelo novo não parecer ter muito impacto, eu sinto que a leitura começa mais perto da esquerda da tela e isso fica mais confortável.

| Antes | Depois |
|:-:|:-:|
|<img width="383" alt="image" src="https://user-images.githubusercontent.com/4248081/186557727-99445158-d977-4bb2-bdb5-5f930dbb3252.png">|<img width="383" alt="image" src="https://user-images.githubusercontent.com/4248081/186557743-936ba6c4-bb1a-4f17-9ac7-6631fbaeeac4.png">|


## Conteúdo (fundo)

O objetivo aqui não é trazer uma solução para o problema de respostas infinitas, isso tem que ser feito com outra abordagem (por exemplo, a partir do nível X aparecer um link para abrir o restante das mensagens em outra página), mas a ideia é tentar não desperdiçar tanto espaço e também não ter uma quebra de linha na data da publicação.

Então note que na versão nova couberam **2 respostas completas nesse caso** (incluindo o botão logo acima ainda).

| Antes | Depois |
|:-:|:-:|
|<img width="383" alt="image" src="https://user-images.githubusercontent.com/4248081/186559012-ce718449-515b-4928-8ca5-dec1a773813c.png">|<img width="383" alt="image" src="https://user-images.githubusercontent.com/4248081/186563262-350af10b-95cb-4f99-b37c-65a00441ebd6.png">|
