### PR TITLE
Adiciona capacidade de renderizar equações matemáticas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@bytemd/plugin-gemoji": "1.20.2",
         "@bytemd/plugin-gfm": "1.20.2",
         "@bytemd/plugin-highlight-ssr": "1.20.2",
+        "@bytemd/plugin-math": "1.20.2",
         "@bytemd/plugin-mermaid": "1.20.2",
         "@bytemd/react": "1.20.2",
         "@primer/octicons-react": "18.2.0",
@@ -735,6 +736,19 @@
       "integrity": "sha512-mZm9v3sY+nnjgDNYtU5iFEjhj58MeQ50ukgkRc4UCU9BCf3YV3+dTI53bBYqOpnACQkzmd3r7N6dZC2OoGZwrg==",
       "dependencies": {
         "rehype-highlight": "^6.0.0"
+      },
+      "peerDependencies": {
+        "bytemd": "^1.5.0"
+      }
+    },
+    "node_modules/@bytemd/plugin-math": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@bytemd/plugin-math/-/plugin-math-1.20.2.tgz",
+      "integrity": "sha512-Ric1oWWz9ggx9UQ3OgpPIruz1UEnqLNsTiDclsoo8YVrGVQE1Mul1tTujy8MNIh15EEe6b9rV2OJ7dxuq6OJdg==",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "katex": "^0.16.4",
+        "remark-math": "^5.1.1"
       },
       "peerDependencies": {
         "bytemd": "^1.5.0"
@@ -2580,6 +2594,11 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "node_modules/@types/katex": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.0.tgz",
+      "integrity": "sha512-hz+S3nV6Mym5xPbT9fnO8dDhBFQguMYpY0Ipxv06JMi1ORgnEM4M1ymWDUhUNer3ElLmT583opRo4RzxKmh9jw=="
     },
     "node_modules/@types/lodash": {
       "version": "4.14.191",
@@ -8484,6 +8503,29 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.4",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.4.tgz",
+      "integrity": "sha512-WudRKUj8yyBeVDI4aYMNxhx5Vhh2PjpzQw1GRu/LVGqL4m1AxwD1GcUp0IMbdJaf5zsjtj8ghP0DOQRYhroNkw==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "dependencies": {
+        "commander": "^8.0.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/khroma": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.0.0.tgz",
@@ -9223,6 +9265,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-math": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-2.0.2.tgz",
+      "integrity": "sha512-8gmkKVp9v6+Tgjtq6SYx9kGPpTf6FVYRa53/DLh479aldR9AyP48qeVOgNZ5X7QUK7nOy4yw7vg6mbiGcs9jWQ==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-to-markdown": "^1.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-phrasing": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-3.0.1.tgz",
@@ -9547,6 +9603,52 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-2.0.2.tgz",
+      "integrity": "sha512-cFv2B/E4pFPBBFuGgLHkkNiFAIQv08iDgPH2HCuR2z3AUgMLecES5Cq7AVtwOtZeRrbA80QgMUk8VVW0Z+D2FA==",
+      "dependencies": {
+        "@types/katex": "^0.11.0",
+        "katex": "^0.13.0",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math/node_modules/@types/katex": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.11.1.tgz",
+      "integrity": "sha512-DUlIj2nk0YnJdlWgsFuVKcX27MLW0KbKmGVoUHmFr+74FYYNUDAaj9ZqTADvsbE8rfxuVmSFc7KczYn5Y09ozg=="
+    },
+    "node_modules/micromark-extension-math/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/micromark-extension-math/node_modules/katex": {
+      "version": "0.13.24",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.13.24.tgz",
+      "integrity": "sha512-jZxYuKCma3VS5UuxOx/rFV1QyGSl3Uy/i0kTJF3HgQ5xMinCQVF8Zd4bMY/9aI9b9A2pjIBOsjSSm68ykTAr8w==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "dependencies": {
+        "commander": "^8.0.0"
+      },
+      "bin": {
+        "katex": "cli.js"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -11621,6 +11723,21 @@
         "@types/mdast": "^3.0.0",
         "mdast-util-gfm": "^2.0.0",
         "micromark-extension-gfm": "^2.0.0",
+        "unified": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-5.1.1.tgz",
+      "integrity": "sha512-cE5T2R/xLVtfFI4cCePtiRn+e6jKMtFDR3P8V3qpv8wpKjwvHoBA4eJzvX+nVrnlNy0911bdGmuspCSwetfYHw==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-math": "^2.0.0",
+        "micromark-extension-math": "^2.0.0",
         "unified": "^10.0.0"
       },
       "funding": {
@@ -13998,6 +14115,16 @@
         "rehype-highlight": "^6.0.0"
       }
     },
+    "@bytemd/plugin-math": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@bytemd/plugin-math/-/plugin-math-1.20.2.tgz",
+      "integrity": "sha512-Ric1oWWz9ggx9UQ3OgpPIruz1UEnqLNsTiDclsoo8YVrGVQE1Mul1tTujy8MNIh15EEe6b9rV2OJ7dxuq6OJdg==",
+      "requires": {
+        "@types/katex": "^0.16.0",
+        "katex": "^0.16.4",
+        "remark-math": "^5.1.1"
+      }
+    },
     "@bytemd/plugin-mermaid": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@bytemd/plugin-mermaid/-/plugin-mermaid-1.20.2.tgz",
@@ -15386,6 +15513,11 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "@types/katex": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.0.tgz",
+      "integrity": "sha512-hz+S3nV6Mym5xPbT9fnO8dDhBFQguMYpY0Ipxv06JMi1ORgnEM4M1ymWDUhUNer3ElLmT583opRo4RzxKmh9jw=="
     },
     "@types/lodash": {
       "version": "4.14.191",
@@ -19718,6 +19850,21 @@
         "object.assign": "^4.1.3"
       }
     },
+    "katex": {
+      "version": "0.16.4",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.4.tgz",
+      "integrity": "sha512-WudRKUj8yyBeVDI4aYMNxhx5Vhh2PjpzQw1GRu/LVGqL4m1AxwD1GcUp0IMbdJaf5zsjtj8ghP0DOQRYhroNkw==",
+      "requires": {
+        "commander": "^8.0.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+          "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
+        }
+      }
+    },
     "khroma": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.0.0.tgz",
@@ -20261,6 +20408,16 @@
         "mdast-util-to-markdown": "^1.3.0"
       }
     },
+    "mdast-util-math": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-2.0.2.tgz",
+      "integrity": "sha512-8gmkKVp9v6+Tgjtq6SYx9kGPpTf6FVYRa53/DLh479aldR9AyP48qeVOgNZ5X7QUK7nOy4yw7vg6mbiGcs9jWQ==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-to-markdown": "^1.3.0"
+      }
+    },
     "mdast-util-phrasing": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-3.0.1.tgz",
@@ -20508,6 +20665,40 @@
         "micromark-util-symbol": "^1.0.0",
         "micromark-util-types": "^1.0.0",
         "uvu": "^0.5.0"
+      }
+    },
+    "micromark-extension-math": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-2.0.2.tgz",
+      "integrity": "sha512-cFv2B/E4pFPBBFuGgLHkkNiFAIQv08iDgPH2HCuR2z3AUgMLecES5Cq7AVtwOtZeRrbA80QgMUk8VVW0Z+D2FA==",
+      "requires": {
+        "@types/katex": "^0.11.0",
+        "katex": "^0.13.0",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      },
+      "dependencies": {
+        "@types/katex": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.11.1.tgz",
+          "integrity": "sha512-DUlIj2nk0YnJdlWgsFuVKcX27MLW0KbKmGVoUHmFr+74FYYNUDAaj9ZqTADvsbE8rfxuVmSFc7KczYn5Y09ozg=="
+        },
+        "commander": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+          "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
+        },
+        "katex": {
+          "version": "0.13.24",
+          "resolved": "https://registry.npmjs.org/katex/-/katex-0.13.24.tgz",
+          "integrity": "sha512-jZxYuKCma3VS5UuxOx/rFV1QyGSl3Uy/i0kTJF3HgQ5xMinCQVF8Zd4bMY/9aI9b9A2pjIBOsjSSm68ykTAr8w==",
+          "requires": {
+            "commander": "^8.0.0"
+          }
+        }
       }
     },
     "micromark-factory-destination": {
@@ -21888,6 +22079,17 @@
         "@types/mdast": "^3.0.0",
         "mdast-util-gfm": "^2.0.0",
         "micromark-extension-gfm": "^2.0.0",
+        "unified": "^10.0.0"
+      }
+    },
+    "remark-math": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-5.1.1.tgz",
+      "integrity": "sha512-cE5T2R/xLVtfFI4cCePtiRn+e6jKMtFDR3P8V3qpv8wpKjwvHoBA4eJzvX+nVrnlNy0911bdGmuspCSwetfYHw==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-math": "^2.0.0",
+        "micromark-extension-math": "^2.0.0",
         "unified": "^10.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "@bytemd/plugin-gemoji": "1.20.2",
     "@bytemd/plugin-gfm": "1.20.2",
     "@bytemd/plugin-highlight-ssr": "1.20.2",
+    "@bytemd/plugin-math": "1.20.2",
     "@bytemd/plugin-mermaid": "1.20.2",
     "@bytemd/react": "1.20.2",
     "@primer/octicons-react": "18.2.0",

--- a/pages/interface/components/Markdown/index.js
+++ b/pages/interface/components/Markdown/index.js
@@ -5,20 +5,27 @@ import { useEffect, useRef } from 'react';
 // ByteMD dependencies:
 import gfmPlugin from '@bytemd/plugin-gfm';
 import highlightSsrPlugin from '@bytemd/plugin-highlight-ssr';
+import mathPlugin from '@bytemd/plugin-math';
 import mermaidPlugin from '@bytemd/plugin-mermaid';
 import breaksPlugin from '@bytemd/plugin-breaks';
 import gemojiPlugin from '@bytemd/plugin-gemoji';
 import byteMDLocale from 'bytemd/locales/pt_BR.json';
 import gfmLocale from '@bytemd/plugin-gfm/locales/pt_BR.json';
+import mathLocale from '@bytemd/plugin-math/locales/pt_BR.json';
 import mermaidLocale from '@bytemd/plugin-mermaid/locales/pt_BR.json';
 import 'bytemd/dist/index.min.css';
 import 'highlight.js/styles/github.css';
 import 'github-markdown-css/github-markdown-light.css';
+import 'katex/dist/katex.css';
 
 const bytemdPluginList = [
   gfmPlugin({ locale: gfmLocale }),
   highlightSsrPlugin(),
   mermaidPlugin({ locale: mermaidLocale }),
+  mathPlugin({
+    locale: mathLocale,
+    katexOptions: { output: 'html' },
+  }),
   breaksPlugin(),
   gemojiPlugin(),
 ];
@@ -95,7 +102,7 @@ function sanitize(defaultSchema) {
   const schema = { ...defaultSchema };
   schema.attributes['*'] = schema.attributes['*'].filter((attr) => attr != 'className');
 
-  schema.attributes['*'].push(['className', /^hljs|^language-|^bytemd-mermaid$/]);
+  schema.attributes['*'].push(['className', /^hljs|^language-|^bytemd-mermaid$|^math/]);
 
   return schema;
 }


### PR DESCRIPTION
Adiciona a capacidade de renderizar fórmulas matemáticas, como solicitado nas issues:

- #901 
- #936 
- #989 

```
$$
\displaystyle \left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \left( \sum_{k=1}^n b_k^2 \right)
$$
```

$$
\displaystyle \left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \left( \sum_{k=1}^n b_k^2 \right)
$$

Um ponto interessante nesse PR é que usando a biblioteca `@bytemd/plugin-math-ssr` adicionaríamos 83kB ao first load do site, ou seja, 18% a mais, mas com a `@bytemd/plugin-math` só adicionamos 5kB.

Com qualquer das duas bibliotecas o usuário irá ver as fórmulas renderizadas corretamente como aqui no GitHub (equação acima). O que muda entre as bibliotecas é o que vem no estático, que em nenhuma das duas opção é algo muito interessante:

### Com SSR (+ 83kB)

![image](https://user-images.githubusercontent.com/77860630/224793697-63122c51-6ffc-493a-9985-6de9bfa9a8df.png)

### Sem SSR (+ 5kB)

![image](https://user-images.githubusercontent.com/77860630/224793757-bb64096d-1f2b-4dde-88e5-91467c16c2a4.png)

Pelo custo benefício, entre as duas opções, eu escolhi a mais leve.

Agora o que deve ser analisado nesse PR é o custo benefício desses 5kB, ou seja, se vale a pena adicionar a capacidade de renderizar equações matemáticas.

Eu acho que vale a pena! 👍