### PR TITLE
Possibilidade de exibir e ocultar parte das respostas dos conteúdos (manualmente e automaticamente)

### DIFF
--- a/pages/interface/components/Footer/index.js
+++ b/pages/interface/components/Footer/index.js
@@ -45,7 +45,7 @@ export default function Footer(props) {
             display: 'flex',
             justifyContent: 'center',
             alignItems: 'center',
-            gap: [2, 3, 4, 5],
+            gap: [3, null, 4, 5],
             paddingX: [2, null, null, 5],
             flexWrap: 'wrap',
           }}>

--- a/pages/interface/components/PublishedSince/index.js
+++ b/pages/interface/components/PublishedSince/index.js
@@ -4,17 +4,25 @@ import { Tooltip } from '@primer/react';
 import { useEffect, useState } from 'react';
 
 function formatPublishedSince(date) {
-  const publishedSince = formatDistanceToNowStrict(new Date(date), {
-    locale: ptBR,
-  });
+  try {
+    const publishedSince = formatDistanceToNowStrict(new Date(date), {
+      locale: ptBR,
+    });
 
-  return `${publishedSince} atrás`;
+    return `${publishedSince} atrás`;
+  } catch (e) {
+    return '';
+  }
 }
 
 function formatTooltipLabel(date, gmt = false) {
   const displayFormat = gmt ? "EEEE, d 'de' MMMM 'de' yyyy 'às' HH:mm z" : "EEEE, d 'de' MMMM 'de' yyyy 'às' HH:mm";
 
-  return format(new Date(date), displayFormat, { locale: ptBR });
+  try {
+    return format(new Date(date), displayFormat, { locale: ptBR });
+  } catch (e) {
+    return '';
+  }
 }
 
 export default function PublishedSince({ date, ...props }) {

--- a/pages/interface/hooks/useCollapse/index.js
+++ b/pages/interface/hooks/useCollapse/index.js
@@ -1,0 +1,170 @@
+import { useEffect, useMemo, useState } from 'react';
+
+export default function useCollapse({ childrenList, renderIntent = 20, renderIncrement = 10, flatten = true }) {
+  const flattenedTree = useMemo(flattenTree, [childrenList, flatten]);
+  const [childrenState, setChildrenState] = useState(() => computeStates(flattenedTree, renderIntent));
+
+  useEffect(() => {
+    setChildrenState((lastState) => computeStates(flattenedTree, renderIntent, lastState));
+  }, [flattenedTree, renderIntent]);
+
+  const filteredTree = useMemo(() => {
+    let merged = [];
+
+    flattenedTree.forEach((child, index) => {
+      if (!child.id) return;
+      if (child.id !== childrenState[index]?.id) return;
+      if (child.renderIntent < 1 && !child.renderShowMore) return;
+      merged.push({ ...childrenState[index], ...child });
+    });
+
+    return merged;
+  }, [childrenState, flattenedTree]);
+
+  function computeStates(children, renderIntent, lastState = []) {
+    let newStates = [];
+    let remaining = renderIntent;
+    let grouperIndex = null;
+    let deltaIndex = 0;
+
+    children.forEach((child, index) => {
+      if (lastState.length > 0) {
+        if (lastState[index + deltaIndex]?.id === child.id && child.id) {
+          newStates.push(lastState[index + deltaIndex]);
+          remaining -= lastState[index + deltaIndex].renderIntent;
+          return;
+        }
+
+        const childLastStateIndex = lastState.findIndex((childLastState) => childLastState.id === child.id && child.id);
+
+        if (childLastStateIndex > -1) {
+          deltaIndex = childLastStateIndex - index;
+          newStates.push(lastState[childLastStateIndex]);
+          remaining -= lastState[childLastStateIndex].renderIntent;
+          return;
+        }
+      }
+
+      if (remaining > 0) {
+        newStates.push({
+          id: child.id,
+          renderIntent: 1,
+          groupedCount: 1 + child.children_deep_count,
+          renderShowMore: false,
+        });
+      }
+
+      if (remaining === 0) {
+        grouperIndex = index;
+
+        newStates.push({
+          id: child.id,
+          renderIntent: 0,
+          groupedCount: 1 + child.children_deep_count,
+          renderShowMore: true,
+        });
+      }
+
+      if (remaining < 0) {
+        if (newStates[grouperIndex]) {
+          newStates[grouperIndex].groupedCount += 1 + child.children_deep_count;
+        }
+
+        newStates.push({
+          id: child.id,
+          renderIntent: 0,
+          groupedCount: 1 + child.children_deep_count,
+          renderShowMore: false,
+        });
+      }
+
+      remaining -= 1;
+    });
+
+    for (const child of newStates) {
+      if (remaining < 1) break;
+
+      if (child.groupedCount - child.renderIntent > remaining) {
+        child.renderIntent += remaining;
+        remaining = 0;
+      } else {
+        remaining -= child.groupedCount - child.renderIntent;
+        child.renderIntent = child.groupedCount;
+      }
+    }
+
+    return newStates;
+  }
+
+  function handleExpand(id) {
+    setChildrenState((lastState) => {
+      const childIndex = lastState.findIndex((child) => child.id === id);
+      let grouperIndex = childIndex;
+      let childrenToExpand = [];
+
+      while (lastState[grouperIndex]?.renderIntent === 0) {
+        childrenToExpand.push(flattenedTree[grouperIndex]);
+        grouperIndex += 1;
+      }
+
+      return [
+        ...lastState.slice(0, childIndex),
+        ...computeStates(childrenToExpand, renderIncrement),
+        ...lastState.slice(grouperIndex),
+      ];
+    });
+  }
+
+  function handleCollapse(id) {
+    setChildrenState((lastState) => {
+      const childIndex = lastState.findIndex((child) => child.id === id);
+      let children = [...lastState];
+
+      if (childIndex < 0) return children;
+
+      children[childIndex].renderIntent = 0;
+      children[childIndex].renderShowMore = true;
+
+      if (lastState[childIndex + 1]?.renderIntent === 0) {
+        children[childIndex].groupedCount += lastState[childIndex + 1].groupedCount;
+        children[childIndex + 1].renderShowMore = false;
+      }
+
+      let groupedIndex = childIndex - 1;
+
+      while (lastState[groupedIndex]?.renderIntent === 0) {
+        if (groupedIndex === childIndex - 1) {
+          children[childIndex].renderShowMore = false;
+        }
+
+        children[groupedIndex].groupedCount += children[childIndex].groupedCount;
+        groupedIndex -= 1;
+      }
+
+      return children;
+    });
+  }
+
+  function flattenTree() {
+    if (!flatten) return childrenList;
+    if (!childrenList.length > 0) return [];
+
+    let flattenTree = [...childrenList];
+
+    while (flattenTree.at(-1)?.children?.length === 1) {
+      flattenTree = [
+        ...flattenTree.slice(0, -1),
+        { ...flattenTree.at(-1), children: [], children_deep_count: 0 },
+        ...flattenTree.at(-1).children,
+      ];
+    }
+
+    return flattenTree;
+  }
+
+  return {
+    filteredTree,
+    handleCollapse,
+    handleExpand,
+  };
+}

--- a/pages/interface/index.js
+++ b/pages/interface/index.js
@@ -13,5 +13,6 @@ export { default as GoToTopButton } from './components/GoToTopButton/index.js';
 export { default as Viewer, Editor } from './components/Markdown/index.js';
 export { default as PasswordInput } from './components/PasswordInput/index.js';
 
+export { default as useCollapse } from './hooks/useCollapse/index.js';
 export { default as useUser } from './hooks/useUser/index.js';
 export { default as useMediaQuery } from './hooks/useMediaQuery/index.js';


### PR DESCRIPTION
Turma, por favor me digam o que ainda pode ou deve ser alterado antes de ir para produção.

## UX

A proposta inicial era usar o Timeline do Primer, mas ele não ajudou muito, então não utilizei.

O visual está bem simples, e bastante similar ao reddit, mas acredito que está legal como primeira versão da funcionalidade.

Fiquei com medo de fazer algo mirabolante, mas como o @filipedeschamps falou em deixar um pouco mais compreensível, coloquei os ícones que podem ser vistos na imagem mais abaixo, onde uma das barras está com hover:

![image](https://user-images.githubusercontent.com/77860630/224520892-45f421eb-895b-4895-b509-d375f1d87db4.png)

Deem suas opiniões, pois mudar a estilização é a parte fácil dessa implementação, e é a mais importante.

## Mais UX nesse PR

Coisas relacionadas que já implementei, onde o primeiro é algo com um impacto real em telas pequenas, então analisem bem:

### Achatar árvore de respostas

Agora os ramos de respostas não ficam na diagonal se não for necessário. Por exemplo, dois usuários respondendo um ao outro em sequência vai fazer aparecer uma resposta abaixo da outra, em ordem cronológica. Só quando uma mesma resposta for a mãe de mais de um filho, aí sim a árvore irá bifurcar. Obs. isso só ocorre no client, não muda nada na estrutura real dos dados.
Compare [essa publicação](https://tabnews-gbs3n8z1r-tabnews.vercel.app/Gustavo33/teste4593832181797422292334945798549354624941348715825899669) como é atualmente e [como fica com esse PR](https://tabnews-3oy3e5vac-tabnews.vercel.app/Gustavo33/teste4593832181797422292334945798549354624941348715825899669). Essa publicação também é interessante, pois mostra uma bifurcação:

| [link para a versão atual](https://tabnews-gbs3n8z1r-tabnews.vercel.app/filipedeschamps/testando-o-novo-metodo-findrootcontent-que-vai-poder-trazer-muito-mais-contexto) | [link para a versão achatada](https://tabnews-9og3kpb67-tabnews.vercel.app/filipedeschamps/testando-o-novo-metodo-findrootcontent-que-vai-poder-trazer-muito-mais-contexto) |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/77860630/224524372-6e4af6a9-3077-44e4-9e9f-2b608cd6a492.png) | ![image](https://user-images.githubusercontent.com/77860630/224524384-a5c1f480-f589-4cbc-a138-ad06c31ad1f5.png) |

### Collapsar automaticamente as mensagens de conteúdos com muitas respostas

Esse PR não abre somente a possibilidade de omitir e exibir as respostas de acordo com a intenção do usuário, mas também já condensa mensagens a partir de um limiar. Esse limiar está definido como a altura da tela em pixels dividido por 50, o que dá cerca de 21 respostas em uma tela full hd, mas qualquer sugestão de alteração nesse valor é bem vinda. Fora isso, para expandir a quantidade de respostas visíveis também existe um limite por clique, que é a metade do valor anterior.

Apenas para facilitar os testes e visualização desse comportamento, existe um deploy que está com um limiar bem inferior. Ele renderiza no máximo 7 respostas iniciais e no máximo 4 a cada nova expansão. Eles podem ser vistos nos links abaixo:

* [Conteúdo para teste](https://tabnews-9og3kpb67-tabnews.vercel.app/filipedeschamps/tentando-consertar-o-oveflow-do-body).

* [Outro conteúdo para teste](https://tabnews-9og3kpb67-tabnews.vercel.app/Gustavo33/teste4593832181797422292334945798549354624941348715825899669)

Obs. Só lembrando que a versão para revisão tem limites maiores: [link 1](https://tabnews-git-collapse-answers-tabnews.vercel.app/filipedeschamps/tentando-consertar-o-oveflow-do-body)  e [link 2](https://tabnews-git-collapse-answers-tabnews.vercel.app/Gustavo33/teste4593832181797422292334945798549354624941348715825899669)

### Margem entre cada nível de resposta

Alterei o limiar que diminui a margem que faz o espaçamento entre cada nível de respostas.

Isso também muda o espaçamento entre as barras que agora são clicáveis.

Antes ele só alargava em telas maiores que 1000px, mas agora o limiar é 800px. O padding geral do site continua como antes, mudando em 1000px.

## Regras de negócio

Parecia algo simples, mas foi bem chato de lidar com todas as possibilidades. Principalmente para não quebrar a interface quando a árvore de conteúdos é atualizada via API e também a questão de mostrar as quantidades corretas de conteúdos quando eles estão agrupados (não é apenas o `children_deep_count`).

No final eu até que consegui simplificar o código que criei inicialmente, mas ainda assim sobrou tanta coisa que achei melhor criar o hook `useCollapse`.

## Bônus

Para conseguir desenvolver e realizar os testes necessários para esse PR, tive que mexer em algumas coisas a mais, o que pode já ter vindo nesse ou irá vir em novos PRs:

1. Acho que todos que usam mais o TabNews já chegaram a acessar algum conteúdo que tinha sido apagado recentemente. Nesses casos, ao carregar a página via cache, a interface quebrava após a revalidação via API retornando 404.

O erro não tratado ocorria por causa do componente `PublishedSince` recebendo uma data como `undefined`. Daria para fazer uma validação desse dado, mas seria algo que iria retornar sucesso em 99,99% dos casos, então é só processamento desnecessário, então só coloquei um try catch no estilo "pedir perdão e não permissão".

Agora quando ocorrer essa situação de conteúdo apagado recentemente, apenas vai sumir o conteúdo, mas sem gerar erros. Só fiz isso para poder isolar os erros específicos desse PR, que foram muitos durante o desenvolvimento. 😅
Mas para um próximo momento pode ser legal renderizar o modo "conteúdo deletado" enquanto faz um redirecionamento via client para a página 404.

2. Enquanto estava tentando utilizar a Timeline do Primer eu acabei fazendo uma refatoração no código da página de conteúdo. Eu gostei do resultado, mas removi as alterações quando desisti do Primer nesse PR. Assim isso pode ser analisado separadamente. Mas acho que vale a pena aguardar a conclusão do PR atual antes de mexer com esse outro.