### PR TITLE
Utiliza ip completo para reduzir quantidade de falsos positivos no Firewall

### DIFF
--- a/models/controller.js
+++ b/models/controller.js
@@ -21,18 +21,8 @@ async function injectRequestMetadata(request, response, next) {
   request.context = {
     ...request.context,
     requestId: uuidV4(),
-    clientIp: extractAnonymousIpFromRequest(request),
+    clientIp: ip.extractFromRequest(request),
   };
-
-  function extractAnonymousIpFromRequest(request) {
-    const realIp = ip.extractFromRequest(request);
-
-    const v4MaskLength = 24;
-    const v6MaskLength = 96;
-    const anonymizedIp = ipAnonymize(realIp, v4MaskLength, v6MaskLength);
-
-    return anonymizedIp;
-  }
 
   next();
 }

--- a/tests/integration/api/v1/contents/firewall.post.test.js
+++ b/tests/integration/api/v1/contents/firewall.post.test.js
@@ -102,7 +102,7 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
       expect(uuidVersion(events[2].id)).toEqual(4);
       expect(events[2].type).toEqual('firewall:block_contents:text_root');
       expect(events[2].originator_user_id).toEqual(defaultUser.id);
-      expect(events[2].originator_ip).toEqual('127.0.0.0');
+      expect(events[2].originator_ip).toEqual('127.0.0.1');
       expect(events[2].metadata).toEqual({
         from_rule: 'create:content:text_root',
         contents: [content1.id, content2.id],
@@ -217,7 +217,7 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
       expect(uuidVersion(events[3].id)).toEqual(4);
       expect(events[3].type).toEqual('firewall:block_contents:text_child');
       expect(events[3].originator_user_id).toEqual(defaultUser.id);
-      expect(events[3].originator_ip).toEqual('127.0.0.0');
+      expect(events[3].originator_ip).toEqual('127.0.0.1');
       expect(events[3].metadata).toEqual({
         from_rule: 'create:content:text_child',
         contents: [content1.id, content2.id],

--- a/tests/integration/api/v1/events/get.test.js
+++ b/tests/integration/api/v1/events/get.test.js
@@ -68,7 +68,7 @@ describe('GET /api/v1/events [NOT YET IMPLEMENTED]', () => {
       expect(uuidVersion(events[0].id)).toEqual(4);
       expect(events[0].type).toEqual('create:user');
       expect(events[0].originator_user_id).toEqual(createUserResponseBody.id);
-      expect(events[0].originator_ip).toEqual('127.0.0.0');
+      expect(events[0].originator_ip).toEqual('127.0.0.1');
       expect(events[0].metadata).toEqual({
         id: createUserResponseBody.id,
       });
@@ -77,7 +77,7 @@ describe('GET /api/v1/events [NOT YET IMPLEMENTED]', () => {
       expect(uuidVersion(events[1].id)).toEqual(4);
       expect(events[1].type).toEqual('create:content:text_root');
       expect(events[1].originator_user_id).toEqual(createUserResponseBody.id);
-      expect(events[1].originator_ip).toEqual('127.0.0.0');
+      expect(events[1].originator_ip).toEqual('127.0.0.1');
       expect(events[1].metadata).toEqual({
         id: createContentRootResponseBody.id,
       });
@@ -86,7 +86,7 @@ describe('GET /api/v1/events [NOT YET IMPLEMENTED]', () => {
       expect(uuidVersion(events[2].id)).toEqual(4);
       expect(events[2].type).toEqual('create:content:text_child');
       expect(events[2].originator_user_id).toEqual(createUserResponseBody.id);
-      expect(events[2].originator_ip).toEqual('127.0.0.0');
+      expect(events[2].originator_ip).toEqual('127.0.0.1');
       expect(events[2].metadata).toEqual({
         id: createContentChildResponseBody.id,
       });

--- a/tests/integration/api/v1/users/firewall.post.test.js
+++ b/tests/integration/api/v1/users/firewall.post.test.js
@@ -80,7 +80,7 @@ describe('POST /api/v1/users [FIREWALL]', () => {
       expect(uuidVersion(events[2].id)).toEqual(4);
       expect(events[2].type).toEqual('firewall:block_users');
       expect(events[2].originator_user_id).toEqual(null);
-      expect(events[2].originator_ip).toEqual('127.0.0.0');
+      expect(events[2].originator_ip).toEqual('127.0.0.1');
       expect(events[2].metadata).toEqual({
         from_rule: 'create:user',
         users: [user1.id, user2.id],


### PR DESCRIPTION
Com a entrada da Cloudflare e do `IPv6`, eu notei que houve um aumento grande de pedidos que estão sendo pegos pelo Firewall e que acredito serem falsos positivos. Isto significa que o Firewall está aplicando os seus side-effects contra pessoas que não tem nada a ver com a história. Isto não estava acontecendo antes, nem com o volume do lançamento, e eu especulo é que a máscara do `IPv6` possa ter algo de errado. Então como experimento, estou removendo temporariamente a máscara para avaliar os resultados, e depois disso voltar com ela quando dominarmos a situação 🤝 