### PR TITLE
fix(transactions): serializable isolation level

### DIFF
--- a/infra/email.js
+++ b/infra/email.js
@@ -1,5 +1,6 @@
 const nodemailer = require('nodemailer');
 import { ServiceError } from 'errors/index.js';
+import webserver from 'infra/webserver.js';
 import logger from './logger.js';
 
 const transporterConfiguration = {
@@ -12,7 +13,7 @@ const transporterConfiguration = {
   },
 };
 
-if (['test', 'development'].includes(process.env.NODE_ENV) || process.env.CI) {
+if (!webserver.isLambdaServer()) {
   transporterConfiguration.secure = false;
 }
 

--- a/infra/rate-limit.js
+++ b/infra/rate-limit.js
@@ -1,10 +1,11 @@
 import { Ratelimit } from '@upstash/ratelimit';
 import { Redis } from '@upstash/redis';
 import { ServiceError } from 'errors/index.js';
+import webserver from 'infra/webserver.js';
 
 async function check(request) {
   if (!process.env.UPSTASH_REDIS_REST_URL || !process.env.UPSTASH_REDIS_REST_TOKEN) {
-    if (['test', 'development'].includes(process.env.NODE_ENV) || process.env.CI || process.env.GITHUB_ACTIONS) {
+    if (!webserver.isLambdaServer()) {
       return { success: true };
     }
 

--- a/infra/webserver.js
+++ b/infra/webserver.js
@@ -1,7 +1,11 @@
+function isLambdaServer() {
+  return !(['test', 'development'].includes(process.env.NODE_ENV) || process.env.CI || process.env.GITHUB_ACTIONS);
+}
+
 function getHost() {
   let webserverHost = 'https://www.tabnews.com.br';
 
-  if (['test', 'development'].includes(process.env.NODE_ENV) || process.env.CI) {
+  if (!isLambdaServer()) {
     webserverHost = `http://${process.env.WEBSERVER_HOST}:${process.env.WEBSERVER_PORT}`;
   }
 
@@ -14,4 +18,5 @@ function getHost() {
 
 export default Object.freeze({
   getHost,
+  isLambdaServer,
 });

--- a/models/activation.js
+++ b/models/activation.js
@@ -1,5 +1,6 @@
 import email from 'infra/email.js';
 import database from 'infra/database.js';
+import webserver from 'infra/webserver.js';
 import user from 'models/user.js';
 import authorization from 'models/authorization.js';
 import { NotFoundError, ForbiddenError } from 'errors/index.js';
@@ -42,27 +43,13 @@ Rua Antônio da Veiga, 495, Blumenau, SC, 89012-500`,
   });
 }
 
-function getWebServerHost() {
-  let webserverHost = 'https://www.tabnews.com.br';
-
-  if (['test', 'development'].includes(process.env.NODE_ENV) || process.env.CI) {
-    webserverHost = `http://${process.env.WEBSERVER_HOST}:${process.env.WEBSERVER_PORT}`;
-  }
-
-  if (['preview'].includes(process.env.VERCEL_ENV)) {
-    webserverHost = `https://${process.env.VERCEL_URL}`;
-  }
-
-  return webserverHost;
-}
-
 function getActivationApiEndpoint() {
-  const webserverHost = getWebServerHost();
+  const webserverHost = webserver.getHost();
   return `${webserverHost}/api/v1/activation`;
 }
 
 function getActivationPageEndpoint(tokenId) {
-  const webserverHost = getWebServerHost();
+  const webserverHost = webserver.getHost();
   return tokenId ? `${webserverHost}/cadastro/ativar/${tokenId}` : `${webserverHost}/cadastro/ativar`;
 }
 

--- a/models/password.js
+++ b/models/password.js
@@ -1,4 +1,5 @@
 import bcryptjs from 'bcryptjs';
+import webserver from 'infra/webserver.js';
 
 async function hash(password) {
   return await bcryptjs.hash(password, getNumberOfSaltRounds());
@@ -11,7 +12,7 @@ async function compare(providedPassword, storedPassword) {
 function getNumberOfSaltRounds() {
   let saltRounds = 14;
 
-  if (['test', 'development'].includes(process.env.NODE_ENV) || process.env.CI) {
+  if (!webserver.isLambdaServer()) {
     saltRounds = 1;
   }
 


### PR DESCRIPTION
Mudança do nível de isolamento das transações com Tabcoins para que ocorram de forma serializada.

A motivação foi a issue #670 que demonstrou que transações simultâneas poderiam permitir votar nos conteúdos mesmo sem ter Tabcoins suficientes.

### Para isso, as alterações diretas são:

1. Mudança no nível de isolamento da transação
2. Criação de um loop que faz cinco tentativas de processar a transação em caso de erro na serialização
3. Retorno de mensagem de erro para o caso de falharem as 5 tentativas
4. Adicionado o erro 40001 (serialization_failure) nas exceções do logger

Já as mudanças indiretas são necessárias para permitir executar os testes em condições parecidas com as encontradas no ambiente da Vercel. Isso porque em ambiente de desenvolvimento e de testes nós não utilizamos as lambdas, então todas as requisições são atendidas pela mesma instância do servidor.

Na Vercel, requisições simultâneas são sempre atendidas por instâncias diferentes, portanto o pool de conexões é configurado para o limite de uma conexão. Já em outros ambientes nós precisamos liberar mais conexões para conseguir fazer testes que só dariam problemas em condição de concorrência. Pois se mantivermos o limite de 1 conexão, o pool já vai isolar as transações serialmente, mas isso não vai representar o que ocorre em produção.

### Mudanças só em ambiente de desenvolvimento/testes/ci:

1. Aumento do limite do pool para 3 conexões. Poderíamos deixar um valor bem maior, mas optei por um valor baixo para rodar de maneira parecida em qualquer nível de hardware.
2. O pool não é mais encerrado em nenhuma condição.
3. Os testes verificam as consistências das transações concorrentes.
4. Os testes verificam se são retornados os erros corretos quando uma transação falha 5 vezes por motivo de serialização.

Inclusive o último teste é importante, pois ele falha se deixarmos o limite do pool com o valor padrão (1), já que não será gerado nenhum erro de serialização.

### Dívidas:

1. Essa alteração vai barrar não somente um usuário que esteja rodando algum script para dar votos (por causa da  `user_current_tabcoin_balance`), mas também vai dar um aviso de "excesso de votos simultâneos" caso uma publicação receba muitos votos ao mesmo tempo, mesmo que de diferentes usuários. Acredito que isso irá demorar para virar um problema. E a solução é retirar a consulta do saldo final de Tabcoins da publicação (`content_current_tabcoin_balance`) de dentro da transação, já que essa informação não é condicional para nenhum passo da transação.

2. Uma maneira melhor de capturar o erro `error.stack?.startsWith('error: could not serialize access due to read/write dependencies among transaction'`