### PR TITLE
style(footer/index.js): align the tabnews icon with the footer text

### DIFF
--- a/pages/interface/components/Footer/index.js
+++ b/pages/interface/components/Footer/index.js
@@ -27,7 +27,14 @@ export default function Footer(props) {
             gap: 1,
             color: 'fg.subtle',
           }}>
-          <Link href="/" sx={{ color: 'fg.subtle' }}>
+          <Link
+            sx={{
+              color: 'fg.subtle',
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'center',
+            }}
+            href="/">
             <CgTab size={26} />
           </Link>
           © {new Date().getFullYear()} TabNews


### PR DESCRIPTION
## 🤔 Por que você está abrindo esse Pull Request?
Um simples ajuste no alinhamento do ícone do rodapé com o texto, algo que estava me incomodando faz tempo 😅️


## 🧐 Descreva sua solução:
Basicamente foi adicionado display: 'flex justifyContent: 'center'. Conforme imagem abaixo:

![Captura de tela em 2022-12-01 10-02-22](https://user-images.githubusercontent.com/5334261/205060320-3b311fb2-65ac-4fb2-b169-e335774cf030.png)


