### PR TITLE
perf(migration): add `balance_operations` index on `balance_type` and `recipient_id`

### DIFF
--- a/infra/migrations/1669087222388_create-index-balance-operations.js
+++ b/infra/migrations/1669087222388_create-index-balance-operations.js
@@ -1,0 +1,5 @@
+exports.up = async (pgm) => {
+  await pgm.createIndex('balance_operations', ['balance_type', 'recipient_id']);
+};
+
+exports.down = false;


### PR DESCRIPTION
Migration que adiciona índice na tabela `balance_operation` conforme discutido nessa issue #879 