### PR TITLE
fix(redirect after login): do not return to registration or login page

### DIFF
--- a/pages/interface/components/Header/index.js
+++ b/pages/interface/components/Header/index.js
@@ -21,6 +21,13 @@ export default function HeaderComponent() {
   const { user, isLoading, logout } = useUser();
   const { asPath } = useRouter();
 
+  const loginUrl =
+    !asPath || user || asPath.startsWith('/cadastro')
+      ? '/login'
+      : asPath.startsWith('/login')
+      ? asPath
+      : `/login?redirect=${asPath}`;
+
   const activeLinkStyle = {
     textDecoration: 'underline',
     textUnderlineOffset: 6,
@@ -57,13 +64,13 @@ export default function HeaderComponent() {
             <ThemeSwitcher />
           </PrimerHeader.Item>
           <PrimerHeader.Item sx={{ display: ['none', 'flex'] }}>
-            <HeaderLink href={{ pathname: '/login', query: { redirect: asPath } }}>Login</HeaderLink>
+            <HeaderLink href={loginUrl}>Login</HeaderLink>
           </PrimerHeader.Item>
           <PrimerHeader.Item sx={{ display: ['none', 'flex'] }}>
             <HeaderLink href="/cadastro">Cadastrar</HeaderLink>
           </PrimerHeader.Item>
           <PrimerHeader.Item sx={{ display: ['flex', 'none'] }}>
-            <HeaderLink href={{ pathname: '/login', query: { redirect: asPath } }}>Entrar</HeaderLink>
+            <HeaderLink href={loginUrl}>Entrar</HeaderLink>
           </PrimerHeader.Item>
         </>
       )}

--- a/pages/interface/hooks/useUser/index.js
+++ b/pages/interface/hooks/useUser/index.js
@@ -96,7 +96,11 @@ export function UserProvider({ children }) {
 
       if (!user?.id || router.pathname !== '/login') return;
 
-      if (router.query?.redirect?.startsWith('/')) {
+      if (
+        router.query?.redirect?.startsWith('/') &&
+        !router.query.redirect.startsWith('/login') &&
+        !router.query.redirect.startsWith('/cadastro')
+      ) {
         router.replace(router.query.redirect);
       } else {
         router.replace('/');


### PR DESCRIPTION
Resolve #1386 

Após o login o usuário é redirecionado para a página em que estava antes, mas isso não vai mais ocorrer se a página anterior for o próprio login ou páginas relacionadas ao cadastro de novos usuários. Nesses casos o redirecionamento será para a página inicial.