### PR TITLE
refactor(register): remove password confirmation input

### DIFF
--- a/pages/cadastro/index.public.js
+++ b/pages/cadastro/index.public.js
@@ -21,7 +21,6 @@ function SignUpForm() {
   const usernameRef = useRef('');
   const emailRef = useRef('');
   const passwordRef = useRef('');
-  const passwordConfirmRef = useRef('');
 
   const [globalErrorMessage, setGlobalErrorMessage] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -47,22 +46,6 @@ function SignUpForm() {
     const username = usernameRef.current.value;
     const email = emailRef.current.value;
     const password = passwordRef.current.value;
-    const passwordConfirm = passwordConfirmRef.current.value;
-
-    if (password !== passwordConfirm) {
-      setErrorObject({
-        key: 'password_confirm',
-        message: 'As senhas devem ser iguais.',
-      });
-      setIsLoading(false);
-      return;
-    }
-
-    if (errorObject) {
-      setIsLoading(false);
-      setErrorObject(undefined);
-      return;
-    }
 
     setIsLoading(true);
     setErrorObject(undefined);
@@ -176,24 +159,6 @@ function SignUpForm() {
           )}
         </FormControl>
 
-        <FormControl id="passwordConfirm">
-          <FormControl.Label>Repita a senha</FormControl.Label>
-          <TextInput
-            ref={passwordConfirmRef}
-            onChange={clearErrors}
-            name="passwordConfirm"
-            type="password"
-            autoCorrect="off"
-            autoCapitalize="off"
-            spellCheck={false}
-            size="large"
-            block={true}
-            aria-label="Repita a senha"
-          />
-          {errorObject?.key === 'password_confirm' && (
-            <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
-          )}
-        </FormControl>
         <FormControl>
           <FormControl.Label visuallyHidden>Criar cadastro</FormControl.Label>
           <Button


### PR DESCRIPTION
Este PR traz duas alterações no formulário da página de **cadastro**:

---

1. Remove o campo de confirmação de senha - `"Repita a senha"`

| Antes | Depois |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/57193392/187305040-7073cf5d-60af-4bb4-bbdd-acd9a694c91f.png) | ![after](https://user-images.githubusercontent.com/57193392/187305068-b2ce0486-f584-4f09-b5af-9fab9f7262b2.png) |

---

2. Padroniza o comportamento do formulário quando há um campo inválido, **exibindo sempre o erro enquanto ele existir**, conforme os formulários de outras páginas, como `login` e `recuperação de senha`

### Comportamento do formulário de login
https://user-images.githubusercontent.com/57193392/187326411-3407d5c6-1fbc-4ee6-bee0-73bdcfae6d00.mp4

### Comportamento do formulário de cadastro (antes)
https://user-images.githubusercontent.com/57193392/187328808-287fee7f-e747-4904-98d3-57a992aee4ab.mp4

### Comportamento do formulário de cadastro (depois)
https://user-images.githubusercontent.com/57193392/187330802-c48fbc90-6ebf-4843-99e1-f78b2b3b7d81.mp4





