### PR TITLE
feat(proxy response): fetch user before redirect

### DIFF
--- a/pages/login/index.public.js
+++ b/pages/login/index.public.js
@@ -10,9 +10,8 @@ import {
   Text,
   TextInput,
 } from '@/TabNewsUI';
-import { useRouter } from 'next/router';
 import { useUser } from 'pages/interface';
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 
 export default function Login() {
   return (
@@ -23,8 +22,7 @@ export default function Login() {
 }
 
 function LoginForm() {
-  const { user, fetchUser } = useUser();
-  const router = useRouter();
+  const { fetchUser } = useUser();
 
   const emailRef = useRef('');
   const passwordRef = useRef('');
@@ -32,15 +30,6 @@ function LoginForm() {
   const [globalErrorMessage, setGlobalErrorMessage] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [errorObject, setErrorObject] = useState(undefined);
-
-  useEffect(() => {
-    if (!user || !router || user.proxyResponse) return;
-    if (router.query?.redirect?.startsWith('/')) {
-      router.replace(router.query.redirect);
-    } else {
-      router.replace('/');
-    }
-  }, [user, router]);
 
   function clearErrors() {
     setErrorObject(undefined);


### PR DESCRIPTION
Movi o código que faz o redirecionamento automático após o login para ser chamado dentro do `useUser`.

Dessa forma temos mais controle sobre o momento que ocorre o redirecionamento, pois isso afetou a mudança feita no PR #1356, que acabou não tendo o efeito desejado, já que o redirecionamento acabava ocorrendo antes da atualização da página, o que fazia o refresh acontecer em uma rota diferente de `\login`.

Ao navegarmos para a página de login existe uma chamada ao endpoint `\user` mesmo se não houver cache do usuário. Essa chamada serve para também para verificar se existe algum bloqueio do proxy e dispara o refresh da página se for necessário.

Durante os testes eu notei que havia uma chamada duplicada ao endpoint `\user`, então já removi a duplicidade. Como essa chamada não ocorria somente na página de login, o resultado desse PR deve ser uma redução nas chamadas ao endpoint.

