### PR TITLE
feat(head): add theme-color bar on mobile

### DIFF
--- a/pages/interface/components/Head/index.js
+++ b/pages/interface/components/Head/index.js
@@ -53,6 +53,7 @@ export function DefaultHead() {
       <meta name="mobile-web-app-capable" content="yes" />
       <meta name="apple-mobile-web-app-capable" content="yes" />
       <meta httpEquiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+      <meta name="theme-color" content="#24292F" />
     </NextHead>
   );
 }

--- a/pages/interface/components/Header/index.js
+++ b/pages/interface/components/Header/index.js
@@ -1,16 +1,64 @@
-import { Header, Box, ActionMenu, ActionList, IconButton, Truncate, Text, Tooltip } from '@primer/react';
+import {
+  Header,
+  Box,
+  ActionMenu,
+  ActionList,
+  IconButton,
+  Truncate,
+  Text,
+  Tooltip,
+  NavList,
+  Dialog,
+} from '@primer/react';
 import { PersonFillIcon, HomeIcon, SquareFillIcon } from '@primer/octicons-react';
-import { CgTab } from 'react-icons/cg';
+import { CgTab, CgMenu } from 'react-icons/cg';
 import { HeaderLink, Link, useUser } from 'pages/interface';
 import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
 
 export default function HeaderComponent() {
   const { user, isLoading, logout } = useUser();
+  const [showMenuMobile, setShowMenuMobile] = useState(false);
+  const [mobileSize, setMobileSize] = useState(false);
+
   const { pathname } = useRouter();
 
   const activeLinkStyle = {
     textDecoration: 'underline',
     textUnderlineOffset: 6,
+  };
+
+  useEffect(() => {
+    const handleWindowResize = () => {
+      setMobileSize(window.innerWidth < 545);
+    };
+
+    window.addEventListener('resize', handleWindowResize);
+
+    return () => {
+      window.removeEventListener('resize', handleWindowResize);
+    };
+  }, []);
+
+  const menuMobile = () => {
+    return (
+      <>
+        <Header.Item sx={{ display: ['flex', 'none'] }}>
+          <CgMenu size={32} onClick={() => setShowMenuMobile(true)} />
+        </Header.Item>
+        <Dialog isOpen={showMenuMobile} onDismiss={() => setShowMenuMobile(false)} aria-labelledby="menu">
+          <Dialog.Header>
+            <CgMenu />
+          </Dialog.Header>
+          <NavList>
+            <NavList.Item href="/" aria-current="page">
+              Relevantes
+            </NavList.Item>
+            <NavList.Item href="/recentes">Recentes</NavList.Item>
+          </NavList>
+        </Dialog>
+      </>
+    );
   };
 
   return (
@@ -19,20 +67,21 @@ export default function HeaderComponent() {
       sx={{
         px: [2, null, null, 3],
       }}>
-      <Header.Item>
+      {menuMobile()}
+      <Header.Item full={mobileSize}>
         <HeaderLink href="/" aria-label="Voltar para a página inicial">
           <CgTab size={32} />
           <Box sx={{ ml: 2, display: ['none', 'block'] }}>TabNews</Box>
         </HeaderLink>
       </Header.Item>
 
-      <Header.Item>
+      <Header.Item sx={{ ml: 2, display: ['none', 'flex'] }}>
         <HeaderLink href="/" sx={pathname === '/' || pathname.startsWith('/pagina') ? activeLinkStyle : undefined}>
           Relevantes
         </HeaderLink>
       </Header.Item>
 
-      <Header.Item full>
+      <Header.Item full sx={{ ml: 2, display: ['none', 'flex'] }}>
         <HeaderLink href="/recentes" sx={pathname.startsWith('/recentes') ? activeLinkStyle : undefined}>
           Recentes
         </HeaderLink>


### PR DESCRIPTION
a barra de pesquisa do android é adaptável ao theme-color informado no head da página, talvez colocar a cor de forma direta não seja o mais adequado, qualquer sugestão é bem-vinda.


|antes| depois|
|:------:|:--------:|
| ![WhatsApp Image 2023-02-26 at 21 10 46](https://user-images.githubusercontent.com/48577990/221446233-e74508d5-dcc5-417d-b7a5-95079b334cee.jpeg)| ![WhatsApp Image 2023-02-26 at 21 10 46 (1)](https://user-images.githubusercontent.com/48577990/221446239-ef9b5800-57eb-4824-bf6b-5d7b76e0e104.jpeg)|


[Referencia](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color)


