### PR TITLE
feat(content): return back tabcoins when deleted

### DIFF
--- a/pages/api/v1/contents/[username]/[slug]/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/index.public.js
@@ -173,6 +173,8 @@ async function patchHandler(request, response) {
 
     const secureOutputValues = authorization.filterOutput(userTryingToPatch, 'read:content', updatedContent);
 
+    await content.returnTabcoinsWhenDeleted(secureOutputValues.id);
+
     return response.status(200).json(secureOutputValues);
   } catch (error) {
     await transaction.query('ROLLBACK');


### PR DESCRIPTION
Devolve as tabcoins usadas para os "down votes" quando a publicação é deletada. Retorna apenas 1 tabcoin por cada downvote(que custa 2) e se compara a uma "recompensa" ao usúario por ter votado corretamente em um conteudo sem valor concreto! Diretamente relacionado a [issue #1155 ](https://github.com/filipedeschamps/tabnews.com.br/issues/1155) de @filipedeschamps e @aprendendofelipe!

Ao contrário do que foi citado, não utilizei a função `undo` uma vez que se o conteúdo tivesse muitos votos para baixo e fosse deletada, teria que ser chamada a função diversas vezes(uma para cada operação), ao invés utilizei uma query que recebe o id de um conteúdo, e se o mesmo ter o status "deleted", será executada a devolução!  A Query é chamada ao final do `patch` do model content, sem muito filtro, pois a própria query seleciona o conteúdo apenas se estiver deletado.