### PR TITLE
Inicia o fluxo de recuperação de senha apenas por `email`

### DIFF
--- a/infra/scripts/seed-database.js
+++ b/infra/scripts/seed-database.js
@@ -45,6 +45,7 @@ async function seedDevelopmentUsers() {
     'update:content',
     'update:user',
   ]);
+  await addUserFeaturesByUsername('admin', ['create:recovery_token:username']);
 
   console.log('------------------------------');
   console.log('> You can now Login to TabNews using the following credentials:');
@@ -65,6 +66,39 @@ async function seedDevelopmentUsers() {
       if (!error.detail.includes('already exists')) {
         throw error;
       }
+    }
+  }
+
+  async function addUserFeaturesByUsername(username, features) {
+    try {
+      const getUserByUsernameQuery = {
+        text: 'SELECT features FROM users WHERE username = $1;',
+        values: [username],
+      };
+      const resultFromGetUserByUsernameQuery = await client.query(getUserByUsernameQuery);
+      const user = resultFromGetUserByUsernameQuery.rows[0];
+
+      const newFeatures = [];
+      const newFeatureCandidatesWithoutDuplicates = new Set([...features]);
+
+      newFeatureCandidatesWithoutDuplicates.forEach((newFeatureCandidate) => {
+        if (!user.features.includes(newFeatureCandidate)) {
+          newFeatures.push(newFeatureCandidate);
+        }
+      });
+
+      const updateUserFeaturesQuery = {
+        text: `
+          UPDATE users SET features = array_cat(features, $1), updated_at = (now() at time zone 'utc')
+          WHERE username = $2
+          RETURNING *;
+        `,
+        values: [newFeatures, username],
+      };
+
+      await client.query(updateUserFeaturesQuery);
+    } catch (error) {
+      throw error;
     }
   }
 }

--- a/models/authorization.js
+++ b/models/authorization.js
@@ -19,6 +19,7 @@ const availableFeatures = new Set([
 
   // RECOVERY_TOKEN
   'read:recovery_token',
+  'create:recovery_token:username',
 
   // EMAIL_CONFIRMATION_TOKEN
   'read:email_confirmation_token',

--- a/pages/cadastro/recuperar/index.public.js
+++ b/pages/cadastro/recuperar/index.public.js
@@ -23,7 +23,7 @@ function RecoverPasswordForm() {
 
   useEffect(() => {
     if (user && !userIsLoading) {
-      userInputRef.current.value = user.username;
+      userInputRef.current.value = user.email;
     }
   }, [user, userIsLoading]);
 
@@ -100,27 +100,64 @@ function RecoverPasswordForm() {
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
         {globalErrorMessage && <Flash variant="danger">{globalErrorMessage}</Flash>}
 
-        <FormControl id="username">
-          <FormControl.Label>Digite seu usuário ou e-mail</FormControl.Label>
-          <TextInput
-            ref={userInputRef}
-            onChange={clearErrors}
-            name="userInput"
-            size="large"
-            autoCorrect="off"
-            autoCapitalize="off"
-            spellCheck={false}
-            block={true}
-            aria-label="Seu usuário ou e-mail"
-          />
-          {['userInput', 'email', 'username'].includes(errorObject?.key) && (
-            <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
-          )}
+        {user?.features.includes('create:recovery_token:username') && (
+          <Flash variant="default">
+            Você pode ajudar outra pessoa a recuperar sua senha, é só digitar o nome de usuário dela.
+          </Flash>
+        )}
 
-          {errorObject?.type === 'string.alphanum' && (
-            <FormControl.Caption>Dica: use somente letras e números, por exemplo: nomeSobrenome4 </FormControl.Caption>
-          )}
-        </FormControl>
+        {user?.features.includes('create:recovery_token:username') && (
+          <FormControl id="userInput">
+            <FormControl.Label>Digite seu e-mail ou o nome de usuário de outra pessoa</FormControl.Label>
+            <TextInput
+              ref={userInputRef}
+              onChange={clearErrors}
+              name="userInput"
+              size="large"
+              autoCorrect="off"
+              autoCapitalize="off"
+              spellCheck={false}
+              block={true}
+              aria-label="Digite seu e-mail ou o nome de usuário de outra pessoa"
+            />
+            {['userInput', 'email', 'username'].includes(errorObject?.key) && (
+              <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
+            )}
+
+            {errorObject?.type === 'string.alphanum' && (
+              <FormControl.Caption>
+                Dica: use somente letras e números, por exemplo: nomeSobrenome4{' '}
+              </FormControl.Caption>
+            )}
+          </FormControl>
+        )}
+
+        {!user?.features.includes('create:recovery_token:username') && (
+          <FormControl id="userInput">
+            <FormControl.Label>Digite seu e-mail</FormControl.Label>
+            <TextInput
+              ref={userInputRef}
+              onChange={clearErrors}
+              name="userInput"
+              size="large"
+              autoCorrect="off"
+              autoCapitalize="off"
+              spellCheck={false}
+              block={true}
+              aria-label="Seu e-mail"
+            />
+            {['userInput', 'email', 'username'].includes(errorObject?.key) && (
+              <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
+            )}
+
+            {errorObject?.type === 'string.alphanum' && (
+              <FormControl.Caption>
+                Dica: use somente letras e números, por exemplo: nomeSobrenome4{' '}
+              </FormControl.Caption>
+            )}
+          </FormControl>
+        )}
+
         <FormControl>
           <FormControl.Label visuallyHidden>Recuperar</FormControl.Label>
           <Button

--- a/pages/cadastro/recuperar/index.public.js
+++ b/pages/cadastro/recuperar/index.public.js
@@ -146,12 +146,12 @@ function RecoverPasswordForm() {
               block={true}
               aria-label="Seu e-mail"
             />
-            {['userInput', 'email'].includes(errorObject?.key) && (
+            {['userInput', 'email', 'username'].includes(errorObject?.key) && (
               <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
             )}
 
             {errorObject?.type === 'string.alphanum' && (
-              <FormControl.Validation variant="error">"email" deve conter um email válido.</FormControl.Validation>
+              <FormControl.Validation variant="error">"email" deve conter um endereço válido.</FormControl.Validation>
             )}
           </FormControl>
         )}

--- a/pages/cadastro/recuperar/index.public.js
+++ b/pages/cadastro/recuperar/index.public.js
@@ -108,7 +108,7 @@ function RecoverPasswordForm() {
 
         {user?.features.includes('create:recovery_token:username') && (
           <FormControl id="userInput">
-            <FormControl.Label>Digite seu e-mail ou o nome de usuário de outra pessoa</FormControl.Label>
+            <FormControl.Label>Digite seu e-mail ou o nome de usuário da pessoa que deseja ajudar</FormControl.Label>
             <TextInput
               ref={userInputRef}
               onChange={clearErrors}
@@ -146,14 +146,12 @@ function RecoverPasswordForm() {
               block={true}
               aria-label="Seu e-mail"
             />
-            {['userInput', 'email', 'username'].includes(errorObject?.key) && (
+            {['userInput', 'email'].includes(errorObject?.key) && (
               <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
             )}
 
             {errorObject?.type === 'string.alphanum' && (
-              <FormControl.Caption>
-                Dica: use somente letras e números, por exemplo: nomeSobrenome4{' '}
-              </FormControl.Caption>
+              <FormControl.Validation variant="error">"email" deve conter um email válido.</FormControl.Validation>
             )}
           </FormControl>
         )}

--- a/tests/integration/api/v1/recovery/post.test.js
+++ b/tests/integration/api/v1/recovery/post.test.js
@@ -28,27 +28,25 @@ describe('POST /api/v1/recovery', () => {
 
       const responseBody = await response.json();
 
-      const tokenInDatabase = await recovery.findOneTokenByUserId(defaultUser.id);
-
-      expect(response.status).toEqual(201);
+      expect(response.status).toEqual(403);
 
       expect(responseBody).toStrictEqual({
-        used: false,
-        expires_at: tokenInDatabase.expires_at.toISOString(),
-        created_at: tokenInDatabase.created_at.toISOString(),
-        updated_at: tokenInDatabase.updated_at.toISOString(),
+        name: 'ForbiddenError',
+        message: 'Você não possui permissão para criar um token de recuperação com username.',
+        action: 'Verifique se este usuário tem a feature "create:recovery_token:username".',
+        status_code: 403,
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'CONTROLLER:RECOVERY:POST_HANDLER:CAN_NOT_CREATE_RECOVERY_TOKEN_USERNAME',
       });
 
-      expect(Date.parse(responseBody.expires_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
-      expect(responseBody.expires_at > responseBody.created_at).toBe(true);
-
       const lastEmail = await orchestrator.getLastEmail();
-      expect(lastEmail.recipients[0].includes(defaultUser.email)).toBe(true);
-      expect(lastEmail.subject).toEqual('Recuperação de Senha');
-      expect(lastEmail.text.includes(defaultUser.username)).toBe(true);
-      expect(lastEmail.text.includes(recovery.getRecoverPageEndpoint(tokenInDatabase.id))).toBe(true);
+      expect(lastEmail?.recipients[0].includes(defaultUser.email)).toBe(undefined);
+      expect(lastEmail?.subject).toEqual(undefined);
+      expect(lastEmail?.text.includes(defaultUser.username)).toBe(undefined);
+
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
     });
 
     test('With "username" valid, but user not found', async () => {
@@ -65,17 +63,16 @@ describe('POST /api/v1/recovery', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toEqual(403);
 
       expect(responseBody).toStrictEqual({
-        name: 'ValidationError',
-        message: 'O "username" informado não foi encontrado no sistema.',
-        action: 'Ajuste os dados enviados e tente novamente.',
-        status_code: 400,
+        name: 'ForbiddenError',
+        message: 'Você não possui permissão para criar um token de recuperação com username.',
+        action: 'Verifique se este usuário tem a feature "create:recovery_token:username".',
+        status_code: 403,
         error_id: responseBody.error_id,
         request_id: responseBody.request_id,
-        error_location_code: 'MODEL:RECOVERY:FIND_USER_BY_USERNAME_OR_EMAIL:NOT_FOUND',
-        key: 'username',
+        error_location_code: 'CONTROLLER:RECOVERY:POST_HANDLER:CAN_NOT_CREATE_RECOVERY_TOKEN_USERNAME',
       });
 
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
@@ -297,6 +294,88 @@ describe('POST /api/v1/recovery', () => {
         error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
         key: 'object',
         type: 'object.min',
+      });
+
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+    });
+  });
+
+  describe('User with "create:recovery_token:username" feature', () => {
+    test('With "username" valid and "user" found', async () => {
+      const defaultUser = await orchestrator.createUser();
+      const userWithPermission = await orchestrator.createUser();
+      await orchestrator.activateUser(userWithPermission);
+      await orchestrator.addFeaturesToUser(userWithPermission, ['create:recovery_token:username']);
+      const sessionObject = await orchestrator.createSession(userWithPermission);
+
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/recovery`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          cookie: `session_id=${sessionObject.token}`,
+        },
+
+        body: JSON.stringify({
+          username: defaultUser.username,
+        }),
+      });
+
+      const responseBody = await response.json();
+
+      const tokenInDatabase = await recovery.findOneTokenByUserId(defaultUser.id);
+
+      expect(response.status).toEqual(201);
+
+      expect(responseBody).toStrictEqual({
+        used: false,
+        expires_at: tokenInDatabase.expires_at.toISOString(),
+        created_at: tokenInDatabase.created_at.toISOString(),
+        updated_at: tokenInDatabase.updated_at.toISOString(),
+      });
+
+      expect(Date.parse(responseBody.expires_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(responseBody.expires_at > responseBody.created_at).toBe(true);
+
+      const lastEmail = await orchestrator.getLastEmail();
+      expect(lastEmail.recipients[0].includes(defaultUser.email)).toBe(true);
+      expect(lastEmail.subject).toEqual('Recuperação de Senha');
+      expect(lastEmail.text.includes(defaultUser.username)).toBe(true);
+      expect(lastEmail.text.includes(recovery.getRecoverPageEndpoint(tokenInDatabase.id))).toBe(true);
+    });
+
+    test('With "username" valid, but user not found', async () => {
+      const userWithPermission = await orchestrator.createUser();
+      await orchestrator.activateUser(userWithPermission);
+      await orchestrator.addFeaturesToUser(userWithPermission, ['create:recovery_token:username']);
+      const sessionObject = await orchestrator.createSession(userWithPermission);
+
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/recovery`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          cookie: `session_id=${sessionObject.token}`,
+        },
+        body: JSON.stringify({
+          username: 'userNotFound',
+        }),
+      });
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+
+      expect(responseBody).toStrictEqual({
+        name: 'ValidationError',
+        message: 'O "username" informado não foi encontrado no sistema.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        status_code: 400,
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:RECOVERY:FIND_USER_BY_USERNAME_OR_EMAIL:NOT_FOUND',
+        key: 'username',
       });
 
       expect(uuidVersion(responseBody.error_id)).toEqual(4);

--- a/tests/integration/api/v1/recovery/post.test.js
+++ b/tests/integration/api/v1/recovery/post.test.js
@@ -12,44 +12,7 @@ beforeAll(async () => {
 
 describe('POST /api/v1/recovery', () => {
   describe('Anonymous user', () => {
-    test('With "username" valid and "user" found', async () => {
-      const defaultUser = await orchestrator.createUser();
-
-      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/recovery`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-
-        body: JSON.stringify({
-          username: defaultUser.username,
-        }),
-      });
-
-      const responseBody = await response.json();
-
-      expect(response.status).toEqual(403);
-
-      expect(responseBody).toStrictEqual({
-        name: 'ForbiddenError',
-        message: 'Você não possui permissão para criar um token de recuperação com username.',
-        action: 'Verifique se este usuário tem a feature "create:recovery_token:username".',
-        status_code: 403,
-        error_id: responseBody.error_id,
-        request_id: responseBody.request_id,
-        error_location_code: 'CONTROLLER:RECOVERY:POST_HANDLER:CAN_NOT_CREATE_RECOVERY_TOKEN_USERNAME',
-      });
-
-      const lastEmail = await orchestrator.getLastEmail();
-      expect(lastEmail?.recipients[0].includes(defaultUser.email)).toBe(undefined);
-      expect(lastEmail?.subject).toEqual(undefined);
-      expect(lastEmail?.text.includes(defaultUser.username)).toBe(undefined);
-
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-    });
-
-    test('With "username" valid, but user not found', async () => {
+    test('With "username" valid', async () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/recovery`, {
         method: 'POST',
         headers: {


### PR DESCRIPTION
Este PR traz uma implementação para **iniciar o fluxo** de [recuperação de senha apenas por `email`](https://github.com/filipedeschamps/tabnews.com.br/issues/1180) porém com a possibilidade de pessoas com uma feature de moderação conseguirem iniciá-lo  utilizando o `username` como fallback.

Importante destacar que com esta implementação uma pessoa com a feature `update:content:others` só pode iniciar o fluxo utilizando o `username` se estiver logada na aplicação.

## Usuário deslogado
https://user-images.githubusercontent.com/57193392/222304018-3a678451-ed3f-4b48-9ec9-7c7391703648.mp4

## Usuário logado mas que não tem feature de moderação
https://user-images.githubusercontent.com/57193392/222304342-017dcee9-32b5-4199-b6b1-29281660c188.mp4

## Usuário logado e que  tem feature de moderação
https://user-images.githubusercontent.com/57193392/222304532-ca09009b-3047-4c83-9eec-d20ceb5b5b4a.mp4
