### PR TITLE
fix(largest contentful paint): fix LCP metric on mobile devices

### DIFF
--- a/pages/_app.public.js
+++ b/pages/_app.public.js
@@ -13,17 +13,17 @@ async function SWRFetcher(resource, init) {
 
 function MyApp({ Component, pageProps }) {
   return (
-    <UserProvider>
-      <DefaultHead />
-      <SWRConfig value={{ fetcher: SWRFetcher }}>
-        <ThemeProvider>
+    <ThemeProvider>
+      <UserProvider>
+        <DefaultHead />
+        <SWRConfig value={{ fetcher: SWRFetcher }}>
           <RevalidateProvider swr={{ swrPath: '/api/v1/swr', ...pageProps.swr }}>
             <Component {...pageProps} />
           </RevalidateProvider>
-        </ThemeProvider>
-      </SWRConfig>
-      <Analytics />
-    </UserProvider>
+        </SWRConfig>
+        <Analytics />
+      </UserProvider>
+    </ThemeProvider>
   );
 }
 

--- a/pages/_document.public.js
+++ b/pages/_document.public.js
@@ -2,7 +2,8 @@ import Document, { Head, Html, Main, NextScript } from 'next/document';
 import Script from 'next/script';
 import { ServerStyleSheet } from 'styled-components';
 
-const noFlashScript = `document.documentElement.setAttribute('data-no-flash', true)`;
+const noFlashScript = `if (['auto','night'].includes(localStorage.getItem('colorMode')))
+document.documentElement.setAttribute('data-no-flash', true)`;
 
 export default class MyDocument extends Document {
   static async getInitialProps(ctx) {

--- a/pages/interface/components/Markdown/styles/index.js
+++ b/pages/interface/components/Markdown/styles/index.js
@@ -875,7 +875,6 @@ export function ViewerStyles() {
   // based on "highlight.js" and "github-markdown-css"
 
   const {
-    resolvedColorScheme,
     theme: { colors, shadows },
   } = useTheme();
 
@@ -884,10 +883,6 @@ export function ViewerStyles() {
   return (
     <style jsx global>
       {`
-        html:root {
-          color-scheme: ${resolvedColorScheme};
-          background: ${colors.canvas.default};
-        }
         pre code.hljs {
           display: block;
           overflow-x: auto;

--- a/pages/interface/components/ThemeProvider/index.js
+++ b/pages/interface/components/ThemeProvider/index.js
@@ -1,10 +1,10 @@
-import { BaseStyles, NextNProgress, PrimerThemeProvider, SSRProvider, ViewerStyles } from '@/TabNewsUI';
+import { BaseStyles, NextNProgress, PrimerThemeProvider, SSRProvider, ViewerStyles, useTheme } from '@/TabNewsUI';
 import { useEffect, useLayoutEffect, useState } from 'react';
-import { createGlobalStyle } from 'styled-components';
 
 // script to be called before interactive in _document.js
+// if (['auto','night'].includes(localStorage.getItem('colorMode')))
 // document.documentElement.setAttribute('data-no-flash', true)
-const NoFleshGlobalStyle = createGlobalStyle`html[data-no-flash='true']:root {visibility: hidden}`;
+
 const removeNoFlashStyle = () => setTimeout(() => document.documentElement.removeAttribute('data-no-flash'));
 const useBrowserLayoutEffect = typeof document === 'undefined' ? useEffect : useLayoutEffect;
 
@@ -13,6 +13,7 @@ export default function ThemeProvider({ children, defaultColorMode, ...props }) 
 
   useBrowserLayoutEffect(() => {
     const cachedColorMode = localStorage.getItem('colorMode') || colorMode;
+    if (cachedColorMode == colorMode) return;
     setColorMode(cachedColorMode);
     removeNoFlashStyle();
   }, []);
@@ -28,5 +29,25 @@ export default function ThemeProvider({ children, defaultColorMode, ...props }) 
         </BaseStyles>
       </PrimerThemeProvider>
     </SSRProvider>
+  );
+}
+
+function NoFleshGlobalStyle() {
+  const {
+    resolvedColorScheme,
+    theme: { colors },
+  } = useTheme();
+  return (
+    <style jsx global>{`
+      html[data-no-flash='true']:root {
+        visibility: hidden;
+      }
+      html:root {
+        color-scheme: ${resolvedColorScheme};
+      }
+      body {
+        background: ${colors.canvas.default};
+      }
+    `}</style>
   );
 }


### PR DESCRIPTION
Nos últimos dias o Search Console do Google começou a mostrar uma degradação na métrica LCP em dispositivos móveis.

O desempenho em dispositivos reais não está ruim, mas a maneira como a ferramenta funciona e como considera o desempenho também em dispositivos bem fracos, precisamos corrigir melhorar a métrica.

![image](https://user-images.githubusercontent.com/77860630/235187881-b7e0005d-fcd1-4c3c-bca6-6bb289a5c896.png)

Esse PR otimiza o código responsável pela mudança do tema no primeiro carregamento da página, onde agora o tema claro é muito mais performático sem mudar a performance do tema dark. Daria pra ser o inverso, mas o tema claro é o default no TabNews, então é melhor que ele seja o mais rápido, pois a ferramenta utilizada pelo Google para medir o desempenho do site irá sempre utilizar o modo padrão.

Os resultados melhoraram bastante no ambiente de homologação.

## Antes

![image](https://user-images.githubusercontent.com/77860630/235188500-0cc4b132-bfbb-4b8a-8774-91853de636d8.png)

## Depois

![image](https://user-images.githubusercontent.com/77860630/235188639-86fb681a-4222-469d-880e-58b959a1863e.png)