### PR TITLE
Alterando os textos padrão dos botões do useConfirm

### DIFF
--- a/pages/[username]/index.public.js
+++ b/pages/[username]/index.public.js
@@ -31,6 +31,8 @@ export default function Home({ contentListFound, pagination, userFound: userFoun
     const confirmDelete1 = await confirm({
       title: `Atenção: Você está realizando um Nuke!`,
       content: `Deseja banir o usuário "${userFound.username}" e desfazer todas as suas ações?`,
+      confirmButtonContent: 'Sim',
+      cancelButtonContent: 'Cancelar',
     });
 
     if (!confirmDelete1) return;

--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -81,6 +81,8 @@ function ViewMode({ setComponentMode, contentObject, viewFrame }) {
     const confirmDelete = await confirm({
       title: 'Você tem certeza?',
       content: 'Deseja realmente apagar essa publicação?',
+      cancelButtonContent: 'Cancelar',
+      confirmButtonContent: 'Sim',
     });
 
     if (!confirmDelete) return;
@@ -369,6 +371,8 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
         ? await confirm({
             title: 'Tem certeza que deseja sair da edição?',
             content: 'Os dados não salvos serão perdidos.',
+            cancelButtonContent: 'Cancelar',
+            confirmButtonContent: 'Sim',
           })
         : true;
 

--- a/pages/perfil/index.public.js
+++ b/pages/perfil/index.public.js
@@ -79,6 +79,8 @@ function EditProfileForm() {
       const confirmChangeUsername = await confirm({
         title: `Você realmente deseja alterar seu nome de usuário?`,
         content: `Isto irá quebrar todas as URLs das suas publicações.`,
+        cancelButtonContent: 'Cancelar',
+        confirmButtonContent: 'Sim',
       });
 
       if (!confirmChangeUsername) {


### PR DESCRIPTION
### Antes

Os botões, por padrão, eram em inglês.

![modaldefault](https://user-images.githubusercontent.com/87894998/217081295-9359e353-5345-402f-8c4c-1959b78f34a1.png)

### Depois

Agora eu alterei para o português.

![newtext](https://user-images.githubusercontent.com/87894998/217081254-bd782944-bdec-42ca-bd51-c7bbf9aa2902.png)

