### PR TITLE
feat: dark mode using so dark mode feature

### DIFF
--- a/pages/_app.public.js
+++ b/pages/_app.public.js
@@ -4,6 +4,7 @@ import { SWRConfig } from 'swr';
 import { UserProvider } from 'pages/interface/hooks/useUser/index.js';
 import NextNProgress from 'pages/interface/components/Progressbar/index.js';
 import { DefaultHead } from 'pages/interface/components/Head/index.js';
+import '../styles.css';
 
 async function SWRFetcher(resource, init) {
   const response = await fetch(resource, init);

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,10 @@
+@media screen and (prefers-color-scheme: dark) {
+  /* Dark mode styles */
+  body {
+    background-color: lightgray;
+  }
+
+  .markdown-body {
+    background-color: lightgray;
+  }
+}


### PR DESCRIPTION

O dark mode observa se o Sistema Operacional está com Dark Mode ativo, e em caso positivo, muda a cor de fundo para lightgray. Esta alteração não quebra as cores do site e suaviza um pouco o fundo branco. 

Como ficou:

![image](https://user-images.githubusercontent.com/1509692/218451259-fd48b205-3375-4126-b892-29cd2aacdbfa.png)

No caso do conteúdo:

![image](https://user-images.githubusercontent.com/1509692/218451321-629d6a03-4f07-47d1-8bcc-a9bdea14a409.png)

login:

![image](https://user-images.githubusercontent.com/1509692/218451384-5bbdbe5a-d5bb-441c-b11f-2e858e32afde.png)


