### PR TITLE
Considera utilizar `cf-connecting-ip` para pegar o IP do cliente que vem pela Cloudflare

### DIFF
--- a/models/controller.js
+++ b/models/controller.js
@@ -23,7 +23,7 @@ async function injectRequestMetadata(request, response, next) {
   };
 
   function extractAnonymousIpFromRequest(request) {
-    let ip = request.headers['x-real-ip'] || request.socket.remoteAddress;
+    let ip = request.headers['cf-connecting-ip'] || request.headers['x-real-ip'] || request.socket.remoteAddress;
 
     if (ip === '::1') {
       ip = '127.0.0.1';


### PR DESCRIPTION
Não tem como testar isso a não ser em produção, e isto está relacionado a esse problema: https://github.com/filipedeschamps/tabnews.com.br/issues/826#issuecomment-1327968557