### PR TITLE
feat(footer): add link to RSS in footer

### DIFF
--- a/pages/interface/components/Footer/index.js
+++ b/pages/interface/components/Footer/index.js
@@ -49,6 +49,7 @@ export default function Footer(props) {
             flexWrap: 'wrap',
           }}>
           <Link href="https://github.com/filipedeschamps/tabnews.com.br">GitHub</Link>
+          <Link href="/recentes/rss">RSS</Link>
           <Link href="/museu">Museu</Link>
           <Link href="https://www.tabnews.com.br/filipedeschamps/tentando-construir-um-pedaco-de-internet-mais-massa">
             Sobre

--- a/pages/interface/components/Footer/index.js
+++ b/pages/interface/components/Footer/index.js
@@ -48,14 +48,14 @@ export default function Footer(props) {
             paddingX: [2, null, null, 5],
             flexWrap: 'wrap',
           }}>
+          <Link href="/contato">Contato</Link>
           <Link href="https://github.com/filipedeschamps/tabnews.com.br">GitHub</Link>
-          <Link href="/recentes/rss">RSS</Link>
           <Link href="/museu">Museu</Link>
+          <Link href="/recentes/rss">RSS</Link>
           <Link href="https://www.tabnews.com.br/filipedeschamps/tentando-construir-um-pedaco-de-internet-mais-massa">
             Sobre
           </Link>
           <Link href="/status">Status</Link>
-          <Link href="/contato">Contato</Link>
           <Link href="/termos-de-uso">Termos de Uso</Link>
         </Box>
       </Box>


### PR DESCRIPTION
Minha ideia inicial era adicionar um ícone para o RSS, ainda mais por causa deste comentário: https://github.com/filipedeschamps/tabnews.com.br/issues/1052#issuecomment-1333835572. No entanto, acredito que isso sairia do padrão do projeto, que é inspirado aqui no GitHub.

Então optei pelo simples mesmo, só adicionei o link para `/recentes/rss`.

Resolve #1175 