### PR TITLE
Habilita Analytics

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,10 +6,6 @@ module.exports = {
   compiler: {
     styledComponents: true,
   },
-  i18n: {
-    locales: ['pt-br'],
-    defaultLocale: 'pt-br',
-  },
   swcMinify: false,
   async redirects() {
     return [

--- a/pages/_document.public.js
+++ b/pages/_document.public.js
@@ -1,4 +1,4 @@
-import Document from 'next/document';
+import Document, { Html, Head, Main, NextScript } from 'next/document';
 import { ServerStyleSheet } from 'styled-components';
 
 export default class MyDocument extends Document {
@@ -25,5 +25,17 @@ export default class MyDocument extends Document {
     } finally {
       sheet.seal();
     }
+  }
+
+  render() {
+    return (
+      <Html lang="pt-br">
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
   }
 }


### PR DESCRIPTION
O [Analytics](https://vercel.com/docs/concepts/analytics/audiences/quickstart) ainda está em beta, então deve possuir alguns bugs.

Um deles, que estava impedindo o funcionamento na primeira implementação #792, é que a rota `/va/scripts.js` retornava um erro `404` por alguma incompatibilidade da configuração de `i18n` no `next.config.js`.

Então removi essa configuração e, como só temos `pt-br`, deixei fixo no `_document`.