### PR TITLE
Adiciona suporte ao `IPv6` e extrai IP real da Cloudflare

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,6 @@
         "react-icons": "4.4.0",
         "react-rewards": "2.0.4",
         "recharts": "2.1.15",
-        "request-ip": "3.3.0",
         "set-cookie-parser": "2.5.1",
         "slug": "8.2.2",
         "snakeize": "0.1.0",
@@ -11384,11 +11383,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/request-ip": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/request-ip/-/request-ip-3.3.0.tgz",
-      "integrity": "sha512-cA6Xh6e0fDBBBwH77SLJaJPBmD3nWVAcF9/XAcsrIHdjhFzFiB5aNQFytdjCGPezU3ROwrR11IddKAM08vohxA=="
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -21419,11 +21413,6 @@
         "mdast-util-to-hast": "^12.1.0",
         "unified": "^10.0.0"
       }
-    },
-    "request-ip": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/request-ip/-/request-ip-3.3.0.tgz",
-      "integrity": "sha512-cA6Xh6e0fDBBBwH77SLJaJPBmD3nWVAcF9/XAcsrIHdjhFzFiB5aNQFytdjCGPezU3ROwrR11IddKAM08vohxA=="
     },
     "require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "react-icons": "4.4.0",
     "react-rewards": "2.0.4",
     "recharts": "2.1.15",
-    "request-ip": "3.3.0",
     "set-cookie-parser": "2.5.1",
     "slug": "8.2.2",
     "snakeize": "0.1.0",


### PR DESCRIPTION
Continuando a investigação do PR #977, agora a aplicação e o firewall que implementamos lida com `IPv6` e extrai o valor correto do ip real do usuário vindo da Cloudflare.

Como infelizmente isto só dá para testar em produção ao fazer o TabNews passar pelo Proxy da Cloudflare, este PR é um risco, mas estou colado aqui nos logs 🤝 