### PR TITLE
Adiciona lista de contribuidores no `README` e página `/status`

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,9 @@ npm run commit
 ## Diário de Desenvolvimento
 
 - [Acessar o diário](https://github.com/filipedeschamps/tabnews.com.br/wiki)
+
+## Contribuidores
+
+<a href="https://github.com/filipedeschamps/tabnews.com.br/graphs/contributors">
+  <img src="https://contributors-img.web.app/image?repo=filipedeschamps/tabnews.com.br&max=500" alt="Lista de contribuidores" width="100%"/>
+</a>

--- a/pages/status/index.public.js
+++ b/pages/status/index.public.js
@@ -165,6 +165,20 @@ export default function Page() {
             </Box>
           )}
         </Box>
+
+        <Box>
+          <h2>Contribuidores</h2>
+
+          <a href="https://github.com/filipedeschamps/tabnews.com.br/graphs/contributors">
+            <picture>
+              <img
+                src="https://contributors-img.web.app/image?repo=filipedeschamps/tabnews.com.br&max=500"
+                alt="Lista de contribuidores"
+                width="100%"
+              />
+            </picture>
+          </a>
+        </Box>
       </Box>
     </DefaultLayout>
   );


### PR DESCRIPTION
**Atenção:** isto só irá funcionar quando o repositório estiver **público**. E quando estiver, todo novo contribuidor do projeto terá sua imagem de perfil do GitHub automaticamente inserida na lista.

Em paralelo, fiz uma simulação usando o https://github.com/filipedeschamps/doom-fire-algorithm e ficará mais ou menos assim:

![image](https://user-images.githubusercontent.com/4248081/189497533-f8b28639-75b5-45ef-83a6-ed3fc286e0c9.png)
