### PR TITLE
Corrige o espaçamento e alinhamento entre label e checkbox de notificações por email

### DIFF
--- a/pages/perfil/index.public.js
+++ b/pages/perfil/index.public.js
@@ -219,10 +219,11 @@ function EditProfileForm() {
           )}
         </FormControl>
 
-        <FormControl id="notifications">
+        <FormControl id="notifications" sx={{ gap: 2, alignItems: 'center' }}>
           <FormControl.Label>Receber notificações por email</FormControl.Label>
 
           <Checkbox
+            sx={{ display: 'flex' }}
             ref={notificationsRef}
             onChange={clearErrors}
             name="notifications"


### PR DESCRIPTION
Já existiam 3 PRs relacionados: #817, #1059 e #1080, mas cada versão deixava desalinhada a checkbox com o texto em pelo menos um navegador.

A solução proposta é a que ficou com melhor alinhamento na maioria dos navegadores (não testei no Safari):

![image](https://user-images.githubusercontent.com/77860630/206914523-7c91734f-10b8-408f-af7b-70784e157aef.png)