### PR TITLE
fix(content): reset state on route change

### DIFF
--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -118,7 +118,7 @@ export default function Post({
               p: 4,
               wordWrap: 'break-word',
             }}>
-            <Content content={{ parent_id: contentFound.id }} mode="compact" />
+            <Content key={contentFound.id} content={{ parent_id: contentFound.id }} mode="compact" />
           </Box>
 
           <RenderChildrenTree childrenList={children} level={0} />


### PR DESCRIPTION
Corrige o bug de respostas recém criadas que acabam aparecendo em diferentes conteúdos (reportado em #745).

Agora o componente `Content`, que renderiza a resposta, recebe o `id` do conteúdo pai como `key`. Dessa forma o componente sempre tem seu estado reiniciado quando navegamos para diferentes conteúdos.