### PR TITLE
fix(cadastro): improve the responsiveness of the registration activat…

### DIFF
--- a/pages/cadastro/ativar/[token].public.js
+++ b/pages/cadastro/ativar/[token].public.js
@@ -18,8 +18,8 @@ export default function ActiveUser() {
 
   useEffect(() => {
     function handleResize() {
-      setConfettiWidth(window.screen.width);
-      setConfettiHeight(window.screen.height);
+      setConfettiWidth(window.innerWidth);
+      setConfettiHeight(window.innerHeight);
     }
 
     window.addEventListener('resize', handleResize);


### PR DESCRIPTION
Para melhorar a responsividade da tela de ativação do registro e evitar o overflow que a animação de confeite estava causando. Alterei o método de obter a largura/altura atual da tela, pois window.screen.width / window.screen.height não representam a largura ou a altura do navegador. Com innerWidth e innerHeight, a animação de confete será responsiva conforme o esperado.

A sugestão de melhoria foi tirada desta issue aqui: #898 