### PR TITLE
Volta a mostrar os comentários nas páginas (menos API)

### DIFF
--- a/models/content.js
+++ b/models/content.js
@@ -120,35 +120,34 @@ async function findAll(values = {}, options = {}) {
         -- the findChildrenCount() method to get the children count. Now we perform a
         -- subquery that is not performant but everything is embedded in one travel.
         -- https://github.com/filipedeschamps/tabnews.com.br/blob/de65be914f0fd7b5eed8905718e4ab286b10557e/models/content.js#L51
-        --        (
-        --          WITH RECURSIVE children AS (
-        --            SELECT
-        --                id,
-        --                parent_id
-        --            FROM
-        --              contents as all_contents
-        --            WHERE
-        --              all_contents.id = contents.id AND
-        --              all_contents.status = 'published'
-        --            UNION ALL
-        --              SELECT
-        --                all_contents.id,
-        --                all_contents.parent_id
-        --              FROM
-        --                contents as all_contents
-        --              INNER JOIN
-        --                children ON all_contents.parent_id = children.id
-        --              WHERE
-        --                all_contents.status = 'published'
-        --          )
-        --          SELECT
-        --            count(children.id)::integer
-        --          FROM
-        --            children
-        --          WHERE
-        --            children.id NOT IN (contents.id)
-        --        ) as children_deep_count
-        0 as children_deep_count
+        (
+          WITH RECURSIVE children AS (
+            SELECT
+                id,
+                parent_id
+            FROM
+              contents as all_contents
+            WHERE
+              all_contents.id = contents.id AND
+              all_contents.status = 'published'
+            UNION ALL
+              SELECT
+                all_contents.id,
+                all_contents.parent_id
+              FROM
+                contents as all_contents
+              INNER JOIN
+                children ON all_contents.parent_id = children.id
+              WHERE
+                all_contents.status = 'published'
+          )
+          SELECT
+            count(children.id)::integer
+          FROM
+            children
+          WHERE
+            children.id NOT IN (contents.id)
+        ) as children_deep_count
       FROM
         contents
       INNER JOIN

--- a/pages/interface/components/ContentList/index.js
+++ b/pages/interface/components/ContentList/index.js
@@ -1,13 +1,10 @@
 import useSWR from 'swr';
-import { useRouter } from 'next/router';
 import { Box, Text } from '@primer/react';
 import { ChevronLeftIcon, ChevronRightIcon, CommentIcon } from '@primer/octicons-react';
 
 import { Link, PublishedSince, EmptyState } from 'pages/interface';
 
 export default function ContentList({ contentList, pagination, paginationBasePath, revalidatePath, emptyStateProps }) {
-  const { pathname } = useRouter();
-
   const listNumberOffset = pagination.perPage * (pagination.currentPage - 1);
 
   // const { data: list } = useSWR(revalidatePath, { fallbackData: contentList, revalidateOnMount: true });
@@ -104,7 +101,7 @@ export default function ContentList({ contentList, pagination, paginationBasePat
             }}>
             {contentObject.parent_id ? (
               <Link
-                sx={{ wordWrap: 'break-word', fontStyle: 'italic' }}
+                sx={{ wordWrap: 'break-word', fontStyle: 'italic', fontWeight: 'normal' }}
                 href={`/${contentObject.owner_username}/${contentObject.slug}`}>
                 <CommentIcon verticalAlign="middle" size="small" /> "{contentObject.body}"
               </Link>
@@ -119,16 +116,10 @@ export default function ContentList({ contentList, pagination, paginationBasePat
               <TabCoinsText count={contentObject.tabcoins} />
             </Text>
             {' · '}
-
-            {pathname === '/' || pathname.startsWith('/pagina') ? (
-              <>
-                <Text>
-                  <ChildrenDeepCountText count={contentObject.children_deep_count} />
-                </Text>
-                {' · '}
-              </>
-            ) : undefined}
-
+            <Text>
+              <ChildrenDeepCountText count={contentObject.children_deep_count} />
+            </Text>
+            {' · '}
             <Link sx={{ color: 'neutral.emphasis' }} href={`/${contentObject.owner_username}`}>
               {contentObject.owner_username}
             </Link>


### PR DESCRIPTION
Continuando o PR #900 agora será mostrado os comentários em todas as páginas com listas. Isto deverá pressurizar um pouco mais o backend e vai ser ótimo para conseguir identificar e notar o que está mais pesando.

Em paralelo, esse PR também propõe um pequeno ajuste de estilização na lista, onde deixa os comentários com uma fonte normal, ao invés de bold.