### PR TITLE
Enlarge header tooltips roll-over area

### DIFF
--- a/pages/interface/components/Header/index.js
+++ b/pages/interface/components/Header/index.js
@@ -51,38 +51,32 @@ export default function HeaderComponent() {
 
       {user && (
         <>
-          <Header.Item sx={{ mr: 2 }}>
-            <Box
-              sx={{
-                fontSize: 0,
-                alignItems: 'center',
-                display: 'inline-flex',
-                fontWeight: 'bold',
-              }}>
-              <Box sx={{ color: 'accent.emphasis', display: 'inline-flex' }}>
+          <Header.Item
+            sx={{
+              mr: 2,
+              fontSize: 0,
+              fontWeight: 'bold',
+            }}>
+            <Tooltip aria-label="TabCoins" direction="s" noDelay={true} wrap={true}>
+              <Box sx={{ display: 'flex', alignItems: 'center', pr: 1, color: 'accent.emphasis' }}>
                 <SquareFillIcon size={16} />
-              </Box>
-              <Tooltip aria-label="TabCoins" direction="s" noDelay={true} wrap={true}>
                 <Text sx={{ color: 'fg.onEmphasis' }}>{user.tabcoins?.toLocaleString('pt-BR')}</Text>
-              </Tooltip>
-            </Box>
+              </Box>
+            </Tooltip>
           </Header.Item>
 
-          <Header.Item>
-            <Box
-              sx={{
-                fontSize: 0,
-                alignItems: 'center',
-                display: 'inline-flex',
-                fontWeight: 'bold',
-              }}>
-              <Box sx={{ color: 'success.emphasis', display: 'inline-flex' }}>
+          <Header.Item
+            sx={{
+              mr: 2,
+              fontSize: 0,
+              fontWeight: 'bold',
+            }}>
+            <Tooltip aria-label="TabCash" direction="s" noDelay={true} wrap={true}>
+              <Box sx={{ display: 'flex', alignItems: 'center', pr: 1, color: 'success.emphasis' }}>
                 <SquareFillIcon size={16} />
-              </Box>
-              <Tooltip aria-label="TabCash" direction="s" noDelay={true} wrap={true}>
                 <Text sx={{ color: 'fg.onEmphasis' }}>{user.tabcash?.toLocaleString('pt-BR')}</Text>
-              </Tooltip>
-            </Box>
+              </Box>
+            </Tooltip>
           </Header.Item>
 
           <Header.Item sx={{ mr: 0 }}>


### PR DESCRIPTION
Quando se está logado no site, notei que a área que ativa as tooltips no canto superior direito (para explicar qual é TabCoins e qual é TabCash) era muito pequena, e passei um tempo achando até que não tinha explicação. Passei a tooltip para cobrir os quadrados coloridos também.

Antes:
![image](https://user-images.githubusercontent.com/11632081/194775994-32226641-84fd-477b-9fc0-e3d8aa97471e.png)

Depois:
![image](https://user-images.githubusercontent.com/11632081/194944901-a85b36d0-7e60-40f2-93ac-5ef4f710617b.png)

