### PR TITLE
feat(status): increase `danger` threshold on `opened_connections`

### DIFF
--- a/pages/status/index.public.js
+++ b/pages/status/index.public.js
@@ -74,7 +74,13 @@ export default function Page() {
               </Box>
               <Box>
                 Conexões abertas:{' '}
-                <Label variant={statusObject?.dependencies.database.opened_connections < 40 ? 'success' : 'danger'}>
+                <Label
+                  variant={
+                    statusObject?.dependencies.database.opened_connections <
+                    statusObject?.dependencies.database.max_connections * 0.7
+                      ? 'success'
+                      : 'danger'
+                  }>
                   {statusObject?.dependencies.database.opened_connections}
                 </Label>
               </Box>


### PR DESCRIPTION
O "Conexões abertas" estava com o threshold da instância anterior do banco de dados. Agora ela considera um valor dinâmico (70% das conexões máximas, antes de ficar vermelho)

<img width="252" alt="image" src="https://user-images.githubusercontent.com/4248081/203320634-54b0c199-b6a8-4b74-9781-709e73361ef9.png">
