### PR TITLE
Não mostrar a senha ao pressionar a tecla `Enter`

### DIFF
--- a/pages/interface/components/PasswordInput/index.js
+++ b/pages/interface/components/PasswordInput/index.js
@@ -1,10 +1,17 @@
-import { useState } from 'react';
-import { FormControl, IconButton, TextInput, Tooltip } from '@primer/react';
+import { useEffect, useState } from 'react';
+import { FormControl, TextInput } from '@primer/react';
 import { EyeClosedIcon, EyeIcon } from '@primer/octicons-react';
 
 export default function PasswordInput({ inputRef, id, name, label, errorObject, setErrorObject, ...props }) {
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
   const [capsLockWarningMessage, setCapsLockWarningMessage] = useState(false);
+
+  useEffect(() => {
+    // change tooltip direction of TextInput.Action
+    const tooltip = inputRef.current.parentElement.getElementsByClassName('tooltipped-n')[0];
+    tooltip?.classList.add('tooltipped-nw');
+    tooltip?.classList.remove('tooltipped-n');
+  }, [inputRef]);
 
   function focusAfterEnd(ref) {
     setTimeout(() => {
@@ -37,26 +44,13 @@ export default function PasswordInput({ inputRef, id, name, label, errorObject, 
     <FormControl id={id}>
       <FormControl.Label>{label}</FormControl.Label>
       <TextInput
-        trailingVisual={
-          <Tooltip
+        trailingAction={
+          <TextInput.Action
             aria-label={isPasswordVisible ? 'Ocultar a senha' : 'Visualizar a senha'}
-            direction="nw"
-            noDelay={true}>
-            <IconButton
-              onClick={handlePasswordVisible}
-              icon={isPasswordVisible ? EyeClosedIcon : EyeIcon}
-              sx={{
-                padding: '0',
-                border: 'none',
-                color: 'fg.subtle',
-                background: 'none',
-                boxShadow: 'none',
-                ':hover:not([disabled])': {
-                  background: 'none',
-                },
-              }}
-            />
-          </Tooltip>
+            onClick={handlePasswordVisible}
+            icon={isPasswordVisible ? EyeClosedIcon : EyeIcon}
+            sx={{ color: 'fg.subtle' }}
+          />
         }
         ref={inputRef}
         onChange={clearErrors}
@@ -75,13 +69,7 @@ export default function PasswordInput({ inputRef, id, name, label, errorObject, 
       {capsLockWarningMessage && (
         <FormControl.Validation variant="warning">{capsLockWarningMessage}</FormControl.Validation>
       )}
-      {errorObject?.key === 'empty' && (
-        <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
-      )}
-      {errorObject?.key === 'password' && (
-        <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
-      )}
-      {errorObject?.key === 'password_confirm' && (
+      {['empty', 'password', 'password_confirm'].includes(errorObject?.key) && (
         <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
       )}
     </FormControl>


### PR DESCRIPTION
O PR #1297 que implementou a opção de mostrar a senha veio com um pequeno bug:

* Ao pressionar a tecla `Enter` no campo de senha, o modo de mostrar a senha era alterado. E com isso a senha era exibida ao invés de submeter os dados.

Então eu substituí o `trailingVisual` + `Tooltip` pelo `trailingAction` + `TextInput.Action` que já tem o comportamento e estilização adequados.

Obs.: Precisei trocar o `className` do `TextInput.Action` dentro de um `useEffect` para mudar o `Tooltip` embutido de `n` para `nw`, pois ele não permite passar essa propriedade. E sem essa mudança o `Tooltip` faria aparecer a barra de rolagem em telas pequenas.

