### PR TITLE
feat(canonical url): add canonical tag to login page

### DIFF
--- a/pages/interface/components/Head/index.js
+++ b/pages/interface/components/Head/index.js
@@ -57,7 +57,10 @@ export function DefaultHead() {
 }
 
 export default function Head({ metadata, children }) {
-  const { type, title, description, image, url, noIndex, author, published_time, modified_time } = metadata || {};
+  const { type, title, description, image, url, noIndex, author, published_time, modified_time, canonical } =
+    metadata || {};
+
+  const canonicalUrl = canonical?.startsWith('http') ? canonical : `${webserverHost}${canonical}`;
 
   return (
     <NextHead>
@@ -77,6 +80,8 @@ export default function Head({ metadata, children }) {
           <meta property="twitter:description" content={description} key="twitter:description" />
         </>
       )}
+
+      {canonical && <link rel="canonical" href={canonicalUrl} key="canonical" />}
 
       {url && (
         <>

--- a/pages/login/index.public.js
+++ b/pages/login/index.public.js
@@ -15,7 +15,7 @@ import { useRef, useState } from 'react';
 
 export default function Login() {
   return (
-    <DefaultLayout containerWidth="small" metadata={{ title: 'Login' }}>
+    <DefaultLayout containerWidth="small" metadata={{ title: 'Login', canonical: '/login' }}>
       <LoginForm />
     </DefaultLayout>
   );


### PR DESCRIPTION
70% das páginas que o Google nos mostra no Console de Pesquisa como não indexadas são por falta da URL canônica.

São mais de 37 mil páginas nessa condição e eu imagino que a maioria seja de páginas de comentários, que o Google percebe que possuiu partes em comum com a página do conteúdo "root".

Só que não temos como ver quais são as 37 mil, pois ele só mostra as primeiras 1000, e 997 são só da página de login com o parâmetro de redirecionamento para alguma outra página do TabNews. Isso quer dizer que o robô não está entendendo que é a mesma página de login porque cada uma tem um parâmetro diferente, por exemplo:

https://www.tabnews.com.br/login?redirect=/

Para mostrar para o Google que, independentemente do parâmetro, ele sempre deve considerar que o endereço da página é o mesmo, estou adicionando a tag de URL canônica com o endereço:

https://www.tabnews.com.br/login

Com isso poderemos aguardar os robôs fazerem novas varreduras e lidar com o que ainda estiver sendo acusado.

O próximo item que deveremos lidar são os cerca de 20% em que a maioria são endereços dos conteúdos, mas acessados via API. Será que é interessante colocarmos o cabeçalho canônico nas respostas da API?

`Link: <https://www.tabnews.com.br/${username}/${slug}>; rel="canonical"`

O que acham?

Referência: https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls