### PR TITLE
perf(contents): initial add on-demand revalidates

### DIFF
--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -12,32 +12,7 @@ import { Box, Tooltip } from '@primer/react';
 import { CommentIcon, CommentDiscussionIcon } from '@primer/octicons-react';
 import webserver from 'infra/webserver.js';
 
-export default function Post({
-  contentFound: contentFoundFallback,
-  childrenFound: childrenFallback,
-  rootContentFound,
-  parentContentFound,
-  contentMetadata,
-}) {
-  const { data: contentFound } = useSWR(
-    `/api/v1/contents/${contentFoundFallback.owner_username}/${contentFoundFallback.slug}`,
-    {
-      fallbackData: contentFoundFallback,
-      revalidateOnFocus: false,
-      revalidateOnReconnect: false,
-    }
-  );
-
-  // TODO: understand why enabling "revalidateOn..." breaks children rendering.
-  const { data: children } = useSWR(
-    `/api/v1/contents/${contentFoundFallback.owner_username}/${contentFoundFallback.slug}/children`,
-    {
-      fallbackData: childrenFallback,
-      revalidateOnFocus: false,
-      revalidateOnReconnect: false,
-    }
-  );
-
+export default function Post({ contentFound, childrenFound, rootContentFound, parentContentFound, contentMetadata }) {
   const [confettiWidth, setConfettiWidth] = useState(0);
   const [confettiHeight, setConfettiHeight] = useState(0);
   const [showConfetti, setShowConfetti] = useState(false);
@@ -121,7 +96,7 @@ export default function Post({
             <Content key={contentFound.id} content={{ parent_id: contentFound.id }} mode="compact" />
           </Box>
 
-          <RenderChildrenTree key={contentFound.id} childrenList={children} level={0} />
+          <RenderChildrenTree key={contentFound.id} childrenList={childrenFound} level={0} />
         </Box>
       </DefaultLayout>
     </>
@@ -386,6 +361,5 @@ export async function getStaticProps(context) {
       parentContentFound: JSON.parse(JSON.stringify(secureParentContentFound)),
       contentMetadata: JSON.parse(JSON.stringify(contentMetadata)),
     },
-    revalidate: 10,
   };
 }

--- a/pages/api/v1/contents/[username]/[slug]/children/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/children/index.public.js
@@ -31,10 +31,12 @@ function getValidationHandler(request, response, next) {
 async function getHandler(request, response) {
   const userTryingToGet = request.context.user;
 
+  const { username, slug } = request.query;
+
   const contentFound = await content.findOne({
     where: {
-      owner_username: request.query.username,
-      slug: request.query.slug,
+      owner_username: username,
+      slug,
       status: 'published',
     },
   });
@@ -56,6 +58,9 @@ async function getHandler(request, response) {
   });
 
   const secureOutputValues = authorization.filterOutput(userTryingToGet, 'read:content:list', childrenFound);
+
+  // Revalidate page for the updated content
+  response.revalidate(`${username}/${slug}/children`);
 
   return response.status(200).json(secureOutputValues);
 }


### PR DESCRIPTION
Abri esse PR antecipadamente sobre a issue  #1164, pois gostaria de saber se a ideia de usar `revalidate` faz sentindo progredir com ela... Vejo vários benefícios nessa abordagem, mas como não tenho conhecimento do projeto inteiro, tenho algumas dúvidas...

Os principais benefícios são:
- Sem gerenciamento de cache com `maxage` (pois sempre ao rolar alguma ação automaticamente sera revalidado, o que na minha visão facilita e evita ter problemas de dessincronização quando é cache por `maxage`..)
- Diminuição de requests.

Qualquer sugestão é bem vinda, gostaria de implementar essa melhoria, mas se essa não for a melhor solução, por favor, me mostre outras soluções.

(Não implementei a solução completa, gostaria de saber se faz sentido continuar com isso antes...)