### PR TITLE
fix(contents): add indexes for findChildrenTree

### DIFF
--- a/infra/migrations/1669088607994_create-index-on-contents-for-find-children-tree.js
+++ b/infra/migrations/1669088607994_create-index-on-contents-for-find-children-tree.js
@@ -1,0 +1,28 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined;
+
+exports.up = async (pgm) => {
+  await pgm.createIndex('contents', ['id', 'parent_id'], {
+    name: 'contents_published_parent_and_children_idx',
+    where: "contents.status = 'published'",
+    unique: true,
+  });
+
+  await pgm.createIndex('users', ['id', 'username'], {
+    name: 'users_id_username_idx',
+    unique: true,
+  });
+};
+
+exports.down = (pgm) => async (pgm) => {
+  await pgm.dropIndex('contents', ['id', 'username'], {
+    name: 'contents_published_parent_and_children_idx',
+    unique: true,
+  });
+
+  await pgm.dropIndex('users', ['id', 'username'], {
+    name: 'users_id_username_idx',
+    unique: true,
+  });
+};


### PR DESCRIPTION
Add indexes for the most frequent query in the product environment.

We're trying to aviod seq scans and hit indexes every time if possible.

WARNING: This migration may lock the target tables. We should create the index concurrently but there is an implementation  detail in the node-pg-migrate that forces a transaction for each pgm.dropIndex call and postgresql does not allow it. At the current time, the database is not huge and we do not expect a heavy system load at this time.

Links:

- https://github.com/filipedeschamps/tabnews.com.br/issues/879
- https://explain.depesz.com/s/OIKV
- https://github.com/salsita/node-pg-migrate/issues/709