### PR TITLE
Make header component a sticky element

### DIFF
--- a/pages/interface/components/Header/index.js
+++ b/pages/interface/components/Header/index.js
@@ -18,6 +18,8 @@ export default function HeaderComponent() {
       id="header"
       sx={{
         px: [2, null, null, 3],
+        position: 'sticky',
+        top: 0,
       }}>
       <Header.Item>
         <HeaderLink href="/" aria-label="Voltar para a página inicial">


### PR DESCRIPTION
#1225 
Makes so that the header element on the page is a position sticky, that means that when the user has not scrolled the page down it will stay an element and not cover any content, but as soon as the user starts scrolling down it will stay on top of the screen allowing the user to quickly access the actions placed on the header without having to scroll all the way up the page to do so