### PR TITLE
Adiciona página `/perfil` e habilita fluxo de atualização de email

### DIFF
--- a/infra/migrations/1662569439391_create-table-email-confirmation-tokens.js
+++ b/infra/migrations/1662569439391_create-table-email-confirmation-tokens.js
@@ -1,0 +1,47 @@
+exports.up = (pgm) => {
+  pgm.createTable('email_confirmation_tokens', {
+    id: {
+      type: 'uuid',
+      default: pgm.func('gen_random_uuid()'),
+      notNull: true,
+      primaryKey: true,
+    },
+
+    user_id: {
+      type: 'uuid',
+      notNull: true,
+    },
+
+    // Why 254 in length? https://stackoverflow.com/a/1199238
+    email: {
+      type: 'varchar(254)',
+      notNull: true,
+      unique: false,
+    },
+
+    used: {
+      type: 'boolean',
+      notNull: true,
+      default: false,
+    },
+
+    expires_at: {
+      type: 'timestamp with time zone',
+      notNull: true,
+    },
+
+    created_at: {
+      type: 'timestamp with time zone',
+      notNull: true,
+      default: pgm.func("(now() at time zone 'utc')"),
+    },
+
+    updated_at: {
+      type: 'timestamp with time zone',
+      notNull: true,
+      default: pgm.func("(now() at time zone 'utc')"),
+    },
+  });
+};
+
+exports.down = false;

--- a/models/authorization.js
+++ b/models/authorization.js
@@ -20,6 +20,9 @@ const availableFeatures = new Set([
   // RECOVERY_TOKEN
   'read:recovery_token',
 
+  // EMAIL_CONFIRMATION_TOKEN
+  'read:email_confirmation_token',
+
   // SESSION
   'create:session',
   'read:session',
@@ -251,6 +254,16 @@ function filterOutput(user, feature, output) {
   }
 
   if (feature === 'read:recovery_token') {
+    filteredOutputValues = validator(output, {
+      id: 'required',
+      used: 'required',
+      expires_at: 'required',
+      created_at: 'required',
+      updated_at: 'required',
+    });
+  }
+
+  if (feature === 'read:email_confirmation_token') {
     filteredOutputValues = validator(output, {
       id: 'required',
       used: 'required',

--- a/models/email-confirmation.js
+++ b/models/email-confirmation.js
@@ -1,0 +1,235 @@
+import email from 'infra/email.js';
+import database from 'infra/database.js';
+import webserver from 'infra/webserver.js';
+import user from 'models/user.js';
+import { NotFoundError } from 'errors/index.js';
+
+async function createAndSendEmail(userId, newEmail) {
+  const userFound = await user.findOneById(userId);
+  const tokenObject = await create(userFound.id, newEmail);
+  await sendEmailToUser(userFound, newEmail, tokenObject.id);
+
+  return tokenObject;
+}
+
+async function create(userId, newEmail) {
+  const query = {
+    text: `
+      INSERT INTO
+        email_confirmation_tokens (user_id, email, expires_at)
+      VALUES
+        ($1, $2, now() + interval '15 minutes')
+      RETURNING
+        *
+      ;`,
+    values: [userId, newEmail],
+  };
+
+  const results = await database.query(query);
+  return results.rows[0];
+}
+
+async function sendEmailToUser(user, newEmail, tokenId) {
+  const emailConfirmationPageEndpoint = getEmailConfirmationPageEndpoint(tokenId);
+
+  await email.send({
+    from: {
+      name: 'TabNews',
+      address: 'contato@tabnews.com.br',
+    },
+    to: newEmail,
+    subject: 'Confirme seu novo email',
+    text: `${user.username}, uma alteração de email foi solicitada.
+
+Clique no link abaixo para confirmar esta alteração:
+
+${emailConfirmationPageEndpoint}
+
+Atenciosamente,
+Equipe TabNews
+Rua Antônio da Veiga, 495, Blumenau, SC, 89012-500`,
+  });
+}
+
+function getEmailConfirmationPageEndpoint(tokenId) {
+  const webserverHost = webserver.getHost();
+  return `${webserverHost}/perfil/confirmar-email/${tokenId}`;
+}
+
+async function findOneTokenById(tokenId) {
+  const query = {
+    text: `
+      SELECT
+        *
+      FROM
+        email_confirmation_tokens
+      WHERE
+        id = $1
+      LIMIT 1
+    ;`,
+    values: [tokenId],
+  };
+  const results = await database.query(query);
+
+  if (results.rowCount === 0) {
+    throw new NotFoundError({
+      message: `O token de confirmação de email utilizado não foi encontrado no sistema.`,
+      action: 'Certifique-se que está sendo enviado o token corretamente.',
+      errorLocationCode: 'MODEL:EMAIL_CONFIRMATION:FIND_ONE_TOKEN_BY_ID:NOT_FOUND',
+      stack: new Error().stack,
+    });
+  }
+
+  return results.rows[0];
+}
+
+async function findOneValidTokenById(tokenId) {
+  const query = {
+    text: `
+      SELECT
+        *
+      FROM
+        email_confirmation_tokens
+      WHERE
+        id = $1
+        AND used = false
+        AND expires_at >= now()
+      LIMIT
+        1
+    ;`,
+    values: [tokenId],
+  };
+
+  const results = await database.query(query);
+
+  if (results.rowCount === 0) {
+    throw new NotFoundError({
+      message: `O token de confirmação de email utilizado não foi encontrado no sistema ou expirou.`,
+      action: 'Solicite uma nova alteração de email.',
+      stack: new Error().stack,
+      errorLocationCode: 'MODEL:EMAIL_CONFIRMATION:FIND_ONE_VALID_TOKEN_BY_ID:NOT_FOUND',
+      key: 'token_id',
+    });
+  }
+
+  return results.rows[0];
+}
+
+async function findOneTokenByUserId(userId) {
+  const query = {
+    text: `
+      SELECT
+        *
+      FROM
+        email_confirmation_tokens
+      WHERE
+        user_id = $1
+      LIMIT
+        1
+    ;`,
+    values: [userId],
+  };
+  const results = await database.query(query);
+
+  if (results.rowCount === 0) {
+    throw new NotFoundError({
+      message: `O token de recuperação de senha utilizado não foi encontrado no sistema.`,
+      action: 'Certifique-se que está sendo enviado o token corretamente.',
+      stack: new Error().stack,
+    });
+  }
+
+  return results.rows[0];
+}
+
+async function markTokenAsUsed(tokenId) {
+  const query = {
+    text: `
+      UPDATE
+        email_confirmation_tokens
+      SET
+        used = true,
+        updated_at = (now() at time zone 'utc')
+      WHERE
+        id = $1
+      RETURNING
+        *
+    ;`,
+    values: [tokenId],
+  };
+
+  const results = await database.query(query);
+  return results.rows[0];
+}
+
+async function updateUserEmail(userId, newEmail) {
+  const currentUser = await user.findOneById(userId);
+
+  await user.update(
+    currentUser.username,
+    {
+      email: newEmail,
+    },
+    {
+      skipEmailConfirmation: true,
+    }
+  );
+}
+
+async function confirmEmailUpdate(tokenId) {
+  const tokenObject = await findOneTokenById(tokenId);
+
+  if (!tokenObject.used) {
+    const validToken = await findOneValidTokenById(tokenId);
+    const usedToken = await markTokenAsUsed(validToken.id);
+    await updateUserEmail(validToken.user_id, validToken.email);
+    return usedToken;
+  }
+
+  return tokenObject;
+}
+
+async function update(tokenId, tokenBody) {
+  const currentToken = await findOneTokenById(tokenId);
+  const updatedToken = { ...currentToken, ...tokenBody };
+
+  const query = {
+    text: `
+      UPDATE
+        email_confirmation_tokens
+      SET
+        user_id = $2,
+        used = $3,
+        email = $4,
+        expires_at = $5,
+        created_at = $6,
+        updated_at = $7
+      WHERE
+        id = $1
+      RETURNING
+        *
+    ;`,
+    values: [
+      tokenId,
+      updatedToken.user_id,
+      updatedToken.used,
+      updatedToken.email,
+      updatedToken.expires_at,
+      updatedToken.created_at,
+      updatedToken.updated_at,
+    ],
+  };
+
+  const results = await database.query(query);
+
+  return results.rows[0];
+}
+
+export default Object.freeze({
+  create,
+  createAndSendEmail,
+  findOneTokenByUserId,
+  getEmailConfirmationPageEndpoint,
+  confirmEmailUpdate,
+  update,
+});

--- a/pages/api/v1/email-confirmation/index.public.js
+++ b/pages/api/v1/email-confirmation/index.public.js
@@ -1,0 +1,41 @@
+import nextConnect from 'next-connect';
+import controller from 'models/controller.js';
+import authentication from 'models/authentication.js';
+import authorization from 'models/authorization.js';
+import emailConfirmation from 'models/email-confirmation.js';
+import validator from 'models/validator.js';
+
+export default nextConnect({
+  attachParams: true,
+  onNoMatch: controller.onNoMatchHandler,
+  onError: controller.onErrorHandler,
+})
+  .use(controller.injectRequestMetadata)
+  .use(authentication.injectAnonymousOrUser)
+  .use(controller.logRequest)
+  .patch(patchValidationHandler, patchHandler);
+
+function patchValidationHandler(request, response, next) {
+  const cleanValues = validator(request.body, {
+    token_id: 'required',
+  });
+
+  request.body = cleanValues;
+
+  next();
+}
+
+async function patchHandler(request, response) {
+  const userTryingToChangeEmail = request.context.user;
+  const validatedInputValues = request.body;
+
+  const tokenObject = await emailConfirmation.confirmEmailUpdate(validatedInputValues.token_id);
+
+  const authorizedValuesToReturn = authorization.filterOutput(
+    userTryingToChangeEmail,
+    'read:email_confirmation_token',
+    tokenObject
+  );
+
+  return response.status(200).json(authorizedValuesToReturn);
+}

--- a/pages/api/v1/users/[username]/index.public.js
+++ b/pages/api/v1/users/[username]/index.public.js
@@ -74,9 +74,8 @@ async function patchHandler(request, response) {
   }
 
   // TEMPORARY BEHAVIOR
-  // TODO: only let user update "email" and "password"
+  // TODO: only let user update "password"
   // once we have double confirmation.
-  delete secureInputValues.email;
   delete secureInputValues.password;
 
   const updatedUser = await user.update(targetUsername, secureInputValues);

--- a/pages/cadastro/recuperar/index.public.js
+++ b/pages/cadastro/recuperar/index.public.js
@@ -1,6 +1,6 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useRouter } from 'next/router';
-import { DefaultLayout } from 'pages/interface/index.js';
+import { DefaultLayout, useUser } from 'pages/interface/index.js';
 import { FormControl, Box, Heading, Button, TextInput, Flash } from '@primer/react';
 
 export default function RecoverPassword() {
@@ -17,8 +17,15 @@ export default function RecoverPassword() {
 
 function RecoverPasswordForm() {
   const router = useRouter();
+  const { user, isLoading: userIsLoading } = useUser();
 
   const userInputRef = useRef('');
+
+  useEffect(() => {
+    if (user && !userIsLoading) {
+      userInputRef.current.value = user.username;
+    }
+  }, [user, userIsLoading]);
 
   const [globalErrorMessage, setGlobalErrorMessage] = useState(false);
   const [isLoading, setIsLoading] = useState(false);

--- a/pages/interface/components/Header/index.js
+++ b/pages/interface/components/Header/index.js
@@ -103,12 +103,7 @@ export default function HeaderComponent() {
                   <ActionList.LinkItem as={Link} href="/publicar">
                     Publicar novo conteúdo
                   </ActionList.LinkItem>
-                  <ActionList.LinkItem
-                    href="/perfil"
-                    onClick={(event) => {
-                      event.preventDefault();
-                      alert('Recurso ainda não implementado.');
-                    }}>
+                  <ActionList.LinkItem as={Link} href="/perfil">
                     Editar perfil
                   </ActionList.LinkItem>
                   <ActionList.Divider />

--- a/pages/interface/hooks/useUser/index.js
+++ b/pages/interface/hooks/useUser/index.js
@@ -16,15 +16,18 @@ export function UserProvider({ children }) {
       const responseBody = await response.json();
 
       if (response.status !== 401 && response.status !== 403) {
-        const fetchedUser = {
+        const fetchedUser = responseBody;
+
+        const cachedUserProperties = {
           id: responseBody.id,
           username: responseBody.username,
           features: responseBody.features,
           tabcoins: responseBody.tabcoins,
           tabcash: responseBody.tabcash,
         };
+
         setUser(fetchedUser);
-        localStorage.setItem('user', JSON.stringify(fetchedUser));
+        localStorage.setItem('user', JSON.stringify(cachedUserProperties));
       } else {
         setUser(null);
         localStorage.removeItem('user');

--- a/pages/perfil/confirmar-email/[token].public.js
+++ b/pages/perfil/confirmar-email/[token].public.js
@@ -1,0 +1,97 @@
+import Confetti from 'react-confetti';
+import fetch from 'cross-fetch';
+import { Box, Flash } from '@primer/react';
+import { DefaultLayout } from 'pages/interface/index.js';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+
+export default function ActiveUser() {
+  const router = useRouter();
+  const { token } = router.query;
+
+  const [globalMessage, setGlobalMessage] = useState(false);
+  const [isSuccess, setIsSuccess] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const [confettiWidth, setConfettiWidth] = useState(0);
+  const [confettiHeight, setConfettiHeight] = useState(0);
+
+  useEffect(() => {
+    function handleResize() {
+      setConfettiWidth(window.screen.width);
+      setConfettiHeight(window.screen.height);
+    }
+
+    window.addEventListener('resize', handleResize);
+    handleResize();
+
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  const handleEmailConfirmation = async (token) => {
+    try {
+      setIsLoading(true);
+
+      const response = await fetch(`/api/v1/email-confirmation`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          token_id: token,
+        }),
+      });
+
+      if (response.status === 200) {
+        setIsSuccess(true);
+        setGlobalMessage('Seu email foi alterado com sucesso!');
+
+        return;
+      }
+
+      if (response.status >= 400 && response.status <= 503) {
+        const responseBody = await response.json();
+        setGlobalMessage(`${responseBody.message} ${responseBody.action}`);
+        setIsSuccess(false);
+        return;
+      }
+
+      setIsSuccess(false);
+      throw new Error(response.statusText);
+    } catch (error) {
+      setGlobalMessage(error.message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (token) {
+      handleEmailConfirmation(token);
+    }
+  }, [token]);
+
+  return (
+    <>
+      {isSuccess && (
+        <Confetti
+          width={confettiWidth}
+          height={confettiHeight}
+          recycle={false}
+          numberOfPieces={800}
+          tweenDuration={15000}
+          gravity={0.15}
+        />
+      )}
+      <DefaultLayout containerWidth="medium" metadata={{ title: 'Confirmar alteração de email' }}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', width: '100%', mt: 10 }}>
+          {isLoading ? (
+            <Flash variant="default">Verificando Token de Alteração de Email...</Flash>
+          ) : (
+            <Flash variant={isSuccess ? 'success' : 'danger'}>{globalMessage}</Flash>
+          )}
+        </Box>
+      </DefaultLayout>
+    </>
+  );
+}

--- a/pages/perfil/index.public.js
+++ b/pages/perfil/index.public.js
@@ -1,0 +1,402 @@
+import { useState, useRef, useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { DefaultLayout, useUser, Link } from 'pages/interface/index.js';
+import { FormControl, Box, Heading, Button, TextInput, Flash, useConfirm } from '@primer/react';
+
+export default function EditProfile() {
+  return (
+    <DefaultLayout containerWidth="small" metadata={{ title: 'Editar Perfil' }}>
+      <Heading as="h1" sx={{ mb: 3 }}>
+        Editar Perfil
+      </Heading>
+
+      <EditProfileForm />
+    </DefaultLayout>
+  );
+}
+
+function EditProfileForm() {
+  const router = useRouter();
+  const confirm = useConfirm();
+
+  const { user, fetchUser, isLoading: userIsLoading } = useUser();
+
+  const usernameRef = useRef('');
+  const emailRef = useRef('');
+
+  useEffect(() => {
+    if (router && !user && !userIsLoading) {
+      router.push(`/login?redirect=${router.asPath}`);
+    }
+
+    if (user && !userIsLoading) {
+      usernameRef.current.value = user.username;
+      emailRef.current.value = user.email;
+    }
+  }, [user, router, userIsLoading]);
+
+  useEffect(() => {
+    fetchUser();
+  }, [fetchUser]);
+
+  const [globalErrorMessage, setGlobalErrorMessage] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorObject, setErrorObject] = useState(undefined);
+  const [emailDisabled, setEmailDisabled] = useState(false);
+
+  function clearErrors() {
+    setErrorObject(undefined);
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+
+    const username = usernameRef.current.value;
+    const email = emailRef.current.value;
+
+    setIsLoading(true);
+    setErrorObject(undefined);
+
+    const suggestedEmail = suggestEmail(email);
+
+    if (suggestedEmail) {
+      setErrorObject({
+        suggestion: suggestedEmail,
+        key: 'email',
+        type: 'typo',
+      });
+
+      setIsLoading(false);
+      return;
+    }
+
+    const payload = {};
+
+    if (user.username !== username) {
+      const confirmChangeUsername = await confirm({
+        title: `Você realmente deseja alterar seu nome de usuário?`,
+        content: `Isto irá quebrar todas as URLs das suas publicações.`,
+      });
+
+      if (!confirmChangeUsername) {
+        setIsLoading(false);
+        return;
+      }
+
+      payload.username = username;
+    }
+
+    if (user.email !== email) {
+      payload.email = email;
+    }
+
+    if (Object.keys(payload).length === 0) {
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      const response = await fetch(`/api/v1/users/${user.username}`, {
+        method: 'PATCH',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+
+      setGlobalErrorMessage(undefined);
+
+      const responseBody = await response.json();
+
+      if (response.status === 200) {
+        await fetchUser();
+
+        if (user.email !== email) {
+          setErrorObject({
+            message: `Atenção: Um email de confirmação foi enviado para ${email}`,
+            key: 'email',
+            type: 'confirmation',
+          });
+          setEmailDisabled(true);
+        }
+
+        setIsLoading(false);
+        return;
+      }
+
+      if (response.status === 400) {
+        setErrorObject(responseBody);
+        setIsLoading(false);
+        return;
+      }
+
+      if (response.status >= 403) {
+        setGlobalErrorMessage(`${responseBody.message} Informe ao suporte este valor: ${responseBody.error_id}`);
+        setIsLoading(false);
+        return;
+      }
+    } catch (error) {
+      setGlobalErrorMessage('Não foi possível se conectar ao TabNews. Por favor, verifique sua conexão.');
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <form style={{ width: '100%' }} onSubmit={handleSubmit}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+        {globalErrorMessage && <Flash variant="danger">{globalErrorMessage}</Flash>}
+
+        <FormControl id="username">
+          <FormControl.Label>Nome de usuário</FormControl.Label>
+          <TextInput
+            ref={usernameRef}
+            onChange={clearErrors}
+            name="username"
+            size="large"
+            autoCorrect="off"
+            autoCapitalize="off"
+            spellCheck={false}
+            block={true}
+            aria-label="Seu nome de usuário"
+          />
+          {errorObject?.key === 'username' && (
+            <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
+          )}
+
+          {errorObject?.type === 'string.alphanum' && (
+            <FormControl.Caption>Dica: use somente letras e números, por exemplo: nomeSobrenome4 </FormControl.Caption>
+          )}
+        </FormControl>
+        <FormControl id="email" disabled={emailDisabled}>
+          <FormControl.Label>Email</FormControl.Label>
+          <TextInput
+            ref={emailRef}
+            onChange={clearErrors}
+            name="email"
+            size="large"
+            autoCorrect="off"
+            autoCapitalize="off"
+            spellCheck={false}
+            block={true}
+            aria-label="Seu email"
+          />
+          {errorObject?.key === 'email' && !errorObject?.type && (
+            <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
+          )}
+          {errorObject?.key === 'email' && errorObject?.type === 'typo' && (
+            <FormControl.Validation variant="error">
+              <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                <Box>Você quis dizer:</Box>
+                <Box>
+                  <Button
+                    variant="invisible"
+                    size="small"
+                    sx={{ p: 1 }}
+                    onClick={(event) => {
+                      event.preventDefault();
+                      clearErrors();
+                      emailRef.current.value = errorObject.suggestion;
+                      passwordRef.current.focus();
+                    }}>
+                    {errorObject.suggestion.split('@')[0]}@<u>{errorObject.suggestion.split('@')[1]}</u>
+                  </Button>
+                </Box>
+              </Box>
+            </FormControl.Validation>
+          )}
+
+          {errorObject?.key === 'email' && errorObject?.type === 'confirmation' && (
+            <FormControl.Validation variant="warning">{errorObject.message}</FormControl.Validation>
+          )}
+        </FormControl>
+
+        <FormControl id="password">
+          <FormControl.Label>Senha</FormControl.Label>
+          <Link href="/cadastro/recuperar" sx={{ fontSize: 0 }}>
+            Utilize o fluxo de recuperação de senha →
+          </Link>
+        </FormControl>
+
+        <FormControl>
+          <FormControl.Label visuallyHidden>Salvar</FormControl.Label>
+          <Button
+            variant="primary"
+            size="large"
+            type="submit"
+            disabled={isLoading}
+            sx={{ width: '100%' }}
+            aria-label="Salvar">
+            Salvar
+          </Button>
+        </FormControl>
+      </Box>
+    </form>
+  );
+}
+
+// TODO: move to a separate file to make it reusable
+// or to a separate module to share it with the open source community.
+function suggestEmail(typedEmail) {
+  const userName = typedEmail.split('@')[0];
+  const typedDomain = typedEmail.split('@')[1];
+  const domains = [
+    ['gmail', 'gmail.com'],
+    ['gmail.', 'gmail.com'],
+    ['gmail.c', 'gmail.com'],
+    ['gmail.co', 'gmail.com'],
+    ['gmail.coom', 'gmail.com'],
+    ['gmail.comm', 'gmail.com'],
+    ['gmail.com.', 'gmail.com'],
+    ['gmail.com.b', 'gmail.com'],
+    ['gmail.com.br', 'gmail.com'],
+    ['mail.com', 'gmail.com'],
+    ['dmail.com', 'gmail.com'],
+    ['gmad.com,', 'gmail.com'],
+    ['gimail.com', 'gmail.com'],
+    ['mgil.com', 'gmail.com'],
+    ['gil.com', 'gmail.com'],
+    ['gmaul.com', 'gmail.com'],
+    ['gnail.com', 'gmail.com'],
+    ['gail.com', 'gmail.com'],
+    ['gamail.com', 'gmail.com'],
+    ['gamial.com', 'gmail.com'],
+    ['gamil.com', 'gmail.com'],
+    ['gmail.cpm', 'gmail.com'],
+    ['ggmail.com', 'gmail.com'],
+    ['gmai.com', 'gmail.com'],
+    ['gmaiil.com', 'gmail.com'],
+    ['gmail.cm', 'gmail.com'],
+    ['gmaild.com', 'gmail.com'],
+    ['gmaile.com', 'gmail.com'],
+    ['gmaill.com', 'gmail.com'],
+    ['gmain.com', 'gmail.com'],
+    ['gmaio.com', 'gmail.com'],
+    ['gmail.cok', 'gmail.com'],
+    ['gmal.com', 'gmail.com'],
+    ['gmali.com', 'gmail.com'],
+    ['gmil.co', 'gmail.com'],
+    ['gmanil.com', 'gmail.com'],
+    ['gmaol.com', 'gmail.com'],
+    ['gmaqil.com', 'gmail.com'],
+    ['gmeil.com', 'gmail.com'],
+    ['gmial.com', 'gmail.com'],
+    ['gmil.com', 'gmail.com'],
+    ['gmmail.com', 'gmail.com'],
+    ['gmsil.com', 'gmail.com'],
+    ['hmail.com', 'gmail.com'],
+    ['ygmail.com', 'gmail.com'],
+    ['gmiail.com', 'gmail.com'],
+    ['gemail.com', 'gmail.com'],
+    ['gmail.con', 'gmail.com'],
+    ['gail.com.ar', 'gmail.com'],
+    ['gamail.com.ar', 'gmail.com'],
+    ['gamial.com.ar', 'gmail.com'],
+    ['gamil.com.ar', 'gmail.com'],
+    ['ggmail.com.ar', 'gmail.com'],
+    ['gmai.com.ar', 'gmail.com'],
+    ['gmaiil.com.ar', 'gmail.com'],
+    ['gmail.cm.br', 'gmail.com'],
+    ['gmail.cm.ar', 'gmail.com'],
+    ['gmaild.com.ar', 'gmail.com'],
+    ['gmaile.com.ar', 'gmail.com'],
+    ['gmaill.com.ar', 'gmail.com'],
+    ['gmain.com.ar', 'gmail.com'],
+    ['gmaio.com.ar', 'gmail.com'],
+    ['gmal.com.ar', 'gmail.com'],
+    ['gmali.com.ar', 'gmail.com'],
+    ['gmanil.com.ar', 'gmail.com'],
+    ['gmaol.com.ar', 'gmail.com'],
+    ['gmailee.com', 'gmail.com'],
+    ['gmaqil.com.ar', 'gmail.com'],
+    ['gmeil.com.ar', 'gmail.com'],
+    ['gmial.com.ar', 'gmail.com'],
+    ['gmil.com.ar', 'gmail.com'],
+    ['gmmail.com.ar', 'gmail.com'],
+    ['gmsil.com.ar', 'gmail.com'],
+    ['hmail.com.ar', 'gmail.com'],
+    ['ygmail.com.ar', 'gmail.com'],
+    ['gmail.cim', 'gmail.com'],
+    ['gmail.com.ar', 'gmail.com'],
+    ['gmailc.om', 'gmail.com'],
+    ['gmnail.com', 'gmail.com'],
+    ['gmakl.com', 'gmail.com'],
+    ['gmol.com', 'gmail.com'],
+    ['gmail.cin', 'gmail.com'],
+    ['gmail.cim', 'gmail.com'],
+    ['gmaiq.com', 'gmail.com'],
+    ['gmailc.mo', 'gmail.com'],
+    ['hitmail.com', 'hotmail.com'],
+    ['htmail.com', 'hotmail.com'],
+    ['hotmail.coom', 'hotmail.com'],
+    ['hotmail.comm', 'hotmail.com'],
+    ['hotnail.ckm', 'hotmail.com'],
+    ['hatmail.com', 'hotmail.com'],
+    ['hotomail.com', 'hotmail.com'],
+    ['otmail.com', 'hotmail.com'],
+    ['hoitmail.com', 'hotmail.com'],
+    ['hoimail.com', 'hotmail.com'],
+    ['hotnail.com', 'hotmail.com'],
+    ['homail.com', 'hotmail.com'],
+    ['homtail.com', 'hotmail.com'],
+    ['homtmail.com', 'hotmail.com'],
+    ['hormail.com', 'hotmail.com'],
+    ['hotail.com', 'hotmail.com'],
+    ['hotamail.com', 'hotmail.com'],
+    ['hotamil.com', 'hotmail.com'],
+    ['hotmaail.com', 'hotmail.com'],
+    ['hotmai.com', 'hotmail.com'],
+    ['hotmaiil.com', 'hotmail.com'],
+    ['hotmail.con', 'hotmail.com'],
+    ['hotmail.co', 'hotmail.com'],
+    ['hotmail.cm', 'hotmail.com'],
+    ['hotmaill.com', 'hotmail.com'],
+    ['hotmail.net', 'hotmail.com'],
+    ['hotmail.ocm', 'hotmail.com'],
+    ['hotmailt.com', 'hotmail.com'],
+    ['hotmal.com', 'hotmail.com'],
+    ['hotmial.com', 'hotmail.com'],
+    ['hotmiail.com', 'hotmail.com'],
+    ['hotmil.co', 'hotmail.com'],
+    ['hotmil.com', 'hotmail.com'],
+    ['hotmmail.com', 'hotmail.com'],
+    ['hotmqil.com', 'hotmail.com'],
+    ['hotmsil.com', 'hotmail.com'],
+    ['htoamil.com', 'hotmail.com'],
+    ['htomail.com', 'hotmail.com'],
+    ['hoymail.com', 'hotmail.com'],
+    ['hootmail.com', 'hotmail.com'],
+    ['hotmi.com', 'hotmail.com'],
+    ['hotmail.com.com', 'hotmail.com'],
+    ['hotma.com', 'hotmail.com'],
+    ['hotmali.com', 'hotmail.com'],
+    ['hotrmail.com', 'hotmail.com'],
+    ['hotmail.cim', 'hotmail.com'],
+    ['hotmail.cin', 'hotmail.com'],
+    ['bol.com', 'bol.com.br'],
+    ['yahoo.coom', 'yahoo.com'],
+    ['yahoo.comm', 'yahoo.com'],
+    ['yahoo.con', 'yahoo.com'],
+    ['yaho.com', 'yahoo.com'],
+    ['protonmil.com', 'protonmail.com'],
+    ['outlok.com', 'outlook.com'],
+    ['outlook.con', 'outlook.com'],
+    ['outloo.com', 'outlook.com'],
+    ['outlook.cm', 'outlook.com'],
+    ['outlook.comm', 'outlook.com'],
+    ['outlook.co', 'outlook.com'],
+    ['prontomail.com', 'protonmail.com'],
+    ['zipmail.combr', 'zipmail.com.br'],
+  ];
+
+  for (const domain of domains) {
+    const wrongDomain = domain[0];
+    const rightDomain = domain[1];
+
+    if (typedDomain === wrongDomain) {
+      return `${userName}@${rightDomain}`;
+    }
+  }
+
+  return false;
+}

--- a/tests/integration/api/v1/email-confirmation/patch.test.js
+++ b/tests/integration/api/v1/email-confirmation/patch.test.js
@@ -1,0 +1,408 @@
+import fetch from 'cross-fetch';
+import { version as uuidVersion } from 'uuid';
+import orchestrator from 'tests/orchestrator.js';
+import user from 'models/user.js';
+import emailConfirmation from 'models/email-confirmation.js';
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.dropAllTables();
+  await orchestrator.runPendingMigrations();
+  await orchestrator.deleteAllEmails();
+});
+
+describe('PATCH /api/v1/email-confirmation', () => {
+  describe('Anonymous user', () => {
+    test('With blank body', async () => {
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/email-confirmation`, {
+        method: 'PATCH',
+      });
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+
+      expect(responseBody).toStrictEqual({
+        name: 'ValidationError',
+        message: 'Body enviado deve ser do tipo Object.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        status_code: 400,
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
+        key: 'object',
+        type: 'object.base',
+      });
+    });
+
+    test('With a null token', async () => {
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/email-confirmation`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+
+        body: JSON.stringify({
+          token_id: null,
+        }),
+      });
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+
+      expect(responseBody).toStrictEqual({
+        name: 'ValidationError',
+        message: '"token_id" deve ser do tipo String.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        status_code: 400,
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
+        key: 'token_id',
+        type: 'string.base',
+      });
+    });
+
+    test('With a malformatted number token', async () => {
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/email-confirmation`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+
+        body: JSON.stringify({
+          token_id: 10000000,
+        }),
+      });
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+
+      expect(responseBody).toStrictEqual({
+        name: 'ValidationError',
+        message: '"token_id" deve ser do tipo String.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        status_code: 400,
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
+        key: 'token_id',
+        type: 'string.base',
+      });
+    });
+
+    test('With an empty string token', async () => {
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/email-confirmation`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+
+        body: JSON.stringify({
+          token_id: '',
+        }),
+      });
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+
+      expect(responseBody).toStrictEqual({
+        name: 'ValidationError',
+        message: '"token_id" não pode estar em branco.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        status_code: 400,
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
+        key: 'token_id',
+        type: 'string.empty',
+      });
+    });
+
+    test('With a malformatted string token', async () => {
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/email-confirmation`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+
+        body: JSON.stringify({
+          token_id: '10000000',
+        }),
+      });
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+
+      expect(responseBody).toStrictEqual({
+        name: 'ValidationError',
+        message: '"token_id" deve possuir um token UUID na versão 4.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        status_code: 400,
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
+        key: 'token_id',
+        type: 'string.guid',
+      });
+    });
+
+    test('With a fresh and valid token', async () => {
+      // 1) UPDATE USER EMAIL
+      const defaultUser = await orchestrator.createUser({
+        email: 'fresh.valid.token@email.com',
+      });
+      await orchestrator.activateUser(defaultUser);
+      const defaultUserSession = await orchestrator.createSession(defaultUser);
+
+      const updateUserResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
+        method: 'patch',
+        headers: {
+          'Content-Type': 'application/json',
+          cookie: `session_id=${defaultUserSession.token}`,
+        },
+
+        body: JSON.stringify({
+          email: 'new@email.com',
+        }),
+      });
+
+      expect(updateUserResponse.status).toEqual(200);
+
+      // Attention: it should not update the email in the database
+      // before the user clicks on the confirmation link sent to the new email.
+      // See `/tests/integration/email-confirmation` for more details.
+      const userInDatabaseCheck1 = await user.findOneById(defaultUser.id);
+      expect(userInDatabaseCheck1.email).toEqual('fresh.valid.token@email.com');
+
+      // 2) RECEIVE CONFIRMATION EMAIL
+      const confirmationEmail = await orchestrator.getLastEmail();
+
+      const tokenObjectInDatabase = await emailConfirmation.findOneTokenByUserId(defaultUser.id);
+      const emailConfirmationPageEndpoint = emailConfirmation.getEmailConfirmationPageEndpoint(
+        tokenObjectInDatabase.id
+      );
+
+      expect(confirmationEmail.sender).toEqual('<contato@tabnews.com.br>');
+      expect(confirmationEmail.recipients).toEqual(['<new@email.com>']);
+      expect(confirmationEmail.subject).toEqual('Confirme seu novo email');
+      expect(confirmationEmail.text.includes(defaultUser.username)).toBe(true);
+      expect(confirmationEmail.text.includes('uma alteração de email foi solicitada')).toBe(true);
+      expect(confirmationEmail.text.includes(emailConfirmationPageEndpoint)).toBe(true);
+
+      // 3) USE CONFIRMATION TOKEN
+      const emailConfirmationResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/email-confirmation`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+
+        body: JSON.stringify({
+          token_id: tokenObjectInDatabase.id,
+        }),
+      });
+
+      const emailConfirmationResponseBody = await emailConfirmationResponse.json();
+
+      expect(emailConfirmationResponse.status).toEqual(200);
+
+      expect(emailConfirmationResponseBody).toStrictEqual({
+        id: emailConfirmationResponseBody.id,
+        used: true,
+        expires_at: tokenObjectInDatabase.expires_at.toISOString(),
+        created_at: tokenObjectInDatabase.created_at.toISOString(),
+        updated_at: emailConfirmationResponseBody.updated_at,
+      });
+
+      expect(uuidVersion(emailConfirmationResponseBody.id)).toEqual(4);
+      expect(emailConfirmationResponseBody.updated_at > tokenObjectInDatabase.updated_at.toISOString()).toBe(true);
+
+      // 4) CHECK IF EMAIL WAS UPDATED
+      const userInDatabaseCheck2 = await user.findOneById(defaultUser.id);
+      expect(userInDatabaseCheck2.email).toEqual('new@email.com');
+    });
+
+    test('With an already used, but valid token', async () => {
+      const defaultUser = await orchestrator.createUser({
+        email: 'already.used.token@email.com',
+      });
+
+      const emailConfirmationToken = await emailConfirmation.create(defaultUser.id, 'idempotent@patch.com');
+
+      const firstTryResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/email-confirmation`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+
+        body: JSON.stringify({
+          token_id: emailConfirmationToken.id,
+        }),
+      });
+
+      const userInDatabase = await user.findOneById(defaultUser.id);
+      expect(userInDatabase.email).toEqual('idempotent@patch.com');
+
+      const firstTryResponseBody = await firstTryResponse.json();
+
+      const secondTryResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/email-confirmation`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+
+        body: JSON.stringify({
+          token_id: emailConfirmationToken.id,
+        }),
+      });
+
+      const secondTryResponseBody = await secondTryResponse.json();
+
+      expect(secondTryResponse.status).toEqual(200);
+
+      expect(secondTryResponseBody).toStrictEqual({
+        id: emailConfirmationToken.id,
+        used: true,
+        expires_at: emailConfirmationToken.expires_at.toISOString(),
+        created_at: emailConfirmationToken.created_at.toISOString(),
+        updated_at: secondTryResponseBody.updated_at,
+      });
+
+      expect(secondTryResponseBody.updated_at > emailConfirmationToken.updated_at.toISOString()).toBe(true);
+
+      expect(firstTryResponse.status).toEqual(secondTryResponse.status);
+      expect(firstTryResponseBody).toEqual(secondTryResponseBody);
+    });
+
+    test('With an already used email (before creating the token)', async () => {
+      const firstUser = await orchestrator.createUser({
+        email: 'validation.error@before.com',
+      });
+      await orchestrator.activateUser(firstUser);
+      const firstUserSession = await orchestrator.createSession(firstUser);
+
+      const secondUser = await orchestrator.createUser({
+        email: 'other.user.email@before.com',
+      });
+
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${firstUser.username}`, {
+        method: 'patch',
+        headers: {
+          'Content-Type': 'application/json',
+          cookie: `session_id=${firstUserSession.token}`,
+        },
+
+        body: JSON.stringify({
+          email: 'other.user.email@before.com',
+        }),
+      });
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+
+      expect(responseBody).toStrictEqual({
+        name: 'ValidationError',
+        message: 'O email informado já está sendo usado.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        status_code: 400,
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:USER:VALIDATE_UNIQUE_EMAIL:ALREADY_EXISTS',
+        key: 'email',
+      });
+
+      const userInDatabaseCheck1 = await user.findOneById(firstUser.id);
+      expect(userInDatabaseCheck1.email).toEqual('validation.error@before.com');
+    });
+
+    test('With an already used email (after creating the token)', async () => {
+      const firstUser = await orchestrator.createUser({
+        email: 'validation.error@after.com',
+      });
+
+      const emailConfirmationToken = await emailConfirmation.create(firstUser.id, 'other.user.email@after.com');
+
+      const secondUser = await orchestrator.createUser({
+        email: 'other.user.email@after.com',
+      });
+
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/email-confirmation`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+
+        body: JSON.stringify({
+          token_id: emailConfirmationToken.id,
+        }),
+      });
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+
+      expect(responseBody).toStrictEqual({
+        name: 'ValidationError',
+        message: 'O email informado já está sendo usado.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        status_code: 400,
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:USER:VALIDATE_UNIQUE_EMAIL:ALREADY_EXISTS',
+        key: 'email',
+      });
+
+      const userInDatabaseCheck1 = await user.findOneById(firstUser.id);
+      expect(userInDatabaseCheck1.email).toEqual('validation.error@after.com');
+    });
+
+    test('With an expired token', async () => {
+      const defaultUser = await orchestrator.createUser({
+        email: 'expired.token@email.com',
+      });
+
+      const emailConfirmationToken = await emailConfirmation.create(
+        defaultUser.id,
+        'expired.token.will.reject@email.com'
+      );
+
+      await emailConfirmation.update(emailConfirmationToken.id, {
+        expires_at: new Date(Date.now() - 1000),
+      });
+
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/email-confirmation`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+
+        body: JSON.stringify({
+          token_id: emailConfirmationToken.id,
+        }),
+      });
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(404);
+
+      expect(responseBody).toStrictEqual({
+        name: 'NotFoundError',
+        message: 'O token de confirmação de email utilizado não foi encontrado no sistema ou expirou.',
+        action: 'Solicite uma nova alteração de email.',
+        status_code: 404,
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:EMAIL_CONFIRMATION:FIND_ONE_VALID_TOKEN_BY_ID:NOT_FOUND',
+        key: 'token_id',
+      });
+
+      const userInDatabaseCheck1 = await user.findOneById(defaultUser.id);
+      expect(userInDatabaseCheck1.email).toEqual('expired.token@email.com');
+    });
+  });
+});


### PR DESCRIPTION
Este PR implementa a primeira versão da página de Editar Perfil. Tem muito o que evoluir ainda, mas já fornece de uma forma fácil a alteração do `username` e `email`. Ainda nessa Milestone irei incluir uma opção de desabilitar as notificações por email, e numa próxima Milestone (ou se alguém quiser fazer nessa), integrar na página a alteração de senha.

O vídeo abaixo mostra:

1. Opção **Editar perfil** habilitada.
2. Editando o nome de usuário.
3. Editando email e passando pelo fluxo de Confirmação de email.
4. Não foi implementado por enquanto Alteração de senha, mas há um link que redireciona para o fluxo de Recuperação de Senha e que auto preenche o `username` por conveniência.

https://user-images.githubusercontent.com/4248081/188969868-00920564-7163-44a3-8a4b-3494b76eb26c.mov

## Testes em Ambiente de Homologação

Você pode testar em ambiente de homologação pela URL https://tabnews-git-user-profile-tabnews.vercel.app/perfil porém **não irá conseguir alterar o email** enquanto a migration deste PR não for rodada 🤝 