### PR TITLE
Analisa publicações anteriores do mesmo usuário ao publicar novo conteúdo ou comentário

### DIFF
--- a/models/content.js
+++ b/models/content.js
@@ -619,6 +619,7 @@ async function update(contentId, postedContent, options = {}) {
   const newContent = { ...oldContent, ...validPostedContent };
 
   throwIfContentIsAlreadyDeleted(oldContent);
+  throwIfContentPublishedIsChangedToDraft(oldContent, newContent);
   checkRootContentTitle(newContent);
   checkForParentIdRecursion(newContent);
 
@@ -748,6 +749,18 @@ function throwIfContentIsAlreadyDeleted(oldContent) {
       message: `Não é possível alterar informações de um conteúdo já deletado.`,
       stack: new Error().stack,
       errorLocationCode: 'MODEL:CONTENT:CHECK_STATUS_CHANGE:STATUS_ALREADY_DELETED',
+      statusCode: 400,
+      key: 'status',
+    });
+  }
+}
+
+function throwIfContentPublishedIsChangedToDraft(oldContent, newContent) {
+  if (oldContent.status === 'published' && newContent.status === 'draft') {
+    throw new ValidationError({
+      message: `Não é possível alterar para rascunho um conteúdo já publicado.`,
+      stack: new Error().stack,
+      errorLocationCode: 'MODEL:CONTENT:CHECK_STATUS_CHANGE:STATUS_ALREADY_PUBLISHED',
       statusCode: 400,
       key: 'status',
     });

--- a/models/content.js
+++ b/models/content.js
@@ -536,7 +536,7 @@ async function creditOrDebitTabCoins(oldContent, newContent, options = {}) {
   if (oldContent && oldContent.published_at && newContent.status === 'deleted') {
     let amountToDebit;
 
-    const userEarnings = await prestige.getByContentId(oldContent.id);
+    const userEarnings = await prestige.getByContentId(oldContent.id, { transaction: options.transaction });
 
     if (oldContent.tabcoins > 0) {
       amountToDebit = contentDefaultEarnings - oldContent.tabcoins - userEarnings;
@@ -565,7 +565,10 @@ async function creditOrDebitTabCoins(oldContent, newContent, options = {}) {
     // We should credit if the content already existed and is now being published for the first time.
     (oldContent && !oldContent.published_at && newContent.status === 'published')
   ) {
-    const userEarnings = await prestige.getByUserId(newContent.owner_id, { isRoot: !newContent.parent_id });
+    const userEarnings = await prestige.getByUserId(newContent.owner_id, {
+      isRoot: !newContent.parent_id,
+      transaction: options.transaction,
+    });
 
     if (userEarnings < 0) {
       throw new ForbiddenError({

--- a/models/content.js
+++ b/models/content.js
@@ -713,7 +713,6 @@ async function update(contentId, postedContent, options = {}) {
 
 function validateUpdateSchema(content) {
   const cleanValues = validator(content, {
-    parent_id: 'optional',
     slug: 'optional',
     title: 'optional',
     body: 'optional',

--- a/models/prestige.js
+++ b/models/prestige.js
@@ -1,0 +1,83 @@
+import database from 'infra/database';
+
+async function getByContentId(contentId) {
+  const result = await database.query({
+    text: queryByContentId,
+    values: [contentId],
+  });
+  return result.rows[0].amount;
+}
+
+const queryByContentId = `
+SELECT
+  amount
+FROM
+  balance_operations
+WHERE
+  originator_id IN (
+    SELECT
+      originator_id
+    FROM
+      balance_operations
+    WHERE 
+      recipient_id = $1
+      AND balance_type = 'content:tabcoin'
+    ORDER BY
+      created_at ASC
+    LIMIT 1
+  )
+  AND balance_type = 'user:tabcoin'
+LIMIT 1
+;
+`;
+
+async function getByUserId(
+  userId,
+  {
+    timeOffset = new Date(Date.now() - 1000 * 60 * 60 * 24 * 2), // 2 days ago
+    isRoot,
+    limit = 10,
+  } = {}
+) {
+  // Minimum percentage of content classified as relevant to earn tabcoins by publishing
+  const thresholdPercentage = 0.6;
+
+  const result = await database.query({
+    text: queryByUserId,
+    values: [userId, timeOffset, isRoot, limit],
+  });
+
+  const length = result.rows?.length;
+
+  if (!length) {
+    return 0;
+  }
+
+  const tabcoins = result.rows.reduce((acc, { tabcoins }) => acc + tabcoins, 0);
+
+  return Math.floor(tabcoins / length - thresholdPercentage);
+}
+
+const queryByUserId = `
+SELECT
+  get_current_balance('content:tabcoin', contents.id) as tabcoins
+FROM
+  contents
+WHERE
+  owner_id = $1
+  AND status = 'published'
+  AND published_at < $2
+  AND (CASE
+    WHEN $3 IS TRUE THEN parent_id IS NULL
+    WHEN $3 IS FALSE THEN parent_id IS NOT NULL
+    ELSE TRUE
+    END)
+ORDER BY
+  published_at DESC
+LIMIT $4
+`;
+
+export default Object.freeze({
+  getByContentId,
+  getByUserId,
+});

--- a/models/prestige.js
+++ b/models/prestige.js
@@ -1,10 +1,13 @@
 import database from 'infra/database';
 
-async function getByContentId(contentId) {
-  const result = await database.query({
-    text: queryByContentId,
-    values: [contentId],
-  });
+async function getByContentId(contentId, { transaction } = {}) {
+  const result = await database.query(
+    {
+      text: queryByContentId,
+      values: [contentId],
+    },
+    { transaction }
+  );
   return result.rows[0].amount;
 }
 
@@ -37,15 +40,19 @@ async function getByUserId(
     timeOffset = new Date(Date.now() - 1000 * 60 * 60 * 24 * 2), // 2 days ago
     isRoot,
     limit = 10,
+    transaction,
   } = {}
 ) {
   // Minimum percentage of content classified as relevant to earn tabcoins by publishing
   const thresholdPercentage = 0.6;
 
-  const result = await database.query({
-    text: queryByUserId,
-    values: [userId, timeOffset, isRoot, limit],
-  });
+  const result = await database.query(
+    {
+      text: queryByUserId,
+      values: [userId, timeOffset, isRoot, limit],
+    },
+    { transaction }
+  );
 
   const length = result.rows?.length;
 

--- a/tests/integration/api/v1/contents/[username]/[slug]/parent/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/parent/get.test.js
@@ -320,7 +320,6 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
         parent_id: childContentLevel1.id,
         title: 'Child content title Level 2',
         body: 'Child content body Level 2',
-        status: 'published',
       });
 
       const childContentLevel2Drafted = await orchestrator.updateContent(childContentLevel2.id, {
@@ -353,12 +352,12 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
         children_deep_count: 0,
         status: 'draft',
         source_url: null,
-        published_at: childContentLevel2.published_at.toISOString(),
+        published_at: null,
         created_at: childContentLevel2.created_at.toISOString(),
         updated_at: childContentLevel2Drafted.updated_at.toISOString(),
         deleted_at: null,
         owner_username: firstUser.username,
-        tabcoins: 1,
+        tabcoins: 0,
       });
     });
 

--- a/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
@@ -2999,6 +2999,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const defaultUser = await orchestrator.createUser();
         await orchestrator.activateUser(defaultUser);
         const sessionObject = await orchestrator.createSession(defaultUser);
+        await orchestrator.createPrestige(defaultUser.id);
 
         const defaultUserContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
@@ -3042,6 +3043,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const defaultUser = await orchestrator.createUser();
         await orchestrator.activateUser(defaultUser);
         const sessionObject = await orchestrator.createSession(defaultUser);
+        await orchestrator.createPrestige(defaultUser.id);
 
         const defaultUserContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
@@ -3085,6 +3087,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const defaultUser = await orchestrator.createUser();
         await orchestrator.activateUser(defaultUser);
         const sessionObject = await orchestrator.createSession(defaultUser);
+        await orchestrator.createPrestige(defaultUser.id);
 
         const defaultUserContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
@@ -3128,6 +3131,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const defaultUser = await orchestrator.createUser();
         await orchestrator.activateUser(defaultUser);
         const sessionObject = await orchestrator.createSession(defaultUser);
+        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: 5 });
 
         const defaultUserContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
@@ -3135,6 +3139,20 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
           body: 'Body',
           status: 'published',
         });
+
+        const userResponseBefore = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+
+        const userResponseBodyBefore = await userResponseBefore.json();
+
+        expect(userResponseBodyBefore.tabcoins).toEqual(5);
+        expect(userResponseBodyBefore.tabcash).toEqual(0);
+
+        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: 1 });
 
         const contentResponse = await fetch(
           `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
@@ -3171,6 +3189,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const defaultUser = await orchestrator.createUser();
         await orchestrator.activateUser(defaultUser);
         const defaultUserSession = await orchestrator.createSession(defaultUser);
+        await orchestrator.createPrestige(defaultUser.id);
 
         const defaultUserContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
@@ -3178,6 +3197,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
           body: 'Body',
           status: 'published',
         });
+
+        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: 8 });
 
         await orchestrator.createBalance({
           balanceType: 'content:tabcoin',
@@ -3236,6 +3257,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const defaultUser = await orchestrator.createUser();
         await orchestrator.activateUser(defaultUser);
         const defaultUserSession = await orchestrator.createSession(defaultUser);
+        await orchestrator.createPrestige(defaultUser.id);
 
         const defaultUserContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
@@ -3243,6 +3265,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
           body: 'Body',
           status: 'published',
         });
+
+        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: 10 });
 
         await orchestrator.createBalance({
           balanceType: 'content:tabcoin',
@@ -3301,6 +3325,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const defaultUser = await orchestrator.createUser();
         await orchestrator.activateUser(defaultUser);
         const sessionObject = await orchestrator.createSession(defaultUser);
+        await orchestrator.createPrestige(defaultUser.id);
 
         const defaultUserContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
@@ -3374,6 +3399,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const defaultUser = await orchestrator.createUser();
         await orchestrator.activateUser(defaultUser);
         const sessionObject = await orchestrator.createSession(defaultUser);
+        await orchestrator.createPrestige(defaultUser.id);
 
         // User will receive tabcoins for publishing a root content.
         const rootContent = await orchestrator.createContent({
@@ -3426,6 +3452,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const defaultUser = await orchestrator.createUser();
         await orchestrator.activateUser(defaultUser);
         const sessionObject = await orchestrator.createSession(defaultUser);
+        await orchestrator.createPrestige(defaultUser.id);
 
         // User will receive tabcoins for publishing a root content.
         const rootContent = await orchestrator.createContent({
@@ -3479,6 +3506,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const secondUser = await orchestrator.createUser();
         await orchestrator.activateUser(secondUser);
         const sessionObject = await orchestrator.createSession(secondUser);
+        await orchestrator.createPrestige(firstUser.id);
+        await orchestrator.createPrestige(secondUser.id);
 
         const rootContent = await orchestrator.createContent({
           owner_id: firstUser.id,
@@ -3534,7 +3563,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
 
         const userResponse2Body = await userResponse2.json();
 
-        expect(userResponse2Body.tabcoins).toEqual(2);
+        expect(userResponse2Body.tabcoins).toEqual(1);
         expect(userResponse2Body.tabcash).toEqual(0);
       });
 
@@ -3542,6 +3571,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const defaultUser = await orchestrator.createUser();
         await orchestrator.activateUser(defaultUser);
         const sessionObject = await orchestrator.createSession(defaultUser);
+        await orchestrator.createPrestige(defaultUser.id);
 
         // User will receive tabcoins for publishing a root content.
         const rootContent = await orchestrator.createContent({
@@ -3607,6 +3637,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const secondUser = await orchestrator.createUser();
         await orchestrator.activateUser(secondUser);
         const sessionObject = await orchestrator.createSession(secondUser);
+        await orchestrator.createPrestige(firstUser.id);
+        await orchestrator.createPrestige(secondUser.id);
 
         const rootContent = await orchestrator.createContent({
           owner_id: firstUser.id,
@@ -3670,6 +3702,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const defaultUser = await orchestrator.createUser();
         await orchestrator.activateUser(defaultUser);
         const sessionObject = await orchestrator.createSession(defaultUser);
+        await orchestrator.createPrestige(defaultUser.id);
 
         // User will receive tabcoins for publishing a root content.
         const rootContent = await orchestrator.createContent({
@@ -3735,6 +3768,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const secondUser = await orchestrator.createUser();
         await orchestrator.activateUser(secondUser);
         const sessionObject = await orchestrator.createSession(secondUser);
+        await orchestrator.createPrestige(secondUser.id, { childPrestigeNumerator: 2 });
 
         const rootContent = await orchestrator.createContent({
           owner_id: firstUser.id,
@@ -3798,6 +3832,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const defaultUser = await orchestrator.createUser();
         await orchestrator.activateUser(defaultUser);
         const sessionObject = await orchestrator.createSession(defaultUser);
+        await orchestrator.createPrestige(defaultUser.id);
 
         // User will receive tabcoins for publishing a root content.
         const rootContent = await orchestrator.createContent({
@@ -3881,6 +3916,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const secondUser = await orchestrator.createUser();
         await orchestrator.activateUser(secondUser);
         const sessionObject = await orchestrator.createSession(secondUser);
+        await orchestrator.createPrestige(firstUser.id);
+        await orchestrator.createPrestige(secondUser.id);
 
         const rootContent = await orchestrator.createContent({
           owner_id: firstUser.id,
@@ -3924,7 +3961,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
 
         const userResponse1Body = await userResponse1.json();
 
-        expect(userResponse1Body.tabcoins).toEqual(2);
+        expect(userResponse1Body.tabcoins).toEqual(1);
         expect(userResponse1Body.tabcash).toEqual(0);
 
         const publishedContentResponse = await fetch(
@@ -3954,7 +3991,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
 
         const userResponse2Body = await userResponse2.json();
 
-        expect(userResponse2Body.tabcoins).toEqual(2);
+        expect(userResponse2Body.tabcoins).toEqual(1);
         expect(userResponse2Body.tabcash).toEqual(0);
       });
     });

--- a/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
@@ -2993,66 +2993,6 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         'CONTROLLER:CONTENTS:PATCH:USER_CANT_UPDATE_CONTENT_FROM_OTHER_USER'
       );
     });
-  });
-
-  describe('User with "update:content:others" feature', () => {
-    test('Content from another user', async () => {
-      const privilegedUser = await orchestrator.createUser();
-      await orchestrator.addFeaturesToUser(privilegedUser, ['update:content:others']);
-      await orchestrator.activateUser(privilegedUser);
-      const privilegedUserSessionObject = await orchestrator.createSession(privilegedUser);
-
-      const secondUser = await orchestrator.createUser();
-      const secondUserContent = await orchestrator.createContent({
-        owner_id: secondUser.id,
-        title: 'Conteúdo do Segundo Usuário antes do patch!',
-        body: 'Body antes do patch!',
-        status: 'published',
-      });
-
-      const response = await fetch(
-        `${orchestrator.webserverUrl}/api/v1/contents/${secondUser.username}/${secondUserContent.slug}`,
-        {
-          method: 'PATCH',
-          headers: {
-            'Content-Type': 'application/json',
-            cookie: `session_id=${privilegedUserSessionObject.token}`,
-          },
-          body: JSON.stringify({
-            title: 'Novo title.',
-            body: 'Novo body.',
-          }),
-        }
-      );
-
-      const responseBody = await response.json();
-
-      expect(response.status).toEqual(200);
-
-      expect(responseBody).toStrictEqual({
-        id: secondUserContent.id,
-        owner_id: secondUser.id,
-        parent_id: null,
-        slug: 'conteudo-do-segundo-usuario-antes-do-patch',
-        title: 'Novo title.',
-        body: 'Novo body.',
-        status: 'published',
-        source_url: null,
-        created_at: responseBody.created_at,
-        updated_at: responseBody.updated_at,
-        published_at: responseBody.published_at,
-        deleted_at: null,
-        tabcoins: 1,
-        owner_username: secondUser.username,
-      });
-
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.published_at)).not.toEqual(NaN);
-      expect(responseBody.published_at).toEqual(secondUserContent.published_at.toISOString());
-      expect(responseBody.updated_at > secondUserContent.updated_at.toISOString()).toEqual(true);
-    });
 
     describe('TabCoins', () => {
       test('"root" content updated from "draft" to "draft" status', async () => {
@@ -4017,6 +3957,66 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         expect(userResponse2Body.tabcoins).toEqual(2);
         expect(userResponse2Body.tabcash).toEqual(0);
       });
+    });
+  });
+
+  describe('User with "update:content:others" feature', () => {
+    test('Content from another user', async () => {
+      const privilegedUser = await orchestrator.createUser();
+      await orchestrator.addFeaturesToUser(privilegedUser, ['update:content:others']);
+      await orchestrator.activateUser(privilegedUser);
+      const privilegedUserSessionObject = await orchestrator.createSession(privilegedUser);
+
+      const secondUser = await orchestrator.createUser();
+      const secondUserContent = await orchestrator.createContent({
+        owner_id: secondUser.id,
+        title: 'Conteúdo do Segundo Usuário antes do patch!',
+        body: 'Body antes do patch!',
+        status: 'published',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${secondUser.username}/${secondUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${privilegedUserSessionObject.token}`,
+          },
+          body: JSON.stringify({
+            title: 'Novo title.',
+            body: 'Novo body.',
+          }),
+        }
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(200);
+
+      expect(responseBody).toStrictEqual({
+        id: secondUserContent.id,
+        owner_id: secondUser.id,
+        parent_id: null,
+        slug: 'conteudo-do-segundo-usuario-antes-do-patch',
+        title: 'Novo title.',
+        body: 'Novo body.',
+        status: 'published',
+        source_url: null,
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+        published_at: responseBody.published_at,
+        deleted_at: null,
+        tabcoins: 1,
+        owner_username: secondUser.username,
+      });
+
+      expect(uuidVersion(responseBody.id)).toEqual(4);
+      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.published_at)).not.toEqual(NaN);
+      expect(responseBody.published_at).toEqual(secondUserContent.published_at.toISOString());
+      expect(responseBody.updated_at > secondUserContent.updated_at.toISOString()).toEqual(true);
     });
   });
 });

--- a/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
@@ -2641,29 +2641,16 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toEqual(400);
 
-      expect(responseBody).toStrictEqual({
-        id: responseBody.id,
-        owner_id: defaultUser.id,
-        parent_id: rootContent.id,
-        slug: 'child-content-title',
-        title: 'Child content title',
-        body: 'Child content body',
-        status: 'draft',
-        source_url: null,
-        created_at: responseBody.created_at,
-        updated_at: responseBody.updated_at,
-        published_at: null,
-        deleted_at: null,
-        tabcoins: 0,
-        owner_username: defaultUser.username,
-      });
-
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
-      expect(responseBody.updated_at > childContent.updated_at.toISOString()).toEqual(true);
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual('Objeto enviado deve ter no mínimo uma chave.');
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "title" and "parent_id" set to Null', async () => {
@@ -2699,29 +2686,16 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toEqual(400);
 
-      expect(responseBody).toStrictEqual({
-        id: responseBody.id,
-        owner_id: defaultUser.id,
-        parent_id: null,
-        slug: 'child-content-title',
-        title: 'Child content title',
-        body: 'Child content body',
-        status: 'draft',
-        source_url: null,
-        created_at: responseBody.created_at,
-        updated_at: responseBody.updated_at,
-        published_at: null,
-        deleted_at: null,
-        tabcoins: 0,
-        owner_username: defaultUser.username,
-      });
-
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
-      expect(responseBody.updated_at > childContent.updated_at.toISOString()).toEqual(true);
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual('Objeto enviado deve ter no mínimo uma chave.');
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content without "title" and "parent_id" set to Null', async () => {
@@ -2758,14 +2732,29 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"title" é um campo obrigatório.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:CONTENT:CHECK_ROOT_CONTENT_TITLE:MISSING_TITLE');
+      expect(response.status).toEqual(200);
+
+      expect(responseBody).toStrictEqual({
+        id: responseBody.id,
+        owner_id: defaultUser.id,
+        parent_id: rootContent.id,
+        slug: 'child-content-title',
+        title: null,
+        body: 'Child content body',
+        status: 'draft',
+        source_url: null,
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+        published_at: null,
+        deleted_at: null,
+        tabcoins: 0,
+        owner_username: defaultUser.username,
+      });
+
+      expect(uuidVersion(responseBody.id)).toEqual(4);
+      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(responseBody.updated_at > childContent.updated_at.toISOString()).toEqual(true);
     });
 
     test('Content with "parent_id" set to itself', async () => {
@@ -2794,13 +2783,14 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       );
       const responseBody = await response.json();
 
+      expect(response.status).toEqual(400);
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"parent_id" não deve apontar para o próprio conteúdo.');
-      expect(responseBody.action).toEqual('Utilize um "parent_id" diferente do "id" do mesmo conteúdo.');
+      expect(responseBody.message).toEqual('Objeto enviado deve ter no mínimo uma chave.');
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:CONTENT:CHECK_FOR_PARENT_ID_RECURSION:RECURSION_FOUND');
+      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "parent_id" containing a Number', async () => {
@@ -2944,13 +2934,11 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       expect(response.status).toEqual(400);
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual(
-        'Você está tentando criar ou atualizar um sub-conteúdo para um conteúdo que não existe.'
-      );
-      expect(responseBody.action).toEqual('Utilize um "parent_id" que aponte para um conteúdo que existe.');
+      expect(responseBody.message).toEqual('Objeto enviado deve ter no mínimo uma chave.');
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:CONTENT:CHECK_IF_PARENT_ID_EXISTS:NOT_FOUND');
+      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content from another user', async () => {

--- a/tests/integration/api/v1/contents/[username]/[slug]/root/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/root/get.test.js
@@ -370,7 +370,6 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
         owner_id: firstUser.id,
         title: 'Root content title',
         body: 'Root content body',
-        status: 'published',
         source_url: 'https://www.tabnews.com.br/',
       });
 
@@ -419,12 +418,12 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
         body: '[Não disponível]',
         status: 'draft',
         source_url: null,
-        published_at: rootContent.published_at.toISOString(),
+        published_at: null,
         created_at: rootContent.created_at.toISOString(),
         updated_at: rootContentDrafted.updated_at.toISOString(),
         deleted_at: null,
         owner_username: firstUser.username,
-        tabcoins: 1,
+        tabcoins: 0,
         children_deep_count: 0,
       });
     });

--- a/tests/integration/api/v1/contents/[username]/[slug]/tabcoins/post.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/tabcoins/post.test.js
@@ -184,7 +184,7 @@ describe('POST /api/v1/contents/tabcoins', () => {
 
       const firstUserResponseBody = await firstUserResponse.json();
 
-      expect(firstUserResponseBody.tabcoins).toStrictEqual(3);
+      expect(firstUserResponseBody.tabcoins).toStrictEqual(1);
       expect(firstUserResponseBody.tabcash).toStrictEqual(0);
 
       const secondUserResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${secondUser.username}`, {
@@ -250,7 +250,7 @@ describe('POST /api/v1/contents/tabcoins', () => {
 
       const firstUserResponseBody = await firstUserResponse.json();
 
-      expect(firstUserResponseBody.tabcoins).toStrictEqual(1);
+      expect(firstUserResponseBody.tabcoins).toStrictEqual(-1);
       expect(firstUserResponseBody.tabcash).toStrictEqual(0);
 
       const secondUserResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${secondUser.username}`, {
@@ -338,7 +338,7 @@ describe('POST /api/v1/contents/tabcoins', () => {
 
       const firstUserResponseBody = await firstUserResponse.json();
 
-      expect(firstUserResponseBody.tabcoins).toStrictEqual(3);
+      expect(firstUserResponseBody.tabcoins).toStrictEqual(1);
       expect(firstUserResponseBody.tabcash).toStrictEqual(0);
 
       const secondUserResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${secondUser.username}`, {
@@ -426,7 +426,7 @@ describe('POST /api/v1/contents/tabcoins', () => {
 
       const firstUserResponseBody = await firstUserResponse.json();
 
-      expect(firstUserResponseBody.tabcoins).toStrictEqual(1);
+      expect(firstUserResponseBody.tabcoins).toStrictEqual(-1);
       expect(firstUserResponseBody.tabcash).toStrictEqual(0);
 
       const secondUserResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${secondUser.username}`, {

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -480,7 +480,7 @@ describe('POST /api/v1/contents', () => {
       expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
-    test('Content with "body" containing untrimmed values', async () => {
+    test('Content with "body" ending with untrimmed values', async () => {
       const defaultUser = await orchestrator.createUser();
       await orchestrator.activateUser(defaultUser);
       const sessionObject = await orchestrator.createSession(defaultUser);

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -2680,6 +2680,7 @@ describe('POST /api/v1/contents', () => {
         const defaultUser = await orchestrator.createUser();
         await orchestrator.activateUser(defaultUser);
         const sessionObject = await orchestrator.createSession(defaultUser);
+        await orchestrator.createPrestige(defaultUser.id);
 
         const contentResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
           method: 'post',
@@ -2714,6 +2715,7 @@ describe('POST /api/v1/contents', () => {
         const defaultUser = await orchestrator.createUser();
         await orchestrator.activateUser(defaultUser);
         const sessionObject = await orchestrator.createSession(defaultUser);
+        await orchestrator.createPrestige(defaultUser.id);
 
         const contentResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
           method: 'post',
@@ -2792,6 +2794,7 @@ describe('POST /api/v1/contents', () => {
         const defaultUser = await orchestrator.createUser();
         await orchestrator.activateUser(defaultUser);
         const sessionObject = await orchestrator.createSession(defaultUser);
+        await orchestrator.createPrestige(defaultUser.id);
 
         // User will receive tabcoins for publishing a root content.
         const rootContent = await orchestrator.createContent({
@@ -2838,6 +2841,7 @@ describe('POST /api/v1/contents', () => {
         const secondUser = await orchestrator.createUser();
         await orchestrator.activateUser(secondUser);
         const sessionObject = await orchestrator.createSession(secondUser);
+        await orchestrator.createPrestige(secondUser.id);
 
         const rootContent = await orchestrator.createContent({
           owner_id: firstUser.id,
@@ -2872,7 +2876,457 @@ describe('POST /api/v1/contents', () => {
 
         const userResponseBody = await userResponse.json();
 
-        expect(userResponseBody.tabcoins).toEqual(2);
+        expect(userResponseBody.tabcoins).toEqual(1);
+        expect(userResponseBody.tabcash).toEqual(0);
+      });
+    });
+
+    describe('Prestige', () => {
+      test('should not be able to create "root" content with negative prestige by more than 40%', async () => {
+        const defaultUser = await orchestrator.createUser();
+        await orchestrator.activateUser(defaultUser);
+        const sessionObject = await orchestrator.createSession(defaultUser);
+        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: -4, rootPrestigeDenominator: 9 });
+
+        const contentResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
+          method: 'post',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            title: 'Title',
+            body: 'Body',
+            status: 'published',
+          }),
+        });
+
+        const responseBody = await contentResponse.json();
+
+        expect(contentResponse.status).toEqual(403);
+        expect(responseBody.status_code).toEqual(403);
+        expect(responseBody.name).toEqual('ForbiddenError');
+        expect(responseBody.message).toEqual(
+          'Não é possível publicar porque há outras publicações mal avaliadas que ainda não foram excluídas.'
+        );
+        expect(responseBody.action).toEqual(
+          'Exclua seus conteúdos mais recentes que estiverem classificados como não relevantes.'
+        );
+        expect(uuidVersion(responseBody.error_id)).toEqual(4);
+        expect(uuidVersion(responseBody.request_id)).toEqual(4);
+        expect(responseBody.error_location_code).toEqual(
+          'MODEL:CONTENT:CREDIT_OR_DEBIT_TABCOINS:NEGATIVE_USER_EARNINGS'
+        );
+      });
+
+      test('should not be able to create "child" content with negative prestige by more than 40%', async () => {
+        const defaultUser = await orchestrator.createUser();
+        await orchestrator.activateUser(defaultUser);
+        const secondUser = await orchestrator.createUser();
+        await orchestrator.activateUser(secondUser);
+        const sessionObject = await orchestrator.createSession(defaultUser);
+        await orchestrator.createPrestige(defaultUser.id, { childPrestigeNumerator: -4, childPrestigeDenominator: 9 });
+
+        const rootContent = await orchestrator.createContent({
+          owner_id: secondUser.id,
+          title: 'Conteúdo raiz',
+          status: 'published',
+        });
+
+        const childResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
+          method: 'post',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            body: 'Não deveria conseguir por possuir comentários mal avaliados.',
+            parent_id: rootContent.id,
+            status: 'published',
+          }),
+        });
+
+        const responseBody = await childResponse.json();
+
+        expect(childResponse.status).toEqual(403);
+        expect(responseBody.status_code).toEqual(403);
+        expect(responseBody.name).toEqual('ForbiddenError');
+        expect(responseBody.message).toEqual(
+          'Não é possível publicar porque há outras publicações mal avaliadas que ainda não foram excluídas.'
+        );
+        expect(responseBody.action).toEqual(
+          'Exclua seus conteúdos mais recentes que estiverem classificados como não relevantes.'
+        );
+        expect(uuidVersion(responseBody.error_id)).toEqual(4);
+        expect(uuidVersion(responseBody.request_id)).toEqual(4);
+        expect(responseBody.error_location_code).toEqual(
+          'MODEL:CONTENT:CREDIT_OR_DEBIT_TABCOINS:NEGATIVE_USER_EARNINGS'
+        );
+      });
+
+      test('Should be able to create "root" content with negative prestige by 40%', async () => {
+        const defaultUser = await orchestrator.createUser();
+        await orchestrator.activateUser(defaultUser);
+        const sessionObject = await orchestrator.createSession(defaultUser);
+        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: -4, rootPrestigeDenominator: 10 });
+
+        const contentResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
+          method: 'post',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            title: 'Title',
+            body: 'Body',
+            status: 'published',
+          }),
+        });
+
+        const responseBody = await contentResponse.json();
+
+        expect(contentResponse.status).toEqual(201);
+
+        expect(responseBody).toStrictEqual({
+          id: responseBody.id,
+          owner_id: defaultUser.id,
+          parent_id: null,
+          slug: 'title',
+          title: 'Title',
+          body: 'Body',
+          status: 'published',
+          source_url: null,
+          created_at: responseBody.created_at,
+          updated_at: responseBody.updated_at,
+          published_at: responseBody.published_at,
+          deleted_at: null,
+          tabcoins: 1,
+          owner_username: defaultUser.username,
+        });
+
+        expect(uuidVersion(responseBody.id)).toEqual(4);
+        expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+        expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+
+        const userResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+
+        const userResponseBody = await userResponse.json();
+
+        expect(userResponseBody.tabcoins).toEqual(0);
+        expect(userResponseBody.tabcash).toEqual(0);
+      });
+
+      test('Should be able to create "child" content with negative prestige by 40%', async () => {
+        const defaultUser = await orchestrator.createUser();
+        await orchestrator.activateUser(defaultUser);
+        const secondUser = await orchestrator.createUser();
+        await orchestrator.activateUser(secondUser);
+        const sessionObject = await orchestrator.createSession(defaultUser);
+        await orchestrator.createPrestige(defaultUser.id, { childPrestigeNumerator: -4, childPrestigeDenominator: 10 });
+
+        const rootContent = await orchestrator.createContent({
+          owner_id: secondUser.id,
+          title: 'Conteúdo raiz',
+          status: 'published',
+        });
+
+        const childResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
+          method: 'post',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            body: 'Deveria conseguir mesmo com alguns comentários mal avaliados.',
+            parent_id: rootContent.id,
+            status: 'published',
+          }),
+        });
+
+        const responseBody = await childResponse.json();
+
+        expect(childResponse.status).toEqual(201);
+
+        expect(responseBody).toStrictEqual({
+          id: responseBody.id,
+          owner_id: defaultUser.id,
+          parent_id: rootContent.id,
+          slug: responseBody.slug,
+          title: null,
+          body: 'Deveria conseguir mesmo com alguns comentários mal avaliados.',
+          status: 'published',
+          source_url: null,
+          created_at: responseBody.created_at,
+          updated_at: responseBody.updated_at,
+          published_at: responseBody.published_at,
+          deleted_at: null,
+          tabcoins: 1,
+          owner_username: defaultUser.username,
+        });
+
+        expect(uuidVersion(responseBody.id)).toEqual(4);
+        expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+        expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+
+        const userResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+
+        const userResponseBody = await userResponse.json();
+
+        expect(userResponseBody.tabcoins).toEqual(0);
+        expect(userResponseBody.tabcash).toEqual(0);
+      });
+
+      test('Should not be able to earn tabcoins if it has less than 60% prestige in "root" content', async () => {
+        const defaultUser = await orchestrator.createUser();
+        await orchestrator.activateUser(defaultUser);
+        const sessionObject = await orchestrator.createSession(defaultUser);
+        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: 1, rootPrestigeDenominator: 2 });
+
+        const contentResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
+          method: 'post',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            title: 'Title',
+            body: 'Body',
+            status: 'published',
+          }),
+        });
+
+        const responseBody = await contentResponse.json();
+
+        expect(contentResponse.status).toEqual(201);
+
+        expect(responseBody).toStrictEqual({
+          id: responseBody.id,
+          owner_id: defaultUser.id,
+          parent_id: null,
+          slug: 'title',
+          title: 'Title',
+          body: 'Body',
+          status: 'published',
+          source_url: null,
+          created_at: responseBody.created_at,
+          updated_at: responseBody.updated_at,
+          published_at: responseBody.published_at,
+          deleted_at: null,
+          tabcoins: 1,
+          owner_username: defaultUser.username,
+        });
+
+        expect(uuidVersion(responseBody.id)).toEqual(4);
+        expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+        expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+
+        const userResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+
+        const userResponseBody = await userResponse.json();
+
+        expect(userResponseBody.tabcoins).toEqual(0);
+        expect(userResponseBody.tabcash).toEqual(0);
+      });
+
+      test('Should not be able to earn tabcoins if it has less than 60% prestige in "child" content', async () => {
+        const defaultUser = await orchestrator.createUser();
+        await orchestrator.activateUser(defaultUser);
+        const secondUser = await orchestrator.createUser();
+        await orchestrator.activateUser(secondUser);
+        const sessionObject = await orchestrator.createSession(defaultUser);
+        await orchestrator.createPrestige(defaultUser.id, { childPrestigeNumerator: 1, childPrestigeDenominator: 2 });
+
+        const rootContent = await orchestrator.createContent({
+          owner_id: secondUser.id,
+          title: 'Conteúdo raiz',
+          status: 'published',
+        });
+
+        const childResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
+          method: 'post',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            body: 'Deve conseguir publicar, mas não deve ganhar TabCoins',
+            parent_id: rootContent.id,
+            status: 'published',
+          }),
+        });
+
+        const responseBody = await childResponse.json();
+
+        expect(childResponse.status).toEqual(201);
+
+        expect(responseBody).toStrictEqual({
+          id: responseBody.id,
+          owner_id: defaultUser.id,
+          parent_id: rootContent.id,
+          slug: responseBody.slug,
+          title: null,
+          body: 'Deve conseguir publicar, mas não deve ganhar TabCoins',
+          status: 'published',
+          source_url: null,
+          created_at: responseBody.created_at,
+          updated_at: responseBody.updated_at,
+          published_at: responseBody.published_at,
+          deleted_at: null,
+          tabcoins: 1,
+          owner_username: defaultUser.username,
+        });
+
+        expect(uuidVersion(responseBody.id)).toEqual(4);
+        expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+        expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+
+        const userResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+
+        const userResponseBody = await userResponse.json();
+
+        expect(userResponseBody.tabcoins).toEqual(0);
+        expect(userResponseBody.tabcash).toEqual(0);
+      });
+
+      test('Should be able to earn tabcoins if it has 60% prestige in "root" content', async () => {
+        const defaultUser = await orchestrator.createUser();
+        await orchestrator.activateUser(defaultUser);
+        const sessionObject = await orchestrator.createSession(defaultUser);
+        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: 6, rootPrestigeDenominator: 10 });
+
+        const contentResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
+          method: 'post',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            title: 'Title',
+            body: 'Body',
+            status: 'published',
+          }),
+        });
+
+        const responseBody = await contentResponse.json();
+
+        expect(contentResponse.status).toEqual(201);
+
+        expect(responseBody).toStrictEqual({
+          id: responseBody.id,
+          owner_id: defaultUser.id,
+          parent_id: null,
+          slug: 'title',
+          title: 'Title',
+          body: 'Body',
+          status: 'published',
+          source_url: null,
+          created_at: responseBody.created_at,
+          updated_at: responseBody.updated_at,
+          published_at: responseBody.published_at,
+          deleted_at: null,
+          tabcoins: 1,
+          owner_username: defaultUser.username,
+        });
+
+        expect(uuidVersion(responseBody.id)).toEqual(4);
+        expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+        expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+
+        const userResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+
+        const userResponseBody = await userResponse.json();
+
+        expect(userResponseBody.tabcoins).toEqual(1);
+        expect(userResponseBody.tabcash).toEqual(0);
+      });
+
+      test('Should be able to earn tabcoins if it has 60% prestige in "child" content', async () => {
+        const defaultUser = await orchestrator.createUser();
+        await orchestrator.activateUser(defaultUser);
+        const secondUser = await orchestrator.createUser();
+        await orchestrator.activateUser(secondUser);
+        const sessionObject = await orchestrator.createSession(defaultUser);
+        await orchestrator.createPrestige(defaultUser.id, { childPrestigeNumerator: 6, childPrestigeDenominator: 10 });
+
+        const rootContent = await orchestrator.createContent({
+          owner_id: secondUser.id,
+          title: 'Conteúdo raiz',
+          status: 'published',
+        });
+
+        const childResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
+          method: 'post',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            body: 'Deve conseguir publicar e ganhar TabCoins.',
+            parent_id: rootContent.id,
+            status: 'published',
+          }),
+        });
+
+        const responseBody = await childResponse.json();
+
+        expect(childResponse.status).toEqual(201);
+
+        expect(responseBody).toStrictEqual({
+          id: responseBody.id,
+          owner_id: defaultUser.id,
+          parent_id: rootContent.id,
+          slug: responseBody.slug,
+          title: null,
+          body: 'Deve conseguir publicar e ganhar TabCoins.',
+          status: 'published',
+          source_url: null,
+          created_at: responseBody.created_at,
+          updated_at: responseBody.updated_at,
+          published_at: responseBody.published_at,
+          deleted_at: null,
+          tabcoins: 1,
+          owner_username: defaultUser.username,
+        });
+
+        expect(uuidVersion(responseBody.id)).toEqual(4);
+        expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+        expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+
+        const userResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+
+        const userResponseBody = await userResponse.json();
+
+        expect(userResponseBody.tabcoins).toEqual(1);
         expect(userResponseBody.tabcash).toEqual(0);
       });
     });

--- a/tests/integration/api/v1/users/[username]/delete.test.js
+++ b/tests/integration/api/v1/users/[username]/delete.test.js
@@ -169,10 +169,12 @@ describe('DELETE /api/v1/users/[username]', () => {
       await orchestrator.activateUser(firstUser);
       const firstUserSession = await orchestrator.createSession(firstUser);
       orchestrator.addFeaturesToUser(firstUser, ['ban:user']);
+      orchestrator.createPrestige(firstUser.id);
 
       const secondUser = await orchestrator.createUser();
       await orchestrator.activateUser(secondUser);
       const secondUserSession = await orchestrator.createSession(secondUser);
+      orchestrator.createPrestige(secondUser.id, { childPrestigeNumerator: 2 });
 
       // 2) CREATE CONTENTS FOR FIRST USER
       const firstUserRootContent = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {


### PR DESCRIPTION
Além do ganho de TabCoins ser baseado nas avaliações dos conteúdos já publicados, a permissão para publicar também considera os conteúdos já publicados. Com isso o usuário que, em média, tenha mais de 40% das últimas publicações classificadas como não relevantes será avisado para excluir seus conteúdos recentes mal avaliados antes de prosseguir com a publicação.

O valor considerado é a média, então conteúdos bem avaliados ou um mal avaliados podem compensar os com qualificações opostas.

Por exemplo, para um usuário que já possua mais de 10 publicações, se o saldo das últimas 10, somando todas as qualificações, der um número menor do que quatro negativo (-5 ou mais negativo ainda), então o usuário terá que excluir as que estiverem levando essa média para baixo.

Já se a soma estiver acima de cinco positivo (6 em diante), então o usuário já começa a ganhar TabCoins no momento da publicação.

Se a média estiver entre os dois valores, então o usuário só ganha ou perde os TabCoins das qualificações recebidas.

Os valores são computados separadamente para conteúdos "root" ou "child", então o usuário pode ter um prestígios diferentes para cada tipo de publicação.

31225e1f8529aa180aad50a6ff853a8d0a1b62c2
* Corrige a árvore de testes de 'TabCoins' que estava dentro do nó 'User with "update:content:others" feature', quando o correto era o nó 'Default user'.

8fd204afa3e9fd7a980c1ca2cb7e00d95cd6bd4e
* No momento da publicação, computa a média das qualificações dos últimos 10 conteúdos ("child" ou "root" de acordo com a publicação atual).
* A média considera apenas os votos positivos e negativos, ou seja, não considera o TabCoin que o conteúdo já ganha no momento da criação.
* O saldo é dividido pela quantidade de publicações (no máximo 10).
* Apenas publicações com mais de 2 dias são consideradas. Com isso um usuário recente não ganhará TabCoins nas suas primeiras publicações (ganhará apenas os de qualificação). E também o saldo sempre irá considerar um valor já consolidado, pois publicações recentes ainda podem estar recebendo qualificações.
* No momento da exclusão do conteúdo é consultada a tabela com o balanço de operações para saber qual foi o valor ganho no momento dessa publicação específica e calcular o valor a ser debitado devido à exclusão.
* Cria a função `orchestrator.createPrestige` para auxiliar nos testes da funcionalidade.
* Adequa os testes existentes e cria os novos testes necessários.

772622f20868c13b6c6c60890f515422fc5d9cab
* Apenas corrige um nome de teste que estava duplicado

d0b8d00ba34af1bdba40e542f88eff08c8f3874b
* Bloqueia a possibilidade de alteração do `parent_id` e adequa os testes.

d66a049d7ab48c459056161c473beca9af90c58c
* Bloqueia a possibilidade de alteração do status de conteúdo de `published` para `draft` e adequa os testes.

9e13135c097dccca0d564ba07cc3560b75b05152
* Faz a consulta do histórico das publicações do usuário ocorrer dentro da mesma transação de publicação do conteúdo.

### Issues relacionadas

- #1169 
- #1339 
- #1364 