### PR TITLE
Mostra os comentários apenas na Home (lista dos relevantes)

### DIFF
--- a/models/queries.js
+++ b/models/queries.js
@@ -133,26 +133,25 @@ const rankedContent = `
         ranked.rank_group,
         ranked.total_rows,
         users.username as owner_username,
-        --        (WITH RECURSIVE children AS
-        --            (SELECT id,
-        --                 parent_id
-        --            FROM contents as all_contents
-        --            WHERE
-        --                all_contents.id = ranked.id
-        --                AND all_contents.status = 'published'
-        --            UNION ALL
-        --            SELECT
-        --                all_contents.id,
-        --                all_contents.parent_id
-        --            FROM contents as all_contents
-        --            INNER JOIN children ON all_contents.parent_id = children.id
-        --            WHERE all_contents.status = 'published'
-        --            )
-        --            SELECT count(children.id)::integer
-        --            FROM children
-        --            WHERE children.id NOT IN (ranked.id)
-        --            ) as children_deep_count
-            0 as children_deep_count
+        (WITH RECURSIVE children AS
+            (SELECT id,
+                 parent_id
+            FROM contents as all_contents
+            WHERE
+                all_contents.id = ranked.id
+                AND all_contents.status = 'published'
+            UNION ALL
+            SELECT
+                all_contents.id,
+                all_contents.parent_id
+            FROM contents as all_contents
+            INNER JOIN children ON all_contents.parent_id = children.id
+            WHERE all_contents.status = 'published'
+            )
+            SELECT count(children.id)::integer
+            FROM children
+            WHERE children.id NOT IN (ranked.id)
+        ) as children_deep_count
         FROM ranked
         INNER JOIN users ON ranked.owner_id = users.id
         ORDER BY

--- a/pages/interface/components/ContentList/index.js
+++ b/pages/interface/components/ContentList/index.js
@@ -1,10 +1,13 @@
 import useSWR from 'swr';
+import { useRouter } from 'next/router';
 import { Box, Text } from '@primer/react';
 import { ChevronLeftIcon, ChevronRightIcon, CommentIcon } from '@primer/octicons-react';
 
 import { Link, PublishedSince, EmptyState } from 'pages/interface';
 
 export default function ContentList({ contentList, pagination, paginationBasePath, revalidatePath, emptyStateProps }) {
+  const { pathname } = useRouter();
+
   const listNumberOffset = pagination.perPage * (pagination.currentPage - 1);
 
   // const { data: list } = useSWR(revalidatePath, { fallbackData: contentList, revalidateOnMount: true });
@@ -116,10 +119,16 @@ export default function ContentList({ contentList, pagination, paginationBasePat
               <TabCoinsText count={contentObject.tabcoins} />
             </Text>
             {' · '}
-            {/* <Text>
-              <ChildrenDeepCountText count={contentObject.children_deep_count} />
-            </Text>
-            {' · '} */}
+
+            {pathname === '/' || pathname.startsWith('/pagina') ? (
+              <>
+                <Text>
+                  <ChildrenDeepCountText count={contentObject.children_deep_count} />
+                </Text>
+                {' · '}
+              </>
+            ) : undefined}
+
             <Link sx={{ color: 'neutral.emphasis' }} href={`/${contentObject.owner_username}`}>
               {contentObject.owner_username}
             </Link>


### PR DESCRIPTION
Isso é um teste, no sentido de que não fizemos nenhuma otimização por enquanto, mas mostrar os comentários ajuda muito na UX da Home, então sugiro nos arriscarmos.

E hoje ainda vou trabalhar no restante das otimizações para voltar a mostrar todos os comentários 🤝 