### PR TITLE
feat: reddit-like comment collapse

### DIFF
--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -8,7 +8,7 @@ import authorization from 'models/authorization.js';
 import removeMarkdown from 'models/remove-markdown.js';
 import { NotFoundError } from 'errors/index.js';
 import { Box, Tooltip } from '@primer/react';
-import { CommentIcon, CommentDiscussionIcon } from '@primer/octicons-react';
+import { CommentIcon, CommentDiscussionIcon, NoEntryFillIcon } from '@primer/octicons-react';
 import webserver from 'infra/webserver.js';
 
 export default function Post({
@@ -196,6 +196,11 @@ function RenderChildrenTree({ childrenList, level }) {
 
 function ChildComponent({ child, level }) {
   const [isCollapsed, setIsCollapsed] = useState(false);
+
+  const toggleCollapsed = () => {
+    setIsCollapsed(!isCollapsed);
+  };
+
   if (isCollapsed)
     return (
       <Box sx={{ display: 'flex', gap: '8px', alignItems: 'center', overflow: 'hidden' }}>
@@ -206,7 +211,7 @@ function ChildComponent({ child, level }) {
             wordWrap: 'break-word',
             display: 'flex',
           }}>
-          <Content content={child} mode="collapsed" setIsCollapsed={setIsCollapsed} />
+          <Content content={child} mode="collapsed" toggleCollapsed={toggleCollapsed} />
         </Box>
       </Box>
     );
@@ -228,19 +233,47 @@ function ChildComponent({ child, level }) {
         }}>
         <TabCoinButtons content={child} />
         <Box
+          onClick={() => toggleCollapsed()}
           sx={{
-            borderWidth: 0,
-            borderRightWidth: 1,
-            borderColor: 'border.muted',
-            borderStyle: 'dotted',
-            width: '50%',
+            width: '100%',
             height: '100%',
-          }}
-        />
+            cursor: 'pointer',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            '&:hover div': {
+              borderColor: 'red',
+            },
+            '&:hover .icon-box': {
+              display: 'block',
+            },
+          }}>
+          <Box
+            className="icon-box"
+            sx={{
+              display: 'none',
+              height: '0',
+              position: 'relative',
+              top: '30px',
+              '.octicon-no-entry-fill': { backgroundColor: 'white' },
+            }}>
+            <NoEntryFillIcon size={12} fill={'red'} />
+          </Box>
+          <Box
+            sx={{
+              borderWidth: 0,
+              borderRightWidth: 1,
+              borderColor: 'border.muted',
+              borderStyle: 'dotted',
+              width: '0',
+              height: '100%',
+            }}
+          />
+        </Box>
       </Box>
 
       <Box sx={{ width: '100%', overflow: 'auto' }}>
-        <Content content={child} mode="view" setIsCollapsed={setIsCollapsed} />
+        <Content content={child} mode="view" />
 
         <Box sx={{ mt: 4 }}>
           <Content content={{ parent_id: child.id }} mode="compact" viewFrame={true} />

--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -191,48 +191,65 @@ function InReplyToLinks({ content, parentContent, rootContent }) {
 }
 
 function RenderChildrenTree({ childrenList, level }) {
-  return childrenList.map((child) => {
+  return childrenList.map((child) => <ChildComponent level={level} key={child.id} child={child} />);
+}
+
+function ChildComponent({ child, level }) {
+  const [isCollapsed, setIsCollapsed] = useState(false);
+  if (isCollapsed)
     return (
-      <Box
-        sx={{
-          width: '100%',
-          wordWrap: 'break-word',
-          display: 'flex',
-          mt: 4,
-        }}
-        key={child.id}>
+      <Box sx={{ display: 'flex', gap: '8px', alignItems: 'center', overflow: 'hidden' }}>
+        <TabCoinButtons content={child} />
         <Box
           sx={{
-            pr: [0, null, null, 2],
+            overflow: 'hidden',
+            wordWrap: 'break-word',
             display: 'flex',
-            flexDirection: 'column',
-            justifyContent: 'center',
           }}>
-          <TabCoinButtons content={child} />
-          <Box
-            sx={{
-              borderWidth: 0,
-              borderRightWidth: 1,
-              borderColor: 'border.muted',
-              borderStyle: 'dotted',
-              width: '50%',
-              height: '100%',
-            }}
-          />
-        </Box>
-
-        <Box sx={{ width: '100%', overflow: 'auto' }}>
-          <Content content={child} mode="view" />
-
-          <Box sx={{ mt: 4 }}>
-            <Content content={{ parent_id: child.id }} mode="compact" viewFrame={true} />
-          </Box>
-
-          {child.children.length > 0 && <RenderChildrenTree childrenList={child.children} level={level + 1} />}
+          <Content content={child} mode="collapsed" setIsCollapsed={setIsCollapsed} />
         </Box>
       </Box>
     );
-  });
+
+  return (
+    <Box
+      sx={{
+        width: '100%',
+        wordWrap: 'break-word',
+        display: 'flex',
+        mt: 4,
+      }}>
+      <Box
+        sx={{
+          pr: [0, null, null, 2],
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+        }}>
+        <TabCoinButtons content={child} />
+        <Box
+          sx={{
+            borderWidth: 0,
+            borderRightWidth: 1,
+            borderColor: 'border.muted',
+            borderStyle: 'dotted',
+            width: '50%',
+            height: '100%',
+          }}
+        />
+      </Box>
+
+      <Box sx={{ width: '100%', overflow: 'auto' }}>
+        <Content content={child} mode="view" setIsCollapsed={setIsCollapsed} />
+
+        <Box sx={{ mt: 4 }}>
+          <Content content={{ parent_id: child.id }} mode="compact" viewFrame={true} />
+        </Box>
+
+        {child.children.length > 0 && <RenderChildrenTree childrenList={child.children} level={level + 1} />}
+      </Box>
+    </Box>
+  );
 }
 
 export async function getStaticPaths() {


### PR DESCRIPTION
The reason for this feature is to make the website more user-friendly and easier to navigate, especially when there are many comments on a post. By allowing users to collapse comments, they can more easily focus on the ones they're interested in and skip over those they're not.