### PR TITLE
fix(validation): remove empty tags in markdown

### DIFF
--- a/models/validator.js
+++ b/models/validator.js
@@ -271,6 +271,7 @@ const schemas = {
         .min(1)
         .max(20000)
         .trim()
+        .replace(/<[^/>][^>]*><\/[^>]+>/, '')
         .invalid(null)
         .when('$required.body', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({

--- a/models/validator.js
+++ b/models/validator.js
@@ -271,7 +271,7 @@ const schemas = {
         .min(1)
         .max(20000)
         .trim()
-        .replace(/<[^/>][^>]*><\/[^>]+>/, '')
+        .replace(/<[^/>][^>]*><\/[^>]+>/g, '')
         .invalid(null)
         .when('$required.body', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({

--- a/models/validator.js
+++ b/models/validator.js
@@ -271,7 +271,7 @@ const schemas = {
         .min(1)
         .max(20000)
         .trim()
-        .replace(/<[^/>][^>]*><\/[^>]+>/g, '')
+        .replace(/<([^\/>]+|[^\/>]*["\'][^"\'>]*["\'][^\/>]+)>\s*<\/[^>]+>/g, '')
         .invalid(null)
         .when('$required.body', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({


### PR DESCRIPTION
This commit will make it impossible to upload content containing only one or more empty tags (empty tags are not rendered).

fix #1131