### PR TITLE
Adicionando plugin customizado para abrir links em uma nova aba (issue #1233)

### DIFF
--- a/pages/interface/components/Markdown/index.js
+++ b/pages/interface/components/Markdown/index.js
@@ -24,10 +24,25 @@ const bytemdPluginList = [
   gemojiPlugin(),
 ];
 
+// Viewer plugin to open links on new tab
+const modifyHrefTarget = () => ({
+  viewerEffect({ markdownBody }) {
+    const linksArr = Array.from(markdownBody.querySelectorAll('a'));
+    for (let i = 0; i < linksArr.length; i++) {
+      const currentElement = linksArr[i];
+      if (currentElement.getAttribute('href')) {
+        currentElement.setAttribute('target', '_blank');
+      }
+    }
+  },
+});
+
+const viewerPlugins = [...bytemdPluginList, modifyHrefTarget()];
+
 const remarkRehypeOptions = { handlers: { code } };
 
 export default function Viewer({ ...props }) {
-  return <ByteMdViewer sanitize={sanitize} plugins={bytemdPluginList} remarkRehype={remarkRehypeOptions} {...props} />;
+  return <ByteMdViewer sanitize={sanitize} plugins={viewerPlugins} remarkRehype={remarkRehypeOptions} {...props} />;
 }
 
 // Editor is not part of Primer, so error messages and styling need to be created manually


### PR DESCRIPTION
Baseado na issue #1233, abri essa PR para que os links sejam abertos em uma nova aba.

Foi uma "dor" que senti enquanto utilizava a plataforma. A partir disso, procurei algo relacionado nas issues, encontrei essa e decidi implementar.

Obs: não consegui rodar os testes na minha máquina, estou investigando isso.