### PR TITLE
Resolve o bug da mensagem "Conteúdo apagado com sucesso"

### DIFF
--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -102,7 +102,7 @@ export default function Post({
           </Box>
 
           <Box sx={{ width: '100%', overflow: 'auto' }}>
-            <Content content={contentFound} mode="view" />
+            <Content key={contentFound.id} content={contentFound} mode="view" />
           </Box>
         </Box>
 
@@ -121,7 +121,7 @@ export default function Post({
             <Content key={contentFound.id} content={{ parent_id: contentFound.id }} mode="compact" />
           </Box>
 
-          <RenderChildrenTree childrenList={children} level={0} />
+          <RenderChildrenTree key={contentFound.id} childrenList={children} level={0} />
         </Box>
       </DefaultLayout>
     </>

--- a/pages/interface/components/Head/index.js
+++ b/pages/interface/components/Head/index.js
@@ -52,7 +52,7 @@ export function DefaultHead() {
       <link rel="manifest" href="/manifest.json" crossOrigin="use-credentials" />
       <meta name="mobile-web-app-capable" content="yes" />
       <meta name="apple-mobile-web-app-capable" content="yes" />
-      <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+      <meta httpEquiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     </NextHead>
   );
 }


### PR DESCRIPTION
Adiciona uma `key` ao conteúdo `root` e `children` (fix #808).

No `children` foi mais pensando em performance do React, mas não tem influência no bug.

Ah, mas utilizou a mesma chave para os dois e para o componente `compact`. Pode isso?

Excelente pergunta! E pode sim!

A chave precisa ser única apenas entre seus elementos irmãos. Elas não precisam ser únicas globalmente.