### PR TITLE
fix(modifies interface component 'tabcoinsbuttons'): disables voting buttons for content owner

### DIFF
--- a/pages/interface/components/TabCoinButtons/index.js
+++ b/pages/interface/components/TabCoinButtons/index.js
@@ -25,6 +25,13 @@ export default function TabCoinButtons({ content }) {
     elementCount: 100,
   });
 
+  let isOwnerOfPost;
+  try {
+    isOwnerOfPost = contentObject.owner_id === user.id;
+  } catch (error) {
+    isOwnerOfPost = false;
+  }
+
   const { reward: rewardDebit, isAnimating: isAnimatingDebit } = useReward(`reward-${contentObject.id}`, 'emoji', {
     position: 'absolute',
     lifetime: 100,
@@ -97,7 +104,7 @@ export default function TabCoinButtons({ content }) {
           onClick={() => {
             transactTabCoin('credit');
           }}
-          disabled={isPosting || isAnimatingCredit || isAnimatingDebit}
+          disabled={isOwnerOfPost || isPosting || isAnimatingCredit || isAnimatingDebit}
         />
       </Box>
       <Box>
@@ -121,7 +128,7 @@ export default function TabCoinButtons({ content }) {
           onClick={() => {
             transactTabCoin('debit');
           }}
-          disabled={isPosting || isAnimatingCredit || isAnimatingDebit}
+          disabled={isOwnerOfPost || isPosting || isAnimatingCredit || isAnimatingDebit}
         />
       </Box>
     </Box>


### PR DESCRIPTION
- The change will disable the Like and Dislike buttons on Posts and Comments authored by the Current User (logged in)

Well, I believe it doesn't make sense for the owner of the post/comment to have the option to click to vote for himself, as the API itself does not allow this behavior. Hence, I wrote a check, which for each post/comment, compares the ID of the Owner of the Content, with the ID of the Current User, thus being able to disable the buttons