### PR TITLE
(perf) add `root_id` to contents

### DIFF
--- a/infra/migrations/1680268160368_alter-table-users-add-alter-table-contents-add-root-id.js
+++ b/infra/migrations/1680268160368_alter-table-users-add-alter-table-contents-add-root-id.js
@@ -1,0 +1,25 @@
+exports.up = async (pgm) => {
+  await pgm.addColumns('contents', {
+    root_id: {
+      type: 'uuid',
+      notNull: false,
+    },
+  });
+
+  pgm.addConstraint('contents', 'root_id_fkey', 'FOREIGN KEY (root_id) REFERENCES contents(id)');
+
+  await pgm.createIndex('contents', 'root_id', { name: 'contents_root_id_index' });
+};
+
+exports.down = async (pgm) => {
+  await pgm.dropConstraint('contents', 'root_id_fkey');
+
+  await pgm.dropIndex('contents', 'root_id', { name: 'contents_root_id_index' });
+
+  await pgm.dropColumns('contents', {
+    root_id: {
+      type: 'uuid',
+      notNull: false,
+    },
+  });
+};

--- a/infra/migrations/1680272261243_alter-table-users-add-set-root-id-on-contents-table.js
+++ b/infra/migrations/1680272261243_alter-table-users-add-set-root-id-on-contents-table.js
@@ -1,0 +1,20 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined;
+
+exports.up = async (pgm) => {
+  const query = `WITH RECURSIVE find_root(id, root_id) AS (
+                  SELECT id, id as root_id FROM contents WHERE parent_id IS NULL
+                  UNION ALL
+                  SELECT c.id, r.root_id FROM contents c JOIN find_root r ON r.id = c.parent_id
+                )
+                UPDATE contents c SET root_id = r.root_id FROM find_root r WHERE c.id = r.id;
+  `;
+  await pgm.sql(query);
+};
+
+exports.down = async (pgm) => {
+  const query = 'UPDATE contents SET root_id = NULL';
+
+  await pgm.sql(query);
+};


### PR DESCRIPTION
Resolve a https://github.com/filipedeschamps/tabnews.com.br/issues/1169

Qualquer dúvida/crítica/sugestão, só avisar. :smile:

#### Mudanças realizadas

- Adição da coluna `root_id` na tabela `contents`. Com ela conseguimos evitar o uso do `WITH RECURSIVE` em pontos da aplicação que pegam o total de filhos de um `content`.
- Adição de migração de dados, onde o `root_id` dos registros atuais são setados, de acordo com o respectivo `content root`.
- Alterações em queries usando o `root_id`, ao invés, do `WITH RECURSIVE`.
- Seta o `root_id`, quando o `content` a ser criado tem um `parentContent`.
- Removida a função `findChildrenCount`, pois a mesma não estava sendo usada.

#### O que não foi alterado

- Não foi possível tirar todos `WITH RECURSIVE`, pois em alguns pontos ele é usado para obter qual o nível do content/comentário, exemplo, se um comentário é do primeiro comentário do artigo, ele é nível 2.

#### Dúvida que surgiu

- Alguns testes pegam os dados de `contents` filhos com os seus filhos. Estamos usando essa funcionalidade em alguma página? Pergunto, pois inicialmente não tinha colocando esse [OR](https://github.com/FabricioFFC/tabnews.com.br/blob/10e7698b3f4e3a6b3a0379fcf3a755910745b8ce/models/content.js#L841), que foi necessário justamente para pegar os dados de `contents` filhos. 