### PR TITLE
chore(terraform): bump database `engine_version` in `staging` to `14.3`

### DIFF
--- a/infra/provisioning/staging/main.tf
+++ b/infra/provisioning/staging/main.tf
@@ -37,7 +37,7 @@ module "database" {
   vpc_cidr_block = module.vpc.vpc_cidr_block
   route_table_id = module.vpc.route_table_id
 
-  engine_version           = "14.1"
+  engine_version           = "14.3"
   instance_class           = "db.t4g.micro"
   allocated_storage        = 20
   max_allocated_storage    = 21


### PR DESCRIPTION
Após o PR #1315 do @FabricioFFC notei que, ao executar o `terraform plan` no ambiente de **homologação** ele apontou um `downgrade` na **versão** da instância do RDS de `14.3` para `14.1` (que é o que estava no arquivo). A AWS fez o upgrade dessa versão de forma automática, e em produção o arquivo do Terraform já tinha sido feita a atualização para ficar em sincronia, mas faltou o de homologação.