### PR TITLE
Substituindo o caractere de copyright pelo HTML entity

### DIFF
--- a/pages/interface/components/Footer/index.js
+++ b/pages/interface/components/Footer/index.js
@@ -37,7 +37,7 @@ export default function Footer(props) {
             href="/">
             <CgTab size={26} />
           </Link>
-          © {new Date().getFullYear()} TabNews
+          &copy; {new Date().getFullYear()} TabNews
         </Box>
         <Box
           sx={{


### PR DESCRIPTION
Substituição do símbolo ```©``` pelo HTML entity ```&copy;``` para garantir a exibição correta em todos os sistemas e navegadores. Isso é útil em situações em que o símbolo não está disponível ou não é exibido corretamente, como em algumas fontes ou sistemas operacionais.