### PR TITLE
fix(use-user): set `user` to `null` instead of `{}`

### DIFF
--- a/pages/interface/hooks/useUser/index.js
+++ b/pages/interface/hooks/useUser/index.js
@@ -58,7 +58,7 @@ export function UserProvider({ children }) {
 
     function onFocus() {
       const cachedUser = JSON.parse(localStorage.getItem('user'));
-      setUser((user) => ({ ...user, ...cachedUser }));
+      setUser((user) => (cachedUser?.username ? { ...user, ...cachedUser } : null));
       if (refreshInterval < Date.now() - cachedUser?.cacheTime) fetchUser();
     }
     addEventListener('focus', onFocus);


### PR DESCRIPTION
Em diversos pontos do sistema estamos verificando se um usuário está logado apenas olhando se `user` é truthy.

Por isso não podemos fazer `setUser({})` quando o usuário não estiver logado, já que isso implicaria:

```js
{} && "logado"
// returns "logado"
```

Então fazendo `setUser(null)`, teremos o esperado:

```js
null && "logado"
// returns null
```

Esse PR corrige o relatado em #1196 

Uma melhoria futura seria fazer `useUser` retornar separadamente cada propriedade do objeto `user` e também uma propriedade como `isLogged`. Assim teríamos uma pequena melhora de performance ao reduzir renderizações causadas por mudanças em propriedades do `user` que não implicam mudanças visuais.