### PR TITLE
feat: adiciona busca de `contents` baseado 

### DIFF
--- a/infra/migrations/1672340348449_add-extension-pg_trgm.js
+++ b/infra/migrations/1672340348449_add-extension-pg_trgm.js
@@ -1,0 +1,11 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined;
+
+exports.up = (pgm) => {
+  pgm.createExtension('pg_trgm');
+};
+
+exports.down = (pgm) => {
+  pgm.dropExtension('pg_trgm');
+};

--- a/infra/migrations/1672341986324_create-index-on-contents-for-full-text-search.js
+++ b/infra/migrations/1672341986324_create-index-on-contents-for-full-text-search.js
@@ -1,0 +1,14 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined;
+
+exports.up = (pgm) => {
+  pgm.createIndex('contents', [{ name: 'title', opclass: 'gin_trgm_ops' }], {
+    name: 'content_titles_trigrams_idx',
+    method: 'gin',
+  });
+};
+
+exports.down = (pgm) => {
+  pgm.dropIndex('contents', 'title');
+};


### PR DESCRIPTION
Conforme a discussão levantada na issue #1084 , acreditamos ser uma funcionalidade importante a busca por `contents` (posts/publicações...) publicados no TabNews, pois dessa forma evitaríamos `contents` duplicados, permitindo centralizar discussões sobre um assunto específico em um mesmo `content`, além de facilitar a busca por um assunto em específico.

Um dos problemas a ser resolvido é que essa busca por `contents` necessita ser efetiva, trazendo `contents` relevantes e que tenham relação com a pesquisa do usuário, ao mesmo tempo que precisa ser flexível, não dependendo de uma busca exata dos termos e palavras presentes no `content`.

Inicialmente, a ideia era utilizar um serviço voltado para esse tipo de busca, como o Algolia ou o MeiliSearch, por exemplo. Provavelmente, esse tipo de serviço iria suprir muito bem essa necessidade, com a desvantagem de gerarem custos extras, tanto financeiros como de manutenção, para o projeto (ou seja, para o @filipedeschamps haha). Por conta disso, acreditamos que é mais interessante utilizarmos um recurso (acredito eu haha) menos robusto, mas sem custos adicionais, e que também pode se mostrar bastante efetivo e, futuramente, caso julgue-se necessário, migrar para uma solução mais robusta.

Uma solução apresentada foi utilizar a extensão [`pg_trgm`](https://www.postgresql.org/docs/current/pgtrgm.html) do Postgres que, basicamente,  adiciona _operator classes_ para índices do tipo `GIN` e `GiST` que nos permite criar índices de colunas textuais e realizar operações de buscas por similaridade, que são muito mais rápidas se comparadas a buscas comuns utilizando `LIKE` ou comparações diretas (`=`) entre strings. 

Por enquanto, acreditamos fazer sentido fazer as buscas apenas pelo `title` do `content` e, futuramente, incluir o `body` (conteúdo) do `content` na pesquisa.

PS: além da documentação oficial do `pg_trgm`, [neste artigo](https://niallburkley.com/blog/index-columns-for-like-in-postgres/) também tem um material legal sobre isso e algumas comparações de desempenho de queries utilizando e não utilizando o `pg_trgm`. 

## Todo's
- [x] Habilitar o `pg_trgm` no Postgres (gerar migration)
- [x] Criar índice em `contents.title` utilizando método `GIN` e com _opclass_ `gin_trgm_ops` (criar migration)
- [ ] Adicionar função em `models/content.js` que recebe uma string e realiza a busca no banco em cima dessa string OU incluir suporte para cláusulas `WHERE ILIKE` na função `findAll` do mesmo arquivo. Ambas abordagens precisarão ter suporte a paginação
- [ ] Adicionar barra de pesquisa na UI e integrar com a busca criada