### PR TITLE
fix(rank_beta3): group_4 where tabcoins > 11

### DIFF
--- a/models/queries_beta.js
+++ b/models/queries_beta.js
@@ -400,6 +400,7 @@ const Beta3 = `
         FROM ranked_published_root_contents
         WHERE
             published_at > NOW() - INTERVAL '3 days'
+            AND tabcoins > 11
             AND id NOT IN (SELECT id FROM group_3)
         ORDER BY
             published_at DESC


### PR DESCRIPTION
Configura o grupo 4 do ranqueamento Beta3 para ser ocupado somente por conteúdos com mais de 11 TabCoins, de acordo com o planejado em #756.