### PR TITLE
feat: adding Dark Mode in a simple but functional way

### DIFF
--- a/pages/_app.public.js
+++ b/pages/_app.public.js
@@ -13,6 +13,12 @@ async function SWRFetcher(resource, init) {
 }
 
 function MyApp({ Component, pageProps }) {
+  let colorMode = 'day';
+
+  if (typeof window !== 'undefined') {
+    colorMode = JSON.parse(localStorage.getItem('themeMode'))?.mode || colorMode;
+  }
+
   return (
     <>
       <UserProvider>
@@ -22,7 +28,7 @@ function MyApp({ Component, pageProps }) {
             fetcher: SWRFetcher,
           }}>
           <SSRProvider>
-            <ThemeProvider preventSSRMismatch colorMode="day">
+            <ThemeProvider preventSSRMismatch colorMode={colorMode}>
               <BaseStyles>
                 <NextNProgress options={{ showSpinner: false }} />
                 <Component {...pageProps} />

--- a/pages/interface/components/Header/index.js
+++ b/pages/interface/components/Header/index.js
@@ -1,12 +1,14 @@
 import { Header, Box, ActionMenu, ActionList, IconButton, Truncate, Text, Tooltip } from '@primer/react';
-import { PersonFillIcon, HomeIcon, SquareFillIcon } from '@primer/octicons-react';
+import { PersonFillIcon, HomeIcon, SquareFillIcon, MoonIcon, SunIcon } from '@primer/octicons-react';
 import { CgTab } from 'react-icons/cg';
 import { HeaderLink, Link, useUser } from 'pages/interface';
 import { useRouter } from 'next/router';
+import useThemeMode from 'pages/interface/hooks/useThemeMode';
 
 export default function HeaderComponent() {
   const { user, isLoading, logout } = useUser();
   const { pathname } = useRouter();
+  const { colorMode, setThemeMode } = useThemeMode();
 
   const activeLinkStyle = {
     textDecoration: 'underline',
@@ -51,6 +53,19 @@ export default function HeaderComponent() {
 
       {user && (
         <>
+          <Header.Item
+            sx={{
+              mr: 2,
+              fontSize: 0,
+              fontWeight: 'bold',
+            }}>
+            <Box
+              sx={{ display: 'flex', alignItems: 'center', pr: 1, color: 'accent.emphasis' }}
+              onClick={() => setThemeMode(colorMode === 'day' ? 'night' : 'day')}>
+              {colorMode === 'day' ? <MoonIcon size={16} /> : <SunIcon size={16} />}
+            </Box>
+          </Header.Item>
+
           <Header.Item
             sx={{
               mr: 2,

--- a/pages/interface/components/Header/index.js
+++ b/pages/interface/components/Header/index.js
@@ -60,7 +60,7 @@ export default function HeaderComponent() {
               fontWeight: 'bold',
             }}>
             <Box
-              sx={{ display: 'flex', alignItems: 'center', pr: 1, color: 'accent.emphasis' }}
+              sx={{ display: 'flex', alignItems: 'center', pr: 1, color: 'accent.emphasis', cursor: 'pointer' }}
               onClick={() => setThemeMode(colorMode === 'day' ? 'night' : 'day')}>
               {colorMode === 'day' ? <MoonIcon size={16} /> : <SunIcon size={16} />}
             </Box>

--- a/pages/interface/hooks/useThemeMode/index.js
+++ b/pages/interface/hooks/useThemeMode/index.js
@@ -1,0 +1,46 @@
+import { useCallback, useEffect } from 'react';
+import { useTheme } from '@primer/react';
+
+export default function useThemeMode() {
+  const { theme, colorMode, setColorMode } = useTheme();
+
+  const setThemeMode = useCallback(
+    (mode) => {
+      const scheme = mode === 'day' ? 'light' : 'dark';
+      const defaultBorder = theme.colorSchemes[scheme].colors.border.default;
+      const defaultFgColor = theme.colorSchemes[scheme].colors.fg.default;
+      const defaultBgColor = theme.colorSchemes[scheme].colors.canvas.default;
+
+      setColorMode(mode);
+      localStorage.setItem('themeMode', JSON.stringify({ mode, scheme, default: defaultBgColor }));
+
+      if (document.head.querySelector('style[data-theme]')) {
+        document.head.querySelector('style[data-theme]').remove();
+      }
+
+      const style = document.createElement('style');
+      style.dataset.theme = mode;
+      style.innerHTML = `
+          body { background-color: ${defaultBgColor} !important; }
+          .bytemd-toolbar-icon:hover { background-color: ${defaultBorder} !important; }
+          .markdown-body, .bytemd, .bytemd-toolbar, .bytemd-editor > div {
+            color: ${defaultFgColor} !important;
+            border-color: ${defaultBorder} !important;
+            background-color: ${defaultBgColor} !important;
+          }
+        `;
+      document.head.appendChild(style);
+    },
+    [setColorMode, theme]
+  );
+
+  useEffect(() => {
+    const themeLocalStorage = JSON.parse(localStorage.getItem('themeMode'));
+
+    if (themeLocalStorage) {
+      setThemeMode(themeLocalStorage.mode);
+    }
+  }, [theme, setThemeMode]);
+
+  return { colorMode, setThemeMode };
+}

--- a/pages/interface/hooks/useThemeMode/index.js
+++ b/pages/interface/hooks/useThemeMode/index.js
@@ -23,7 +23,7 @@ export default function useThemeMode() {
       style.innerHTML = `
           body { background-color: ${defaultBgColor} !important; }
           .bytemd-toolbar-icon:hover { background-color: ${defaultBorder} !important; }
-          .markdown-body, .bytemd, .bytemd-toolbar, .bytemd-editor > div {
+          .markdown-body, .bytemd, .bytemd-toolbar, .bytemd-editor > div, .markdown-body tr {
             color: ${defaultFgColor} !important;
             border-color: ${defaultBorder} !important;
             background-color: ${defaultBgColor} !important;


### PR DESCRIPTION
O ajuste que eu fiz é simples eu usei as configurações e cores nativas do Primer e algumas partes do site que não funcionaram no modo Dark como Body e outras coisas do ByteMD eu adicionei um style no Head via JS.

Eu criei um Hook então o ajuste que eu fiz está isolado, assim caso precise remover isso no futuro ou modificar fica muito mais fácil.