### PR TITLE
Adiciona estratégia de cache SWR a todos conteúdos públicos (API e Web)

### DIFF
--- a/middleware.public.js
+++ b/middleware.public.js
@@ -48,6 +48,13 @@ export async function middleware(request) {
       return NextResponse.rewrite(url);
     }
 
+    if (url.pathname === '/api/v1/swr') {
+      return new NextResponse(JSON.stringify({ timestamp: Date.now() }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
     return NextResponse.next();
   } catch (error) {
     console.error(snakeize({ message: error.message, ...error }));

--- a/models/analytics.js
+++ b/models/analytics.js
@@ -1,0 +1,106 @@
+import database from 'infra/database.js';
+
+async function getChildContentsPublished() {
+  const results = await database.query(`
+  WITH range_values AS (
+    SELECT date_trunc('day', NOW() - INTERVAL '2 MONTHS') as minval,
+           date_trunc('day', max(published_at)) as maxval
+    FROM contents),
+
+  day_range AS (
+    SELECT generate_series(minval, maxval, '1 day'::interval) as date
+    FROM range_values
+  ),
+
+  daily_counts AS (
+    SELECT date_trunc('day', created_at) as date,
+           count(*) as ct
+    FROM contents WHERE parent_id is not null
+    GROUP BY 1
+  )
+
+  SELECT TO_CHAR(day_range.date :: DATE, 'dd/mm') as date,
+         daily_counts.ct::INTEGER as respostas
+  FROM day_range
+  LEFT OUTER JOIN daily_counts on day_range.date = daily_counts.date;
+  `);
+
+  return results.rows.map((row) => {
+    return {
+      date: row.date,
+      respostas: row.respostas || 0,
+    };
+  });
+}
+
+async function getRootContentsPublished() {
+  const results = await database.query(`
+  WITH range_values AS (
+    SELECT date_trunc('day', NOW() - INTERVAL '2 MONTHS') as minval,
+           date_trunc('day', max(published_at)) as maxval
+    FROM contents),
+
+  day_range AS (
+    SELECT generate_series(minval, maxval, '1 day'::interval) as date
+    FROM range_values
+  ),
+
+  daily_counts AS (
+    SELECT date_trunc('day', created_at) as date,
+           count(*) as ct
+    FROM contents WHERE parent_id is null
+    GROUP BY 1
+  )
+
+  SELECT TO_CHAR(day_range.date :: DATE, 'dd/mm') as date,
+         daily_counts.ct::INTEGER as conteudos
+  FROM day_range
+  LEFT OUTER JOIN daily_counts on day_range.date = daily_counts.date;
+  `);
+
+  return results.rows.map((row) => {
+    return {
+      date: row.date,
+      conteudos: row.conteudos || 0,
+    };
+  });
+}
+
+async function getUsersCreated() {
+  const results = await database.query(`
+  WITH range_values AS (
+    SELECT date_trunc('day', NOW() - INTERVAL '2 MONTHS') as minval,
+           date_trunc('day', max(created_at)) as maxval
+    FROM users),
+
+  day_range AS (
+    SELECT generate_series(minval, maxval, '1 day'::interval) as date
+    FROM range_values
+  ),
+
+  daily_counts AS (
+    SELECT date_trunc('day', created_at) as date,
+           count(*) as ct
+    FROM users
+    GROUP BY 1
+  )
+
+  SELECT TO_CHAR(day_range.date :: DATE, 'dd/mm') as date,
+         daily_counts.ct::INTEGER as cadastros
+  FROM day_range
+  LEFT OUTER JOIN daily_counts on day_range.date = daily_counts.date;
+  `);
+
+  return results.rows.map((row) => {
+    return {
+      date: row.date,
+      cadastros: row.cadastros || 0,
+    };
+  });
+}
+
+export default Object.freeze({
+  getChildContentsPublished,
+  getRootContentsPublished,
+  getUsersCreated,
+});

--- a/models/validator.js
+++ b/models/validator.js
@@ -947,6 +947,7 @@ const reservedUsernames = [
   'superuser',
   'suporte',
   'support',
+  'swr',
   'sysadmin',
   'tabnew',
   'tabnews',

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "joi": "17.8.3",
         "next": "13.2.4",
         "next-connect": "0.13.0",
+        "next-swr": "0.1.1",
         "node-pg-migrate": "6.2.2",
         "nodemailer": "6.9.1",
         "nprogress": "0.2.0",
@@ -10221,6 +10222,18 @@
       "integrity": "sha512-f2G4edY01XomjCECSrgOpb/zzQinJO6Whd8Zds0+rLUYhj5cLwkh6FVvZsQCSSbxSc4k9nCwNuk5NLIhvO1gUA==",
       "dependencies": {
         "trouter": "^3.2.0"
+      }
+    },
+    "node_modules/next-swr": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/next-swr/-/next-swr-0.1.1.tgz",
+      "integrity": "sha512-ej2DnDRaZ9QQA7z8lF8SD9BKe99b76CYqthdWaRbneQ0b8Ots5j+l/8kSv8yE/Lbn9IlLbpEltFWAKbb8N6JXw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "next": ">=12",
+        "react": ">=16"
       }
     },
     "node_modules/next/node_modules/postcss": {
@@ -21095,6 +21108,12 @@
       "requires": {
         "trouter": "^3.2.0"
       }
+    },
+    "next-swr": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/next-swr/-/next-swr-0.1.1.tgz",
+      "integrity": "sha512-ej2DnDRaZ9QQA7z8lF8SD9BKe99b76CYqthdWaRbneQ0b8Ots5j+l/8kSv8yE/Lbn9IlLbpEltFWAKbb8N6JXw==",
+      "requires": {}
     },
     "node-fetch": {
       "version": "2.6.7",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "joi": "17.8.3",
     "next": "13.2.4",
     "next-connect": "0.13.0",
+    "next-swr": "0.1.1",
     "node-pg-migrate": "6.2.2",
     "nodemailer": "6.9.1",
     "nprogress": "0.2.0",

--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -405,5 +405,6 @@ export const getStaticProps = getStaticPropsRevalidate(async (context) => {
       contentMetadata: JSON.parse(JSON.stringify(contentMetadata)),
     },
     revalidate: 10,
+    swr: { revalidateOnFocus: false },
   };
 });

--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -7,36 +7,11 @@ import content from 'models/content.js';
 import removeMarkdown from 'models/remove-markdown.js';
 import user from 'models/user.js';
 import validator from 'models/validator.js';
+import { getStaticPropsRevalidate } from 'next-swr';
 import { useCollapse } from 'pages/interface';
 import { useEffect, useState } from 'react';
-import useSWR from 'swr';
 
-export default function Post({
-  contentFound: contentFoundFallback,
-  childrenFound: childrenFallback,
-  rootContentFound,
-  parentContentFound,
-  contentMetadata,
-}) {
-  const { data: contentFound } = useSWR(
-    `/api/v1/contents/${contentFoundFallback.owner_username}/${contentFoundFallback.slug}`,
-    {
-      fallbackData: contentFoundFallback,
-      revalidateOnFocus: false,
-      revalidateOnReconnect: false,
-    }
-  );
-
-  // TODO: understand why enabling "revalidateOn..." breaks children rendering.
-  const { data: children } = useSWR(
-    `/api/v1/contents/${contentFoundFallback.owner_username}/${contentFoundFallback.slug}/children`,
-    {
-      fallbackData: childrenFallback,
-      revalidateOnFocus: false,
-      revalidateOnReconnect: false,
-    }
-  );
-
+export default function Post({ contentFound, childrenFound, rootContentFound, parentContentFound, contentMetadata }) {
   const [childrenToShow, setChildrenToShow] = useState(108);
   const [showConfetti, setShowConfetti] = useState(false);
 
@@ -104,7 +79,7 @@ export default function Post({
 
           <RenderChildrenTree
             key={contentFound.id}
-            childrenList={children}
+            childrenList={childrenFound}
             renderIntent={childrenToShow}
             renderIncrement={Math.ceil(childrenToShow / 2)}
           />
@@ -331,7 +306,7 @@ export async function getStaticPaths() {
   };
 }
 
-export async function getStaticProps(context) {
+export const getStaticProps = getStaticPropsRevalidate(async (context) => {
   const userTryingToGet = user.createAnonymous();
 
   try {
@@ -431,4 +406,4 @@ export async function getStaticProps(context) {
     },
     revalidate: 10,
   };
-}
+});

--- a/pages/[username]/index.public.js
+++ b/pages/[username]/index.public.js
@@ -18,6 +18,7 @@ import content from 'models/content.js';
 import removeMarkdown from 'models/remove-markdown.js';
 import user from 'models/user.js';
 import validator from 'models/validator.js';
+import { getStaticPropsRevalidate } from 'next-swr';
 import { useRouter } from 'next/router';
 import { useUser } from 'pages/interface';
 import { useState } from 'react';
@@ -184,7 +185,7 @@ export async function getStaticPaths() {
   };
 }
 
-export async function getStaticProps(context) {
+export const getStaticProps = getStaticPropsRevalidate(async (context) => {
   const userTryingToGet = user.createAnonymous();
 
   try {
@@ -247,4 +248,4 @@ export async function getStaticProps(context) {
 
     revalidate: 10,
   };
-}
+});

--- a/pages/[username]/pagina/[page]/index.public.js
+++ b/pages/[username]/pagina/[page]/index.public.js
@@ -5,6 +5,7 @@ import authorization from 'models/authorization.js';
 import validator from 'models/validator.js';
 import removeMarkdown from 'models/remove-markdown.js';
 import { NotFoundError } from 'errors/index.js';
+import { getStaticPropsRevalidate } from 'next-swr';
 
 export default function Home({ contentListFound, pagination, username }) {
   return (
@@ -28,7 +29,7 @@ export async function getStaticPaths() {
   };
 }
 
-export async function getStaticProps(context) {
+export const getStaticProps = getStaticPropsRevalidate(async (context) => {
   const userTryingToGet = user.createAnonymous();
 
   try {
@@ -88,4 +89,4 @@ export async function getStaticProps(context) {
 
     revalidate: 10,
   };
-}
+});

--- a/pages/_app.public.js
+++ b/pages/_app.public.js
@@ -1,5 +1,6 @@
 import { ThemeProvider } from '@/TabNewsUI';
 import { Analytics } from '@vercel/analytics/react';
+import { useRevalidate } from 'next-swr';
 import { DefaultHead, UserProvider } from 'pages/interface';
 import { SWRConfig } from 'swr';
 
@@ -11,6 +12,7 @@ async function SWRFetcher(resource, init) {
 }
 
 function MyApp({ Component, pageProps }) {
+  useRevalidate({ swr: { swrPath: '/api/v1/swr', ...pageProps.swr } });
   return (
     <UserProvider>
       <DefaultHead />

--- a/pages/api/v1/analytics/root-content-published/index.public.js
+++ b/pages/api/v1/analytics/root-content-published/index.public.js
@@ -1,6 +1,6 @@
 import nextConnect from 'next-connect';
 import controller from 'models/controller.js';
-import database from 'infra/database.js';
+import analytics from 'models/analytics.js';
 
 export default nextConnect({
   attachParams: true,
@@ -12,36 +12,7 @@ export default nextConnect({
   .get(getHandler);
 
 async function getHandler(request, response) {
-  const results = await database.query(`
-  WITH range_values AS (
-    SELECT date_trunc('day', NOW() - INTERVAL '2 MONTHS') as minval,
-           date_trunc('day', max(published_at)) as maxval
-    FROM contents),
-
-  day_range AS (
-    SELECT generate_series(minval, maxval, '1 day'::interval) as date
-    FROM range_values
-  ),
-
-  daily_counts AS (
-    SELECT date_trunc('day', created_at) as date,
-           count(*) as ct
-    FROM contents WHERE parent_id is null
-    GROUP BY 1
-  )
-
-  SELECT TO_CHAR(day_range.date :: DATE, 'dd/mm') as date,
-         daily_counts.ct::INTEGER as conteudos
-  FROM day_range
-  LEFT OUTER JOIN daily_counts on day_range.date = daily_counts.date;
-  `);
-
-  const contentsPublished = results.rows.map((row) => {
-    return {
-      date: row.date,
-      conteudos: row.conteudos || 0,
-    };
-  });
+  const contentsPublished = await analytics.getRootContentsPublished();
 
   response.setHeader('Cache-Control', 'public, 300, stale-while-revalidate');
   return response.status(200).json(contentsPublished);

--- a/pages/api/v1/analytics/users-created/index.public.js
+++ b/pages/api/v1/analytics/users-created/index.public.js
@@ -1,6 +1,6 @@
 import nextConnect from 'next-connect';
 import controller from 'models/controller.js';
-import database from 'infra/database.js';
+import analytics from 'models/analytics.js';
 
 export default nextConnect({
   attachParams: true,
@@ -12,36 +12,7 @@ export default nextConnect({
   .get(getHandler);
 
 async function getHandler(request, response) {
-  const results = await database.query(`
-  WITH range_values AS (
-    SELECT date_trunc('day', NOW() - INTERVAL '2 MONTHS') as minval,
-           date_trunc('day', max(created_at)) as maxval
-    FROM users),
-
-  day_range AS (
-    SELECT generate_series(minval, maxval, '1 day'::interval) as date
-    FROM range_values
-  ),
-
-  daily_counts AS (
-    SELECT date_trunc('day', created_at) as date,
-           count(*) as ct
-    FROM users
-    GROUP BY 1
-  )
-
-  SELECT TO_CHAR(day_range.date :: DATE, 'dd/mm') as date,
-         daily_counts.ct::INTEGER as cadastros
-  FROM day_range
-  LEFT OUTER JOIN daily_counts on day_range.date = daily_counts.date;
-  `);
-
-  const usersCreated = results.rows.map((row) => {
-    return {
-      date: row.date,
-      cadastros: row.cadastros || 0,
-    };
-  });
+  const usersCreated = await analytics.getUsersCreated();
 
   response.setHeader('Cache-Control', 'public, 300, stale-while-revalidate');
   return response.status(200).json(usersCreated);

--- a/pages/api/v1/contents/[username]/[slug]/parent/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/parent/index.public.js
@@ -66,5 +66,7 @@ async function getHandler(request, response) {
 
   const secureParentContent = authorization.filterOutput(userTryingToGet, 'read:content', parentContentFound);
 
+  response.setHeader('Cache-Control', 'public, s-maxage=10, stale-while-revalidate');
+
   return response.status(200).json(secureParentContent);
 }

--- a/pages/api/v1/contents/[username]/[slug]/root/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/root/index.public.js
@@ -66,5 +66,7 @@ async function getHandler(request, response) {
 
   const secureOutputValues = authorization.filterOutput(userTryingToGet, 'read:content', rootContentFound);
 
+  response.setHeader('Cache-Control', 'public, s-maxage=10, stale-while-revalidate');
+
   return response.status(200).json(secureOutputValues);
 }

--- a/pages/api/v1/contents/[username]/[slug]/thumbnail/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/thumbnail/index.public.js
@@ -48,5 +48,6 @@ async function getHandler(request, response) {
 
   response.statusCode = 200;
   response.setHeader('Content-Type', `image/png`);
+  response.setHeader('Cache-Control', 'public, s-maxage=60, stale-while-revalidate');
   response.end(thumbnailPng);
 }

--- a/pages/api/v1/contents/[username]/index.public.js
+++ b/pages/api/v1/contents/[username]/index.public.js
@@ -1,10 +1,10 @@
 import nextConnect from 'next-connect';
 import controller from 'models/controller.js';
-import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
 import validator from 'models/validator.js';
 import content from 'models/content.js';
 import removeMarkdown from 'models/remove-markdown.js';
+import user from 'models/user.js';
 
 export default nextConnect({
   attachParams: true,
@@ -12,7 +12,6 @@ export default nextConnect({
   onError: controller.onErrorHandler,
 })
   .use(controller.injectRequestMetadata)
-  .use(authentication.injectAnonymousOrUser)
   .use(controller.logRequest)
   .get(getValidationHandler, getHandler);
 
@@ -30,7 +29,7 @@ function getValidationHandler(request, response, next) {
 }
 
 async function getHandler(request, response) {
-  const userTryingToGet = request.context.user;
+  const userTryingToGet = user.createAnonymous();
 
   const results = await content.findWithStrategy({
     strategy: request.query.strategy,
@@ -54,5 +53,8 @@ async function getHandler(request, response) {
   }
 
   controller.injectPaginationHeaders(results.pagination, `/api/v1/contents/${request.query.username}`, response);
+
+  response.setHeader('Cache-Control', 'public, s-maxage=10, stale-while-revalidate');
+
   return response.status(200).json(secureOutputValues);
 }

--- a/pages/api/v1/contents/index.public.js
+++ b/pages/api/v1/contents/index.public.js
@@ -17,10 +17,10 @@ export default nextConnect({
   onError: controller.onErrorHandler,
 })
   .use(controller.injectRequestMetadata)
+  .use(controller.logRequest)
   .get(getValidationHandler, getHandler)
   .post(
     authentication.injectAnonymousOrUser,
-    controller.logRequest,
     postValidationHandler,
     authorization.canRequest('create:content'),
     firewallValidationHandler,

--- a/pages/index.public.js
+++ b/pages/index.public.js
@@ -3,6 +3,7 @@ import authorization from 'models/authorization.js';
 import content from 'models/content.js';
 import user from 'models/user.js';
 import validator from 'models/validator.js';
+import { getStaticPropsRevalidate } from 'next-swr';
 import { FaTree } from 'react-icons/fa';
 
 export default function Home({ contentListFound, pagination }) {
@@ -25,7 +26,7 @@ export default function Home({ contentListFound, pagination }) {
   );
 }
 
-export async function getStaticProps(context) {
+export const getStaticProps = getStaticPropsRevalidate(async (context) => {
   const userTryingToGet = user.createAnonymous();
 
   context.params = context.params ? context.params : {};
@@ -66,4 +67,4 @@ export async function getStaticProps(context) {
     },
     revalidate: 10,
   };
-}
+});

--- a/pages/interface/components/Progressbar/index.js
+++ b/pages/interface/components/Progressbar/index.js
@@ -11,7 +11,6 @@ export default function NextNProgress({
   height = 3,
   showOnShallow = true,
   options,
-  nonce,
 }) {
   useEffect(() => {
     let timer = null;
@@ -20,7 +19,8 @@ export default function NextNProgress({
       NProgress.configure(options);
     }
 
-    const routeChangeStart = (_, { shallow }) => {
+    const routeChangeStart = (url, { shallow }) => {
+      if (Router.asPath === url) return;
       if (!shallow || showOnShallow) {
         NProgress.set(startPosition);
         NProgress.start();
@@ -28,6 +28,7 @@ export default function NextNProgress({
     };
 
     const routeChangeEnd = (_, { shallow }) => {
+      if (NProgress.status === null) return;
       if (!shallow || showOnShallow) {
         if (timer) clearTimeout(timer);
         timer = setTimeout(() => {
@@ -47,73 +48,73 @@ export default function NextNProgress({
   }, [options, showOnShallow, startPosition, stopDelayMs]);
 
   return (
-    <style nonce={nonce}>{`
-            #nprogress {
-                pointer-events: none;
-            }
-            #nprogress .bar {
-                background: ${color};
-                position: fixed;
-                z-index: 9999;
-                top: 0;
-                left: 0;
-                width: 100%;
-                height: ${height}px;
-            }
-            #nprogress .peg {
-                display: block;
-                position: absolute;
-                right: 0px;
-                width: 100px;
-                height: 100%;
-                box-shadow: 0 0 10px ${color}, 0 0 5px ${color};
-                opacity: 1;
-                -webkit-transform: rotate(3deg) translate(0px, -4px);
-                -ms-transform: rotate(3deg) translate(0px, -4px);
-                transform: rotate(3deg) translate(0px, -4px);
-            }
-            #nprogress .spinner {
-                display: block;
-                position: fixed;
-                z-index: 1031;
-                top: 15px;
-                right: 15px;
-            }
-            #nprogress .spinner-icon {
-                width: 18px;
-                height: 18px;
-                box-sizing: border-box;
-                border: solid 2px transparent;
-                border-top-color: ${color};
-                border-left-color: ${color};
-                border-radius: 50%;
-                -webkit-animation: nprogresss-spinner 400ms linear infinite;
-                animation: nprogress-spinner 400ms linear infinite;
-            }
-            .nprogress-custom-parent {
-                overflow: hidden;
-                position: relative;
-            }
-            .nprogress-custom-parent #nprogress .spinner,
-            .nprogress-custom-parent #nprogress .bar {
-                position: absolute;
-            }
-            @-webkit-keyframes nprogress-spinner {
-                0% {
-                -webkit-transform: rotate(0deg);
-                }
-                100% {
-                -webkit-transform: rotate(360deg);
-                }
-            }
-            @keyframes nprogress-spinner {
-                0% {
-                transform: rotate(0deg);
-                }
-                100% {
-                transform: rotate(360deg);
-                }
-            }
-        `}</style>
+    <style jsx global>{`
+      #nprogress {
+        pointer-events: none;
+      }
+      #nprogress .bar {
+        background: ${color};
+        position: fixed;
+        z-index: 9999;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: ${height}px;
+      }
+      #nprogress .peg {
+        display: block;
+        position: absolute;
+        right: 0px;
+        width: 100px;
+        height: 100%;
+        box-shadow: 0 0 10px ${color}, 0 0 5px ${color};
+        opacity: 1;
+        -webkit-transform: rotate(3deg) translate(0px, -4px);
+        -ms-transform: rotate(3deg) translate(0px, -4px);
+        transform: rotate(3deg) translate(0px, -4px);
+      }
+      #nprogress .spinner {
+        display: block;
+        position: fixed;
+        z-index: 1031;
+        top: 15px;
+        right: 15px;
+      }
+      #nprogress .spinner-icon {
+        width: 18px;
+        height: 18px;
+        box-sizing: border-box;
+        border: solid 2px transparent;
+        border-top-color: ${color};
+        border-left-color: ${color};
+        border-radius: 50%;
+        -webkit-animation: nprogresss-spinner 400ms linear infinite;
+        animation: nprogress-spinner 400ms linear infinite;
+      }
+      .nprogress-custom-parent {
+        overflow: hidden;
+        position: relative;
+      }
+      .nprogress-custom-parent #nprogress .spinner,
+      .nprogress-custom-parent #nprogress .bar {
+        position: absolute;
+      }
+      @-webkit-keyframes nprogress-spinner {
+        0% {
+          -webkit-transform: rotate(0deg);
+        }
+        100% {
+          -webkit-transform: rotate(360deg);
+        }
+      }
+      @keyframes nprogress-spinner {
+        0% {
+          transform: rotate(0deg);
+        }
+        100% {
+          transform: rotate(360deg);
+        }
+      }
+    `}</style>
   );
 }

--- a/pages/pagina/[page]/index.public.js
+++ b/pages/pagina/[page]/index.public.js
@@ -3,6 +3,7 @@ import authorization from 'models/authorization.js';
 import content from 'models/content.js';
 import user from 'models/user.js';
 import validator from 'models/validator.js';
+import { getStaticPropsRevalidate } from 'next-swr';
 
 export default function Home({ contentListFound, pagination }) {
   return (
@@ -26,7 +27,7 @@ export async function getStaticPaths() {
   };
 }
 
-export async function getStaticProps(context) {
+export const getStaticProps = getStaticPropsRevalidate(async (context) => {
   const userTryingToGet = user.createAnonymous();
 
   context.params = context.params ? context.params : {};
@@ -67,4 +68,4 @@ export async function getStaticProps(context) {
     // https://nextjs.org/docs/basic-features/data-fetching/incremental-static-regeneration#using-on-demand-revalidation
     revalidate: 10,
   };
-}
+});

--- a/pages/recentes/index.public.js
+++ b/pages/recentes/index.public.js
@@ -3,6 +3,7 @@ import authorization from 'models/authorization.js';
 import content from 'models/content.js';
 import user from 'models/user.js';
 import validator from 'models/validator.js';
+import { getStaticPropsRevalidate } from 'next-swr';
 
 export default function Home({ contentListFound, pagination }) {
   return (
@@ -23,7 +24,7 @@ export default function Home({ contentListFound, pagination }) {
   );
 }
 
-export async function getStaticProps(context) {
+export const getStaticProps = getStaticPropsRevalidate(async (context) => {
   const userTryingToGet = user.createAnonymous();
 
   context.params = context.params ? context.params : {};
@@ -64,4 +65,4 @@ export async function getStaticProps(context) {
     },
     revalidate: 10,
   };
-}
+});

--- a/pages/recentes/pagina/[page]/index.public.js
+++ b/pages/recentes/pagina/[page]/index.public.js
@@ -3,6 +3,7 @@ import authorization from 'models/authorization.js';
 import content from 'models/content.js';
 import user from 'models/user.js';
 import validator from 'models/validator.js';
+import { getStaticPropsRevalidate } from 'next-swr';
 
 export default function Home({ contentListFound, pagination }) {
   return (
@@ -26,7 +27,7 @@ export async function getStaticPaths() {
   };
 }
 
-export async function getStaticProps(context) {
+export const getStaticProps = getStaticPropsRevalidate(async (context) => {
   const userTryingToGet = user.createAnonymous();
 
   context.params = context.params ? context.params : {};
@@ -64,4 +65,4 @@ export async function getStaticProps(context) {
     },
     revalidate: 10,
   };
-}
+});

--- a/pages/status/index.public.js
+++ b/pages/status/index.public.js
@@ -1,17 +1,12 @@
 import { Box, DefaultLayout, Heading, Label, LabelGroup, Truncate } from '@/TabNewsUI';
+import analytics from 'models/analytics.js';
+import { getStaticPropsRevalidate } from 'next-swr';
 import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis } from 'recharts';
 import useSWR from 'swr';
 
-export default function Page() {
+export default function Page({ usersCreated, rootContentPublished, childContentPublished }) {
   const { data: statusObject, isLoading: statusObjectIsLoading } = useSWR('/api/v1/status', {
     refreshInterval: 1000 * 10,
-  });
-  const { data: usersCreated } = useSWR('/api/v1/analytics/users-created', { refreshInterval: 1000 * 60 * 5 });
-  const { data: rootContentPublished } = useSWR('/api/v1/analytics/root-content-published', {
-    refreshInterval: 1000 * 60 * 5,
-  });
-  const { data: childContentPublished } = useSWR('/api/v1/analytics/child-content-published', {
-    refreshInterval: 1000 * 60 * 5,
   });
 
   return (
@@ -191,3 +186,19 @@ export default function Page() {
     </DefaultLayout>
   );
 }
+
+export const getStaticProps = getStaticPropsRevalidate(async () => {
+  const childContentPublished = await analytics.getChildContentsPublished();
+  const rootContentPublished = await analytics.getRootContentsPublished();
+  const usersCreated = await analytics.getUsersCreated();
+
+  return {
+    props: {
+      usersCreated,
+      rootContentPublished,
+      childContentPublished,
+    },
+    revalidate: 30,
+    swr: { refreshInterval: 1000 * 60 * 5 },
+  };
+});

--- a/tests/integration/api/v1/swr/get.test.js
+++ b/tests/integration/api/v1/swr/get.test.js
@@ -1,0 +1,15 @@
+import fetch from 'cross-fetch';
+import orchestrator from 'tests/orchestrator.js';
+
+describe('GET /swr', () => {
+  test('Get timestamp from server', async () => {
+    const startTime = Date.now();
+    const serverTimeResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/swr`);
+    const serverTimeBody = await serverTimeResponse.json();
+    const serverTime = serverTimeBody.timestamp;
+
+    expect(serverTimeResponse.status).toEqual(200);
+    expect(serverTime).toBeGreaterThanOrEqual(startTime);
+    expect(serverTime).toBeLessThanOrEqual(Date.now());
+  });
+});


### PR DESCRIPTION
Adota a mesma estratégia de cache para todo conteúdo público do sistema.

Toda requisição que possuir cache será atendida por esse cache, mesmo que obsoleto. E essa requisição dispara a revalidação do cache em segundo plano caso ele esteja obsoleto.

No lado do client web foram criadas estratégias para sempre obter os dados mais recentes possíveis. Não será mais necessário usar a tecla F5 para garantir dados mais atualizados, pois tudo é feito de forma automática em segundo plano.

## API

Para os endpoints da API a mudança é bem simples e são só duas alterações nas requisições GET públicas:

1. Foram substituídos os dados do usuário por dados anônimos (para não armazenar dados privados em cache);
2. Foi adicionado o cabeçalho de controle de cache `stale-while-revalidate` .

Endpoints com cache:
```
/api/v1/contents
/api/v1/contents/[username]
/api/v1/contents/[username]/[slug]
/api/v1/contents/[username]/[slug]/children
/api/v1/contents/[username]/[slug]/parent
/api/v1/contents/[username]/[slug]/root
/api/v1/contents/[username]/[slug]/thumbnail
/api/v1/users/[username]
```

Sendo que o `/contents` já possuía a configuração, mas ajustei para gerar logs em mais casos.

## Páginas Web

As páginas que possuem conteúdos dinâmicos públicos já utilizavam a estratégia SWR. Mas essa estratégia implica em receber dados desatualizados em algumas situações, como ao acessar páginas que não recebem muitas visitas, onde o cache acaba ficando mais antigo.

Para contornar isso, assim que as páginas de conteúdos eram carregadas, ocorria uma chamada para a API para buscar os dados mais atualizados.

Só que agora utilizando a mesma estratégia de cache na API, não é simples garantir que a API sempre esteja mais atualizada que as páginas estáticas, então poderia ocorrer de uma página ser carregada com dados recentes e logo em seguida ficar com dados um pouco defasados vindos da API.

Uma estratégia para evitar isso seria mantermos um identificador de quando o cache foi gerado para poder comparar entre os dois dados e utilizar o mais atual. Mas isso só garante o uso de dados mais atualizados entre esses dois, mas não evita dados desatualizados, pois os dois podem já estar obsoletos.

A solução adotada foi não utilizar a API para obter dados atualizados, mas sim computar dados de quando o cache foi gerado para estimar tempos de revalidação e, quando necessário, fazer uma nova requisição de dados estáticos após aguardar a revalidação em segundo plano.

Para isso foi utilizada a biblioteca `next-swr` que eu criei para facilitar a adoção dessa estratégia. Ela possui funcionalidades similares a biblioteca SWR da Vercel, mas sem utilizar a API. No TabNews estão habilitadas as seguintes:

* Função `getStaticProps` customizada que envia dados extras sobre a última revalidação de cada página.
* Hook `useRevalidate` que utiliza esses dados para, em segundo plano, fazer novas requisições quando necessário:

1. Caso os dados estáticos estejam obsoletos, faz uma requisição para forçar a revalidação (o Next.js já faz isso automaticamente com uma requisição HEAD, mas essa não propaga a revalidação na borda da Vercel);
2. Caso essa nova requisição já receba dados atualizados, o processo acaba aqui;
3. Com dados sobre a última revalidação, aguarda o tempo necessário para uma nova revalidação e obtem os dados mais atualizados;
4. Caso as lambdas estejam congeladas o tempo para revalidação será um pouco maior, então uma última tentativa de revalidação é realizada após um novo tempo;
5. O hook também revalida os dados quando retornamos para a guia do navegador deixada aberta;
6. Também existe a possibilidade de revalidação dos dados em intervalo de tempo fixo, mas isso só foi habilitado na página de status;

Sobre a página de status, ela era uma página estática com os dados dinâmicos obtidos apenas pelo client. Agora parte dos dados são obtidos coma a função `getStaticProps` no lado do servidor. Como ela fazia requisições para a API em diferentes intervalos, os dados atualizados com mais frequência continuam utilizando a API, já os demais dados agora são atualizados com o `refreshInterval` da `next-swr`.

Já a estratégia de revalidação em segundo plano ao carregar a página e ao voltar na aba foi aplicada para todos os conteúdos públicos, não apenas os que já faziam isso via API, então agora é esperado que tenhamos dados mais atualizados em todas as páginas.

## Detalhes extras sobre o PR

Uma vantagem extra da biblioteca ao usar dados sobre as revalidações anteriores é que em momentos de uso mais elevado do bando de dados em que o intervalo de revalidação estiver demorando mais, o tempo entre as revalidações deve aumentar proporcionalmente, dando um refresco ao banco nesses casos.

Como pode haver uma diferença de horário entre cliente e servidor, a biblioteca fornece um middleware que pode ser utilizado para a sincronização dos relógios. Como no TabNews nós já utilizamos o middleware, então foi só um "if" a mais no fluxo para fornecer essa sincronização e não precisamos da função fornecida pela biblioteca. Essa requisição de sincronização só ocorre uma vez por sessão do navegador.

Foi criado o model analytics para reunir o código que agora é utilizado tanto pela API como pela geração da página estática

O `swr` da Vercel agora só está sendo utilizado para obter os dados do endpoint `/api/v1/status`.

Fiz ajustes na barra de progresso que mostra as navegações SPA, pois ela iria ficar mostrando as revalidações em segundo plano. Então ela continua funcionando, mas apenas quando ocorre alteração no `router.asPath`. Aproveitei que mexi nesse componente para já arrumar o CSS para o mesmo padrão do restante do código. Ele ficava com um destaque bem esquisito no código fonte das páginas.

## Resultados esperados

* Respostas mais rápidas da API por utilizar cache;
* Dados sempre atuais na versão Web;

## Observação final

A biblioteca `next-swr` acabou de ser criada e podem existir bugs desconhecidos.