### PR TITLE
feat(header-menu): add new link to user contents

### DIFF
--- a/pages/interface/components/Header/index.js
+++ b/pages/interface/components/Header/index.js
@@ -6,7 +6,7 @@ import { useRouter } from 'next/router';
 
 export default function HeaderComponent() {
   const { user, isLoading, logout } = useUser();
-  const { pathname, query } = useRouter();
+  const { pathname } = useRouter();
 
   const activeLinkStyle = {
     textDecoration: 'underline',
@@ -32,7 +32,7 @@ export default function HeaderComponent() {
         </HeaderLink>
       </Header.Item>
 
-      <Header.Item full={!isLoading && !user}>
+      <Header.Item full>
         <HeaderLink href="/recentes" sx={pathname.startsWith('/recentes') ? activeLinkStyle : undefined}>
           Recentes
         </HeaderLink>
@@ -51,14 +51,6 @@ export default function HeaderComponent() {
 
       {user && (
         <>
-          <Header.Item full>
-            <HeaderLink
-              href={`/${user.username}`}
-              sx={query.username === `${user.username}` ? activeLinkStyle : undefined}>
-              Meus conteúdos
-            </HeaderLink>
-          </Header.Item>
-
           <Header.Item
             sx={{
               mr: 2,
@@ -102,6 +94,9 @@ export default function HeaderComponent() {
                     <Truncate>{user.username}</Truncate>
                   </ActionList.LinkItem>
                   <ActionList.Divider />
+                  <ActionList.LinkItem as={Link} href={`/${user.username}`}>
+                    Meus conteúdos
+                  </ActionList.LinkItem>
                   <ActionList.LinkItem as={Link} href="/publicar">
                     Publicar novo conteúdo
                   </ActionList.LinkItem>

--- a/pages/interface/components/Header/index.js
+++ b/pages/interface/components/Header/index.js
@@ -94,11 +94,11 @@ export default function HeaderComponent() {
                     <Truncate>{user.username}</Truncate>
                   </ActionList.LinkItem>
                   <ActionList.Divider />
-                  <ActionList.LinkItem as={Link} href={`/${user.username}`}>
-                    Meus conteúdos
-                  </ActionList.LinkItem>
                   <ActionList.LinkItem as={Link} href="/publicar">
                     Publicar novo conteúdo
+                  </ActionList.LinkItem>
+                  <ActionList.LinkItem as={Link} href={`/${user.username}`}>
+                    Meus conteúdos
                   </ActionList.LinkItem>
                   <ActionList.LinkItem as={Link} href="/perfil">
                     Editar perfil

--- a/pages/interface/components/Header/index.js
+++ b/pages/interface/components/Header/index.js
@@ -6,7 +6,7 @@ import { useRouter } from 'next/router';
 
 export default function HeaderComponent() {
   const { user, isLoading, logout } = useUser();
-  const { pathname } = useRouter();
+  const { pathname, query } = useRouter();
 
   const activeLinkStyle = {
     textDecoration: 'underline',
@@ -32,7 +32,7 @@ export default function HeaderComponent() {
         </HeaderLink>
       </Header.Item>
 
-      <Header.Item full>
+      <Header.Item full={!isLoading && !user}>
         <HeaderLink href="/recentes" sx={pathname.startsWith('/recentes') ? activeLinkStyle : undefined}>
           Recentes
         </HeaderLink>
@@ -51,6 +51,14 @@ export default function HeaderComponent() {
 
       {user && (
         <>
+          <Header.Item full>
+            <HeaderLink
+              href={`/${user.username}`}
+              sx={query.username === `${user.username}` ? activeLinkStyle : undefined}>
+              Meus conteúdos
+            </HeaderLink>
+          </Header.Item>
+
           <Header.Item
             sx={{
               mr: 2,


### PR DESCRIPTION
Adiciona novo item ao `header` para facilitar, agilizar e estimular o acesso aos conteúdos criados pelo próprio usuário. O acesso aos conteúdos diretamente no `header` torna mais **acessível** a visualização da criação do seu conteúdo no site, **facilitando**, agilizando e **estimulando** o acompanhamento de suas interações e recebimento de `tabcoins`, assim como também pode estimular a produção de mais conteúdos de valor ao site, ao visualizar com recorrência suas contribuições ao `tabnews`.




![pr](https://user-images.githubusercontent.com/59850744/221411242-16a69e9e-22c0-48fd-9078-4c63ae65ed90.png)
