### PR TITLE
Query de ranqueamento Beta3

### DIFF
--- a/models/queries_beta.js
+++ b/models/queries_beta.js
@@ -319,7 +319,168 @@ const Beta2 = `
             published_at DESC;
 `;
 
+const Beta3 = `
+    WITH
+    latest_published_root_contents AS (
+        SELECT
+            contents.id,
+            contents.owner_id,
+            contents.parent_id,
+            contents.slug,
+            contents.title,
+            contents.status,
+            contents.source_url,
+            contents.created_at,
+            contents.updated_at,
+            contents.published_at,
+            contents.deleted_at,
+            get_current_balance('content:tabcoin', contents.id) as tabcoins
+        FROM contents
+        WHERE 
+            parent_id IS NULL
+            AND status = 'published'
+            AND published_at > NOW() - INTERVAL '1 week'
+    ),
+    ranked_published_root_contents AS (
+        SELECT 
+            *,
+            COUNT(*) OVER()::INTEGER as total_rows
+        FROM latest_published_root_contents
+        WHERE tabcoins >= 0
+        ORDER BY
+            tabcoins DESC,
+            published_at DESC
+    ),
+    group_1 AS (
+        SELECT
+            *,
+            1 as rank_group
+        FROM ranked_published_root_contents
+        WHERE
+            published_at > NOW() - INTERVAL '36 hours'
+            AND tabcoins > 11
+        ORDER BY
+            published_at DESC
+        LIMIT 10
+    ),
+    group_2 AS (
+        SELECT * FROM group_1
+        UNION ALL
+        SELECT
+            *,
+            2 as rank_group
+        FROM ranked_published_root_contents
+        WHERE
+            published_at > NOW() - INTERVAL '24 hours'
+            AND tabcoins > 6
+            AND id NOT IN (SELECT id FROM group_1)
+        ORDER BY
+            rank_group,
+            published_at DESC
+        LIMIT 20
+    ),
+    group_3 AS (
+        (SELECT 
+            *,
+            3 as rank_group
+        FROM ranked_published_root_contents
+        WHERE
+            published_at > NOW() - INTERVAL '12 hours'
+            AND id NOT IN (SELECT id FROM group_2)
+        ORDER BY
+            published_at DESC
+        LIMIT 5)
+        UNION ALL
+        SELECT * FROM group_2
+    ),
+    group_4 AS (
+        (SELECT 
+            *,
+            4 as rank_group
+        FROM ranked_published_root_contents
+        WHERE
+            published_at > NOW() - INTERVAL '3 days'
+            AND id NOT IN (SELECT id FROM group_3)
+        ORDER BY
+            published_at DESC
+        LIMIT 10)
+        UNION ALL
+        SELECT * FROM group_3
+    ),
+    group_5 AS (
+        (SELECT 
+            *,
+            5 as rank_group
+        FROM ranked_published_root_contents
+        WHERE
+            published_at > NOW() - INTERVAL '12 hours'
+            AND id NOT IN (SELECT id FROM group_4)
+        ORDER BY
+            published_at DESC
+        LIMIT 10)      
+        UNION ALL
+        SELECT * FROM group_4
+    ),
+    ranked AS (
+        SELECT * FROM group_5
+        UNION ALL
+        SELECT
+            *,
+            6 as rank_group
+        FROM ranked_published_root_contents
+        WHERE id NOT IN (SELECT id FROM group_5)
+        ORDER BY
+            rank_group,
+            tabcoins DESC,
+            published_at DESC
+        LIMIT $1
+        OFFSET $2
+    )
+    SELECT
+        ranked.id,
+        ranked.owner_id,
+        ranked.parent_id,
+        ranked.slug,
+        ranked.title,
+        ranked.status,
+        ranked.source_url,
+        ranked.created_at,
+        ranked.updated_at,
+        ranked.published_at,
+        ranked.deleted_at,
+        ranked.tabcoins,
+        ranked.rank_group,
+        ranked.total_rows,
+        users.username as owner_username,
+        (WITH RECURSIVE children AS
+            (SELECT id,
+                 parent_id
+            FROM contents as all_contents
+            WHERE
+                all_contents.id = ranked.id
+                AND all_contents.status = 'published'
+            UNION ALL
+            SELECT
+                all_contents.id,
+                all_contents.parent_id
+            FROM contents as all_contents
+            INNER JOIN children ON all_contents.parent_id = children.id
+            WHERE all_contents.status = 'published'
+            )
+            SELECT count(children.id)::integer
+            FROM children
+            WHERE children.id NOT IN (ranked.id)
+            ) as children_deep_count
+        FROM ranked
+        INNER JOIN users ON ranked.owner_id = users.id
+        ORDER BY
+            rank_group,
+            tabcoins DESC,
+            published_at DESC;
+`;
+
 export default Object.freeze({
   Beta1,
   Beta2,
+  Beta3,
 });


### PR DESCRIPTION
Mais uma proposta de query de ranqueamento baseada nas considerações a seguir.

Utilizando [intervalo de confiança](https://en.wikipedia.org/wiki/Binomial_proportion_confidence_interval), foram estimadas as quantidades de votos positivos e negativos para podermos afirmar com 95% de certeza qual é a relevância do conteúdo:

![image](https://user-images.githubusercontent.com/77860630/193922612-c3bd6061-18a9-4a9d-a002-da6604e62981.png)

Obs.: Os votos positivos começam em 1 na tabela, pois os conteúdos sempre começam com 1 TabCoin, mas o cálculo foi efetuado com a quantidade real de votos, ou seja, de 0 a 19 positivos e de 0 a 10 negativos.

Por enquanto não estamos computando separadamente os votos positivos e negativos, portanto foi feita a seguinte aproximação em que só temos acesso à faixa em L de -10 a +20:

![image](https://user-images.githubusercontent.com/77860630/193922732-9b60c75c-2483-4586-9a26-468392490ad0.png)

Obs.: Só temos acesso ao saldo, mas não podemos ignorar o fato de que um mesmo conteúdo pode ter recebido votos positivos e negativos. Isso é só uma aproximação inicial para a próxima versão de ranqueamento, mas a versão correta irá utilizar os valores reais de votos positivos e negativos (não apenas o saldo).

Como podemos ver, com poucos votos não dá pra afirmar com muita certeza se um conteúdo é relevante ou não. Então seria interessante os conteúdos novos surgirem no meio do ranking e subirem ou descerem conforme o passar do tempo e das qualificações. Com isso em mente, montamos a tabela abaixo com seis grupos divididos de acordo com a idade dos conteúdos e com a sua pontuação.

Então deixamos a faixa 3 para os 5 conteúdos recém postados, ou seja, que ainda não temos como classificar, e a faixa 5 para os demais conteúdos que excederem aos 5 da faixa 3. Essa faixa 5 só será ocupada quando muitos conteúdos novos forem postados e permanecerem sem qualificação.

Grupo | Saldo mín. | Tempo máx. | Qtd. reservada | Qtd. máx. | Excedente para para o grupo
-- | -- | -- | -- | -- | --
1 | 12 | 36 horas | 10 mais novos | 10 | 4
2 | 7 | 1 dia | 10 mais novos | 20 | 4
3 | 0 | 12 horas | 5 mais novos | 5 | 5
4 | 12 | 3 dias | 10 mais novos | 10 | 6
5 | 0 | 12 horas | 10 mais novos | 10 | 6
6 | 0 | 1 semana | - | - | -

Outra forma de enxergar os dados da tabela acima:

![image](https://user-images.githubusercontent.com/77860630/193922867-9237b9e1-e636-4182-83a4-d59e152bd5fe.png)

Assim podemos imaginar alguns percursos diferentes que conteúdos postados ao mesmo tempo poderiam percorrer no ranking de acordo com as qualificações:

![image](https://user-images.githubusercontent.com/77860630/193923030-85efc8da-42dc-498f-ac2f-40f70140f4c0.png)

Notem que todos iniciam no grupo 3 e sobem ou descem de acordo com os votos e o passar do tempo.
\* Esse tempo limite do Grupo 3 é dinamicamente determinado de acordo com o volume de conteúdos, mas nunca será maior do que 12h.

Todos esses parâmetros podem ser ajustados, mas o mais indicado é ajustar somente os tempos, caso não estejam se comportando de acordo.


