### PR TITLE
fix(modifies interface component 'tabcoinsbuttons'): disables voting buttons for content owner

### DIFF
--- a/pages/interface/components/TabCoinButtons/index.js
+++ b/pages/interface/components/TabCoinButtons/index.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, use } from 'react';
+import { useState, useEffect } from 'react';
 import { Box, Text, IconButton } from '@primer/react';
 import { ChevronUpIcon, ChevronDownIcon } from '@primer/octicons-react';
 import { useReward } from 'react-rewards';

--- a/pages/interface/components/TabCoinButtons/index.js
+++ b/pages/interface/components/TabCoinButtons/index.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, use } from 'react';
 import { Box, Text, IconButton } from '@primer/react';
 import { ChevronUpIcon, ChevronDownIcon } from '@primer/octicons-react';
 import { useReward } from 'react-rewards';
@@ -24,6 +24,13 @@ export default function TabCoinButtons({ content }) {
     spread: 60,
     elementCount: 100,
   });
+
+  let isOwnerOfPost;
+  try {
+    isOwnerOfPost = contentObject.owner_id === user.id;
+  } catch (error) {
+    isOwnerOfPost = false;
+  }
 
   const { reward: rewardDebit, isAnimating: isAnimatingDebit } = useReward(`reward-${contentObject.id}`, 'emoji', {
     position: 'absolute',
@@ -97,7 +104,7 @@ export default function TabCoinButtons({ content }) {
           onClick={() => {
             transactTabCoin('credit');
           }}
-          disabled={isPosting || isAnimatingCredit || isAnimatingDebit}
+          disabled={isOwnerOfPost || isPosting || isAnimatingCredit || isAnimatingDebit}
         />
       </Box>
       <Box>
@@ -121,7 +128,7 @@ export default function TabCoinButtons({ content }) {
           onClick={() => {
             transactTabCoin('debit');
           }}
-          disabled={isPosting || isAnimatingCredit || isAnimatingDebit}
+          disabled={isOwnerOfPost || isPosting || isAnimatingCredit || isAnimatingDebit}
         />
       </Box>
     </Box>

--- a/pages/perfil/index.public.js
+++ b/pages/perfil/index.public.js
@@ -24,6 +24,7 @@ function EditProfileForm() {
   const usernameRef = useRef('');
   const emailRef = useRef('');
   const notificationsRef = useRef('');
+  const passwordRef = useRef('');
 
   useEffect(() => {
     if (router && !user && !userIsLoading) {
@@ -56,6 +57,7 @@ function EditProfileForm() {
     const username = usernameRef.current.value;
     const email = emailRef.current.value;
     const notifications = notificationsRef.current.checked;
+    const password = passwordRef.current.value;
 
     setIsLoading(true);
     setErrorObject(undefined);
@@ -100,6 +102,39 @@ function EditProfileForm() {
     if (Object.keys(payload).length === 0) {
       setIsLoading(false);
       return;
+    }
+
+    try {
+      // Qualquer mudança que exista nos campos, será cobrada a senha para confirmar o processo
+      const passwordCheck = await fetch(`/api/v1/sessions`, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          email: user.email,
+          password,
+        }),
+      });
+
+      setGlobalErrorMessage(undefined);
+
+      const passwordCheckBody = await passwordCheck.json();
+      passwordRef.current.value = '';
+
+      if (passwordCheck.status !== 201) {
+        usernameRef.current.value = user.username;
+        emailRef.current.value = user.email;
+        notificationsRef.current.checked = user.notifications;
+
+        setErrorObject(passwordCheckBody);
+        setIsLoading(false);
+        return;
+      }
+    } catch (error) {
+      setGlobalErrorMessage('Não foi possível se conectar ao TabNews. Por favor, verifique sua conexão.');
+      setIsLoading(false);
     }
 
     try {
@@ -234,11 +269,26 @@ function EditProfileForm() {
           )}
         </FormControl>
 
-        <FormControl id="password">
-          <FormControl.Label>Senha</FormControl.Label>
+        <FormControl id="recover_password">
+          <FormControl.Label>Recuperar Senha</FormControl.Label>
           <Link href="/cadastro/recuperar" sx={{ fontSize: 0 }}>
             Utilize o fluxo de recuperação de senha →
           </Link>
+        </FormControl>
+
+        <FormControl id="password">
+          <FormControl.Label>Confirmar Senha</FormControl.Label>
+          <TextInput
+            ref={passwordRef}
+            name="password"
+            type="password"
+            autoCorrect="off"
+            autoCapitalize="off"
+            spellCheck={false}
+            size="large"
+            block={true}
+            aria-label="Sua senha"
+          />
         </FormControl>
 
         <FormControl>


### PR DESCRIPTION
### How to delete the 'file edit' of '/profile/index.js', from the current PR (#1099), as it is part of my other PR (#1098)?

Well, I believe it doesn't make sense for the owner of the post/comment to have the option to click to vote for himself, as the API itself does not allow this behavior.

Hence, I wrote a check, which for each post/comment, compares the ID of the Owner of the Content, with the ID of the Current User, thus being able to disable the buttons when it detects that the Owner and the User are the same person.