### PR TITLE
refactor(authorization): simplify "can" function

### DIFF
--- a/models/authorization.js
+++ b/models/authorization.js
@@ -53,7 +53,7 @@ function can(user, feature, resource) {
   if (feature === 'update:user' && resource) {
     authorized = false;
 
-    if (user.id === resource.id) {
+    if (user.id === resource.id && user.features.includes('update:user')) {
       authorized = true;
     }
   }
@@ -61,7 +61,7 @@ function can(user, feature, resource) {
   if (feature === 'update:content' && resource) {
     authorized = false;
 
-    if (user.id === resource.owner_id || can(user, 'update:content:others')) {
+    if (user.id === resource.owner_id || user.features.includes('update:content:others')) {
       authorized = true;
     }
   }

--- a/models/authorization.js
+++ b/models/authorization.js
@@ -43,27 +43,18 @@ function can(user, feature, resource) {
   validateUser(user);
   validateFeature(feature);
 
-  let authorized = false;
+  var authorized = false;
+  if (user.features.includes(feature)) authorized = true;
 
-  if (user.features.includes(feature)) {
-    authorized = true;
-  }
-
-  // TODO: Double check if this is right and covered by tests
-  if (feature === 'update:user' && resource) {
-    authorized = false;
-
-    if (user.id === resource.id) {
+  if (Boolean(resource)) {
+    if (feature === 'update:user' || feature === 'update:content') authorized = false;
+    if (
+      !authorized &&
+      ((user.id === resource.id && user.features.includes('update:user')) ||
+        user.id === resource.owner_id ||
+        user.features.includes('update:content:others'))
+    )
       authorized = true;
-    }
-  }
-
-  if (feature === 'update:content' && resource) {
-    authorized = false;
-
-    if (user.id === resource.owner_id || can(user, 'update:content:others')) {
-      authorized = true;
-    }
   }
 
   return authorized;

--- a/models/authorization.js
+++ b/models/authorization.js
@@ -43,18 +43,27 @@ function can(user, feature, resource) {
   validateUser(user);
   validateFeature(feature);
 
-  var authorized = false;
-  if (user.features.includes(feature)) authorized = true;
+  let authorized = false;
 
-  if (Boolean(resource)) {
-    if (feature === 'update:user' || feature === 'update:content') authorized = false;
-    if (
-      !authorized &&
-      ((user.id === resource.id && user.features.includes('update:user')) ||
-        user.id === resource.owner_id ||
-        user.features.includes('update:content:others'))
-    )
+  if (user.features.includes(feature)) {
+    authorized = true;
+  }
+
+  // TODO: Double check if this is right and covered by tests
+  if (feature === 'update:user' && resource) {
+    authorized = false;
+
+    if (user.id === resource.id) {
       authorized = true;
+    }
+  }
+
+  if (feature === 'update:content' && resource) {
+    authorized = false;
+
+    if (user.id === resource.owner_id || can(user, 'update:content:others')) {
+      authorized = true;
+    }
   }
 
   return authorized;


### PR DESCRIPTION
Seguindo a [issue #1307](https://github.com/filipedeschamps/tabnews.com.br/issues/1307) de @aprendendofelipe, este PR traz a simplificação do código na função can, trazendo o teste da feature `user.features.includes('update:user')` e removendo as chamadas recursivas!