### PR TITLE
Melhoria da acessibilidade dos links

### DIFF
--- a/pages/interface/components/Footer/index.js
+++ b/pages/interface/components/Footer/index.js
@@ -34,7 +34,8 @@ export default function Footer(props) {
               justifyContent: 'center',
               alignItems: 'center',
             }}
-            href="/">
+            href="/"
+            aria-label="Voltar para a página inicial">
             <CgTab size={26} />
           </Link>
           &copy; {new Date().getFullYear()} TabNews

--- a/pages/interface/components/Header/index.js
+++ b/pages/interface/components/Header/index.js
@@ -20,7 +20,7 @@ export default function HeaderComponent() {
         px: [2, null, null, 3],
       }}>
       <Header.Item>
-        <HeaderLink href="/">
+        <HeaderLink href="/" aria-label="Voltar para a página inicial">
           <CgTab size={32} />
           <Box sx={{ ml: 2, display: ['none', 'block'] }}>TabNews</Box>
         </HeaderLink>


### PR DESCRIPTION
Este Pull Request tem como objetivo melhorar a acessibilidade dos links, resolvendo parcialmente a issue #1259. Para alcançar esse objetivo, foram adicionados "aria-labels" nos links que eram reportados pelo PageSpeed. Embora não resolva todos os problemas relacionados à issue, é uma importante contribuição para a melhoria do site.

Como estava no computador antes do aria-label:
![pc97](https://user-images.githubusercontent.com/87894998/217943372-206cfbeb-34a0-4c70-b1d3-1dc15d38e94e.png)

Depois:
![pc100](https://user-images.githubusercontent.com/87894998/217943467-29fc4bc7-dd95-4458-8f2b-ccf5b7e40c89.png)

Como estava o mobile antes do aria-label:
![mob97](https://user-images.githubusercontent.com/87894998/217943556-8b90db12-062d-419f-8576-4ee527923dc0.png)

Depois:
![mob100](https://user-images.githubusercontent.com/87894998/217943582-77c9d720-8f20-43d7-987d-42208a0e5f73.png)

