### PR TITLE
Otimizações gerais em: /publicar, retentativas do banco e revalidações das páginas

### DIFF
--- a/infra/database.js
+++ b/infra/database.js
@@ -58,7 +58,7 @@ async function query(query, options = {}) {
 
 async function tryToGetNewClientFromPool() {
   const clientFromPool = await retry(newClientFromPool, {
-    retries: 12,
+    retries: 1,
     minTimeout: 150,
     maxTimeout: 5000,
     factor: 2,

--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -391,6 +391,6 @@ export async function getStaticProps(context) {
       parentContentFound: JSON.parse(JSON.stringify(secureParentContentFound)),
       contentMetadata: JSON.parse(JSON.stringify(contentMetadata)),
     },
-    revalidate: 1,
+    revalidate: 10,
   };
 }

--- a/pages/[username]/index.public.js
+++ b/pages/[username]/index.public.js
@@ -232,7 +232,7 @@ export async function getStaticProps(context) {
       userFound: JSON.parse(JSON.stringify(secureUserFound)),
     },
 
-    revalidate: 1,
+    revalidate: 10,
   };
 }
 

--- a/pages/[username]/pagina/[page]/index.public.js
+++ b/pages/[username]/pagina/[page]/index.public.js
@@ -87,7 +87,7 @@ export async function getStaticProps(context) {
       username: context.params.username,
     },
 
-    revalidate: 1,
+    revalidate: 10,
   };
 }
 

--- a/pages/api/v1/analytics/child-content-published/index.public.js
+++ b/pages/api/v1/analytics/child-content-published/index.public.js
@@ -43,6 +43,6 @@ async function getHandler(request, response) {
     };
   });
 
-  response.setHeader('Cache-Control', 'public, s-maxage=1, stale-while-revalidate');
+  response.setHeader('Cache-Control', 'public, 300, stale-while-revalidate');
   return response.status(200).json(contentsPublished);
 }

--- a/pages/api/v1/analytics/root-content-published/index.public.js
+++ b/pages/api/v1/analytics/root-content-published/index.public.js
@@ -43,6 +43,6 @@ async function getHandler(request, response) {
     };
   });
 
-  response.setHeader('Cache-Control', 'public, s-maxage=1, stale-while-revalidate');
+  response.setHeader('Cache-Control', 'public, 300, stale-while-revalidate');
   return response.status(200).json(contentsPublished);
 }

--- a/pages/api/v1/analytics/users-created/index.public.js
+++ b/pages/api/v1/analytics/users-created/index.public.js
@@ -43,6 +43,6 @@ async function getHandler(request, response) {
     };
   });
 
-  response.setHeader('Cache-Control', 'public, s-maxage=1, stale-while-revalidate');
+  response.setHeader('Cache-Control', 'public, 300, stale-while-revalidate');
   return response.status(200).json(usersCreated);
 }

--- a/pages/api/v1/status/index.public.js
+++ b/pages/api/v1/status/index.public.js
@@ -21,7 +21,7 @@ async function getHandler(request, response) {
     statusCode = 503;
   }
 
-  response.setHeader('Cache-Control', 'public, s-maxage=1, stale-while-revalidate');
+  response.setHeader('Cache-Control', 'public, s-maxage=5, stale-while-revalidate');
 
   return response.status(statusCode).json({
     updated_at: formatISO(Date.now()),

--- a/pages/index.public.js
+++ b/pages/index.public.js
@@ -64,6 +64,6 @@ export async function getStaticProps(context) {
       contentListFound: JSON.parse(JSON.stringify(secureContentValues)),
       pagination: results.pagination,
     },
-    revalidate: 1,
+    revalidate: 10,
   };
 }

--- a/pages/interface/components/Footer/index.js
+++ b/pages/interface/components/Footer/index.js
@@ -41,9 +41,7 @@ export default function Footer(props) {
             paddingX: [2, null, null, 5],
             flexWrap: 'wrap',
           }}>
-          <Link href="https://www.tabnews.com.br/filipedeschamps/quem-deseja-acesso-ao-repositorio-privado-do-tabnews">
-            Contribuir
-          </Link>
+          <Link href="https://github.com/filipedeschamps/tabnews.com.br">GitHub</Link>
           <Link href="/museu">Museu</Link>
           <Link href="https://www.tabnews.com.br/filipedeschamps/tentando-construir-um-pedaco-de-internet-mais-massa">
             Sobre

--- a/pages/pagina/[page]/index.public.js
+++ b/pages/pagina/[page]/index.public.js
@@ -65,6 +65,6 @@ export async function getStaticProps(context) {
 
     // TODO: instead of `revalidate`, understand how to use this:
     // https://nextjs.org/docs/basic-features/data-fetching/incremental-static-regeneration#using-on-demand-revalidation
-    revalidate: 1,
+    revalidate: 10,
   };
 }

--- a/pages/publicar/index.public.js
+++ b/pages/publicar/index.public.js
@@ -7,7 +7,7 @@ import { useEffect } from 'react';
 export default function Post() {
   const router = useRouter();
   const { user, isLoading } = useUser();
-  const { data: contents } = useSWR(user ? `/api/v1/contents/${user.username}?strategy=new` : null, {
+  const { data: contents } = useSWR(user ? `/api/v1/contents/${user.username}?strategy=new&per_page=1` : null, {
     revalidateOnFocus: false,
     revalidateOnReconnect: false,
   });

--- a/pages/recentes/index.public.js
+++ b/pages/recentes/index.public.js
@@ -62,6 +62,6 @@ export async function getStaticProps(context) {
       contentListFound: JSON.parse(JSON.stringify(secureContentValues)),
       pagination: results.pagination,
     },
-    revalidate: 1,
+    revalidate: 10,
   };
 }

--- a/pages/recentes/pagina/[page]/index.public.js
+++ b/pages/recentes/pagina/[page]/index.public.js
@@ -62,6 +62,6 @@ export async function getStaticProps(context) {
       contentListFound: JSON.parse(JSON.stringify(secureContentValues)),
       pagination: results.pagination,
     },
-    revalidate: 1,
+    revalidate: 10,
   };
 }

--- a/pages/status/index.public.js
+++ b/pages/status/index.public.js
@@ -5,11 +5,15 @@ import { ResponsiveContainer, BarChart, Bar, Tooltip, XAxis } from 'recharts';
 import { DefaultLayout } from 'pages/interface/index.js';
 
 export default function Page() {
-  const { data: statusObject, isLoading: statusObjectIsLoading } = useSWR('/api/v1/status', { refreshInterval: 1000 });
-  const { data: usersCreated } = useSWR('/api/v1/analytics/users-created', { refreshInterval: 30000 });
-  const { data: rootContentPublished } = useSWR('/api/v1/analytics/root-content-published', { refreshInterval: 30000 });
+  const { data: statusObject, isLoading: statusObjectIsLoading } = useSWR('/api/v1/status', {
+    refreshInterval: 1000 * 10,
+  });
+  const { data: usersCreated } = useSWR('/api/v1/analytics/users-created', { refreshInterval: 1000 * 60 * 5 });
+  const { data: rootContentPublished } = useSWR('/api/v1/analytics/root-content-published', {
+    refreshInterval: 1000 * 60 * 5,
+  });
   const { data: childContentPublished } = useSWR('/api/v1/analytics/child-content-published', {
-    refreshInterval: 30000,
+    refreshInterval: 1000 * 60 * 5,
   });
 
   return (


### PR DESCRIPTION
493ea542364ea1368add8ffe33123e1326052ff0
- Ao acessar o `/publicar`, limitar a busca por conteúdos existentes para apenas `1` conteúdo do usuário

70c630f3e1785551aedf33061e04313b802ef170
- Reduz a retentativa de conexão ao banco apenas para `1` vez.

69abf85509e4f10aa1970ffbbbe6cdac2c45d2bc
- Reduz o `revalidate` das páginas para `10` segundos.