### PR TITLE
fix(tabcoins cache): use latest API data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "joi": "17.8.3",
         "next": "13.2.4",
         "next-connect": "0.13.0",
-        "next-swr": "0.1.1",
+        "next-swr": "0.1.2-canary.0",
         "node-pg-migrate": "6.2.2",
         "nodemailer": "6.9.1",
         "nprogress": "0.2.0",
@@ -10225,9 +10225,9 @@
       }
     },
     "node_modules/next-swr": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/next-swr/-/next-swr-0.1.1.tgz",
-      "integrity": "sha512-ej2DnDRaZ9QQA7z8lF8SD9BKe99b76CYqthdWaRbneQ0b8Ots5j+l/8kSv8yE/Lbn9IlLbpEltFWAKbb8N6JXw==",
+      "version": "0.1.2-canary.0",
+      "resolved": "https://registry.npmjs.org/next-swr/-/next-swr-0.1.2-canary.0.tgz",
+      "integrity": "sha512-ImSuLD7jP0umzeBsa3hGHIGbJIPpNEgP0uSZoc9GyArJH0FXojyBHPXVrXuyJgmy8olb0rHbnmTUUv2sXgR2HQ==",
       "engines": {
         "node": ">=12"
       },
@@ -21110,9 +21110,9 @@
       }
     },
     "next-swr": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/next-swr/-/next-swr-0.1.1.tgz",
-      "integrity": "sha512-ej2DnDRaZ9QQA7z8lF8SD9BKe99b76CYqthdWaRbneQ0b8Ots5j+l/8kSv8yE/Lbn9IlLbpEltFWAKbb8N6JXw==",
+      "version": "0.1.2-canary.0",
+      "resolved": "https://registry.npmjs.org/next-swr/-/next-swr-0.1.2-canary.0.tgz",
+      "integrity": "sha512-ImSuLD7jP0umzeBsa3hGHIGbJIPpNEgP0uSZoc9GyArJH0FXojyBHPXVrXuyJgmy8olb0rHbnmTUUv2sXgR2HQ==",
       "requires": {}
     },
     "node-fetch": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "joi": "17.8.3",
     "next": "13.2.4",
     "next-connect": "0.13.0",
-    "next-swr": "0.1.1",
+    "next-swr": "0.1.2-canary.0",
     "node-pg-migrate": "6.2.2",
     "nodemailer": "6.9.1",
     "nprogress": "0.2.0",

--- a/pages/_app.public.js
+++ b/pages/_app.public.js
@@ -1,6 +1,6 @@
 import { ThemeProvider } from '@/TabNewsUI';
 import { Analytics } from '@vercel/analytics/react';
-import { useRevalidate } from 'next-swr';
+import { RevalidateProvider } from 'next-swr';
 import { DefaultHead, UserProvider } from 'pages/interface';
 import { SWRConfig } from 'swr';
 
@@ -12,13 +12,14 @@ async function SWRFetcher(resource, init) {
 }
 
 function MyApp({ Component, pageProps }) {
-  useRevalidate({ swr: { swrPath: '/api/v1/swr', ...pageProps.swr } });
   return (
     <UserProvider>
       <DefaultHead />
       <SWRConfig value={{ fetcher: SWRFetcher }}>
         <ThemeProvider>
-          <Component {...pageProps} />
+          <RevalidateProvider swr={{ swrPath: '/api/v1/swr', ...pageProps.swr }}>
+            <Component {...pageProps} />
+          </RevalidateProvider>
         </ThemeProvider>
       </SWRConfig>
       <Analytics />

--- a/pages/interface/components/TabCoinButtons/index.js
+++ b/pages/interface/components/TabCoinButtons/index.js
@@ -1,20 +1,17 @@
 import { Box, IconButton, Text, Tooltip } from '@/TabNewsUI';
 import { ChevronDownIcon, ChevronUpIcon } from '@primer/octicons-react';
+import { useRevalidate } from 'next-swr';
 import { useRouter } from 'next/router';
 import { useUser } from 'pages/interface';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useReward } from 'react-rewards';
 
 export default function TabCoinButtons({ content }) {
   const router = useRouter();
   const { user, isLoading, fetchUser } = useUser();
 
-  const [contentObject, setContentObject] = useState(content);
+  const [contentObject, setContentObject] = useRevalidate(content);
   const [isPosting, setIsPosting] = useState(false);
-
-  useEffect(() => {
-    setContentObject(content);
-  }, [content]);
 
   const { reward: rewardCredit, isAnimating: isAnimatingCredit } = useReward(`reward-${contentObject.id}`, 'confetti', {
     position: 'absolute',


### PR DESCRIPTION
Resolve #1383 ao comparar se o dado que está vindo do servidor (via revalidação) é mais novo ou mais antigo do que o recebido pela API na hora da qualificação de um conteúdo. A interface vai manter visível o dado mais recente entre os dois.

Mas ao navegar entre páginas ou dar refresh, como o estado da página é perdido, o dado em cache será o único visível, e apenas após nova revalidação é que o dado mais atual será mostrado novamente.

A versão do `next-swr` utilizada também está com uma redução em 25% no tempo que é aguardado para revalidação. Esse tempo deve ser suficiente para a maioria das revalidações, mas quando as lambdas estiverem congeladas ele não vai ser suficiente, então uma nova tentativa de revalidar irá ocorrer pouco depois.