### PR TITLE
Corrige as rotas `beta` para utilizarem as queries corretas

### DIFF
--- a/models/content.js
+++ b/models/content.js
@@ -22,8 +22,8 @@ async function findAll(values = {}, options = {}) {
   }
 
   if (options.strategy === 'relevant') {
-    if (values.beta) {
-      query.text = queryRankedContent_beta['beta' + values.beta];
+    if (options.beta) {
+      query.text = queryRankedContent_beta[options.beta];
     } else {
       query.text = queryRankedContent;
     }

--- a/models/queries_beta.js
+++ b/models/queries_beta.js
@@ -1,4 +1,4 @@
-export const beta1 = `
+const Beta1 = `
     WITH
     latest_published_root_contents AS (
         SELECT
@@ -183,7 +183,7 @@ export const beta1 = `
             published_at DESC;
 `;
 
-export const beta2 = `
+const Beta2 = `
     WITH
     latest_published_root_contents AS (
         SELECT
@@ -320,6 +320,6 @@ export const beta2 = `
 `;
 
 export default Object.freeze({
-  beta1,
-  beta2,
+  Beta1,
+  Beta2,
 });

--- a/pages/interface/components/Header/index.js
+++ b/pages/interface/components/Header/index.js
@@ -4,6 +4,7 @@ import { CgTab } from 'react-icons/cg';
 import { useUser } from 'pages/interface/index.js';
 import { HeaderLink, Link } from 'pages/interface/components/Link';
 import { useRouter } from 'next/router';
+import queryRankedContent_beta from 'models/queries_beta';
 
 export default function HeaderComponent() {
   const { user, isLoading, logout } = useUser();
@@ -33,21 +34,24 @@ export default function HeaderComponent() {
       </Header.Item>
 
       <Header.Item>
-        <HeaderLink href="/relevantes_beta/1" sx={query.beta === '1' && activeLinkStyle}>
-          Beta1
-        </HeaderLink>
-      </Header.Item>
-
-      <Header.Item>
-        <HeaderLink href="/relevantes_beta/2" sx={query.beta === '2' && activeLinkStyle}>
-          Beta2
+        <HeaderLink href="/recentes" sx={pathname.startsWith('/recentes') && activeLinkStyle}>
+          Recentes
         </HeaderLink>
       </Header.Item>
 
       <Header.Item full>
-        <HeaderLink href="/recentes" sx={pathname.startsWith('/recentes') && activeLinkStyle}>
-          Recentes
-        </HeaderLink>
+        <ActionMenu>
+          <ActionMenu.Button>{query.beta || 'Beta'}</ActionMenu.Button>
+          <ActionMenu.Overlay>
+            <ActionList>
+              {Object.keys(queryRankedContent_beta).map((beta) => (
+                <ActionList.LinkItem as={Link} key={beta} href={`/relevantes_beta/${beta}`}>
+                  {beta}
+                </ActionList.LinkItem>
+              ))}
+            </ActionList>
+          </ActionMenu.Overlay>
+        </ActionMenu>
       </Header.Item>
 
       {!isLoading && !user && (

--- a/pages/relevantes_beta/[beta]/index.public.js
+++ b/pages/relevantes_beta/[beta]/index.public.js
@@ -4,6 +4,7 @@ import content from 'models/content.js';
 import authorization from 'models/authorization.js';
 import validator from 'models/validator.js';
 import { FaTree } from 'react-icons/fa';
+import queryRankedContent_beta from 'models/queries_beta';
 
 export default function Home({ contentListFound, pagination, beta }) {
   return (
@@ -12,8 +13,8 @@ export default function Home({ contentListFound, pagination, beta }) {
         <ContentList
           contentList={contentListFound}
           pagination={pagination}
-          paginationBasePath="/relevantes_beta/1/pagina"
-          revalidatePath={`/relevantes_beta/${beta}/pagina`}
+          paginationBasePath={`/relevantes_beta/${beta}/pagina`}
+          revalidatePath="/api/v1/contents?strategy=relevant"
           emptyStateProps={{
             title: 'Nenhum conteúdo encontrado',
             description: 'Quando eu cheguei era tudo mato...',
@@ -26,8 +27,18 @@ export default function Home({ contentListFound, pagination, beta }) {
 }
 
 export async function getStaticPaths() {
+  const paths = [];
+
+  Object.keys(queryRankedContent_beta).forEach((beta) => {
+    paths.push({
+      params: {
+        beta: beta,
+      },
+    });
+  });
+
   return {
-    paths: [{ params: { beta: '1' } }, { params: { beta: '2' } }],
+    paths,
     fallback: 'blocking',
   };
 }
@@ -35,6 +46,13 @@ export async function getStaticPaths() {
 export async function getStaticProps(context) {
   const userTryingToGet = user.createAnonymous();
   const beta = context.params.beta;
+
+  if (!queryRankedContent_beta[beta]) {
+    return {
+      notFound: true,
+      revalidate: 1,
+    };
+  }
 
   context.params = context.params ? context.params : {};
 

--- a/pages/relevantes_beta/[beta]/pagina/[page]/index.public.js
+++ b/pages/relevantes_beta/[beta]/pagina/[page]/index.public.js
@@ -3,6 +3,7 @@ import user from 'models/user.js';
 import content from 'models/content.js';
 import authorization from 'models/authorization.js';
 import validator from 'models/validator.js';
+import queryRankedContent_beta from 'models/queries_beta';
 
 export default function Home({ contentListFound, pagination, beta }) {
   return (
@@ -20,13 +21,24 @@ export default function Home({ contentListFound, pagination, beta }) {
 }
 
 export async function getStaticPaths() {
+  const paths = [];
+
+  Object.keys(queryRankedContent_beta).forEach((beta) => {
+    paths.push({
+      params: {
+        beta: beta,
+        page: '2',
+      },
+    });
+    paths.push({
+      params: {
+        beta: beta,
+        page: '3',
+      },
+    });
+  });
   return {
-    paths: [
-      { params: { beta: '1', page: '2' } },
-      { params: { beta: '1', page: '3' } },
-      { params: { beta: '2', page: '2' } },
-      { params: { beta: '2', page: '3' } },
-    ],
+    paths,
     fallback: 'blocking',
   };
 }
@@ -34,6 +46,13 @@ export async function getStaticPaths() {
 export async function getStaticProps(context) {
   const userTryingToGet = user.createAnonymous();
   const beta = context.params.beta;
+
+  if (!queryRankedContent_beta[beta]) {
+    return {
+      notFound: true,
+      revalidate: 1,
+    };
+  }
 
   context.params = context.params ? context.params : {};
 


### PR DESCRIPTION
Além de corrigir as rotas para utilizarem as queries corretas, agora está mais fácil criar novas variações de query, pois basta incluí-las no arquivo `queries_beta.js` que ela já será incluída no menu `Beta` do `Header`. 