### PR TITLE
fix(next-link): change Link component import/export

### DIFF
--- a/pages/interface/components/Header/index.js
+++ b/pages/interface/components/Header/index.js
@@ -112,7 +112,6 @@ export default function HeaderComponent() {
                     Publicar novo conteúdo
                   </ActionList.LinkItem>
                   <ActionList.LinkItem
-                    as={Link}
                     href="/perfil"
                     onClick={(event) => {
                       event.preventDefault();

--- a/pages/interface/components/Link/index.js
+++ b/pages/interface/components/Link/index.js
@@ -1,18 +1,18 @@
-import Link from 'next/link';
+import NextLink from 'next/link';
 import { Header, Link as PrimerLink } from '@primer/react';
 
-export default function LinkComponent({ href, children, ...props }) {
+export function Link({ href, children, ...props }) {
   return (
-    <Link href={href} passHref>
+    <NextLink href={href} passHref>
       <PrimerLink {...props}>{children}</PrimerLink>
-    </Link>
+    </NextLink>
   );
 }
 
 export function HeaderLink({ href, children, ...props }) {
   return (
-    <Link href={href} passHref>
+    <NextLink href={href} passHref>
       <Header.Link {...props}>{children}</Header.Link>
-    </Link>
+    </NextLink>
   );
 }

--- a/pages/interface/index.js
+++ b/pages/interface/index.js
@@ -6,7 +6,7 @@ export { default as Head } from './components/Head/index.js';
 export { default as TabCoinButtons } from './components/TabCoinButtons/index.js';
 export { default as PublishedSince } from './components/PublishedSince/index.js';
 export { default as EmptyState } from './components/EmptyState/index.js';
-export { default as Link } from './components/Link/index.js';
+export { Link } from './components/Link/index.js';
 
 export { default as useUser } from './hooks/useUser/index.js';
 export { default as useMediaQuery } from './hooks/useMediaQuery/index.js';


### PR DESCRIPTION
Como observado pelo @luantoningalvan aqui https://github.com/filipedeschamps/tabnews.com.br/pull/690#issuecomment-1228933834, o next/link não estava sendo aplicado no menu de usuário.

A importação do `Link` estava retornando `undefined`.

Por isso foi realizada a mudança na forma como está sendo exportado o componente Link customizado para também permitir ser importado do caminho `pages/interface/components/Link` e não somente de `pages/interface`.

Assim é possível importar os dois componentes customizados da seguinte maneira:

`import { HeaderLink, Link } from 'pages/interface/components/Link';`