### PR TITLE
fix(date tooltip): fix client time zone

### DIFF
--- a/pages/interface/components/PublishedSince/index.js
+++ b/pages/interface/components/PublishedSince/index.js
@@ -1,6 +1,7 @@
 import { formatDistanceToNowStrict, format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { Tooltip } from '@primer/react';
+import { useEffect, useState } from 'react';
 
 function formatPublishedSince(date) {
   const publishedSince = formatDistanceToNowStrict(new Date(date), {
@@ -10,13 +11,21 @@ function formatPublishedSince(date) {
   return `${publishedSince} atrás`;
 }
 
-function formatTooltipLabel(date) {
-  return format(new Date(date), "EEEE, d 'de' MMMM 'de' yyyy 'às' HH:mm", { locale: ptBR });
+function formatTooltipLabel(date, gmt = false) {
+  const displayFormat = gmt ? "EEEE, d 'de' MMMM 'de' yyyy 'às' HH:mm z" : "EEEE, d 'de' MMMM 'de' yyyy 'às' HH:mm";
+
+  return format(new Date(date), displayFormat, { locale: ptBR });
 }
 
 export default function PublishedSince({ date, ...props }) {
+  const [tooltipLabel, setTooltipLabel] = useState(formatTooltipLabel(date, true));
+
+  useEffect(() => {
+    setTooltipLabel(formatTooltipLabel(date));
+  }, [date]);
+
   return (
-    <Tooltip sx={{ position: 'absolute', ml: 1 }} aria-label={formatTooltipLabel(date)} {...props}>
+    <Tooltip sx={{ position: 'absolute', ml: 1 }} aria-label={tooltipLabel} suppressHydrationWarning {...props}>
       <span style={{ whiteSpace: 'nowrap' }} suppressHydrationWarning>
         {formatPublishedSince(date)}
       </span>


### PR DESCRIPTION
Durante a revisão do PR #1294 foi identificado um bug que já estava presente anteriormente.

O horário mostrado na página de conteúdos (no contentList não ocorre) fica 3 horas adiantado, mas só ocorre quando acessamos um conteúdo diretamente pelo seu endereço e não através do next/link.

O que ocorre é que o Tooltip não é atualizado com a mudança somente do fuso. Nem mesmo usando `useState` e `useEffect`. E eu não consegui entender a razão disso, pois são duas strings diferentes.

Como alternativa para forçar a atualização, no lado do server (`useState`), eu inseri um caractere invisível antes do texto do horário. E no client (`useEffect`) o estado é atualizado sem esse caractere, o que faz o horário no Tooltip ser atualizado corretamente.

Também estou adicionando um `suppressHydrationWarning` no `Tooltip` para eliminar erros do console que ocorrem em modo de desenvolvimento remoto, como no Gitpod.