### PR TITLE
feat(session): only renew on `/user`

### DIFF
--- a/models/authentication.js
+++ b/models/authentication.js
@@ -48,12 +48,10 @@ async function injectAnonymousOrUser(request, response, next) {
       });
     }
 
-    const sessionRenewed = await session.renew(sessionObject.id, response);
-
     request.context = {
       ...request.context,
       user: userObject,
-      session: sessionRenewed,
+      session: sessionObject,
     };
   }
 

--- a/pages/api/v1/sessions/index.public.js
+++ b/pages/api/v1/sessions/index.public.js
@@ -16,18 +16,8 @@ export default nextConnect({
   .use(controller.injectRequestMetadata)
   .use(authentication.injectAnonymousOrUser)
   .use(controller.logRequest)
-  .get(authorization.canRequest('read:session'), getHandler)
   .delete(authorization.canRequest('read:session'), deleteHandler)
   .post(postValidationHandler, authorization.canRequest('create:session'), postHandler);
-
-async function getHandler(request, response) {
-  const authenticatedUser = request.context.user;
-  const sessionObject = request.context.session;
-
-  const secureOutputValues = authorization.filterOutput(authenticatedUser, 'read:session', sessionObject);
-
-  return response.status(200).json(secureOutputValues);
-}
 
 async function deleteHandler(request, response) {
   const authenticatedUser = request.context.user;

--- a/pages/api/v1/user/index.public.js
+++ b/pages/api/v1/user/index.public.js
@@ -2,6 +2,7 @@ import nextConnect from 'next-connect';
 import controller from 'models/controller.js';
 import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
+import session from 'models/session';
 
 export default nextConnect({
   attachParams: true,
@@ -11,7 +12,7 @@ export default nextConnect({
   .use(controller.injectRequestMetadata)
   .use(authentication.injectAnonymousOrUser)
   .use(controller.logRequest)
-  .get(authorization.canRequest('read:session'), getHandler);
+  .get(authorization.canRequest('read:session'), renewSessionIfNecessary, getHandler);
 
 async function getHandler(request, response) {
   const authenticatedUser = request.context.user;
@@ -19,4 +20,16 @@ async function getHandler(request, response) {
   const secureOutputValues = authorization.filterOutput(authenticatedUser, 'read:user:self', authenticatedUser);
 
   return response.status(200).json(secureOutputValues);
+}
+
+async function renewSessionIfNecessary(request, response, next) {
+  let sessionObject = request.context.session;
+
+  // Renew session if it expires in less than 3 weeks.
+  if (new Date(sessionObject.expires_at) < Date.now() + 1000 * 60 * 60 * 24 * 7 * 3) {
+    sessionObject = await session.renew(sessionObject.id, response);
+
+    request.context.session = sessionObject;
+  }
+  return next();
 }

--- a/tests/integration/api/v1/_use-cases/registration-flow.test.js
+++ b/tests/integration/api/v1/_use-cases/registration-flow.test.js
@@ -133,30 +133,35 @@ describe('Use case: Registration Flow (all successfully)', () => {
     expect(parsedCookiesFromPost.session_id.httpOnly).toEqual(true);
   });
 
-  test('Use session (successfully)', async () => {
-    const getSessionResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/sessions`, {
+  test('Get user (successfully)', async () => {
+    const getUserResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/user`, {
       method: 'get',
       headers: {
         cookie: `session_id=${parsedCookiesFromPost.session_id.value}`,
       },
     });
 
-    const getSessionResponseBody = await getSessionResponse.json();
+    const getUserResponseBody = await getUserResponse.json();
 
-    expect(getSessionResponse.status).toEqual(200);
-    expect(getSessionResponseBody.id).toEqual(postSessionResponseBody.id);
-    expect(Date.parse(getSessionResponseBody.expires_at)).not.toEqual(NaN);
-    expect(Date.parse(getSessionResponseBody.created_at)).not.toEqual(NaN);
-    expect(Date.parse(getSessionResponseBody.updated_at)).not.toEqual(NaN);
-    expect(getSessionResponseBody.expires_at > postSessionResponseBody.expires_at).toBe(true);
-    expect(getSessionResponseBody.created_at === postSessionResponseBody.created_at).toBe(true);
-    expect(getSessionResponseBody.updated_at > postSessionResponseBody.updated_at).toBe(true);
-
-    const parsedCookiesFromGet = authentication.parseSetCookies(getSessionResponse);
-    expect(parsedCookiesFromGet.session_id.name).toEqual('session_id');
-    expect(parsedCookiesFromGet.session_id.value).toEqual(parsedCookiesFromPost.session_id.value);
-    expect(parsedCookiesFromGet.session_id.maxAge).toEqual(60 * 60 * 24 * 30);
-    expect(parsedCookiesFromGet.session_id.path).toEqual('/');
-    expect(parsedCookiesFromGet.session_id.httpOnly).toEqual(true);
+    expect(getUserResponse.status).toEqual(200);
+    expect(getUserResponseBody).toStrictEqual({
+      id: postUserResponseBody.id,
+      username: postUserResponseBody.username,
+      email: 'regularregistrationflow@gmail.com',
+      notifications: true,
+      features: [
+        'create:session',
+        'read:session',
+        'create:content',
+        'create:content:text_root',
+        'create:content:text_child',
+        'update:content',
+        'update:user',
+      ],
+      tabcoins: 0,
+      tabcash: 0,
+      created_at: postUserResponseBody.created_at,
+      updated_at: getUserResponseBody.updated_at,
+    });
   });
 });

--- a/tests/integration/api/v1/sessions/get.test.js
+++ b/tests/integration/api/v1/sessions/get.test.js
@@ -4,140 +4,30 @@ import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();
-  await orchestrator.dropAllTables();
-  await orchestrator.runPendingMigrations();
 });
 
 describe('GET /api/v1/sessions', () => {
   describe('Anonymous user', () => {
-    test('Retrieving the endpoint', async () => {
-      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/sessions`);
-
-      const responseBody = await response.json();
-
-      expect(response.status).toEqual(403);
-      expect(responseBody.status_code).toEqual(403);
-      expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('Usuário não pode executar esta operação.');
-      expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "read:session".');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
-    });
-
-    test('Retrieving the endpoint with malformatted "session_id" (too short)', async () => {
+    test('With invalid HTTP `method`', async () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/sessions`, {
         method: 'GET',
-        headers: {
-          cookie: `session_id=tooshort`,
-        },
       });
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"session_id" deve possuir 96 caracteres.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(responseBody.key).toEqual('session_id');
-    });
+      expect(response.status).toEqual(404);
 
-    test('Retrieving the endpoint with malformatted "session_id" (too long)', async () => {
-      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/sessions`, {
-        method: 'GET',
-        headers: {
-          cookie: `session_id=97characterslongggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg`,
-        },
+      expect(responseBody).toStrictEqual({
+        name: 'NotFoundError',
+        message: 'Não foi possível encontrar este recurso no sistema.',
+        action: 'Verifique se o caminho (PATH) e o método (GET, POST, PUT, DELETE) estão corretos.',
+        status_code: 404,
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
       });
 
-      const responseBody = await response.json();
-
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"session_id" deve possuir 96 caracteres.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(responseBody.key).toEqual('session_id');
-    });
-
-    test('Retrieving the endpoint with correct length "session_id", but with invalid characters', async () => {
-      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/sessions`, {
-        method: 'GET',
-        headers: {
-          cookie: `session_id=%208427a9as213d2a80da05b25c76b43fa539ec09303fb7ea146ba661208c1a475ed0d91847f16123d257c858994e4aaf8`,
-        },
-      });
-
-      const responseBody = await response.json();
-
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"session_id" deve conter apenas caracteres alfanuméricos.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(responseBody.key).toEqual('session_id');
-    });
-  });
-
-  describe('Default user', () => {
-    test('With valid session and necessary features', async () => {
-      const defaultUser = await orchestrator.createUser();
-      await orchestrator.activateUser(defaultUser);
-      const sessionObject = await orchestrator.createSession(defaultUser);
-
-      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/sessions`, {
-        method: 'GET',
-        headers: {
-          cookie: `session_id=${sessionObject.token}`,
-        },
-      });
-
-      const responseBody = await response.json();
-
-      expect(response.status).toBe(200);
-      expect(responseBody.id).toEqual(sessionObject.id);
-      expect(responseBody.created_at).toEqual(sessionObject.created_at.toISOString());
-      expect(responseBody.expires_at > sessionObject.expires_at.toISOString()).toEqual(true);
-      expect(responseBody.updated_at > sessionObject.updated_at.toISOString()).toEqual(true);
-    });
-
-    test('With valid session, but user lost "read:session" feature', async () => {
-      const defaultUser = await orchestrator.createUser();
-      await orchestrator.activateUser(defaultUser);
-      const sessionObject = await orchestrator.createSession(defaultUser);
-      await orchestrator.removeFeaturesFromUser(defaultUser, ['read:session']);
-
-      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/sessions`, {
-        method: 'GET',
-        headers: {
-          cookie: `session_id=${sessionObject.token}`,
-        },
-      });
-
-      const responseBody = await response.json();
-
-      expect(response.status).toBe(403);
-      expect(responseBody.status_code).toEqual(403);
-      expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('Você não possui permissão para executar esta ação.');
-      expect(responseBody.action).toEqual(
-        'Verifique se este usuário já ativou a sua conta e recebeu a feature "read:session".'
-      );
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual(
-        'MODEL:AUTHENTICATION:INJECT_AUTHENTICATED_USER:USER_CANT_READ_SESSION'
-      );
     });
   });
 });

--- a/tests/integration/api/v1/user/get.test.js
+++ b/tests/integration/api/v1/user/get.test.js
@@ -1,6 +1,7 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
 import orchestrator from 'tests/orchestrator.js';
+import authentication from 'models/authentication';
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();
@@ -23,6 +24,81 @@ describe('GET /api/v1/user', () => {
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
       expect(responseBody.error_location_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
+
+      const parsedCookiesFromGet = authentication.parseSetCookies(response);
+      expect(parsedCookiesFromGet).toStrictEqual({});
+    });
+
+    test('Retrieving the endpoint with malformatted "session_id" (too short)', async () => {
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/user`, {
+        method: 'GET',
+        headers: {
+          cookie: `session_id=tooshort`,
+        },
+      });
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual('"session_id" deve possuir 96 caracteres.');
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.key).toEqual('session_id');
+
+      const parsedCookiesFromGet = authentication.parseSetCookies(response);
+      expect(parsedCookiesFromGet).toStrictEqual({});
+    });
+
+    test('Retrieving the endpoint with malformatted "session_id" (too long)', async () => {
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/user`, {
+        method: 'GET',
+        headers: {
+          cookie: `session_id=97characterslongggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg`,
+        },
+      });
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual('"session_id" deve possuir 96 caracteres.');
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.key).toEqual('session_id');
+
+      const parsedCookiesFromGet = authentication.parseSetCookies(response);
+      expect(parsedCookiesFromGet).toStrictEqual({});
+    });
+
+    test('Retrieving the endpoint with correct length "session_id", but with invalid characters', async () => {
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/user`, {
+        method: 'GET',
+        headers: {
+          cookie: `session_id=%208427a9as213d2a80da05b25c76b43fa539ec09303fb7ea146ba661208c1a475ed0d91847f16123d257c858994e4aaf8`,
+        },
+      });
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+      expect(responseBody.status_code).toEqual(400);
+      expect(responseBody.name).toEqual('ValidationError');
+      expect(responseBody.message).toEqual('"session_id" deve conter apenas caracteres alfanuméricos.');
+      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.key).toEqual('session_id');
+
+      const parsedCookiesFromGet = authentication.parseSetCookies(response);
+      expect(parsedCookiesFromGet).toStrictEqual({});
     });
   });
 
@@ -30,12 +106,12 @@ describe('GET /api/v1/user', () => {
     test('With valid session and necessary features', async () => {
       let defaultUser = await orchestrator.createUser();
       defaultUser = await orchestrator.activateUser(defaultUser);
-      const sessionObject = await orchestrator.createSession(defaultUser);
+      const defaultUserSession = await orchestrator.createSession(defaultUser);
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/user`, {
         method: 'GET',
         headers: {
-          cookie: `session_id=${sessionObject.token}`,
+          cookie: `session_id=${defaultUserSession.token}`,
         },
       });
 
@@ -53,6 +129,12 @@ describe('GET /api/v1/user', () => {
         created_at: defaultUser.created_at.toISOString(),
         updated_at: defaultUser.updated_at.toISOString(),
       });
+
+      const parsedCookiesFromGet = authentication.parseSetCookies(response);
+      expect(parsedCookiesFromGet).toStrictEqual({});
+
+      const sessionObject = await orchestrator.findSessionByToken(defaultUserSession.token);
+      expect(sessionObject).toStrictEqual(defaultUserSession);
     });
 
     test('With valid session, but user lost "read:session" feature', async () => {
@@ -82,6 +164,200 @@ describe('GET /api/v1/user', () => {
       expect(responseBody.error_location_code).toEqual(
         'MODEL:AUTHENTICATION:INJECT_AUTHENTICATED_USER:USER_CANT_READ_SESSION'
       );
+
+      const parsedCookiesFromGet = authentication.parseSetCookies(response);
+      expect(parsedCookiesFromGet).toStrictEqual({});
+    });
+
+    test('With expired session', async () => {
+      jest.useFakeTimers({
+        now: new Date(Date.now() - 1000 * 60 * 60 * 24 * 30), // 30 days ago
+        advanceTimers: true,
+      });
+
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const defaultUserSession = await orchestrator.createSession(defaultUser);
+
+      jest.useRealTimers();
+
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/user`, {
+        method: 'GET',
+        headers: {
+          cookie: `session_id=${defaultUserSession.token}`,
+        },
+      });
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(401);
+      expect(responseBody.status_code).toEqual(401);
+      expect(responseBody.name).toEqual('UnauthorizedError');
+      expect(responseBody.message).toEqual('Usuário não possui sessão ativa.');
+      expect(responseBody.action).toEqual('Verifique se este usuário está logado.');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+
+      const parsedCookiesFromGet = authentication.parseSetCookies(response);
+      expect(parsedCookiesFromGet.session_id.name).toEqual('session_id');
+      expect(parsedCookiesFromGet.session_id.value).toEqual('invalid');
+      expect(parsedCookiesFromGet.session_id.maxAge).toEqual(-1);
+      expect(parsedCookiesFromGet.session_id.path).toEqual('/');
+      expect(parsedCookiesFromGet.session_id.httpOnly).toEqual(true);
+
+      const sessionObject = await orchestrator.findSessionByToken(defaultUserSession.token);
+      expect(sessionObject).toBeUndefined();
+    });
+
+    describe('Renew Session', () => {
+      test('Should be able to renew with token almost expiring', async () => {
+        // 29 days, 23 hours and 59 minutes (1 minute left to expire)
+        jest.useFakeTimers({
+          now: new Date(Date.now() - 1000 * 60 * 60 * 24 * 30 + 1000 * 60),
+          advanceTimers: true,
+        });
+
+        let defaultUser = await orchestrator.createUser();
+        defaultUser = await orchestrator.activateUser(defaultUser);
+        const defaultUserSession = await orchestrator.createSession(defaultUser);
+
+        jest.useRealTimers();
+
+        const sessionObjectBeforeRenew = await orchestrator.findSessionByToken(defaultUserSession.token);
+
+        const response = await fetch(`${orchestrator.webserverUrl}/api/v1/user`, {
+          method: 'GET',
+          headers: {
+            cookie: `session_id=${sessionObjectBeforeRenew.token}`,
+          },
+        });
+
+        const responseBody = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(responseBody).toStrictEqual({
+          id: defaultUser.id,
+          username: defaultUser.username,
+          email: defaultUser.email,
+          notifications: defaultUser.notifications,
+          features: defaultUser.features,
+          tabcoins: defaultUser.tabcoins,
+          tabcash: defaultUser.tabcash,
+          created_at: defaultUser.created_at.toISOString(),
+          updated_at: defaultUser.updated_at.toISOString(),
+        });
+
+        const parsedCookiesFromGet = authentication.parseSetCookies(response);
+        expect(parsedCookiesFromGet.session_id.name).toEqual('session_id');
+        expect(parsedCookiesFromGet.session_id.value).toEqual(sessionObjectBeforeRenew.token);
+        expect(parsedCookiesFromGet.session_id.maxAge).toEqual(60 * 60 * 24 * 30);
+        expect(parsedCookiesFromGet.session_id.path).toEqual('/');
+        expect(parsedCookiesFromGet.session_id.httpOnly).toEqual(true);
+
+        const sessionObjectAfterRenew = await orchestrator.findSessionByToken(defaultUserSession.token);
+        expect(sessionObjectBeforeRenew).toStrictEqual(defaultUserSession);
+        expect(sessionObjectAfterRenew.id).toEqual(sessionObjectBeforeRenew.id);
+        expect(sessionObjectAfterRenew.created_at).toEqual(sessionObjectBeforeRenew.created_at);
+        expect(sessionObjectAfterRenew.expires_at > sessionObjectBeforeRenew.expires_at).toEqual(true);
+        expect(sessionObjectAfterRenew.updated_at > sessionObjectBeforeRenew.updated_at).toEqual(true);
+      });
+
+      test('Should be able to renew with 9 day token', async () => {
+        jest.useFakeTimers({
+          now: new Date(Date.now() - 1000 * 60 * 60 * 24 * 9), // 9 days ago
+          advanceTimers: true,
+        });
+
+        let defaultUser = await orchestrator.createUser();
+        defaultUser = await orchestrator.activateUser(defaultUser);
+        const defaultUserSession = await orchestrator.createSession(defaultUser);
+
+        jest.useRealTimers();
+
+        const sessionObjectBeforeRenew = await orchestrator.findSessionByToken(defaultUserSession.token);
+
+        expect(sessionObjectBeforeRenew).toStrictEqual(defaultUserSession);
+
+        const response = await fetch(`${orchestrator.webserverUrl}/api/v1/user`, {
+          method: 'GET',
+          headers: {
+            cookie: `session_id=${sessionObjectBeforeRenew.token}`,
+          },
+        });
+
+        const responseBody = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(responseBody).toStrictEqual({
+          id: defaultUser.id,
+          username: defaultUser.username,
+          email: defaultUser.email,
+          notifications: defaultUser.notifications,
+          features: defaultUser.features,
+          tabcoins: defaultUser.tabcoins,
+          tabcash: defaultUser.tabcash,
+          created_at: defaultUser.created_at.toISOString(),
+          updated_at: defaultUser.updated_at.toISOString(),
+        });
+
+        const parsedCookiesFromGet = authentication.parseSetCookies(response);
+        expect(parsedCookiesFromGet.session_id.name).toEqual('session_id');
+        expect(parsedCookiesFromGet.session_id.value).toEqual(sessionObjectBeforeRenew.token);
+        expect(parsedCookiesFromGet.session_id.maxAge).toEqual(60 * 60 * 24 * 30);
+        expect(parsedCookiesFromGet.session_id.path).toEqual('/');
+        expect(parsedCookiesFromGet.session_id.httpOnly).toEqual(true);
+
+        const sessionObjectAfterRenew = await orchestrator.findSessionByToken(defaultUserSession.token);
+        expect(sessionObjectAfterRenew.id).toEqual(sessionObjectBeforeRenew.id);
+        expect(sessionObjectAfterRenew.created_at).toEqual(sessionObjectBeforeRenew.created_at);
+        expect(sessionObjectAfterRenew.expires_at > sessionObjectBeforeRenew.expires_at).toEqual(true);
+        expect(sessionObjectAfterRenew.updated_at > sessionObjectBeforeRenew.updated_at).toEqual(true);
+      });
+
+      test('Should not be able to renew with less than 9 days token', async () => {
+        jest.useFakeTimers({
+          now: new Date(Date.now() - 1000 * 60 * 60 * 24 * 9 + 1000 * 60), // 1 minute left for 9 days
+          advanceTimers: true,
+        });
+
+        let defaultUser = await orchestrator.createUser();
+        defaultUser = await orchestrator.activateUser(defaultUser);
+        const defaultUserSession = await orchestrator.createSession(defaultUser);
+
+        jest.useRealTimers();
+
+        const sessionObjectBeforeRenew = await orchestrator.findSessionByToken(defaultUserSession.token);
+
+        expect(sessionObjectBeforeRenew).toStrictEqual(defaultUserSession);
+
+        const response = await fetch(`${orchestrator.webserverUrl}/api/v1/user`, {
+          method: 'GET',
+          headers: {
+            cookie: `session_id=${sessionObjectBeforeRenew.token}`,
+          },
+        });
+
+        const responseBody = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(responseBody).toStrictEqual({
+          id: defaultUser.id,
+          username: defaultUser.username,
+          email: defaultUser.email,
+          notifications: defaultUser.notifications,
+          features: defaultUser.features,
+          tabcoins: defaultUser.tabcoins,
+          tabcash: defaultUser.tabcash,
+          created_at: defaultUser.created_at.toISOString(),
+          updated_at: defaultUser.updated_at.toISOString(),
+        });
+
+        const parsedCookiesFromGet = authentication.parseSetCookies(response);
+        expect(parsedCookiesFromGet).toStrictEqual({});
+
+        const sessionObjectAfterRenew = await orchestrator.findSessionByToken(defaultUserSession.token);
+        expect(sessionObjectAfterRenew).toStrictEqual(sessionObjectBeforeRenew);
+      });
     });
   });
 });

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -131,6 +131,10 @@ async function createSession(userObject) {
   return await session.create(userObject.id);
 }
 
+async function findSessionByToken(token) {
+  return await session.findOneValidByToken(token);
+}
+
 async function createContent(contentObject) {
   return await content.create({
     parent_id: contentObject?.parent_id || undefined,
@@ -276,6 +280,7 @@ export default {
   createUser,
   activateUser,
   createSession,
+  findSessionByToken,
   addFeaturesToUser,
   removeFeaturesFromUser,
   createContent,


### PR DESCRIPTION
Faz a renovação da sessão do usuário ocorrer apenas no endpoint `/user` conforme a issue #1375.

Outra mudança é que a renovação vai ocorrer apenas se faltar menos do que 3 semanas para o token expirar.

Por fim, o método `GET` do endpoint `/sessions` foi removido, mas ele tinha uma certa utilidade nos testes, pois era a única maneira de obter mais dados sobre o token.

Esses dados realmente não deveriam existir fora do backend, então estou pensando qual das alternativas usar para confirmar o teste de renovação do token.