### PR TITLE
Corrige erro de hydration no tooltip da data do post

### DIFF
--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -13,7 +13,6 @@ import {
   ActionMenu,
   ActionList,
   IconButton,
-  Tooltip,
   useConfirm,
 } from '@primer/react';
 import { KebabHorizontalIcon, PencilIcon, TrashIcon, LinkIcon } from '@primer/octicons-react';
@@ -182,15 +181,8 @@ function ViewMode({ setComponentMode, contentObject, viewFrame }) {
             <Link
               href={`/${contentObject.owner_username}/${contentObject.slug}`}
               prefetch={false}
-              sx={{ fontSize: 0, color: 'fg.muted', mr: '100px', height: '22px' }}>
-              <Tooltip
-                sx={{ position: 'absolute', ml: 1, mt: '1px' }}
-                aria-label={new Date(contentObject.published_at).toLocaleString('pt-BR', {
-                  dateStyle: 'full',
-                  timeStyle: 'short',
-                })}>
-                <PublishedSince date={contentObject.published_at} />
-              </Tooltip>
+              sx={{ fontSize: 0, color: 'fg.muted', mr: '100px', py: '1px', height: '22px' }}>
+              <PublishedSince date={contentObject.published_at} />
             </Link>
           </Box>
           {(user?.id === contentObject.owner_id || user?.features?.includes('update:content:others')) && (

--- a/pages/interface/components/ContentList/index.js
+++ b/pages/interface/components/ContentList/index.js
@@ -1,5 +1,5 @@
 import useSWR from 'swr';
-import { Box, Text, Tooltip } from '@primer/react';
+import { Box, Text } from '@primer/react';
 import { ChevronLeftIcon, ChevronRightIcon, CommentIcon } from '@primer/octicons-react';
 
 import { Link, PublishedSince, EmptyState } from 'pages/interface';
@@ -125,14 +125,7 @@ export default function ContentList({ contentList, pagination, paginationBasePat
             </Link>
             {' · '}
             <Text>
-              <Tooltip
-                sx={{ position: 'absolute', ml: 1 }}
-                aria-label={new Date(contentObject.published_at).toLocaleString('pt-BR', {
-                  dateStyle: 'full',
-                  timeStyle: 'short',
-                })}>
-                <PublishedSince date={contentObject.published_at} />
-              </Tooltip>
+              <PublishedSince date={contentObject.published_at} />
             </Text>
           </Box>
         </Box>,

--- a/pages/interface/components/PublishedSince/index.js
+++ b/pages/interface/components/PublishedSince/index.js
@@ -1,16 +1,23 @@
-import { formatDistanceToNowStrict } from 'date-fns';
-import { pt } from 'date-fns/locale';
+import { formatDistanceToNowStrict, format } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+import { Tooltip } from '@primer/react';
+
+function formatPublishedSince(date) {
+  const publishedSince = formatDistanceToNowStrict(new Date(date), {
+    locale: ptBR,
+  });
+
+  return `${publishedSince} atrás`;
+}
+
+function formatTooltipLabel(date) {
+  return format(new Date(date), "EEEE, d 'de' MMMM 'de' yyyy 'às' HH:mm", { locale: ptBR });
+}
 
 export default function PublishedSince({ date }) {
-  return <span suppressHydrationWarning={true}>{formatPublishedSince(date)}</span>;
-
-  function formatPublishedSince(date) {
-    const publishedSince = formatDistanceToNowStrict(new Date(date), {
-      addSuffix: false,
-      includeSeconds: true,
-      locale: pt,
-    });
-
-    return `${publishedSince} atrás`;
-  }
+  return (
+    <Tooltip sx={{ position: 'absolute', ml: 1 }} aria-label={formatTooltipLabel(date)}>
+      <span suppressHydrationWarning>{formatPublishedSince(date)}</span>
+    </Tooltip>
+  );
 }


### PR DESCRIPTION
A formatação de datas utilizando `Date.toLocaleString` têm implementações diferentes entre browser e nodejs.

Não vi muitos detalhes mas aparentemente esse já é um erro conhecido (https://github.com/nodejs/node/issues/45945). Fiz uns testes na versão 19.7.0  e acho que isso já foi resolvido, mas de qualquer forma isso só deve ser usado aqui no TabNews quando lançarem o nodejs 20 LTS.

Para contornar esse erro fiz uma pequena refatoração no componente `PublishSince` para utilizar o date-fns na formação de datas do tooltip. Isso deve resolver esse problema tanto na página inicial quanto na `[username]/[slug]`.

- **Erro em dev**

![image](https://user-images.githubusercontent.com/30873873/222495800-09e49d31-66fc-4f03-a750-da4cd8edd353.png)

- **Erro em prod**  *_em uma guia anônima não recebo nenhum erro no console_

![Captura de tela de 2023-03-02 13-28-41](https://user-images.githubusercontent.com/30873873/222494227-42801cb2-2b6b-4626-9743-25aa7509a0b1.png)

- **Depois da correção**

![Captura de tela de 2023-03-02 13-53-09](https://user-images.githubusercontent.com/30873873/222497719-2b5507d1-7a32-488a-b51e-de0a7083f2b4.png)