### PR TITLE
chore(postgres): enable slow query log

### DIFF
--- a/infra/provisioning/modules/database/main.tf
+++ b/infra/provisioning/modules/database/main.tf
@@ -92,6 +92,11 @@ resource "aws_db_parameter_group" "parameter_group" {
     value = "0"
   }
 
+  parameter {
+    name  = "log_min_duration_statement"
+    value = "2000"
+  }
+
   tags = {
     Name        = "${var.environment}-parameter-group"
     Environment = var.environment


### PR DESCRIPTION
Consultas que levam mais de 2s serão logadas no `slow query log`. Com essa configuração teremos visibilidade de quais queries estão demorando, e podemos diminuir esse tempo até 1s, após uma primeira iteração.