### PR TITLE
Recentes dentro de relevantes só mostrar no máximo um conteúdo por usuário

### DIFF
--- a/models/queries.js
+++ b/models/queries.js
@@ -60,6 +60,7 @@ const rankedContent = `
     ),
     group_3 AS (
         (SELECT
+            DISTINCT ON (owner_id)
             *,
             3 as rank_group
         FROM ranked_published_root_contents
@@ -67,6 +68,7 @@ const rankedContent = `
             published_at > NOW() - INTERVAL '12 hours'
             AND id NOT IN (SELECT id FROM group_2)
         ORDER BY
+            owner_id,
             published_at DESC
         LIMIT 5)
         UNION ALL

--- a/tests/integration/api/v1/contents/get.test.js
+++ b/tests/integration/api/v1/contents/get.test.js
@@ -456,9 +456,9 @@ describe('GET /api/v1/contents', () => {
       expect(responseBody[0].title).toEqual('Conteúdo #31');
       expect(responseBody[1].title).toEqual('Conteúdo #36');
       expect(responseBody[2].title).toEqual('Conteúdo #60');
-      expect(responseBody[3].title).toEqual('Conteúdo #59');
-      expect(responseBody[6].title).toEqual('Conteúdo #56');
-      expect(responseBody[7].title).toEqual('Conteúdo #6');
+      expect(responseBody[3].title).toEqual('Conteúdo #6');
+      expect(responseBody[4].title).toEqual('Conteúdo #59');
+      expect(responseBody[7].title).toEqual('Conteúdo #56');
       expect(responseBody[27].title).toEqual('Conteúdo #33');
       expect(responseBody[28].title).toEqual('Conteúdo #32');
       expect(responseBody[29].title).toEqual('Conteúdo #30');


### PR DESCRIPTION
Dentre as diferentes classificações de conteúdos nas distintas faixas dos relevantes existe uma pequena janela que mostra os últimos 5 conteúdos postados que não possuem votos negativos.

Esse PR adiciona mais uma restrição que é a de não mostrar mais de um conteúdo do mesmo usuário.