### PR TITLE
refactor(interface): create ConfettiScreen to reuse the logic and avoid rerenders

### DIFF
--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -1,7 +1,7 @@
 import useSWR from 'swr';
 import { useEffect, useState } from 'react';
 import Confetti from 'react-confetti';
-import { Link, DefaultLayout, Content, TabCoinButtons } from 'pages/interface/index.js';
+import { Link, DefaultLayout, Content, TabCoinButtons, useResize } from 'pages/interface/index.js';
 import user from 'models/user.js';
 import content from 'models/content.js';
 import validator from 'models/validator.js';
@@ -19,6 +19,7 @@ export default function Post({
   parentContentFound,
   contentMetadata,
 }) {
+  const documentSize = useResize();
   const { data: contentFound } = useSWR(
     `/api/v1/contents/${contentFoundFallback.owner_username}/${contentFoundFallback.slug}`,
     {
@@ -27,7 +28,6 @@ export default function Post({
       revalidateOnReconnect: false,
     }
   );
-
   // TODO: understand why enabling "revalidateOn..." breaks children rendering.
   const { data: children } = useSWR(
     `/api/v1/contents/${contentFoundFallback.owner_username}/${contentFoundFallback.slug}/children`,
@@ -37,36 +37,23 @@ export default function Post({
       revalidateOnReconnect: false,
     }
   );
-
-  const [confettiWidth, setConfettiWidth] = useState(0);
-  const [confettiHeight, setConfettiHeight] = useState(0);
   const [showConfetti, setShowConfetti] = useState(false);
 
   useEffect(() => {
-    function handleResize() {
-      setConfettiWidth(window.screen.width);
-      setConfettiHeight(window.screen.height);
-    }
-
-    window.addEventListener('resize', handleResize);
-    handleResize();
-
     const justPublishedNewRootContent = localStorage.getItem('justPublishedNewRootContent');
 
     if (justPublishedNewRootContent) {
       setShowConfetti(true);
       localStorage.removeItem('justPublishedNewRootContent');
     }
-
-    return () => window.removeEventListener('resize', handleResize);
   }, []);
 
   return (
     <>
       {showConfetti && (
         <Confetti
-          width={confettiWidth}
-          height={confettiHeight}
+          width={documentSize.width}
+          height={documentSize.height}
           recycle={false}
           numberOfPieces={800}
           tweenDuration={15000}

--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -1,7 +1,6 @@
 import useSWR from 'swr';
-import { useEffect, useState } from 'react';
-import Confetti from 'react-confetti';
-import { Link, DefaultLayout, Content, TabCoinButtons, useResize } from 'pages/interface/index.js';
+import { useEffect } from 'react';
+import { Link, DefaultLayout, Content, TabCoinButtons, ConfettiScreen } from 'pages/interface/index.js';
 import user from 'models/user.js';
 import content from 'models/content.js';
 import validator from 'models/validator.js';
@@ -19,7 +18,6 @@ export default function Post({
   parentContentFound,
   contentMetadata,
 }) {
-  const documentSize = useResize();
   const { data: contentFound } = useSWR(
     `/api/v1/contents/${contentFoundFallback.owner_username}/${contentFoundFallback.slug}`,
     {
@@ -37,79 +35,68 @@ export default function Post({
       revalidateOnReconnect: false,
     }
   );
-  const [showConfetti, setShowConfetti] = useState(false);
 
   useEffect(() => {
     const justPublishedNewRootContent = localStorage.getItem('justPublishedNewRootContent');
 
     if (justPublishedNewRootContent) {
-      setShowConfetti(true);
       localStorage.removeItem('justPublishedNewRootContent');
     }
   }, []);
 
   return (
     <>
-      {showConfetti && (
-        <Confetti
-          width={documentSize.width}
-          height={documentSize.height}
-          recycle={false}
-          numberOfPieces={800}
-          tweenDuration={15000}
-          gravity={0.15}
-        />
-      )}
       <DefaultLayout metadata={contentMetadata}>
-        <InReplyToLinks content={contentFound} parentContent={parentContentFound} rootContent={rootContentFound} />
-
-        <Box
-          sx={{
-            width: '100%',
-            display: 'flex',
-          }}>
+        <ConfettiScreen showConfetti={isSuccess}>
+          <InReplyToLinks content={contentFound} parentContent={parentContentFound} rootContent={rootContentFound} />
           <Box
             sx={{
-              pr: [0, null, null, 2],
+              width: '100%',
               display: 'flex',
-              flexDirection: 'column',
-              justifyContent: 'center',
             }}>
-            <TabCoinButtons content={contentFound} />
             <Box
               sx={{
-                borderWidth: 0,
-                borderRightWidth: 1,
-                borderColor: 'border.muted',
-                borderStyle: 'dotted',
-                width: '50%',
-                height: '100%',
-              }}
-            />
+                pr: [0, null, null, 2],
+                display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'center',
+              }}>
+              <TabCoinButtons content={contentFound} />
+              <Box
+                sx={{
+                  borderWidth: 0,
+                  borderRightWidth: 1,
+                  borderColor: 'border.muted',
+                  borderStyle: 'dotted',
+                  width: '50%',
+                  height: '100%',
+                }}
+              />
+            </Box>
+
+            <Box sx={{ width: '100%', overflow: 'auto' }}>
+              <Content content={contentFound} mode="view" />
+            </Box>
           </Box>
 
-          <Box sx={{ width: '100%', overflow: 'auto' }}>
-            <Content content={contentFound} mode="view" />
-          </Box>
-        </Box>
+          <Box sx={{ width: '100%' }}>
+            <Box
+              sx={{
+                borderRadius: '6px',
+                borderWidth: 1,
+                borderColor: 'border.default',
+                borderStyle: 'solid',
+                mt: 4,
+                mb: 4,
+                p: 4,
+                wordWrap: 'break-word',
+              }}>
+              <Content key={contentFound.id} content={{ parent_id: contentFound.id }} mode="compact" />
+            </Box>
 
-        <Box sx={{ width: '100%' }}>
-          <Box
-            sx={{
-              borderRadius: '6px',
-              borderWidth: 1,
-              borderColor: 'border.default',
-              borderStyle: 'solid',
-              mt: 4,
-              mb: 4,
-              p: 4,
-              wordWrap: 'break-word',
-            }}>
-            <Content key={contentFound.id} content={{ parent_id: contentFound.id }} mode="compact" />
+            <RenderChildrenTree childrenList={children} level={0} />
           </Box>
-
-          <RenderChildrenTree childrenList={children} level={0} />
-        </Box>
+        </ConfettiScreen>
       </DefaultLayout>
     </>
   );

--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -1,5 +1,5 @@
 import useSWR from 'swr';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Link, DefaultLayout, Content, TabCoinButtons, ConfettiScreen } from 'pages/interface/index.js';
 import user from 'models/user.js';
 import content from 'models/content.js';
@@ -18,6 +18,7 @@ export default function Post({
   parentContentFound,
   contentMetadata,
 }) {
+  const [showConfetti, setShowConfetti] = useState(false);
   const { data: contentFound } = useSWR(
     `/api/v1/contents/${contentFoundFallback.owner_username}/${contentFoundFallback.slug}`,
     {
@@ -40,6 +41,7 @@ export default function Post({
     const justPublishedNewRootContent = localStorage.getItem('justPublishedNewRootContent');
 
     if (justPublishedNewRootContent) {
+      setShowConfetti(true);
       localStorage.removeItem('justPublishedNewRootContent');
     }
   }, []);
@@ -47,7 +49,7 @@ export default function Post({
   return (
     <>
       <DefaultLayout metadata={contentMetadata}>
-        <ConfettiScreen showConfetti={isSuccess}>
+        <ConfettiScreen showConfetti={showConfetti}>
           <InReplyToLinks content={contentFound} parentContent={parentContentFound} rootContent={rootContentFound} />
           <Box
             sx={{

--- a/pages/cadastro/ativar/[token].public.js
+++ b/pages/cadastro/ativar/[token].public.js
@@ -4,29 +4,16 @@ import { Box, Flash } from '@primer/react';
 import { DefaultLayout } from 'pages/interface/index.js';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
+import { useResize } from 'pages/interface/hooks';
 
 export default function ActiveUser() {
+  const documentSize = useResize();
   const router = useRouter();
   const { token } = router.query;
 
   const [globalMessage, setGlobalMessage] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-
-  const [confettiWidth, setConfettiWidth] = useState(0);
-  const [confettiHeight, setConfettiHeight] = useState(0);
-
-  useEffect(() => {
-    function handleResize() {
-      setConfettiWidth(window.screen.width);
-      setConfettiHeight(window.screen.height);
-    }
-
-    window.addEventListener('resize', handleResize);
-    handleResize();
-
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
 
   const handleActivateUser = async (token) => {
     try {
@@ -75,8 +62,8 @@ export default function ActiveUser() {
     <>
       {isSuccess && (
         <Confetti
-          width={confettiWidth}
-          height={confettiHeight}
+          width={documentSize.width}
+          height={documentSize.height}
           recycle={false}
           numberOfPieces={800}
           tweenDuration={15000}

--- a/pages/cadastro/ativar/[token].public.js
+++ b/pages/cadastro/ativar/[token].public.js
@@ -1,13 +1,10 @@
-import Confetti from 'react-confetti';
 import fetch from 'cross-fetch';
 import { Box, Flash } from '@primer/react';
-import { DefaultLayout } from 'pages/interface/index.js';
+import { ConfettiScreen, DefaultLayout } from 'pages/interface/index.js';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-import { useResize } from 'pages/interface/hooks';
 
 export default function ActiveUser() {
-  const documentSize = useResize();
   const router = useRouter();
   const { token } = router.query;
 
@@ -60,24 +57,16 @@ export default function ActiveUser() {
 
   return (
     <>
-      {isSuccess && (
-        <Confetti
-          width={documentSize.width}
-          height={documentSize.height}
-          recycle={false}
-          numberOfPieces={800}
-          tweenDuration={15000}
-          gravity={0.15}
-        />
-      )}
       <DefaultLayout containerWidth="medium" metadata={{ title: 'Ativar cadastro' }}>
-        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', width: '100%', mt: 10 }}>
-          {isLoading ? (
-            <Flash variant="default">Verificando Token de Ativação...</Flash>
-          ) : (
-            <Flash variant={isSuccess ? 'success' : 'danger'}>{globalMessage}</Flash>
-          )}
-        </Box>
+        <ConfettiScreen showConfetti={isSuccess}>
+          <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', width: '100%', mt: 10 }}>
+            {isLoading ? (
+              <Flash variant="default">Verificando Token de Ativação...</Flash>
+            ) : (
+              <Flash variant={isSuccess ? 'success' : 'danger'}>{globalMessage}</Flash>
+            )}
+          </Box>
+        </ConfettiScreen>
       </DefaultLayout>
     </>
   );

--- a/pages/interface/components/ConfettiScreen/index.js
+++ b/pages/interface/components/ConfettiScreen/index.js
@@ -1,0 +1,21 @@
+import Confetti from 'react-confetti';
+
+export default function ConfettiScreen({ children, showConfetti }) {
+  const { width, height } = useResize();
+
+  const options = {
+    width,
+    height,
+    recycle: false,
+    numberOfPieces: 800,
+    tweenDuration: 15000,
+    gravity: 0.15,
+  };
+
+  return (
+    <>
+      {showConfetti && <Confetti {...options} />}
+      {children}
+    </>
+  );
+}

--- a/pages/interface/hooks/useResize/index.js
+++ b/pages/interface/hooks/useResize/index.js
@@ -1,0 +1,25 @@
+export default function useResize() {
+  const initialWidthScreen = document.body.clientWidth;
+  const initialHeightScreen = document.body.clientWidth;
+  const [width, setWidth] = useState(initialWidthScreen);
+  const [height, setHeight] = useState(initialHeightScreen);
+
+  const handleResize = () => {
+    const screenWidth = window.innerWidth;
+    const screenHeight = window.innerWidth;
+    setWidth(screenWidth);
+    setHeight(screenHeight);
+  };
+
+  useEffect(() => {
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  return {
+    width,
+    height,
+  };
+}

--- a/pages/interface/index.js
+++ b/pages/interface/index.js
@@ -8,6 +8,7 @@ export { default as TabCoinButtons } from './components/TabCoinButtons/index.js'
 export { default as PublishedSince } from './components/PublishedSince/index.js';
 export { default as EmptyState } from './components/EmptyState/index.js';
 export { default as NextLink, HeaderLink, Link } from './components/Link/index.js';
+export { default as ConfettiScreen } from './components/ConfettiScreen/index.js';
 
 export { default as useUser } from './hooks/useUser/index.js';
 export { default as useMediaQuery } from './hooks/useMediaQuery/index.js';

--- a/pages/interface/index.js
+++ b/pages/interface/index.js
@@ -11,3 +11,4 @@ export { default as NextLink, HeaderLink, Link } from './components/Link/index.j
 
 export { default as useUser } from './hooks/useUser/index.js';
 export { default as useMediaQuery } from './hooks/useMediaQuery/index.js';
+export { default as useResize } from './hooks/useResize/index.js';

--- a/pages/login/sucesso/index.public.js
+++ b/pages/login/sucesso/index.public.js
@@ -1,10 +1,7 @@
 import { Box, Heading, Text } from '@primer/react';
-import { DefaultLayout, useResize } from 'pages/interface/index.js';
-import Confetti from 'react-confetti';
+import { ConfettiScreen, DefaultLayout, useResize } from 'pages/interface/index.js';
 
 export default function ConfirmSignup() {
-  const documentSize = useResize();
-
   return (
     <>
       <style>{`
@@ -14,14 +11,7 @@ export default function ConfirmSignup() {
         }
       `}</style>
       <div className="pl-3 pr-3">
-        <Confetti
-          width={documentSize.width}
-          height={documentSize.height}
-          recycle={false}
-          numberOfPieces={800}
-          tweenDuration={15000}
-          gravity={0.15}
-        />
+        <ConfettiScreen showConfetti={true} />
       </div>
 
       <DefaultLayout containerWidth="medium" metadata={{ title: 'Confirme seu email' }}>

--- a/pages/login/sucesso/index.public.js
+++ b/pages/login/sucesso/index.public.js
@@ -1,5 +1,5 @@
 import { Box, Heading, Text } from '@primer/react';
-import { ConfettiScreen, DefaultLayout, useResize } from 'pages/interface/index.js';
+import { ConfettiScreen, DefaultLayout } from 'pages/interface/index.js';
 
 export default function ConfirmSignup() {
   return (

--- a/pages/login/sucesso/index.public.js
+++ b/pages/login/sucesso/index.public.js
@@ -1,23 +1,9 @@
 import { Box, Heading, Text } from '@primer/react';
-import { useState, useEffect } from 'react';
-import { DefaultLayout } from 'pages/interface/index.js';
+import { DefaultLayout, useResize } from 'pages/interface/index.js';
 import Confetti from 'react-confetti';
 
 export default function ConfirmSignup() {
-  const [confettiWidth, setConfettiWidth] = useState(0);
-  const [confettiHeight, setConfettiHeight] = useState(0);
-
-  useEffect(() => {
-    function handleResize() {
-      setConfettiWidth(window.screen.width);
-      setConfettiHeight(window.screen.height);
-    }
-
-    window.addEventListener('resize', handleResize);
-    handleResize();
-
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
+  const documentSize = useResize();
 
   return (
     <>
@@ -29,8 +15,8 @@ export default function ConfirmSignup() {
       `}</style>
       <div className="pl-3 pr-3">
         <Confetti
-          width={confettiWidth}
-          height={confettiHeight}
+          width={documentSize.width}
+          height={documentSize.height}
           recycle={false}
           numberOfPieces={800}
           tweenDuration={15000}

--- a/pages/perfil/confirmar-email/[token].public.js
+++ b/pages/perfil/confirmar-email/[token].public.js
@@ -1,32 +1,18 @@
 import Confetti from 'react-confetti';
 import fetch from 'cross-fetch';
 import { Box, Flash } from '@primer/react';
-import { DefaultLayout } from 'pages/interface/index.js';
+import { DefaultLayout, useResize } from 'pages/interface/index.js';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 
 export default function ActiveUser() {
   const router = useRouter();
+  const documentSize = useResize();
   const { token } = router.query;
 
   const [globalMessage, setGlobalMessage] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-
-  const [confettiWidth, setConfettiWidth] = useState(0);
-  const [confettiHeight, setConfettiHeight] = useState(0);
-
-  useEffect(() => {
-    function handleResize() {
-      setConfettiWidth(window.screen.width);
-      setConfettiHeight(window.screen.height);
-    }
-
-    window.addEventListener('resize', handleResize);
-    handleResize();
-
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
 
   const handleEmailConfirmation = async (token) => {
     try {
@@ -75,8 +61,8 @@ export default function ActiveUser() {
     <>
       {isSuccess && (
         <Confetti
-          width={confettiWidth}
-          height={confettiHeight}
+          width={documentSize.width}
+          height={documentSize.height}
           recycle={false}
           numberOfPieces={800}
           tweenDuration={15000}

--- a/pages/perfil/confirmar-email/[token].public.js
+++ b/pages/perfil/confirmar-email/[token].public.js
@@ -1,13 +1,11 @@
-import Confetti from 'react-confetti';
 import fetch from 'cross-fetch';
 import { Box, Flash } from '@primer/react';
-import { DefaultLayout, useResize } from 'pages/interface/index.js';
+import { ConfettiScreen, DefaultLayout } from 'pages/interface/index.js';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 
 export default function ActiveUser() {
   const router = useRouter();
-  const documentSize = useResize();
   const { token } = router.query;
 
   const [globalMessage, setGlobalMessage] = useState(false);
@@ -59,24 +57,16 @@ export default function ActiveUser() {
 
   return (
     <>
-      {isSuccess && (
-        <Confetti
-          width={documentSize.width}
-          height={documentSize.height}
-          recycle={false}
-          numberOfPieces={800}
-          tweenDuration={15000}
-          gravity={0.15}
-        />
-      )}
       <DefaultLayout containerWidth="medium" metadata={{ title: 'Confirmar alteração de email' }}>
-        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', width: '100%', mt: 10 }}>
-          {isLoading ? (
-            <Flash variant="default">Verificando Token de Alteração de Email...</Flash>
-          ) : (
-            <Flash variant={isSuccess ? 'success' : 'danger'}>{globalMessage}</Flash>
-          )}
-        </Box>
+        <ConfettiScreen showConfetti={isSuccess}>
+          <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', width: '100%', mt: 10 }}>
+            {isLoading ? (
+              <Flash variant="default">Verificando Token de Alteração de Email...</Flash>
+            ) : (
+              <Flash variant={isSuccess ? 'success' : 'danger'}>{globalMessage}</Flash>
+            )}
+          </Box>
+        </ConfettiScreen>
       </DefaultLayout>
     </>
   );


### PR DESCRIPTION
## Problema
Em nossa interface, temos uma interação com o usuário no qual aparece coffetti quando é executado alguma ação de sucesso, e isso se dá em varias das nossa páginas.

O que acontece hoje é que estamos repetindo essa lógica em vários components, induzindo a criação de bugs. Outro problema encontrado na correção é que todos os components filhos estão sendo rerenderizados quando é dado resize na pagina.

## Correção
- Criado um custom hook chamado useResize para que não seja espalhada essa lógica;
- Criado um component chamdo ConfettiScreen para que também reduzir a complexidade dos components que chamam essa funcionalidade, mas também evitar rerenders.

## Tasks
- [] Testes -  O correto seria a criação de testes para garantir a funcionalidade, porém não temos a biblioteca necessário para isso, acredito que podemos criar uma task para isso;
- [] Testes visuais: Não consegui acessar todas as telas que contém o component;
