### PR TITLE
Ajustes de cores e responsividade do editor e visualizador de Markdown

### DIFF
--- a/pages/interface/components/Markdown/styles/index.js
+++ b/pages/interface/components/Markdown/styles/index.js
@@ -80,7 +80,7 @@ export function EditorColors() {
         }
         .tippy-box[data-theme~='light-border'] {
           background-color: ${colors.canvas.default};
-          color: ${colors.fg.subtle};
+          color: ${colors.fg.default};
           box-shadow: ${shadows.overlay.shadow};
         }
         .tippy-box[data-theme~='light-border'] > .tippy-backdrop {

--- a/pages/interface/components/Markdown/styles/index.js
+++ b/pages/interface/components/Markdown/styles/index.js
@@ -68,6 +68,9 @@ export function EditorColors() {
         .bytemd-fullscreen.bytemd {
           background-color: ${colors.canvas.subtle};
         }
+        .bytemd-fullscreen.bytemd:focus-within {
+          box-shadow: none;
+        }
         .tippy-box {
           background-color: ${colors.neutral.emphasisPlus};
           color: ${colors.fg.onEmphasis};
@@ -277,16 +280,20 @@ export function EditorStyles({ mode, compact }) {
           display: ${mode === 'split' ? 'none' : 'inline-block'};
         }
         .bytemd-body {
-          height: ${compact ? '30vh' : 'calc(100vh - 350px)'};
-          min-height: 200px;
+          height: ${compact ? '30vh' : 'calc(100vh - 410px)'};
+          min-height: 150px;
           overflow: auto;
           resize: vertical;
           border-radius: 4px;
         }
         .bytemd-fullscreen .bytemd-body {
-          height: calc(100vh - 100px);
+          flex: 1;
+          resize: none;
         }
-
+        .bytemd-fullscreen {
+          display: flex !important;
+          flex-direction: column;
+        }
         .bytemd {
           display: inline-block;
           width: 100%;
@@ -297,7 +304,6 @@ export function EditorStyles({ mode, compact }) {
           font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji,
             Segoe UI Emoji;
           box-sizing: border-box;
-          resize: vertical;
         }
         .bytemd * {
           box-sizing: border-box;
@@ -564,6 +570,9 @@ export function EditorStyles({ mode, compact }) {
         }
         .CodeMirror-sizer {
           position: relative;
+        }
+        .CodeMirror-sizer > div {
+          box-sizing: content-box;
         }
         .CodeMirror-vscrollbar,
         .CodeMirror-hscrollbar,
@@ -1800,7 +1809,9 @@ export function ViewerStyles() {
           background-color: ${colors.canvas.subtle};
           border-radius: 6px;
         }
-
+        .markdown-body .math {
+          overflow: auto;
+        }
         .markdown-body pre code,
         .markdown-body pre tt {
           display: inline;


### PR DESCRIPTION
### Responsividade

* Ajusta melhor o tamanho inicial do campo de texto de acordo com o tamanho da janela.
* Ajusta o tamanho do campo de texto para ocupar o máximo do tamanho da janela quando selecionado o modo fullscreen.
* Mostra barras de rolagem em fórmulas matemáticas quando elas forem maiores que a largura da janela.

### Cores

* Corrige as cores resolvendo o relatado em #1350.
* Adiciona a mudança de tema nos gráficos mermaid para corrigir o que o @Rafatcb [relatou no ambiente de homologação](https://tabnews-git-markdown-responsivity-tabnews.vercel.app/rafael/e380ee30-55f7-4a28-a8d9-07c65b502e61).

Obs. Sobre os gráficos mermaid, como a estilização dele não se dá por variáveis css, o visualizador do ByteMD precisa ser renderizado novamente quando ocorrer a troca do tema. A maneira que usei para forçar uma nova renderização foi mudar o valor do texto e voltar ao valor correto dentro do mesmo `useEffect`. Utilizando um parâmetro ID ou atualizando a lista de plugins não causava a nova renderização.