### PR TITLE
Melhoras de UX - Habilita zoom na versão mobile e restaura scroll da página ao voltar

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   experimental: {
     allowMiddlewareResponseBody: true,
+    scrollRestoration: true,
   },
   pageExtensions: ['public.js'],
   eslint: {

--- a/pages/interface/components/ContentList/index.js
+++ b/pages/interface/components/ContentList/index.js
@@ -40,7 +40,7 @@ export default function ContentList({ contentList, pagination, paginationBasePat
             mb: 2,
           }}>
           {pagination.previousPage ? (
-            <Link href={previousPageUrl}>
+            <Link href={previousPageUrl} scroll={false}>
               <ChevronLeftIcon size={16} />
               Anterior
             </Link>

--- a/pages/interface/components/Head/index.js
+++ b/pages/interface/components/Head/index.js
@@ -47,7 +47,7 @@ export function DefaultHead() {
       <meta property="twitter:description" content={description} key="twitter:description" />
       <meta property="twitter:image" content={image} key="twitter:image" />
 
-      <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
       <link rel="icon" href={favicon} type="image/png" />
       <link rel="manifest" href="/manifest.json" crossOrigin="use-credentials" />
       <meta name="mobile-web-app-capable" content="yes" />

--- a/pages/status/index.public.js
+++ b/pages/status/index.public.js
@@ -18,7 +18,7 @@ export default function Page() {
 
   return (
     <DefaultLayout metadata={{ title: 'Estatísticas e Status do Site' }}>
-      <Box sx={{ display: 'grid', width: '100%' }}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
         <Heading as="h1">Estatísticas e Status do Site</Heading>
 
         <Box>


### PR DESCRIPTION
## Melhorias de UX

### Scroll

Restaura o scroll ao voltar a página pelo navegador ou ao clicar no link `Anterior`.

Assim o usuário não precisa procurar novamente em qual posição estava na lista antes de clicar em um conteúdo. (Closes #1138).

### Zoom mobile

Habilita a possibilidade de mudar a escala da página em dispositivos móveis.

Isso facilita visualizar detalhes de imagens que contenham muita informação.

### Responsividade dos gráficos

Corrige a responsividade dos gráficos da página de status que não funcionava bem com `display: grid`