### PR TITLE
Botão de nova publicação movido para a barra superior

### DIFF
--- a/pages/interface/components/Header/index.js
+++ b/pages/interface/components/Header/index.js
@@ -50,6 +50,9 @@ export default function HeaderComponent() {
 
       {user && (
         <>
+          <Header.Item>
+            <HeaderLink href="/publicar">Publicar novo conteúdo</HeaderLink>
+          </Header.Item>
           <Header.Item
             sx={{
               mr: 2,
@@ -93,9 +96,6 @@ export default function HeaderComponent() {
                     <Truncate>{user.username}</Truncate>
                   </ActionList.LinkItem>
                   <ActionList.Divider />
-                  <ActionList.LinkItem as={Link} href="/publicar">
-                    Publicar novo conteúdo
-                  </ActionList.LinkItem>
                   <ActionList.LinkItem as={Link} href="/perfil">
                     Editar perfil
                   </ActionList.LinkItem>


### PR DESCRIPTION
Botão de nova publicação movido do menu dropdown para a barra superior, assim ficará mais fácil, visível e convidativo para iniciar uma nova publicação!