### PR TITLE
feat(analytics): return only last `2 months`

### DIFF
--- a/pages/api/v1/analytics/child-content-published/index.public.js
+++ b/pages/api/v1/analytics/child-content-published/index.public.js
@@ -14,7 +14,7 @@ export default nextConnect({
 async function getHandler(request, response) {
   const results = await database.query(`
   WITH range_values AS (
-    SELECT date_trunc('day', min(published_at)) as minval,
+    SELECT date_trunc('day', NOW() - INTERVAL '2 MONTHS') as minval,
            date_trunc('day', max(published_at)) as maxval
     FROM contents),
 

--- a/pages/api/v1/analytics/root-content-published/index.public.js
+++ b/pages/api/v1/analytics/root-content-published/index.public.js
@@ -14,7 +14,7 @@ export default nextConnect({
 async function getHandler(request, response) {
   const results = await database.query(`
   WITH range_values AS (
-    SELECT date_trunc('day', min(published_at)) as minval,
+    SELECT date_trunc('day', NOW() - INTERVAL '2 MONTHS') as minval,
            date_trunc('day', max(published_at)) as maxval
     FROM contents),
 

--- a/pages/api/v1/analytics/users-created/index.public.js
+++ b/pages/api/v1/analytics/users-created/index.public.js
@@ -14,7 +14,7 @@ export default nextConnect({
 async function getHandler(request, response) {
   const results = await database.query(`
   WITH range_values AS (
-    SELECT date_trunc('day', min(created_at)) as minval,
+    SELECT date_trunc('day', NOW() - INTERVAL '2 MONTHS') as minval,
            date_trunc('day', max(created_at)) as maxval
     FROM users),
 


### PR DESCRIPTION
Uma tarefa pequena fora da Milestone, mas que vai ajudar a acompanhar melhor o gráfico na página `/status`. Antes a query pegava os dados desde o primeiro dia e isto acabava dando uma visão ruim dado ao pico de registros do lançamento da API. Fora que o gráfico entre cadastros de usuários e criação de conteúdos estavam dessincronizados, pois havia mais dias de cadastros de usuários do que de conteúdos (dado que essa feature veio depois).

Agora para todos os gráficos estamos mostrando os últimos 2 meses.