### PR TITLE
feat: remove tabcoins buttons and replies when content is deleted

### DIFF
--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -90,7 +90,8 @@ export default function Post({
               key={contentFound.id}
               content={contentFound}
               mode={contentMode}
-              onModeChange={(mode) => setContentMode(mode)}
+              onModeChange={setContentMode}
+              asRoot={true}
             />
           </Box>
         </Box>

--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -39,6 +39,7 @@ export default function Post({
 
   const [childrenToShow, setChildrenToShow] = useState(108);
   const [showConfetti, setShowConfetti] = useState(false);
+  const [contentMode, setContentMode] = useState('view');
 
   useEffect(() => {
     setChildrenToShow(Math.ceil(window.innerHeight / 10));
@@ -62,53 +63,62 @@ export default function Post({
             width: '100%',
             display: 'flex',
           }}>
-          <Box
-            sx={{
-              pr: 2,
-              display: 'flex',
-              flexDirection: 'column',
-              justifyContent: 'center',
-            }}>
-            <TabCoinButtons content={contentFound} />
+          {contentMode !== 'deleted' && (
             <Box
               sx={{
-                borderWidth: 0,
-                borderRightWidth: 1,
-                borderColor: 'border.muted',
-                borderStyle: 'dotted',
-                width: '50%',
-                height: '100%',
-              }}
-            />
-          </Box>
+                pr: 2,
+                display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'center',
+              }}>
+              <TabCoinButtons content={contentFound} />
+              <Box
+                sx={{
+                  borderWidth: 0,
+                  borderRightWidth: 1,
+                  borderColor: 'border.muted',
+                  borderStyle: 'dotted',
+                  width: '50%',
+                  height: '100%',
+                }}
+              />
+            </Box>
+          )}
 
           <Box sx={{ width: '100%', overflow: 'auto' }}>
-            <Content key={contentFound.id} content={contentFound} mode="view" />
+            <Content
+              key={contentFound.id}
+              content={contentFound}
+              mode={contentMode}
+              onModeChange={(mode) => setContentMode(mode)}
+            />
           </Box>
         </Box>
 
-        <Box sx={{ width: '100%' }}>
-          <Box
-            sx={{
-              borderRadius: '6px',
-              borderWidth: 1,
-              borderColor: 'border.default',
-              borderStyle: 'solid',
-              mt: 4,
-              mb: 4,
-              p: 4,
-              wordWrap: 'break-word',
-            }}>
-            <Content key={contentFound.id} content={{ parent_id: contentFound.id }} mode="compact" />
-          </Box>
+        {contentMode !== 'deleted' && (
+          <Box sx={{ width: '100%' }}>
+            <Box
+              sx={{
+                borderRadius: '6px',
+                borderWidth: 1,
+                borderColor: 'border.default',
+                borderStyle: 'solid',
+                mt: 4,
+                mb: 4,
+                p: 4,
+                wordWrap: 'break-word',
+              }}>
+              <Content key={contentFound.id} content={{ parent_id: contentFound.id }} mode="compact" />
+            </Box>
 
-          <RenderChildrenTree
-            key={contentFound.id}
-            childrenList={children}
-            renderIntent={childrenToShow}
-            renderIncrement={Math.ceil(childrenToShow / 2)}
-          />
-        </Box>
+            <RenderChildrenTree
+              key={contentFound.id}
+              childrenList={children}
+              renderIntent={childrenToShow}
+              renderIncrement={Math.ceil(childrenToShow / 2)}
+            />
+          </Box>
+        )}
       </DefaultLayout>
     </>
   );

--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -18,7 +18,13 @@ import {
 import { KebabHorizontalIcon, PencilIcon, TrashIcon, LinkIcon } from '@primer/octicons-react';
 import { Editor, Link, PublishedSince, useUser, Viewer } from 'pages/interface';
 
-export default function Content({ content, mode = 'view', viewFrame = false, onModeChange = () => {} }) {
+export default function Content({
+  content,
+  mode = 'view',
+  viewFrame = false,
+  onModeChange = () => {},
+  asRoot = false,
+}) {
   const [componentMode, setComponentMode] = useState(mode);
   const [contentObject, setContentObject] = useState(content);
   const { user } = useUser();
@@ -71,7 +77,7 @@ export default function Content({ content, mode = 'view', viewFrame = false, onM
       />
     );
   } else if (componentMode === 'deleted') {
-    return <DeletedMode viewFrame={viewFrame} />;
+    return <DeletedMode viewFrame={viewFrame} asRoot={asRoot} />;
   }
 }
 
@@ -510,7 +516,7 @@ function CompactMode({ setComponentMode }) {
   );
 }
 
-function DeletedMode({ viewFrame }) {
+function DeletedMode({ viewFrame, asRoot }) {
   return (
     <Box
       sx={{
@@ -519,7 +525,7 @@ function DeletedMode({ viewFrame }) {
         alignItems: 'center',
         justifyContent: 'center',
         gap: 2,
-        height: 'calc(90vh - 64px)',
+        height: !asRoot ? 'fit-content' : 'calc(90vh - 64px)',
         width: '100%',
         borderWidth: viewFrame ? 1 : 0,
         borderRadius: '6px',
@@ -538,7 +544,7 @@ function DeletedMode({ viewFrame }) {
 
         <Heading sx={{ fontSize: 3 }}>Conteúdo apagado com sucesso.</Heading>
 
-        <Link href="/">Retornar à tela inicial</Link>
+        {asRoot && <Link href="/">Retornar à tela inicial</Link>}
       </Box>
     </Box>
   );

--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -18,7 +18,7 @@ import {
 import { KebabHorizontalIcon, PencilIcon, TrashIcon, LinkIcon } from '@primer/octicons-react';
 import { Editor, Link, PublishedSince, useUser, Viewer } from 'pages/interface';
 
-export default function Content({ content, mode = 'view', viewFrame = false }) {
+export default function Content({ content, mode = 'view', viewFrame = false, onModeChange = () => {} }) {
   const [componentMode, setComponentMode] = useState(mode);
   const [contentObject, setContentObject] = useState(content);
   const { user } = useUser();
@@ -26,6 +26,10 @@ export default function Content({ content, mode = 'view', viewFrame = false }) {
   useEffect(() => {
     setComponentMode(mode);
   }, [mode]);
+
+  useEffect(() => {
+    onModeChange(componentMode);
+  }, [componentMode, onModeChange]);
 
   useEffect(() => {
     setContentObject((contentObject) => {
@@ -513,10 +517,11 @@ function DeletedMode({ viewFrame }) {
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
+        justifyContent: 'center',
         gap: 2,
+        height: 'calc(90vh - 64px)',
         width: '100%',
         borderWidth: viewFrame ? 1 : 0,
-        p: viewFrame ? 4 : 0,
         borderRadius: '6px',
         borderColor: 'border.default',
         borderStyle: 'solid',
@@ -527,7 +532,13 @@ function DeletedMode({ viewFrame }) {
           flexDirection: 'column',
           alignItems: 'center',
         }}>
-        Conteúdo apagado com sucesso.
+        <Box sx={{ color: 'danger.fg' }}>
+          <TrashIcon size={40} style={{ marginBottom: '1rem' }} />
+        </Box>
+
+        <Heading sx={{ fontSize: 3 }}>Conteúdo apagado com sucesso.</Heading>
+
+        <Link href="/">Retornar à tela inicial</Link>
       </Box>
     </Box>
   );


### PR DESCRIPTION
Remove os indicadores de tabcoins e os comentários quando um post é deletado.

Antes | Depois
----- | ------
![Antes](https://user-images.githubusercontent.com/111156073/225776855-5a0da43c-95eb-4a84-a45c-7cf7932d202e.png) | ![Depois](https://user-images.githubusercontent.com/111156073/225776807-b442b3cc-fe00-4769-afd1-fefa40ba3772.png)

#1089

