### PR TITLE
Logs de erros melhores

### DIFF
--- a/pages/api/v1/_responses/rate-limit-reached-sessions.public.js
+++ b/pages/api/v1/_responses/rate-limit-reached-sessions.public.js
@@ -4,6 +4,7 @@ import snakeize from 'snakeize';
 import logger from 'infra/logger.js';
 import controller from 'models/controller.js';
 import validator from 'models/validator.js';
+import ip from 'models/ip.js';
 import { UnauthorizedError, ForbiddenError, TooManyRequestsError } from 'errors/index.js';
 
 export default nextConnect({
@@ -30,6 +31,8 @@ function logRequest(request, response, next) {
       method: request.method,
       url: request.url,
       body: request.body,
+      clientIp: ip.extractFromRequest(request),
+      type: 'sessions',
     },
   });
 

--- a/pages/api/v1/_responses/rate-limit-reached.public.js
+++ b/pages/api/v1/_responses/rate-limit-reached.public.js
@@ -1,5 +1,6 @@
 import snakeize from 'snakeize';
 import logger from 'infra/logger.js';
+import ip from 'models/ip.js';
 import { TooManyRequestsError } from 'errors/index.js';
 
 export default function handler(request, response) {
@@ -8,6 +9,8 @@ export default function handler(request, response) {
       method: request.method,
       url: request.url,
       body: request.body,
+      clientIp: ip.extractFromRequest(request),
+      type: 'general',
     },
   });
 


### PR DESCRIPTION
Continuando a série apagando fogo pós-lançamento, estou fazendo esta alteração para melhorar a nossa visualização pelos logs sobre o que está acontecendo, principalmente após colocar a Cloudflare na frente do TabNews.

E também é separado o que é `publicErrorObject` (que será retornado ao usuário) e `privateErrorObject` (que contém contém informações do contexto).

Próximo passo é montar uma dashboard no Axiom que agrupe os ips que estão gerando mais erros para rapidamente isolar quem está atacando a API.