### PR TITLE
refactor(modifies page 'user profile'): adds the 'confirm password' field, which will be requested whenever saving any changes to 'user information'

### DIFF
--- a/pages/perfil/index.public.js
+++ b/pages/perfil/index.public.js
@@ -24,6 +24,7 @@ function EditProfileForm() {
   const usernameRef = useRef('');
   const emailRef = useRef('');
   const notificationsRef = useRef('');
+  const passwordRef = useRef('');
 
   useEffect(() => {
     if (router && !user && !userIsLoading) {
@@ -56,6 +57,7 @@ function EditProfileForm() {
     const username = usernameRef.current.value;
     const email = emailRef.current.value;
     const notifications = notificationsRef.current.checked;
+    const password = passwordRef.current.value;
 
     setIsLoading(true);
     setErrorObject(undefined);
@@ -100,6 +102,39 @@ function EditProfileForm() {
     if (Object.keys(payload).length === 0) {
       setIsLoading(false);
       return;
+    }
+
+    try {
+      // Qualquer mudança que exista nos campos, será cobrada a senha para confirmar o processo
+      const passwordCheck = await fetch(`/api/v1/sessions`, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          email: user.email,
+          password,
+        }),
+      });
+
+      setGlobalErrorMessage(undefined);
+
+      const passwordCheckBody = await passwordCheck.json();
+      passwordRef.current.value = '';
+
+      if (passwordCheck.status !== 201) {
+        usernameRef.current.value = user.username;
+        emailRef.current.value = user.email;
+        notificationsRef.current.checked = user.notifications;
+
+        setErrorObject(passwordCheckBody);
+        setIsLoading(false);
+        return;
+      }
+    } catch (error) {
+      setGlobalErrorMessage('Não foi possível se conectar ao TabNews. Por favor, verifique sua conexão.');
+      setIsLoading(false);
     }
 
     try {
@@ -234,11 +269,26 @@ function EditProfileForm() {
           )}
         </FormControl>
 
-        <FormControl id="password">
-          <FormControl.Label>Senha</FormControl.Label>
+        <FormControl id="recover_password">
+          <FormControl.Label>Recuperar Senha</FormControl.Label>
           <Link href="/cadastro/recuperar" sx={{ fontSize: 0 }}>
             Utilize o fluxo de recuperação de senha →
           </Link>
+        </FormControl>
+
+        <FormControl id="password">
+          <FormControl.Label>Confirmar Senha</FormControl.Label>
+          <TextInput
+            ref={passwordRef}
+            name="password"
+            type="password"
+            autoCorrect="off"
+            autoCapitalize="off"
+            spellCheck={false}
+            size="large"
+            block={true}
+            aria-label="Sua senha"
+          />
         </FormControl>
 
         <FormControl>


### PR DESCRIPTION
- Added [input] Confirm Password
- This input will be requested whenever any profile value is modified (username, email, notifications)
- A call will be made with: Current Email and the Input Value of 'Check Password' to the 'Session' API.
- If the return value is related to an error, the request returns, restoring the modified fields, and clearing the password input.
- If the entered password is correct, the request will continue normally, updating the modified values.

``'PROFILE EDIT' PAGE SCREEN WITH CHANGES``
![1](https://user-images.githubusercontent.com/15692310/206053935-f577cb24-e419-48c5-aa6e-5a0f004549f1.PNG)

``USERNAME UPDATE: WITH WRONG PASSWORD. [THE SYSTEM DID NOT COMPLETE THE MODIFICATION]`` ![2](https://user-images.githubusercontent.com/15692310/206053940-7932daae-2df0-4401-9aee-711bd07559fb.PNG)

``USERNAME UPDATE: WITH CORRECT PASSWORD. [THE SYSTEM COMPLETED THE MODIFICATION]`` ![3](https://user-images.githubusercontent.com/15692310/206053942-bca357f2-611c-41d8-b8bf-5620c1575b7f.PNG)