### PR TITLE
fix(docker setup): support the new `docker compose` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,8 +70,8 @@
   "scripts": {
     "dev": "kill-port 3000 && npm run services:up && npm run migration:run && npm run migration:seed && npm run next && npm run services:stop",
     "next": "next dev",
-    "services:up": "docker-compose -f infra/docker-compose.development.yml up -d",
-    "services:stop": "docker-compose -f infra/docker-compose.development.yml stop",
+    "services:up": "docker-compose -f infra/docker-compose.development.yml up -d || docker compose -f infra/docker-compose.development.yml up -d",
+    "services:stop": "docker-compose -f infra/docker-compose.development.yml stop || docker compose -f infra/docker-compose.development.yml stop",
     "build": "cross-env BUILD_TIME=true next build",
     "build:local": "kill-port 3000 && npm run services:up && npm run migration:run && npm run migration:seed && next build && npm run services:stop",
     "start": "next start",


### PR DESCRIPTION
Uma pequena adição no `package.json`, para suportar o novo comando `docker compose`, que substitui o antigo `docker-compose`, a partir da versão 20.10 (19-01-2023).

A adição suporta ambas versões do comando.