### PR TITLE
Opção de habilitar/desabilitar notificações por email

### DIFF
--- a/infra/migrations/1662663951003_alter-table-users-add-notifications.js
+++ b/infra/migrations/1662663951003_alter-table-users-add-notifications.js
@@ -1,0 +1,11 @@
+exports.up = async (pgm) => {
+  await pgm.addColumns('users', {
+    notifications: {
+      type: 'boolean',
+      notNull: true,
+      default: true,
+    },
+  });
+};
+
+exports.down = false;

--- a/models/authorization.js
+++ b/models/authorization.js
@@ -95,6 +95,7 @@ function filterInput(user, feature, input) {
       username: input.username,
       email: input.email,
       password: input.password,
+      notifications: input.notifications,
     };
   }
 
@@ -194,6 +195,7 @@ function filterOutput(user, feature, output) {
         id: output.id,
         username: output.username,
         email: output.email,
+        notifications: output.notifications,
         features: output.features,
         tabcoins: output.tabcoins,
         tabcash: output.tabcash,

--- a/models/notification.js
+++ b/models/notification.js
@@ -16,6 +16,11 @@ async function sendReplyEmailToParentUser(createdContent) {
 
   if (parentContent.owner_id !== secureCreatedContent.owner_id) {
     const parentContentUser = await user.findOneById(parentContent.owner_id);
+
+    if (parentContentUser.notifications === false) {
+      return;
+    }
+
     const childContendUrl = getChildContendUrl(secureCreatedContent);
     const rootContent = await content.findRootContent({
       where: {

--- a/models/user.js
+++ b/models/user.js
@@ -409,26 +409,28 @@ async function update(username, postedUserData, options = {}) {
         UPDATE
           users
         SET
-          username = $1,
-          email = $2,
-          password = $3,
+          username = $2,
+          email = $3,
+          password = $4,
+          notifications = $5,
           updated_at = (now() at time zone 'utc')
         WHERE
-          id = $4
+          id = $1
         RETURNING
           *
       ;`,
       values: [
+        currentUser.id,
         userWithUpdatedValues.username,
         userWithUpdatedValues.email,
         userWithUpdatedValues.password,
-        currentUser.id,
+        userWithUpdatedValues.notifications,
       ],
     };
 
     const results = await database.query(query);
-
     const updatedUser = results.rows[0];
+
     updatedUser.tabcoins = await balance.getTotal({
       balanceType: 'user:tabcoin',
       recipientId: updatedUser.id,
@@ -447,6 +449,7 @@ async function validatePatchSchema(postedUserData) {
     username: 'optional',
     email: 'optional',
     password: 'optional',
+    notifications: 'optional',
   });
 
   return cleanValues;

--- a/models/validator.js
+++ b/models/validator.js
@@ -148,6 +148,20 @@ const schemas = {
     });
   },
 
+  notifications: function () {
+    return Joi.object({
+      notifications: Joi.boolean()
+        .invalid(null)
+        .when('$required.notifications', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
+        .messages({
+          'any.required': `"notifications" é um campo obrigatório.`,
+          'string.empty': `"notifications" não pode estar em branco.`,
+          'boolean.base': `"notifications" deve ser do tipo Boolean.`,
+          'any.invalid': `"notifications" possui o valor inválido "null".`,
+        }),
+    });
+  },
+
   token_id: function () {
     return Joi.object({
       token_id: Joi.string()

--- a/pages/api/v1/users/[username]/index.public.js
+++ b/pages/api/v1/users/[username]/index.public.js
@@ -51,6 +51,7 @@ function patchValidationHandler(request, response, next) {
     username: 'optional',
     email: 'optional',
     password: 'optional',
+    notifications: 'optional',
   });
 
   request.body = cleanBodyValues;

--- a/pages/perfil/index.public.js
+++ b/pages/perfil/index.public.js
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { DefaultLayout, useUser, Link } from 'pages/interface/index.js';
-import { FormControl, Box, Heading, Button, TextInput, Flash, useConfirm } from '@primer/react';
+import { FormControl, Box, Heading, Button, TextInput, Checkbox, Flash, useConfirm } from '@primer/react';
 
 export default function EditProfile() {
   return (
@@ -23,6 +23,7 @@ function EditProfileForm() {
 
   const usernameRef = useRef('');
   const emailRef = useRef('');
+  const notificationsRef = useRef('');
 
   useEffect(() => {
     if (router && !user && !userIsLoading) {
@@ -32,6 +33,7 @@ function EditProfileForm() {
     if (user && !userIsLoading) {
       usernameRef.current.value = user.username;
       emailRef.current.value = user.email;
+      notificationsRef.current.checked = user.notifications;
     }
   }, [user, router, userIsLoading]);
 
@@ -53,6 +55,7 @@ function EditProfileForm() {
 
     const username = usernameRef.current.value;
     const email = emailRef.current.value;
+    const notifications = notificationsRef.current.checked;
 
     setIsLoading(true);
     setErrorObject(undefined);
@@ -88,6 +91,10 @@ function EditProfileForm() {
 
     if (user.email !== email) {
       payload.email = email;
+    }
+
+    if (user.notifications !== notifications) {
+      payload.notifications = notifications;
     }
 
     if (Object.keys(payload).length === 0) {
@@ -168,6 +175,7 @@ function EditProfileForm() {
             <FormControl.Caption>Dica: use somente letras e números, por exemplo: nomeSobrenome4 </FormControl.Caption>
           )}
         </FormControl>
+
         <FormControl id="email" disabled={emailDisabled}>
           <FormControl.Label>Email</FormControl.Label>
           <TextInput
@@ -208,6 +216,21 @@ function EditProfileForm() {
 
           {errorObject?.key === 'email' && errorObject?.type === 'confirmation' && (
             <FormControl.Validation variant="warning">{errorObject.message}</FormControl.Validation>
+          )}
+        </FormControl>
+
+        <FormControl id="notifications">
+          <FormControl.Label>Receber notificações por email</FormControl.Label>
+
+          <Checkbox
+            ref={notificationsRef}
+            onChange={clearErrors}
+            name="notifications"
+            aria-label="Você deseja receber notificações?"
+          />
+
+          {errorObject?.key === 'notifications' && (
+            <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
           )}
         </FormControl>
 

--- a/tests/integration/api/v1/user/get.test.js
+++ b/tests/integration/api/v1/user/get.test.js
@@ -46,6 +46,7 @@ describe('GET /api/v1/user', () => {
         id: defaultUser.id,
         username: defaultUser.username,
         email: defaultUser.email,
+        notifications: defaultUser.notifications,
         features: defaultUser.features,
         tabcoins: defaultUser.tabcoins,
         tabcash: defaultUser.tabcash,


### PR DESCRIPTION
Este PR adiciona a propriedade `notifications` ao objeto `user` e que pode conter o valor `true` (padrão) ou `false`. Esta propriedade é usada para o usuário decidir receber ou não a notificação por email de respostas em suas publicações. Junto deste PR também foi atualizada a página `/perfil` para o usuário conseguir controlar isso pelo client web.

E por hora, `notifications` é uma propriedade **privada**, ou seja, não será retornada no endpoint público do usuário que fica em `/api/v1/users/[username]` e só pode ser acessada pelo endpoint `/api/v1/user` que requer autenticação.

Em paralelo, eu fiquei aqui pensando em como já aproveitar essa migration para considerar planos futuros, por exemplo, outros tipos de notificação como `SMS` ou `Push`, mas vi que virou uma otimização prematura e melhor deixar para quando o sistema final de notificação for construído, onde eu imagino que o controle disso não ficará no objeto `user` e sim num outro objeto que conseguirá controlar a notificação de uma forma mais fragmentada, incluindo assinar por notificações de conteúdos de outras pessoas ou até qualquer tipo de publicação de qualquer outra pessoa.

---

Esta opção já pode ser vista na página [`/perfil`](https://tabnews-git-user-notifications-tabnews.vercel.app/perfil) em Homologação, mas não poderá ser utilizada enquanto não rodarmos a **migration** que está nesse PR.