### PR TITLE
Habilita novamente o `prefetch` dos links para UX mais rápida

### DIFF
--- a/pages/interface/components/Link/index.js
+++ b/pages/interface/components/Link/index.js
@@ -1,9 +1,10 @@
 import NextLink from 'next/link';
-import { Header, Link as PrimerLink } from '@primer/react';
+import { Header, Link as PrimerLink, NavList } from '@primer/react';
+import { useRouter } from 'next/router';
 
 export function Link({ href, children, ...props }) {
   return (
-    <PrimerLink as={NextLink} href={href} {...props} prefetch={false}>
+    <PrimerLink as={NextLink} href={href} {...props}>
       {children}
     </PrimerLink>
   );
@@ -11,10 +12,20 @@ export function Link({ href, children, ...props }) {
 
 export function HeaderLink({ href, children, ...props }) {
   return (
-    <Header.Link as={NextLink} href={href} {...props} prefetch={true}>
+    <Header.Link as={NextLink} href={href} {...props}>
       {children}
     </Header.Link>
   );
 }
 
 export default NextLink;
+
+export function NavItem({ href, children, ...props }) {
+  const router = useRouter();
+  const isCurrent = typeof href === 'string' ? router.asPath === href : router.pathname === href.pathname;
+  return (
+    <NavList.Item as={NextLink} href={href} aria-current={isCurrent ? 'page' : false} {...props}>
+      {children}
+    </NavList.Item>
+  );
+}

--- a/pages/interface/components/Link/index.js
+++ b/pages/interface/components/Link/index.js
@@ -11,7 +11,7 @@ export function Link({ href, children, ...props }) {
 
 export function HeaderLink({ href, children, ...props }) {
   return (
-    <Header.Link as={NextLink} href={href} {...props} prefetch={false}>
+    <Header.Link as={NextLink} href={href} {...props} prefetch={true}>
       {children}
     </Header.Link>
   );

--- a/pages/interface/index.js
+++ b/pages/interface/index.js
@@ -8,7 +8,7 @@ export { default as TabCoinButtons } from './components/TabCoinButtons/index.js'
 export { default as PublishedSince } from './components/PublishedSince/index.js';
 export { default as EmptyState } from './components/EmptyState/index.js';
 export { default as Confetti } from './components/Confetti/index.js';
-export { default as NextLink, HeaderLink, Link } from './components/Link/index.js';
+export { default as NextLink, HeaderLink, Link, NavItem } from './components/Link/index.js';
 export { default as GoToTopButton } from './components/GoToTopButton/index.js';
 export { default as Viewer, Editor } from './components/Markdown/index.js';
 export { default as PasswordInput } from './components/PasswordInput/index.js';


### PR DESCRIPTION
Turma, acredito que este seja o último PR da bateria de implementações que eu queria fazer antes de abrir uma nova milestone e avaliar as issues e PRs da comunidade. Estou voltando o comportamento anterior do `prefetch` dos links 🤝  

A última coisa que tinha no passado e falta voltar é o `preload` usando o `swr` das listas de conteúdo, mas isso só me sinto seguro fazer depois de abrir a nova milestone sugerindo novas otimizações 👍 