### PR TITLE
feat: added tooltip to show full date in post list

### DIFF
--- a/pages/interface/components/ContentList/index.js
+++ b/pages/interface/components/ContentList/index.js
@@ -1,5 +1,5 @@
 import useSWR from 'swr';
-import { Box, Text } from '@primer/react';
+import { Box, Text, Tooltip } from '@primer/react';
 import { ChevronLeftIcon, ChevronRightIcon, CommentIcon } from '@primer/octicons-react';
 
 import { Link, PublishedSince, EmptyState } from 'pages/interface';
@@ -125,7 +125,14 @@ export default function ContentList({ contentList, pagination, paginationBasePat
             </Link>
             {' · '}
             <Text>
-              <PublishedSince date={contentObject.published_at} />
+              <Tooltip
+                sx={{ position: 'absolute', ml: 1 }}
+                aria-label={new Date(contentObject.published_at).toLocaleString('pt-BR', {
+                  dateStyle: 'full',
+                  timeStyle: 'short',
+                })}>
+                <PublishedSince date={contentObject.published_at} />
+              </Tooltip>
             </Text>
           </Box>
         </Box>,


### PR DESCRIPTION
Percebi que tem um componente de Tooltip bem legal quando passamos o mouse em cima da data quando estamos lendo o post, pensei em colocar o mesmo nas listas de posts.

## antes
![image](https://user-images.githubusercontent.com/48577990/220211528-b0e8affa-48bb-4765-9dfb-e56507d7a146.png)

## depois
![image](https://user-images.githubusercontent.com/48577990/220211493-61aaf5e1-ac6b-42a5-8232-0971b770dd52.png)
