### PR TITLE
Desativa o achatamento da árvore de respostas e renderiza inicialmente um número maior de respostas

### DIFF
--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -37,11 +37,11 @@ export default function Post({
     }
   );
 
-  const [childrenToShow, setChildrenToShow] = useState(21);
+  const [childrenToShow, setChildrenToShow] = useState(108);
   const [showConfetti, setShowConfetti] = useState(false);
 
   useEffect(() => {
-    setChildrenToShow(Math.ceil(window.innerHeight / 50));
+    setChildrenToShow(Math.ceil(window.innerHeight / 10));
 
     const justPublishedNewRootContent = localStorage.getItem('justPublishedNewRootContent');
 

--- a/pages/interface/components/Link/index.js
+++ b/pages/interface/components/Link/index.js
@@ -4,7 +4,7 @@ import { useRouter } from 'next/router';
 
 export function Link({ href, children, ...props }) {
   return (
-    <PrimerLink as={NextLink} href={href} {...props}>
+    <PrimerLink as={NextLink} href={href} prefetch={false} {...props}>
       {children}
     </PrimerLink>
   );
@@ -12,7 +12,7 @@ export function Link({ href, children, ...props }) {
 
 export function HeaderLink({ href, children, ...props }) {
   return (
-    <Header.Link as={NextLink} href={href} {...props}>
+    <Header.Link as={NextLink} href={href} prefetch={false} {...props}>
       {children}
     </Header.Link>
   );
@@ -24,7 +24,7 @@ export function NavItem({ href, children, ...props }) {
   const router = useRouter();
   const isCurrent = typeof href === 'string' ? router.asPath === href : router.pathname === href.pathname;
   return (
-    <NavList.Item as={NextLink} href={href} aria-current={isCurrent ? 'page' : false} {...props}>
+    <NavList.Item as={NextLink} href={href} aria-current={isCurrent ? 'page' : false} prefetch={false} {...props}>
       {children}
     </NavList.Item>
   );

--- a/pages/interface/hooks/useCollapse/index.js
+++ b/pages/interface/hooks/useCollapse/index.js
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 
-export default function useCollapse({ childrenList, renderIntent = 20, renderIncrement = 10, flatten = true }) {
+export default function useCollapse({ childrenList, renderIntent = 20, renderIncrement = 10, flatten = false }) {
   const flattenedTree = useMemo(flattenTree, [childrenList, flatten]);
   const [childrenState, setChildrenState] = useState(() => computeStates(flattenedTree, renderIntent));
 


### PR DESCRIPTION
Desativei o achatamento e aumentei o número de respostas iniciais para: 

altura da tela em pixels  / 10