### PR TITLE
feat(component): creates the password input component with the option to see the password

### DIFF
--- a/pages/cadastro/index.public.js
+++ b/pages/cadastro/index.public.js
@@ -1,6 +1,6 @@
 import { useState, useRef } from 'react';
 import { useRouter } from 'next/router';
-import { DefaultLayout } from 'pages/interface/index.js';
+import { DefaultLayout, PasswordInput } from 'pages/interface/index.js';
 import { FormControl, Box, Heading, Button, TextInput, Flash } from '@primer/react';
 
 export default function Register() {
@@ -25,16 +25,6 @@ function SignUpForm() {
   const [globalErrorMessage, setGlobalErrorMessage] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [errorObject, setErrorObject] = useState(undefined);
-  const [capsLockWarningMessage, setCapsLockWarningMessage] = useState(false);
-
-  function detectCapsLock(event) {
-    if (event.getModifierState('CapsLock')) {
-      setCapsLockWarningMessage('Atenção: Caps Lock está ativado.');
-      return;
-    }
-
-    setCapsLockWarningMessage(false);
-  }
 
   function clearErrors() {
     setErrorObject(undefined);
@@ -169,29 +159,14 @@ function SignUpForm() {
           )}
         </FormControl>
 
-        <FormControl id="password">
-          <FormControl.Label>Senha</FormControl.Label>
-          <TextInput
-            ref={passwordRef}
-            onChange={clearErrors}
-            onKeyDown={detectCapsLock}
-            onKeyUp={detectCapsLock}
-            name="password"
-            type="password"
-            autoCorrect="off"
-            autoCapitalize="off"
-            spellCheck={false}
-            size="large"
-            block={true}
-            aria-label="Sua senha"
-          />
-          {capsLockWarningMessage && (
-            <FormControl.Validation variant="warning">{capsLockWarningMessage}</FormControl.Validation>
-          )}
-          {errorObject?.key === 'password' && (
-            <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
-          )}
-        </FormControl>
+        <PasswordInput
+          inputRef={passwordRef}
+          id="password"
+          name="password"
+          label="Senha"
+          errorObject={errorObject}
+          setErrorObject={setErrorObject}
+        />
 
         <FormControl>
           <FormControl.Label visuallyHidden>Criar cadastro</FormControl.Label>

--- a/pages/cadastro/recuperar/[token].public.js
+++ b/pages/cadastro/recuperar/[token].public.js
@@ -1,7 +1,7 @@
 import { useState, useRef } from 'react';
 import fetch from 'cross-fetch';
-import { FormControl, Box, Heading, Button, TextInput, Flash } from '@primer/react';
-import { DefaultLayout } from 'pages/interface/index.js';
+import { FormControl, Box, Heading, Button, Flash } from '@primer/react';
+import { DefaultLayout, PasswordInput } from 'pages/interface/index.js';
 import { useRouter } from 'next/router';
 
 export default function RecoverPassword() {
@@ -26,20 +26,6 @@ function RecoverPasswordForm() {
   const [globalErrorMessage, setGlobalErrorMessage] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [errorObject, setErrorObject] = useState(undefined);
-  const [capsLockWarningMessage, setCapsLockWarningMessage] = useState(false);
-
-  function detectCapsLock(event) {
-    if (event.getModifierState('CapsLock')) {
-      setCapsLockWarningMessage('Atenção: Caps Lock está ativado.');
-      return;
-    }
-
-    setCapsLockWarningMessage(false);
-  }
-
-  function clearErrors() {
-    setErrorObject(undefined);
-  }
 
   async function handleSubmit(event) {
     event.preventDefault();
@@ -107,51 +93,22 @@ function RecoverPasswordForm() {
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
         {globalErrorMessage && <Flash variant="danger">{globalErrorMessage}</Flash>}
 
-        <FormControl id="password">
-          <FormControl.Label>Senha</FormControl.Label>
-          <TextInput
-            ref={passwordRef}
-            onChange={clearErrors}
-            onKeyDown={detectCapsLock}
-            onKeyUp={detectCapsLock}
-            name="password"
-            type="password"
-            autoCorrect="off"
-            autoCapitalize="off"
-            spellCheck={false}
-            size="large"
-            block={true}
-            aria-label="Sua senha"
-          />
-          {capsLockWarningMessage && (
-            <FormControl.Validation variant="warning">{capsLockWarningMessage}</FormControl.Validation>
-          )}
-          {errorObject?.key === 'empty' && (
-            <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
-          )}
-          {errorObject?.key === 'password' && (
-            <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
-          )}
-        </FormControl>
-
-        <FormControl id="passwordConfirm">
-          <FormControl.Label>Repita a senha</FormControl.Label>
-          <TextInput
-            ref={passwordConfirmRef}
-            onChange={clearErrors}
-            name="passwordConfirm"
-            type="password"
-            autoCorrect="off"
-            autoCapitalize="off"
-            spellCheck={false}
-            size="large"
-            block={true}
-            aria-label="Repita a senha"
-          />
-          {errorObject?.key === 'password_confirm' && (
-            <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
-          )}
-        </FormControl>
+        <PasswordInput
+          inputRef={passwordRef}
+          id="password"
+          name="password"
+          label="Senha"
+          errorObject={errorObject}
+          setErrorObject={setErrorObject}
+        />
+        <PasswordInput
+          inputRef={passwordConfirmRef}
+          id="passwordConfirm"
+          name="passwordConfirm"
+          label="Repita a senha"
+          errorObject={errorObject}
+          setErrorObject={setErrorObject}
+        />
         <FormControl>
           <FormControl.Label visuallyHidden>Alterar senha</FormControl.Label>
           <Button

--- a/pages/interface/components/PasswordInput/index.js
+++ b/pages/interface/components/PasswordInput/index.js
@@ -2,8 +2,7 @@ import { useState } from 'react';
 import { FormControl, IconButton, TextInput, Tooltip } from '@primer/react';
 import { EyeClosedIcon, EyeIcon } from '@primer/octicons-react';
 
-export default function PasswordInput(props) {
-  const { inputRef, id, name, label, errorObject, setErrorObject } = props;
+export default function PasswordInput({ inputRef, id, name, label, errorObject, setErrorObject, ...props }) {
 
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
   const [capsLockWarningMessage, setCapsLockWarningMessage] = useState(false);

--- a/pages/interface/components/PasswordInput/index.js
+++ b/pages/interface/components/PasswordInput/index.js
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { FormControl, IconButton, TextInput, Tooltip } from '@primer/react';
 import { EyeClosedIcon, EyeIcon } from '@primer/octicons-react';
 
-export default function PasswordInput({ inputRef, id, name, label, errorObject, setErrorObject, ...props }) {
+export default function PasswordInput({ inputRef, id, name, label, errorObject, setErrorObject }) {
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
   const [capsLockWarningMessage, setCapsLockWarningMessage] = useState(false);
 

--- a/pages/interface/components/PasswordInput/index.js
+++ b/pages/interface/components/PasswordInput/index.js
@@ -45,7 +45,16 @@ export default function PasswordInput({ inputRef, id, name, label, errorObject, 
             <IconButton
               onClick={handlePasswordVisible}
               icon={isPasswordVisible ? EyeClosedIcon : EyeIcon}
-              sx={{ padding: '0', border: 'none', color: 'fg.subtle' }}
+              sx={{
+                padding: '0',
+                border: 'none',
+                color: 'fg.subtle',
+                background: 'none',
+                boxShadow: 'none',
+                ':hover:not([disabled])': {
+                  background: 'none',
+                },
+              }}
             />
           </Tooltip>
         }

--- a/pages/interface/components/PasswordInput/index.js
+++ b/pages/interface/components/PasswordInput/index.js
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { FormControl, IconButton, TextInput, Tooltip } from '@primer/react';
 import { EyeClosedIcon, EyeIcon } from '@primer/octicons-react';
 
-export default function PasswordInput({ inputRef, id, name, label, errorObject, setErrorObject }) {
+export default function PasswordInput({ inputRef, id, name, label, errorObject, setErrorObject, ...props }) {
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
   const [capsLockWarningMessage, setCapsLockWarningMessage] = useState(false);
 
@@ -70,6 +70,7 @@ export default function PasswordInput({ inputRef, id, name, label, errorObject, 
         size="large"
         block={true}
         aria-label={label}
+        {...props}
       />
       {capsLockWarningMessage && (
         <FormControl.Validation variant="warning">{capsLockWarningMessage}</FormControl.Validation>

--- a/pages/interface/components/PasswordInput/index.js
+++ b/pages/interface/components/PasswordInput/index.js
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+import { FormControl, IconButton, TextInput, Tooltip } from '@primer/react';
+import { EyeClosedIcon, EyeIcon } from '@primer/octicons-react';
+
+export default function PasswordInput(props) {
+  const { inputRef, id, name, label, errorObject, setErrorObject } = props;
+
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+  const [capsLockWarningMessage, setCapsLockWarningMessage] = useState(false);
+
+  function focusAfterEnd(ref) {
+    setTimeout(() => {
+      let len = ref.current.value.length;
+      ref.current.focus();
+      ref.current.setSelectionRange(len, len);
+    }, 5);
+  }
+
+  function handlePasswordVisible(event) {
+    event.preventDefault();
+    setIsPasswordVisible(!isPasswordVisible);
+    focusAfterEnd(inputRef);
+    detectCapsLock(event);
+  }
+
+  function detectCapsLock(event) {
+    if (event.getModifierState('CapsLock')) {
+      setCapsLockWarningMessage('Atenção: Caps Lock está ativado.');
+    } else {
+      setCapsLockWarningMessage(false);
+    }
+  }
+
+  function clearErrors() {
+    setErrorObject(undefined);
+  }
+
+  return (
+    <FormControl id={id}>
+      <FormControl.Label>{label}</FormControl.Label>
+      <TextInput
+        trailingVisual={
+          <Tooltip
+            aria-label={isPasswordVisible ? 'Ocultar a senha' : 'Visualizar a senha'}
+            direction="nw"
+            noDelay={true}>
+            <IconButton
+              onClick={handlePasswordVisible}
+              icon={isPasswordVisible ? EyeClosedIcon : EyeIcon}
+              sx={{ padding: '0', border: 'none', color: 'fg.subtle' }}
+            />
+          </Tooltip>
+        }
+        ref={inputRef}
+        onChange={clearErrors}
+        onKeyDown={detectCapsLock}
+        onKeyUp={detectCapsLock}
+        name={name}
+        type={isPasswordVisible ? 'text' : 'password'}
+        autoCorrect="off"
+        autoCapitalize="off"
+        spellCheck={false}
+        size="large"
+        block={true}
+        aria-label={label}
+      />
+      {capsLockWarningMessage && (
+        <FormControl.Validation variant="warning">{capsLockWarningMessage}</FormControl.Validation>
+      )}
+      {errorObject?.key === 'empty' && (
+        <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
+      )}
+      {errorObject?.key === 'password' && (
+        <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
+      )}
+      {errorObject?.key === 'password_confirm' && (
+        <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
+      )}
+    </FormControl>
+  );
+}

--- a/pages/interface/components/PasswordInput/index.js
+++ b/pages/interface/components/PasswordInput/index.js
@@ -3,7 +3,6 @@ import { FormControl, IconButton, TextInput, Tooltip } from '@primer/react';
 import { EyeClosedIcon, EyeIcon } from '@primer/octicons-react';
 
 export default function PasswordInput({ inputRef, id, name, label, errorObject, setErrorObject, ...props }) {
-
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
   const [capsLockWarningMessage, setCapsLockWarningMessage] = useState(false);
 

--- a/pages/interface/index.js
+++ b/pages/interface/index.js
@@ -11,6 +11,7 @@ export { default as Confetti } from './components/Confetti/index.js';
 export { default as NextLink, HeaderLink, Link } from './components/Link/index.js';
 export { default as GoToTopButton } from './components/GoToTopButton/index.js';
 export { default as Viewer, Editor } from './components/Markdown/index.js';
+export { default as PasswordInput } from './components/PasswordInput/index.js';
 
 export { default as useUser } from './hooks/useUser/index.js';
 export { default as useMediaQuery } from './hooks/useMediaQuery/index.js';

--- a/pages/login/index.public.js
+++ b/pages/login/index.public.js
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import { useRouter } from 'next/router';
-import { DefaultLayout, useUser } from 'pages/interface/index.js';
+import { DefaultLayout, useUser, PasswordInput } from 'pages/interface/index.js';
 import { FormControl, Box, Heading, Button, TextInput, Flash, Link, Text } from '@primer/react';
 
 export default function Login() {
@@ -21,7 +21,6 @@ function LoginForm() {
   const [globalErrorMessage, setGlobalErrorMessage] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [errorObject, setErrorObject] = useState(undefined);
-  const [capsLockWarningMessage, setCapsLockWarningMessage] = useState(false);
 
   useEffect(() => {
     if (!user || !router) return;
@@ -31,15 +30,6 @@ function LoginForm() {
       router.push('/publicar');
     }
   }, [user, router]);
-
-  function detectCapsLock(event) {
-    if (event.getModifierState('CapsLock')) {
-      setCapsLockWarningMessage('Atenção: Caps Lock está ativado.');
-      return;
-    }
-
-    setCapsLockWarningMessage(false);
-  }
 
   function clearErrors() {
     setErrorObject(undefined);
@@ -119,29 +109,14 @@ function LoginForm() {
               <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
             )}
           </FormControl>
-          <FormControl id="password">
-            <FormControl.Label>Senha</FormControl.Label>
-            <TextInput
-              ref={passwordRef}
-              onChange={clearErrors}
-              onKeyDown={detectCapsLock}
-              onKeyUp={detectCapsLock}
-              name="password"
-              type="password"
-              autoCorrect="off"
-              autoCapitalize="off"
-              spellCheck={false}
-              size="large"
-              block={true}
-              aria-label="Sua senha"
-            />
-            {capsLockWarningMessage && (
-              <FormControl.Validation variant="warning">{capsLockWarningMessage}</FormControl.Validation>
-            )}
-            {errorObject?.key === 'password' && (
-              <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
-            )}
-          </FormControl>
+          <PasswordInput
+            inputRef={passwordRef}
+            id="password"
+            name="password"
+            label="Senha"
+            errorObject={errorObject}
+            setErrorObject={setErrorObject}
+          />
           <FormControl>
             <FormControl.Label visuallyHidden>Login</FormControl.Label>
             <Button


### PR DESCRIPTION
**Motivação:** 

Durante o processo de cadastro no site, enquanto digitava minha senha, percebi que não havia um botão que permitisse visualizar a senha que estava sendo digitada. Essa funcionalidade é bastante comum em muitos sites e aplicativos e pode ser extremamente útil para evitar erros de digitação e garantir que a senha cadastrada esteja correta.

**Nesta PR:**

Criei um componente de input de senha com um botão para o usuário conseguir ver a senha que está digitando e atualizei as paginas de login, registro e recuperação de senha para começarem a usar esse componente.

**Resultado:**

https://user-images.githubusercontent.com/27015559/222832211-8d1a3b1f-593c-430d-adff-7dad46f194fe.mp4

