### PR TITLE
NÃO FAZER MERGE: Reorganiza todos os endpoints genéricos

### DIFF
--- a/models/controller.js
+++ b/models/controller.js
@@ -56,26 +56,26 @@ function onErrorHandler(error, request, response) {
     error instanceof ForbiddenError ||
     error instanceof UnprocessableEntityError
   ) {
-    const errorObject = { ...error, requestId: request.context.requestId };
+    const errorObject = { ...error, requestId: request.context?.requestId || uuidV4() };
     logger.info(snakeize(errorObject));
     return response.status(error.statusCode).json(snakeize(errorObject));
   }
 
   if (error instanceof UnauthorizedError) {
-    const errorObject = { ...error, requestId: request.context.requestId };
+    const errorObject = { ...error, requestId: request.context?.requestId || uuidV4() };
     logger.info(snakeize(errorObject));
     session.clearSessionIdCookie(response);
     return response.status(error.statusCode).json(snakeize(errorObject));
   }
 
   if (error instanceof TooManyRequestsError) {
-    const errorObject = { ...error, requestId: request.context.requestId };
+    const errorObject = { ...error, requestId: request.context?.requestId || uuidV4() };
     logger.info(snakeize(errorObject));
     return response.status(error.statusCode).json(snakeize(errorObject));
   }
 
   const errorObject = new InternalServerError({
-    requestId: request.context.requestId,
+    requestId: request.context?.requestId || uuidV4(),
     errorId: error.errorId,
     stack: error.stack,
     statusCode: error.statusCode,

--- a/models/firewall.js
+++ b/models/firewall.js
@@ -53,7 +53,7 @@ async function createUserRuleSideEffect(context) {
 
   await event.create({
     type: 'firewall:block_users',
-    originatorUserId: context.user.id,
+    originatorUserId: undefined,
     originatorIp: context.clientIp,
     metadata: {
       from_rule: 'create:user',

--- a/pages/api/v1/activation/index.public.js
+++ b/pages/api/v1/activation/index.public.js
@@ -1,9 +1,9 @@
 import nextConnect from 'next-connect';
 import controller from 'models/controller.js';
 import activation from 'models/activation.js';
-import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
 import validator from 'models/validator.js';
+import user from 'models/user.js';
 
 export default nextConnect({
   attachParams: true,
@@ -11,9 +11,8 @@ export default nextConnect({
   onError: controller.onErrorHandler,
 })
   .use(controller.injectRequestMetadata)
-  .use(authentication.injectAnonymousOrUser)
   .use(controller.logRequest)
-  .patch(patchValidationHandler, authorization.canRequest('read:activation_token'), patchHandler);
+  .patch(patchValidationHandler, patchHandler);
 
 function patchValidationHandler(request, response, next) {
   const cleanValues = validator(request.body, {
@@ -24,10 +23,9 @@ function patchValidationHandler(request, response, next) {
   next();
 }
 async function patchHandler(request, response) {
-  const userTryingToActivate = request.context.user;
+  const userTryingToActivate = user.createAnonymous();
   const insecureInputValues = request.body;
 
-  //TODO: validate input values with the new validation strategy
   const secureInputValues = authorization.filterInput(
     userTryingToActivate,
     'read:activation_token',

--- a/pages/api/v1/contents/[username]/[slug]/children/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/children/index.public.js
@@ -1,20 +1,16 @@
 import nextConnect from 'next-connect';
 import controller from 'models/controller.js';
-import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
 import validator from 'models/validator.js';
 import content from 'models/content.js';
+import user from 'models/user.js';
 import { NotFoundError } from 'errors/index.js';
 
 export default nextConnect({
   attachParams: true,
   onNoMatch: controller.onNoMatchHandler,
   onError: controller.onErrorHandler,
-})
-  .use(controller.injectRequestMetadata)
-  .use(authentication.injectAnonymousOrUser)
-  .use(controller.logRequest)
-  .get(getValidationHandler, getHandler);
+}).get(getValidationHandler, getHandler);
 
 function getValidationHandler(request, response, next) {
   const cleanValues = validator(request.query, {
@@ -27,9 +23,8 @@ function getValidationHandler(request, response, next) {
   next();
 }
 
-// TODO: cache the response
 async function getHandler(request, response) {
-  const userTryingToGet = request.context.user;
+  const userTryingToGet = user.createAnonymous();
 
   const contentFound = await content.findOne({
     where: {

--- a/pages/api/v1/contents/[username]/[slug]/parent/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/parent/index.public.js
@@ -10,10 +10,7 @@ export default nextConnect({
   attachParams: true,
   onNoMatch: controller.onNoMatchHandler,
   onError: controller.onErrorHandler,
-})
-  .use(controller.injectRequestMetadata)
-  .use(controller.logRequest)
-  .get(getValidationHandler, getHandler);
+}).get(getValidationHandler, getHandler);
 
 function getValidationHandler(request, response, next) {
   const cleanValues = validator(request.query, {

--- a/pages/api/v1/contents/[username]/[slug]/root/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/root/index.public.js
@@ -10,10 +10,7 @@ export default nextConnect({
   attachParams: true,
   onNoMatch: controller.onNoMatchHandler,
   onError: controller.onErrorHandler,
-})
-  .use(controller.injectRequestMetadata)
-  .use(controller.logRequest)
-  .get(getValidationHandler, getHandler);
+}).get(getValidationHandler, getHandler);
 
 function getValidationHandler(request, response, next) {
   const cleanValues = validator(request.query, {

--- a/pages/api/v1/contents/[username]/[slug]/tabcoins/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/tabcoins/index.public.js
@@ -15,7 +15,7 @@ export default nextConnect({
   onError: controller.onErrorHandler,
 })
   .use(controller.injectRequestMetadata)
-  .use(authentication.injectAnonymousOrUser)
+  .use(authentication.injectUser)
   .use(controller.logRequest)
   .post(postValidationHandler, authorization.canRequest('update:content'), postHandler);
 

--- a/pages/api/v1/contents/[username]/index.public.js
+++ b/pages/api/v1/contents/[username]/index.public.js
@@ -1,19 +1,15 @@
 import nextConnect from 'next-connect';
 import controller from 'models/controller.js';
-import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
 import validator from 'models/validator.js';
 import content from 'models/content.js';
+import user from 'models/user.js';
 
 export default nextConnect({
   attachParams: true,
   onNoMatch: controller.onNoMatchHandler,
   onError: controller.onErrorHandler,
-})
-  .use(controller.injectRequestMetadata)
-  .use(authentication.injectAnonymousOrUser)
-  .use(controller.logRequest)
-  .get(getValidationHandler, getHandler);
+}).get(getValidationHandler, getHandler);
 
 function getValidationHandler(request, response, next) {
   const cleanValues = validator(request.query, {
@@ -29,7 +25,7 @@ function getValidationHandler(request, response, next) {
 }
 
 async function getHandler(request, response) {
-  const userTryingToGet = request.context.user;
+  const userTryingToGet = user.createAnonymous();
 
   const results = await content.findWithStrategy({
     strategy: request.query.strategy,

--- a/pages/api/v1/contents/index.public.js
+++ b/pages/api/v1/contents/index.public.js
@@ -7,6 +7,7 @@ import content from 'models/content.js';
 import notification from 'models/notification.js';
 import event from 'models/event.js';
 import firewall from 'models/firewall.js';
+import user from 'models/user.js';
 import database from 'infra/database.js';
 import { ForbiddenError } from 'errors/index.js';
 
@@ -15,10 +16,10 @@ export default nextConnect({
   onNoMatch: controller.onNoMatchHandler,
   onError: controller.onErrorHandler,
 })
-  .use(controller.injectRequestMetadata)
-  .use(authentication.injectAnonymousOrUser)
-  .use(controller.logRequest)
   .get(getValidationHandler, getHandler)
+  .use(controller.injectRequestMetadata)
+  .use(authentication.injectUser)
+  .use(controller.logRequest)
   .post(postValidationHandler, authorization.canRequest('create:content'), firewallValidationHandler, postHandler);
 
 function getValidationHandler(request, response, next) {
@@ -34,7 +35,7 @@ function getValidationHandler(request, response, next) {
 }
 
 async function getHandler(request, response) {
-  const userTryingToList = request.context.user;
+  const userTryingToList = user.createAnonymous();
 
   const results = await content.findWithStrategy({
     strategy: request.query.strategy,

--- a/pages/api/v1/contents/rss/index.public.js
+++ b/pages/api/v1/contents/rss/index.public.js
@@ -9,10 +9,7 @@ export default nextConnect({
   attachParams: true,
   onNoMatch: controller.onNoMatchHandler,
   onError: controller.onErrorHandler,
-})
-  .use(controller.injectRequestMetadata)
-  .use(controller.logRequest)
-  .get(handleRequest);
+}).get(handleRequest);
 
 async function handleRequest(request, response) {
   const userTryingToList = user.createAnonymous();

--- a/pages/api/v1/migrations/index.public.js
+++ b/pages/api/v1/migrations/index.public.js
@@ -10,7 +10,7 @@ export default nextConnect({
   onError: controller.onErrorHandler,
 })
   .use(controller.injectRequestMetadata)
-  .use(authentication.injectAnonymousOrUser)
+  .use(authentication.injectUser)
   .use(controller.logRequest)
   .get(authorization.canRequest('read:migration'), getHandler)
   .post(authorization.canRequest('create:migration'), postHandler);

--- a/pages/api/v1/recovery/index.public.js
+++ b/pages/api/v1/recovery/index.public.js
@@ -1,18 +1,15 @@
 import nextConnect from 'next-connect';
 import controller from 'models/controller.js';
-import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
 import recovery from 'models/recovery.js';
 import validator from 'models/validator.js';
+import user from 'models/user.js';
 
 export default nextConnect({
   attachParams: true,
   onNoMatch: controller.onNoMatchHandler,
   onError: controller.onErrorHandler,
 })
-  .use(controller.injectRequestMetadata)
-  .use(authentication.injectAnonymousOrUser)
-  .use(controller.logRequest)
   .post(postValidationHandler, postHandler)
   .patch(patchValidationHandler, patchHandler);
 
@@ -28,7 +25,7 @@ function postValidationHandler(request, response, next) {
 }
 
 async function postHandler(request, response) {
-  const userTryingToRecover = request.context.user;
+  const userTryingToRecover = user.createAnonymous();
   const validatedInputValues = request.body;
 
   const tokenObject = await recovery.createAndSendRecoveryEmail(validatedInputValues);
@@ -50,7 +47,7 @@ function patchValidationHandler(request, response, next) {
 }
 
 async function patchHandler(request, response) {
-  const userTryingToRecover = request.context.user;
+  const userTryingToRecover = user.createAnonymous();
   const validatedInputValues = request.body;
 
   const tokenObject = await recovery.resetUserPassword(validatedInputValues);

--- a/pages/api/v1/status/index.public.js
+++ b/pages/api/v1/status/index.public.js
@@ -7,10 +7,7 @@ export default nextConnect({
   attachParams: true,
   onNoMatch: controller.onNoMatchHandler,
   onError: controller.onErrorHandler,
-})
-  .use(controller.injectRequestMetadata)
-  .use(controller.logRequest)
-  .get(getHandler);
+}).get(getHandler);
 
 async function getHandler(request, response) {
   let statusCode = 200;

--- a/pages/api/v1/user/index.public.js
+++ b/pages/api/v1/user/index.public.js
@@ -9,7 +9,7 @@ export default nextConnect({
   onError: controller.onErrorHandler,
 })
   .use(controller.injectRequestMetadata)
-  .use(authentication.injectAnonymousOrUser)
+  .use(authentication.injectUser)
   .use(controller.logRequest)
   .get(authorization.canRequest('read:session'), getHandler);
 

--- a/pages/api/v1/users/[username].public.js
+++ b/pages/api/v1/users/[username].public.js
@@ -11,10 +11,10 @@ export default nextConnect({
   onNoMatch: controller.onNoMatchHandler,
   onError: controller.onErrorHandler,
 })
-  .use(controller.injectRequestMetadata)
-  .use(authentication.injectAnonymousOrUser)
-  .use(controller.logRequest)
   .get(getValidationHandler, getHandler)
+  .use(controller.injectRequestMetadata)
+  .use(authentication.injectUser)
+  .use(controller.logRequest)
   .patch(patchValidationHandler, authorization.canRequest('update:user'), patchHandler);
 
 function getValidationHandler(request, response, next) {
@@ -28,7 +28,7 @@ function getValidationHandler(request, response, next) {
 }
 
 async function getHandler(request, response) {
-  const userTryingToGet = request.context.user;
+  const userTryingToGet = user.createAnonymous();
   const userStoredFromDatabase = await user.findOneByUsername(request.query.username);
 
   const secureOutputValues = authorization.filterOutput(userTryingToGet, 'read:user', userStoredFromDatabase);

--- a/tests/integration/api/v1/activation/patch.test.js
+++ b/tests/integration/api/v1/activation/patch.test.js
@@ -267,35 +267,5 @@ describe('PATCH /api/v1/activation', () => {
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
       expect(responseBody.error_location_code).toEqual('MODEL:ACTIVATION:ACTIVATE_USER_BY_USER_ID:FEATURE_NOT_FOUND');
     });
-
-    test('Already active, logged in and trying to activate with a valid token', async () => {
-      let defaultUser = await orchestrator.createUser();
-      defaultUser = await orchestrator.activateUser(defaultUser);
-      const activationToken = await activation.create(defaultUser);
-      let defaultUserSession = await orchestrator.createSession(defaultUser);
-
-      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/activation`, {
-        method: 'patch',
-        headers: {
-          'Content-Type': 'application/json',
-          cookie: `session_id=${defaultUserSession.token}`,
-        },
-
-        body: JSON.stringify({
-          token_id: activationToken.id,
-        }),
-      });
-
-      const responseBody = await response.json();
-
-      expect(response.status).toEqual(403);
-      expect(responseBody.status_code).toEqual(403);
-      expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('Usuário não pode executar esta operação.');
-      expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "read:activation_token".');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
-    });
   });
 });

--- a/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
@@ -27,11 +27,11 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       expect(response.status).toEqual(403);
       expect(responseBody.status_code).toEqual(403);
       expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('Usuário não pode executar esta operação.');
-      expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "update:content".');
+      expect(responseBody.message).toEqual('Você precisa estar logado para executar esta ação.');
+      expect(responseBody.action).toEqual('Faça o login no TabNews e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
+      expect(responseBody.error_location_code).toEqual('MODEL:AUTHENTICATION:INJECT_USER:NO_SESSION_ID_COOKIE');
     });
   });
 

--- a/tests/integration/api/v1/contents/[username]/[slug]/tabcoins/post.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/tabcoins/post.test.js
@@ -39,12 +39,12 @@ describe('POST /api/v1/contents/tabcoins', () => {
 
       expect(responseBody).toStrictEqual({
         name: 'ForbiddenError',
-        message: 'Usuário não pode executar esta operação.',
-        action: 'Verifique se este usuário possui a feature "update:content".',
+        message: 'Você precisa estar logado para executar esta ação.',
+        action: 'Faça o login no TabNews e tente novamente.',
         status_code: 403,
         error_id: responseBody.error_id,
         request_id: responseBody.request_id,
-        error_location_code: 'MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND',
+        error_location_code: 'MODEL:AUTHENTICATION:INJECT_USER:NO_SESSION_ID_COOKIE',
       });
     });
   });

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -27,11 +27,11 @@ describe('POST /api/v1/contents', () => {
       expect(response.status).toEqual(403);
       expect(responseBody.status_code).toEqual(403);
       expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('Usuário não pode executar esta operação.');
-      expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "create:content".');
+      expect(responseBody.message).toEqual('Você precisa estar logado para executar esta ação.');
+      expect(responseBody.action).toEqual('Faça o login no TabNews e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
+      expect(responseBody.error_location_code).toEqual('MODEL:AUTHENTICATION:INJECT_USER:NO_SESSION_ID_COOKIE');
     });
   });
 

--- a/tests/integration/api/v1/migrations/get.test.js
+++ b/tests/integration/api/v1/migrations/get.test.js
@@ -17,12 +17,12 @@ describe('GET /api/v1/migrations', () => {
 
       expect(response.status).toEqual(403);
       expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('Usuário não pode executar esta operação.');
-      expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "read:migration".');
+      expect(responseBody.message).toEqual('Você precisa estar logado para executar esta ação.');
+      expect(responseBody.action).toEqual('Faça o login no TabNews e tente novamente.');
       expect(responseBody.status_code).toEqual(403);
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
+      expect(responseBody.error_location_code).toEqual('MODEL:AUTHENTICATION:INJECT_USER:NO_SESSION_ID_COOKIE');
     });
   });
 

--- a/tests/integration/api/v1/migrations/post.test.js
+++ b/tests/integration/api/v1/migrations/post.test.js
@@ -22,12 +22,12 @@ describe('POST /api/v1/migrations', () => {
 
       expect(response.status).toEqual(403);
       expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('Usuário não pode executar esta operação.');
-      expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "create:migration".');
+      expect(responseBody.message).toEqual('Você precisa estar logado para executar esta ação.');
+      expect(responseBody.action).toEqual('Faça o login no TabNews e tente novamente.');
       expect(responseBody.status_code).toEqual(403);
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
+      expect(responseBody.error_location_code).toEqual('MODEL:AUTHENTICATION:INJECT_USER:NO_SESSION_ID_COOKIE');
     });
   });
 

--- a/tests/integration/api/v1/sessions/delete.test.js
+++ b/tests/integration/api/v1/sessions/delete.test.js
@@ -21,12 +21,12 @@ describe('DELETE /api/v1/sessions', () => {
 
       expect(responseBody).toStrictEqual({
         name: 'ForbiddenError',
-        message: 'Usuário não pode executar esta operação.',
-        action: 'Verifique se este usuário possui a feature "read:session".',
+        message: 'Você precisa estar logado para executar esta ação.',
+        action: 'Faça o login no TabNews e tente novamente.',
         status_code: 403,
         error_id: responseBody.error_id,
         request_id: responseBody.request_id,
-        error_location_code: 'MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND',
+        error_location_code: 'MODEL:AUTHENTICATION:INJECT_USER:NO_SESSION_ID_COOKIE',
       });
 
       expect(uuidVersion(responseBody.error_id)).toEqual(4);

--- a/tests/integration/api/v1/sessions/get.test.js
+++ b/tests/integration/api/v1/sessions/get.test.js
@@ -18,11 +18,11 @@ describe('GET /api/v1/sessions', () => {
       expect(response.status).toEqual(403);
       expect(responseBody.status_code).toEqual(403);
       expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('Usuário não pode executar esta operação.');
-      expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "read:session".');
+      expect(responseBody.message).toEqual('Você precisa estar logado para executar esta ação.');
+      expect(responseBody.action).toEqual('Faça o login no TabNews e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
+      expect(responseBody.error_location_code).toEqual('MODEL:AUTHENTICATION:INJECT_USER:NO_SESSION_ID_COOKIE');
     });
 
     test('Retrieving the endpoint with malformatted "session_id" (too short)', async () => {

--- a/tests/integration/api/v1/user/get.test.js
+++ b/tests/integration/api/v1/user/get.test.js
@@ -18,11 +18,11 @@ describe('GET /api/v1/user', () => {
       expect(response.status).toEqual(403);
       expect(responseBody.status_code).toEqual(403);
       expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('Usuário não pode executar esta operação.');
-      expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "read:session".');
+      expect(responseBody.message).toEqual('Você precisa estar logado para executar esta ação.');
+      expect(responseBody.action).toEqual('Faça o login no TabNews e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
+      expect(responseBody.error_location_code).toEqual('MODEL:AUTHENTICATION:INJECT_USER:NO_SESSION_ID_COOKIE');
     });
   });
 

--- a/tests/integration/api/v1/users/[username]/patch.test.js
+++ b/tests/integration/api/v1/users/[username]/patch.test.js
@@ -32,12 +32,12 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       expect(response.status).toEqual(403);
       expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('Usuário não pode executar esta operação.');
-      expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "update:user".');
+      expect(responseBody.message).toEqual('Você precisa estar logado para executar esta ação.');
+      expect(responseBody.action).toEqual('Faça o login no TabNews e tente novamente.');
       expect(responseBody.status_code).toEqual(403);
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
+      expect(responseBody.error_location_code).toEqual('MODEL:AUTHENTICATION:INJECT_USER:NO_SESSION_ID_COOKIE');
     });
   });
 

--- a/tests/integration/api/v1/users/get.test.js
+++ b/tests/integration/api/v1/users/get.test.js
@@ -22,12 +22,12 @@ describe('GET /api/v1/users', () => {
 
       expect(response.status).toEqual(403);
       expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('Usuário não pode executar esta operação.');
-      expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "read:user:list".');
+      expect(responseBody.message).toEqual('Você precisa estar logado para executar esta ação.');
+      expect(responseBody.action).toEqual('Faça o login no TabNews e tente novamente.');
       expect(responseBody.status_code).toEqual(403);
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
+      expect(responseBody.error_location_code).toEqual('MODEL:AUTHENTICATION:INJECT_USER:NO_SESSION_ID_COOKIE');
     });
   });
 


### PR DESCRIPTION
## Antes de tudo

Não estou seguro de fazer uma alteração tão grande, mesmo com os testes de integração. Talvez devemos fazer em passos pequenos e pensar muito bem o que está sendo feito, então sugiro **fechar esse PR**.

De qualquer forma, estou abrindo ele e deixando registrado o que foi feito, pois essa implementação me fez notar outro ponto na qual estamos retornando os dados **sem usar o filtro de saída**, que é na geração das thumbnails. Então pelo que eu entendi, o sistema tem 3 pontos de saída de dados: `controllers` respondendo em `JSON`, `emails` respondendo em `texto` e `thumbnail` respondendo em `png`. Toda saída precisa ser filtrada, mas isso deixa para outro PR.

Bom, segue abaixo o que eu estava escrevendo antes de desistir do PR.

## Por que esta alteração existe e qual era a estratégia passada?

* Antes disso, não interessava se o usuário estava autenticado ou não, dentro do controller sempre existia um `user`, nem que ele fosse um usuário anônimo (que era apenas uma "casca", um mock em memória de um "user" que possuía poucas features).
* Isso "facilita" programar um controller, pois sempre irá existir algo em `context.user` no objeto da `request`.
* Mas isso se demonstrou uma estratégia ruim no momento de fazer o `cache` dos endpoints na CDN, uma vez que, caso você use um usuário autenticado e passe por esse cache, o `session_id` desse usuário ficará salvo na CDN. Isto foi responsável pelo nosso primeiro [Postmortem](https://www.tabnews.com.br/filipedeschamps/postmortem-todas-as-sessoes-foram-invalidadas-por-conta-do-endpoint-thumbnail).
* Então como queremos fazer o cache cada vez mais de certos endpoints com método `GET`, devemos completamente separar o que é uma request que pode ser feita de forma **anônima**, de uma request que deve estar **autenticada**.

## Pontos importantes da execução

* No model `authentication`, não existe mais o método `injectAnonymousOrUser()` e ele foi substituído por `injectUser()` para parar de existir a probabilidade de num mesmo local existir alguém anônimo ou autenticado. Isto fez quebrar 100% dos endpoints que precisavam de um usuário e eu fui 1 a 1 ajustando e consertando os testes.
* Agora se um endpoint precisa de um usuário autenticado mas você acessa ele sem enviar o `session_id`, é retornado uma mensagem que você precisa fazer o login no TabNews antes mesmo que o código continue fazendo a verificação pela feature necessária para acessar aquele endpoint. Então agora ele vai reclamar **antes** da injeção do usuário no contexto e da verificação da feature.
* Outro reflexo foi a remoção de metadados no contexto e do logging de vários endpoints, pois nada disso faz sentido no contexto do retorno deles estarem cacheados na CDN e serem entregues por lá.
* **E foi aqui que desisti de continuar com o PR, pois quanto mais eu lia o `diff` para construir esse report aqui, mais eu via que era arriscado seguir com um PR tão grande**.