### PR TITLE
fix(date tooltip): fix horizontal scrolling caused by tooltip position

### DIFF
--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -182,7 +182,7 @@ function ViewMode({ setComponentMode, contentObject, viewFrame }) {
               href={`/${contentObject.owner_username}/${contentObject.slug}`}
               prefetch={false}
               sx={{ fontSize: 0, color: 'fg.muted', mr: '100px', py: '1px', height: '22px' }}>
-              <PublishedSince date={contentObject.published_at} />
+              <PublishedSince direction="n" date={contentObject.published_at} />
             </Link>
           </Box>
           {(user?.id === contentObject.owner_id || user?.features?.includes('update:content:others')) && (

--- a/pages/interface/components/ContentList/index.js
+++ b/pages/interface/components/ContentList/index.js
@@ -125,7 +125,7 @@ export default function ContentList({ contentList, pagination, paginationBasePat
             </Link>
             {' · '}
             <Text>
-              <PublishedSince date={contentObject.published_at} />
+              <PublishedSince direction="nw" date={contentObject.published_at} />
             </Text>
           </Box>
         </Box>,

--- a/pages/interface/components/PublishedSince/index.js
+++ b/pages/interface/components/PublishedSince/index.js
@@ -14,7 +14,7 @@ function formatTooltipLabel(date) {
   return format(new Date(date), "EEEE, d 'de' MMMM 'de' yyyy 'às' HH:mm", { locale: ptBR });
 }
 
-export default function PublishedSince({ direction, date }) {
+export default function PublishedSince({ date, ...props }) {
   return (
     <Tooltip direction={direction} sx={{ position: 'absolute', ml: 1 }} aria-label={formatTooltipLabel(date)}>
       <span suppressHydrationWarning>{formatPublishedSince(date)}</span>

--- a/pages/interface/components/PublishedSince/index.js
+++ b/pages/interface/components/PublishedSince/index.js
@@ -17,7 +17,9 @@ function formatTooltipLabel(date) {
 export default function PublishedSince({ date, ...props }) {
   return (
     <Tooltip sx={{ position: 'absolute', ml: 1 }} aria-label={formatTooltipLabel(date)} {...props}>
-      <span suppressHydrationWarning>{formatPublishedSince(date)}</span>
+      <span style={{ whiteSpace: 'nowrap' }} suppressHydrationWarning>
+        {formatPublishedSince(date)}
+      </span>
     </Tooltip>
   );
 }

--- a/pages/interface/components/PublishedSince/index.js
+++ b/pages/interface/components/PublishedSince/index.js
@@ -14,9 +14,9 @@ function formatTooltipLabel(date) {
   return format(new Date(date), "EEEE, d 'de' MMMM 'de' yyyy 'às' HH:mm", { locale: ptBR });
 }
 
-export default function PublishedSince({ date }) {
+export default function PublishedSince({ direction, date }) {
   return (
-    <Tooltip sx={{ position: 'absolute', ml: 1 }} aria-label={formatTooltipLabel(date)}>
+    <Tooltip direction={direction} sx={{ position: 'absolute', ml: 1 }} aria-label={formatTooltipLabel(date)}>
       <span suppressHydrationWarning>{formatPublishedSince(date)}</span>
     </Tooltip>
   );

--- a/pages/interface/components/PublishedSince/index.js
+++ b/pages/interface/components/PublishedSince/index.js
@@ -16,7 +16,7 @@ function formatTooltipLabel(date) {
 
 export default function PublishedSince({ date, ...props }) {
   return (
-    <Tooltip direction={direction} sx={{ position: 'absolute', ml: 1 }} aria-label={formatTooltipLabel(date)}>
+    <Tooltip sx={{ position: 'absolute', ml: 1 }} aria-label={formatTooltipLabel(date)} {...props}>
       <span suppressHydrationWarning>{formatPublishedSince(date)}</span>
     </Tooltip>
   );


### PR DESCRIPTION
**Motivação:**

Estava acessando o TabNews pelo celular quando cliquei na hora da postagem o tooltip não apareceu por completo e criou uma rolagem horizontal na pagina. Acredito que seja um bug.

**Nesta PR:**

Adicionei uma propriedade direction no component PublishedSince e atualizei os componentes Content e ContentList que utilizavam este componente. Utilizei como base a documentação do primer.
![TooltipDirection](https://user-images.githubusercontent.com/27015559/222918593-b5eb0bcd-a182-43c6-8c48-63d51a91765d.png)

**Antes**
![AntesTabNews](https://user-images.githubusercontent.com/27015559/222918679-522edf03-840b-4d9a-acfd-cfac0c457c24.png)


**Depois**
![SoluçãoTabNews](https://user-images.githubusercontent.com/27015559/222918601-0eb03fe6-381f-4540-8644-794ecbb7373e.png)

