### PR TITLE
Move a verificação de permissão de um usuário em relação à feature `create:recovery_token:username` para dentro do model `authorization`

### DIFF
--- a/models/authorization.js
+++ b/models/authorization.js
@@ -66,6 +66,14 @@ function can(user, feature, resource) {
     }
   }
 
+  if (feature === 'create:recovery_token:username' && resource) {
+    authorized = false;
+
+    if (resource.username && user.features.includes(feature)) {
+      authorized = true;
+    }
+  }
+
   return authorized;
 }
 
@@ -142,6 +150,28 @@ function filterInput(user, feature, input) {
       status: input.status,
       source_url: input.source_url,
     };
+  }
+
+  if (feature === 'create:recovery_token:username') {
+    if (input.username && !can(user, feature, input)) {
+      throw new ForbiddenError({
+        message: `Usuário não pode executar esta operação.`,
+        action: `Verifique se este usuário possui a feature "${feature}".`,
+        errorLocationCode: 'MODEL:AUTHORIZATION:FILTER_INPUT:CAN_NOT_CREATE_RECOVERY_TOKEN_USERNAME',
+      });
+    }
+
+    if (input.username) {
+      filteredInputValues = {
+        username: input.username,
+      };
+    }
+
+    if (input.email) {
+      filteredInputValues = {
+        email: input.email,
+      };
+    }
   }
 
   // Force the clean up of "undefined" values

--- a/pages/api/v1/recovery/index.public.js
+++ b/pages/api/v1/recovery/index.public.js
@@ -4,7 +4,6 @@ import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
 import recovery from 'models/recovery.js';
 import validator from 'models/validator.js';
-import { ForbiddenError } from 'errors';
 
 export default nextConnect({
   attachParams: true,
@@ -32,15 +31,13 @@ async function postHandler(request, response) {
   const userTryingToRecover = request.context.user;
   const validatedInputValues = request.body;
 
-  if (validatedInputValues.username && !authorization.can(userTryingToRecover, 'create:recovery_token:username')) {
-    throw new ForbiddenError({
-      message: `Você não possui permissão para criar um token de recuperação com username.`,
-      action: `Verifique se este usuário tem a feature "create:recovery_token:username".`,
-      errorLocationCode: 'CONTROLLER:RECOVERY:POST_HANDLER:CAN_NOT_CREATE_RECOVERY_TOKEN_USERNAME',
-    });
-  }
+  const filteredInputValues = authorization.filterInput(
+    userTryingToRecover,
+    'create:recovery_token:username',
+    validatedInputValues
+  );
 
-  const tokenObject = await recovery.createAndSendRecoveryEmail(validatedInputValues);
+  const tokenObject = await recovery.createAndSendRecoveryEmail(filteredInputValues);
 
   const authorizedValuesToReturn = authorization.filterOutput(userTryingToRecover, 'read:recovery_token', tokenObject);
 

--- a/tests/integration/api/v1/recovery/post.test.js
+++ b/tests/integration/api/v1/recovery/post.test.js
@@ -30,12 +30,12 @@ describe('POST /api/v1/recovery', () => {
 
       expect(responseBody).toStrictEqual({
         name: 'ForbiddenError',
-        message: 'Você não possui permissão para criar um token de recuperação com username.',
-        action: 'Verifique se este usuário tem a feature "create:recovery_token:username".',
+        message: 'Usuário não pode executar esta operação.',
+        action: 'Verifique se este usuário possui a feature "create:recovery_token:username".',
         status_code: 403,
         error_id: responseBody.error_id,
         request_id: responseBody.request_id,
-        error_location_code: 'CONTROLLER:RECOVERY:POST_HANDLER:CAN_NOT_CREATE_RECOVERY_TOKEN_USERNAME',
+        error_location_code: 'MODEL:AUTHORIZATION:FILTER_INPUT:CAN_NOT_CREATE_RECOVERY_TOKEN_USERNAME',
       });
 
       expect(uuidVersion(responseBody.error_id)).toEqual(4);


### PR DESCRIPTION
No PR #1290 o @aprendendofelipe sugeriu isolar a verificação de permissão de um usuário em relação à feature `create:recovery_token:username` dentro do model `authorization`, achei uma ótima sugestão mas não consegui implementar pois a função `can` do model de autorização precisava passar por uma refatoração como mencionado na issue #1307.

**Felizmente** :heart_eyes: o @eletroswing refatorou a função e agora estou voltando para melhorar a implementação feita no PR citado acima.