### PR TITLE
fix(validator): invalidate blank characters and empty markdown

### DIFF
--- a/models/content.js
+++ b/models/content.js
@@ -404,7 +404,7 @@ function getSlug(title) {
     trim: true,
   });
 
-  const truncatedSlug = generatedSlug.substring(0, 256);
+  const truncatedSlug = generatedSlug.substring(0, 255);
 
   return truncatedSlug;
 }

--- a/models/remove-markdown.js
+++ b/models/remove-markdown.js
@@ -3,6 +3,7 @@
 
 export default function removeMarkdown(md, options) {
   options = options || {};
+  options.oneLine = options.hasOwnProperty('oneLine') ? options.oneLine : true;
   options.listUnicodeChar = options.hasOwnProperty('listUnicodeChar') ? options.listUnicodeChar : false;
   options.stripListLeaders = options.hasOwnProperty('stripListLeaders') ? options.stripListLeaders : true;
   options.gfm = options.hasOwnProperty('gfm') ? options.gfm : true;
@@ -85,6 +86,24 @@ export default function removeMarkdown(md, options) {
       // .replace(/(\S+)\n\s*(\S+)/g, '$1 $2')
       // Replace strike through
       .replace(/~(.*?)~/g, '$1');
+
+    if (options.oneLine) {
+      output = output.replace(/\s+/g, ' ');
+    }
+
+    if (output.length > options.maxLength) {
+      output = output
+        .substring(0, options.maxLength - 3)
+        .trim()
+        .concat('...');
+    }
+
+    if (options.trim) {
+      output = output.replace(
+        /^(\s|\p{C}|\u2800|\u034f|\u115f|\u1160|\u17b4|\u17b5|\u3164|\uffa0)+|(\s|\p{C}|\u2800|\u034f|\u115f|\u1160|\u17b4|\u17b5|\u3164|\uffa0)+$|\u0000/gsu,
+        ''
+      );
+    }
   } catch (e) {
     console.error(e);
     return md;

--- a/models/rss.js
+++ b/models/rss.js
@@ -33,7 +33,7 @@ function generateRss2(contentList) {
       title: contentObject.title,
       id: contentUrl,
       link: contentUrl,
-      description: removeMarkdown(contentObject.body).replace(/\s+/g, ' ').substring(0, 190) + '...',
+      description: removeMarkdown(contentObject.body, { maxLength: 190 }),
       content: renderToStaticMarkup(<Viewer value={contentObject.body} />).replace(/[\r\n]/gm, ''),
       author: [
         {

--- a/models/thumbnail.js
+++ b/models/thumbnail.js
@@ -36,7 +36,7 @@ export function parseContent(content, parentContent) {
   let title = content.title;
 
   if (!title) {
-    title = removeMarkdown(content.body).substring(0, 120).replace(/\s+/g, ' ');
+    title = removeMarkdown(content.body, { maxLength: 120 });
   }
 
   // Regex to wrap text: https://stackoverflow.com/a/51506718

--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -342,7 +342,7 @@ export async function getStaticProps(context) {
 
   const secureChildrenList = authorization.filterOutput(userTryingToGet, 'read:content:list', childrenFound);
 
-  const oneLineBody = removeMarkdown(secureContentFound.body).replace(/\s+/g, ' ');
+  const oneLineBody = removeMarkdown(secureContentFound.body, { maxLength: 190 });
 
   const webserverHost = webserver.getHost();
 
@@ -350,7 +350,7 @@ export async function getStaticProps(context) {
     title: `${secureContentFound.title ?? oneLineBody.substring(0, 80)} · ${secureContentFound.owner_username}`,
     image: `${webserverHost}/api/v1/contents/${secureContentFound.owner_username}/${secureContentFound.slug}/thumbnail`,
     url: `${webserverHost}/${secureContentFound.owner_username}/${secureContentFound.slug}`,
-    description: oneLineBody.substring(0, 190),
+    description: oneLineBody,
     published_time: secureContentFound.published_at,
     modified_time: secureContentFound.updated_at,
     author: secureContentFound.owner_username,
@@ -375,7 +375,7 @@ export async function getStaticProps(context) {
       },
     });
 
-    parentContentFound.body = removeMarkdown(parentContentFound.body).replace(/\s+/g, ' ').substring(0, 50);
+    parentContentFound.body = removeMarkdown(parentContentFound.body, { maxLength: 50 });
     secureParentContentFound = authorization.filterOutput(userTryingToGet, 'read:content', parentContentFound);
   }
 

--- a/pages/[username]/index.public.js
+++ b/pages/[username]/index.public.js
@@ -219,7 +219,7 @@ export async function getStaticProps(context) {
 
   for (const content of secureContentListFound) {
     if (content.parent_id) {
-      content.body = shortenAndCleanBody(content.body);
+      content.body = removeMarkdown(content.body, { maxLength: 255 });
     } else {
       delete content.body;
     }
@@ -234,13 +234,4 @@ export async function getStaticProps(context) {
 
     revalidate: 10,
   };
-}
-
-function shortenAndCleanBody(body) {
-  const titleLength = 256;
-  const bodyLength = titleLength - '...'.length;
-  const cleanBody = removeMarkdown(body).replace(/\s+/g, ' ');
-
-  const shortenedBody = cleanBody.substring(0, bodyLength).trim();
-  return cleanBody.length < bodyLength ? shortenedBody : shortenedBody + '...';
 }

--- a/pages/[username]/pagina/[page]/index.public.js
+++ b/pages/[username]/pagina/[page]/index.public.js
@@ -74,7 +74,7 @@ export async function getStaticProps(context) {
 
   for (const content of secureContentListFound) {
     if (content.parent_id) {
-      content.body = shortenAndCleanBody(content.body);
+      content.body = removeMarkdown(content.body, { maxLength: 255 });
     } else {
       delete content.body;
     }
@@ -89,13 +89,4 @@ export async function getStaticProps(context) {
 
     revalidate: 10,
   };
-}
-
-function shortenAndCleanBody(body) {
-  const titleLength = 256;
-  const bodyLength = titleLength - '...'.length;
-  const cleanBody = removeMarkdown(body).replace(/\s+/g, ' ');
-
-  const shortenedBody = cleanBody.substring(0, bodyLength).trim();
-  return cleanBody.length < bodyLength ? shortenedBody : shortenedBody + '...';
 }

--- a/pages/api/v1/contents/[username]/index.public.js
+++ b/pages/api/v1/contents/[username]/index.public.js
@@ -47,7 +47,7 @@ async function getHandler(request, response) {
 
   for (const content of secureOutputValues) {
     if (content.parent_id) {
-      content.body = shortenAndCleanBody(content.body);
+      content.body = removeMarkdown(content.body, { maxLength: 255 });
     } else {
       delete content.body;
     }
@@ -55,13 +55,4 @@ async function getHandler(request, response) {
 
   controller.injectPaginationHeaders(results.pagination, `/api/v1/contents/${request.query.username}`, response);
   return response.status(200).json(secureOutputValues);
-}
-
-function shortenAndCleanBody(body) {
-  const titleLength = 256;
-  const bodyLength = titleLength - '...'.length;
-  const cleanBody = removeMarkdown(body).replace(/\s+/g, ' ');
-
-  const shortenedBody = cleanBody.substring(0, bodyLength).trim();
-  return cleanBody.length < bodyLength ? shortenedBody : shortenedBody + '...';
 }

--- a/tests/integration/api/v1/contents/[username]/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/get.test.js
@@ -164,7 +164,7 @@ describe('GET /api/v1/contents/[username]', () => {
           parent_id: rootContent.id,
           slug: childContent.slug,
           title: null,
-          body: 'Diferente do teste anterior, o corpo dessa publicação é grande, com quebras de linha, Markdown e ultrapassa o limite de caracteres que iremos devolver pelo response. Motivo Hoje estamos usando o mesmo número de caracteres de um title para que o frontend...',
+          body: 'Diferente do teste anterior, o corpo dessa publicação é grande, com quebras de linha, Markdown e ultrapassa o limite de caracteres que iremos devolver pelo response. Motivo Hoje estamos usando o mesmo número de caracteres de um title para que o fronten...',
           status: 'published',
           source_url: null,
           created_at: childContent.created_at.toISOString(),

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -265,6 +265,90 @@ describe('POST /api/v1/contents', () => {
       expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
+    test('Content with "body" containing empty Markdown', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
+        method: 'post',
+        headers: {
+          'Content-Type': 'application/json',
+          cookie: `session_id=${sessionObject.token}`,
+        },
+        body: JSON.stringify({
+          title: 'Título normal',
+          body: `![](https://image-url.com/image.png)
+          <div>\u00a0</div>
+          <b>\u2800</b>
+          <>\u200e</>
+          <p>\u200f</p>
+          <h1>\u0009</h1>
+          <strong>\u0020</strong>
+          <em><\u00ad/em>
+          <abbr>͏</abbr>
+          <address>\u061c</address>
+          <bdo>\u180e</bdo>
+          <q>\u2000</q>
+          <code>\u2001</code>
+          <ins>\u2002</ins>
+          <del>\u2003</del>
+          <dfn>\u2004</dfn>
+          <kbd>\u2005</kbd>
+          <pre>\u2006</pre>
+          <samp>\u2007</samp>
+          <var>\u2008</var>
+          <br>\u2009</br>
+          <div>\u200a</div>
+          <a>\u200b</a>
+          <base>\u200c</base>
+          <img>\u200d</img>
+          <area>\u200e</area>
+          <map>\u200f</map>
+          <param>\u205f</param>
+          <object>\u2060</object>
+          <ul>\u2061</ul>
+          <ol>\u2062</ol>
+          <li>\u2063</li>
+          <dl>\u2064</dl>
+          <dd>\u206a</dd>
+          <h1>\u206b</h1>
+          <h2>\u206c</h2>
+          <h3>\u206d</h3>
+          <h4>\u3000</h4>
+          <h5>\ufeff</h5>
+          <h6>𝅳</h6>
+          <>𝅴</>
+          <>𝅵</>
+          <>𝅶</>
+          <>𝅷</>
+          <>𝅸</>
+          <>𝅹</>
+          <>𝅺</>
+          <>\u115f</>
+          <>\u1160</>
+          <>\u17b4</>
+          <>\u17b5</>
+          <>\u3164</>
+          <>\uffa0</>
+          </code></a></div></other>
+          <code><a><div><other>
+          `,
+        }),
+      });
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual('Markdown deve conter algum texto');
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+    });
+
     test('Content with "title", "body" and "source_url" containing \\u0000 null characters', async () => {
       const defaultUser = await orchestrator.createUser();
       await orchestrator.activateUser(defaultUser);
@@ -321,35 +405,21 @@ describe('POST /api/v1/contents', () => {
           cookie: `session_id=${sessionObject.token}`,
         },
         body: JSON.stringify({
-          title: '\u200eTítulo começando e terminando com caracteres inválidos.\u200f',
+          title: '\u200eTítulo começando e terminando com caracteres inválidos.\u2800',
           body: '\u200fTexto começando e terminando com caracteres inválidos.\u200e',
         }),
       });
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(201);
-
-      expect(responseBody).toStrictEqual({
-        id: responseBody.id,
-        owner_id: defaultUser.id,
-        parent_id: null,
-        slug: 'titulo-comecando-e-terminando-com-caracteres-invalidos',
-        title: 'Título começando e terminando com caracteres inválidos.',
-        body: 'Texto começando e terminando com caracteres inválidos.',
-        status: 'draft',
-        source_url: null,
-        created_at: responseBody.created_at,
-        updated_at: responseBody.updated_at,
-        published_at: null,
-        deleted_at: null,
-        tabcoins: 0,
-        owner_username: defaultUser.username,
-      });
-
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual('"body" deve começar com caracteres visíveis.');
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "body" containing more than 20.000 characters', async () => {
@@ -400,6 +470,35 @@ describe('POST /api/v1/contents', () => {
 
       const responseBody = await response.json();
 
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual('"body" deve começar com caracteres visíveis.');
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+    });
+
+    test('Content with "body" containing untrimmed values', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
+        method: 'post',
+        headers: {
+          'Content-Type': 'application/json',
+          cookie: `session_id=${sessionObject.token}`,
+        },
+        body: JSON.stringify({
+          title: 'Título normal',
+          body: 'Espaço só no fim ',
+        }),
+      });
+
+      const responseBody = await response.json();
+
       expect(response.status).toEqual(201);
 
       expect(responseBody).toStrictEqual({
@@ -408,7 +507,7 @@ describe('POST /api/v1/contents', () => {
         parent_id: null,
         slug: 'titulo-normal',
         title: 'Título normal',
-        body: 'Espaço no início e no fim',
+        body: 'Espaço só no fim',
         status: 'draft',
         source_url: null,
         created_at: responseBody.created_at,
@@ -527,7 +626,7 @@ describe('POST /api/v1/contents', () => {
       expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
-    test('Content with "slug" containing more than 256 characters', async () => {
+    test('Content with "slug" containing more than 255 bytes', async () => {
       const defaultUser = await orchestrator.createUser();
       await orchestrator.activateUser(defaultUser);
       const sessionObject = await orchestrator.createSession(defaultUser);
@@ -541,20 +640,34 @@ describe('POST /api/v1/contents', () => {
         body: JSON.stringify({
           title: 'Mini curso de Node.js',
           body: 'Instale o Node.js',
-          slug: 'this-slug-is-to-257-characterssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss',
+          slug: 'this-slug-must-be-changed-to-255-bytesssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss',
         }),
       });
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"slug" deve conter no máximo 256 caracteres.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toEqual(201);
+
+      expect(responseBody).toStrictEqual({
+        id: responseBody.id,
+        owner_id: defaultUser.id,
+        parent_id: null,
+        slug: 'this-slug-must-be-changed-to-255-bytessssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss',
+        title: 'Mini curso de Node.js',
+        body: 'Instale o Node.js',
+        status: 'draft',
+        source_url: null,
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+        published_at: null,
+        deleted_at: null,
+        tabcoins: 0,
+        owner_username: defaultUser.username,
+      });
+
+      expect(uuidVersion(responseBody.id)).toEqual(4);
+      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
     });
 
     test('Content with "slug" containing special characters', async () => {
@@ -793,7 +906,7 @@ describe('POST /api/v1/contents', () => {
       expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
-    test('Content with "title" containing more than 256 characters', async () => {
+    test('Content with "title" containing more than 255 characters', async () => {
       const defaultUser = await orchestrator.createUser();
       await orchestrator.activateUser(defaultUser);
       const sessionObject = await orchestrator.createSession(defaultUser);
@@ -806,7 +919,7 @@ describe('POST /api/v1/contents', () => {
         },
         body: JSON.stringify({
           title:
-            'Este título possui 257 caracteresssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss',
+            'Este título possui 256 caracteressssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss',
           body: 'Qualquer coisa.',
         }),
       });
@@ -816,11 +929,142 @@ describe('POST /api/v1/contents', () => {
       expect(response.status).toEqual(400);
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"title" deve conter no máximo 256 caracteres.');
+      expect(responseBody.message).toEqual('"title" deve conter no máximo 255 caracteres.');
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
       expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+    });
+
+    test('Content with "title" containing 255 characters but more than 255 bytes', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
+        method: 'post',
+        headers: {
+          'Content-Type': 'application/json',
+          cookie: `session_id=${sessionObject.token}`,
+        },
+        body: JSON.stringify({
+          title:
+            'Este título possui 255 caracteres ocupando 256 bytes e deve com 100% de certeza gerar um slug ocupando menos de 256 bytesssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss',
+          body: 'Instale o Node.js',
+        }),
+      });
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(201);
+
+      expect(responseBody).toStrictEqual({
+        id: responseBody.id,
+        owner_id: defaultUser.id,
+        parent_id: null,
+        slug: 'este-titulo-possui-255-caracteres-ocupando-256-bytes-e-deve-com-100-por-cento-de-certeza-gerar-um-slug-ocupando-menos-de-256-bytessssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss',
+        title:
+          'Este título possui 255 caracteres ocupando 256 bytes e deve com 100% de certeza gerar um slug ocupando menos de 256 bytesssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss',
+        body: 'Instale o Node.js',
+        status: 'draft',
+        source_url: null,
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+        published_at: null,
+        deleted_at: null,
+        tabcoins: 0,
+        owner_username: defaultUser.username,
+      });
+
+      expect(uuidVersion(responseBody.id)).toEqual(4);
+      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+    });
+
+    test('Content with "title" containing Braille Pattern Blank Unicode Character', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
+        method: 'post',
+        headers: {
+          'Content-Type': 'application/json',
+          cookie: `session_id=${sessionObject.token}`,
+        },
+        body: JSON.stringify({
+          title: '\u2800 Braille Pattern Blank Unicode Character \u2800',
+          body: 'Instale o Node.js',
+        }),
+      });
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(201);
+
+      expect(responseBody).toStrictEqual({
+        id: responseBody.id,
+        owner_id: defaultUser.id,
+        parent_id: null,
+        slug: 'braille-pattern-blank-unicode-character',
+        title: 'Braille Pattern Blank Unicode Character',
+        body: 'Instale o Node.js',
+        status: 'draft',
+        source_url: null,
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+        published_at: null,
+        deleted_at: null,
+        tabcoins: 0,
+        owner_username: defaultUser.username,
+      });
+
+      expect(uuidVersion(responseBody.id)).toEqual(4);
+      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+    });
+
+    test('Content with "title" containing special characters occupying more than 255 bytes', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
+        method: 'post',
+        headers: {
+          'Content-Type': 'application/json',
+          cookie: `session_id=${sessionObject.token}`,
+        },
+        body: JSON.stringify({
+          title: '♥'.repeat(255),
+          body: 'The title is 255 characters but 765 bytes and the slug should only be 255 bytes',
+        }),
+      });
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(201);
+
+      expect(responseBody).toStrictEqual({
+        id: responseBody.id,
+        owner_id: defaultUser.id,
+        parent_id: null,
+        slug: '4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pm',
+        title: '♥'.repeat(255),
+        body: 'The title is 255 characters but 765 bytes and the slug should only be 255 bytes',
+        status: 'draft',
+        source_url: null,
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+        published_at: null,
+        deleted_at: null,
+        tabcoins: 0,
+        owner_username: defaultUser.username,
+      });
+
+      expect(uuidVersion(responseBody.id)).toEqual(4);
+      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
     });
 
     test('Content with "title" containing untrimmed values', async () => {

--- a/tests/integration/api/v1/contents/rss/get.test.js
+++ b/tests/integration/api/v1/contents/rss/get.test.js
@@ -98,7 +98,7 @@ describe('GET /recentes/rss', () => {
             <link>http://localhost:3000/${secondRootContent.owner_username}/${secondRootContent.slug}</link>
             <guid>http://localhost:3000/${secondRootContent.owner_username}/${secondRootContent.slug}</guid>
             <pubDate>${new Date(secondRootContent.published_at).toUTCString()}</pubDate>
-            <description><![CDATA[Este é um corpo bastante longo, vamos ver como que a propriedade description irá reagir, pois por padrão ela deverá cortar após um número X de caracteres. Não vou tomar nota aqui da quantida...]]></description>
+            <description><![CDATA[Este é um corpo bastante longo, vamos ver como que a propriedade description irá reagir, pois por padrão ela deverá cortar após um número X de caracteres. Não vou tomar nota aqui da quant...]]></description>
             <content:encoded><![CDATA[<div class="markdown-body"><p>Este é um corpo bastante longo, vamos ver como que a propriedade description irá reagir, pois por padrão ela deverá cortar após um número X de caracteres. Não vou tomar nota aqui da quantidade exata de caracteres, pois isso pode mudar ao longo do tempo.</p></div>]]></content:encoded>
         </item>
         <item>
@@ -106,7 +106,7 @@ describe('GET /recentes/rss', () => {
             <link>http://localhost:3000/${firstRootContent.owner_username}/${firstRootContent.slug}</link>
             <guid>http://localhost:3000/${firstRootContent.owner_username}/${firstRootContent.slug}</guid>
             <pubDate>${new Date(firstRootContent.published_at).toUTCString()}</pubDate>
-            <description><![CDATA[Corpo com HTML É importante lidar corretamente com o HTML, incluindo estilos especiais do GFM....]]></description>
+            <description><![CDATA[Corpo com HTML É importante lidar corretamente com o HTML, incluindo estilos especiais do GFM.]]></description>
             <content:encoded><![CDATA[<div class="markdown-body"><h1>Corpo com HTML</h1><p>É <strong>importante</strong> lidar corretamente com o <code>HTML</code>, incluindo estilos <del>especiais</del> do <code>GFM</code>.</p></div>]]></content:encoded>
         </item>
     </channel>


### PR DESCRIPTION
## Ajustes no validador em situações de caracteres em branco

### Trim

Já não era permitido iniciar uma publicação com espaços em branco, pois tinha o `trim` no `validator`, mas isso não era informado ao usuário e poderia alterar a publicação, pois remover a tabulação inicial pode fazer um bloco de código virar markdown válido e mudar a maneira de ser renderizado. E isso não seria visto no modo preview, mas apenas após publicar.

Então foi removido o `trim` do começo do `body` e agora existe o erro `"body" deve começar com caracteres visíveis.`

No final do `body` nada mudou, ou seja, os espaços ainda são removidos sem erros ou avisos.

### Tipos de caracteres em branco

Agora o validador abrange uma maior variedade de caracteres vazios.

### Markdown vazio

Também informa erro ao criar publicação em que o body ficar vazio após a remoção do markdown:

`Markdown deve conter algum texto`

### Limite de caracteres/bytes

O título agora está limitado a 255 caracteres ao invés de 256.

E o slug está limitado a 255 bytes.