### PR TITLE
fix(tabcoins state): force reset state on content change

### DIFF
--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -44,7 +44,7 @@ export default function Post({ contentFound, childrenFound, rootContentFound, pa
               flexDirection: 'column',
               justifyContent: 'center',
             }}>
-            <TabCoinButtons content={contentFound} />
+            <TabCoinButtons key={contentFound.id} content={contentFound} />
             <Box
               sx={{
                 borderWidth: 0,

--- a/pages/interface/components/TabCoinButtons/index.js
+++ b/pages/interface/components/TabCoinButtons/index.js
@@ -3,7 +3,7 @@ import { ChevronDownIcon, ChevronUpIcon } from '@primer/octicons-react';
 import { useRevalidate } from 'next-swr';
 import { useRouter } from 'next/router';
 import { useUser } from 'pages/interface';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useReward } from 'react-rewards';
 
 export default function TabCoinButtons({ content }) {
@@ -12,6 +12,11 @@ export default function TabCoinButtons({ content }) {
 
   const [contentObject, setContentObject] = useRevalidate(content);
   const [isPosting, setIsPosting] = useState(false);
+
+  useEffect(() => {
+    setContentObject(content);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [content.id]);
 
   const { reward: rewardCredit, isAnimating: isAnimatingCredit } = useReward(`reward-${contentObject.id}`, 'confetti', {
     position: 'absolute',


### PR DESCRIPTION
Usa o saldo de TabCoins mais recente entre cache e API, mas reinicia o estado quando se navega entre diferentes conteúdos.

Isso deve resolver boa parte dos problemas reportados pelo @maniero na issue #1383, sobrando apenas o que for característico de cache.