### PR TITLE
feat(rate-limit): added 4s upstash service timeout

### DIFF
--- a/middleware.public.js
+++ b/middleware.public.js
@@ -2,14 +2,6 @@ import { NextResponse } from 'next/server';
 import rateLimit from 'infra/rate-limit.js';
 import snakeize from 'snakeize';
 
-// TODO: Next.js still didn't fix this bug:
-// https://github.com/vercel/next.js/issues/39262
-// But this bug doesn't affect Preview and Production environments.
-// So it's time enable the middleware on all routes, but then
-// we need to skip these two tests for now as a collateral effect:
-// https://github.com/filipedeschamps/tabnews.com.br/blob/35bd984db122f30ae3ed7a3b5d7baf830669a345/tests/integration/api/v1/contents/post.test.js#L268
-// https://github.com/filipedeschamps/tabnews.com.br/blob/35bd984db122f30ae3ed7a3b5d7baf830669a345/tests/integration/api/v1/contents/%5Busername%5D/%5Bslug%5D/patch.test.js#L500
-
 export const config = {
   matcher: ['/api/:path*'],
 };


### PR DESCRIPTION
Devido ao limite de tempo de 5 segundos do middleware, esse PR cria um *timeout* e ignora o *rate-limit* se não houver uma resposta do Upstash dentro de 4 segundos.

Isso evita que a API do TabNews saia do ar em caso de problemas com o serviço Upstash, conforme conversado [aqui](https://github.com/filipedeschamps/tabnews.com.br/issues/744#issuecomment-1252939012).

Eu criei uma conta no Upstash para fazer os testes desse PR, mas fica como tarefa futura a criação de testes para o *rate-limit*.

Bora aumentar a resiliência do TabNews que o lançamento está quase aí 🚀

