### PR TITLE
Melhora a performance das consultas de conteúdos

### DIFF
--- a/models/authorization.js
+++ b/models/authorization.js
@@ -235,6 +235,7 @@ function filterOutput(user, feature, output) {
       clonedOutput.body = '[Não disponível]';
       clonedOutput.slug = 'nao-disponivel';
       clonedOutput.source_url = null;
+      clonedOutput.children_deep_count = 0;
     }
 
     filteredOutputValues = validator(clonedOutput, {

--- a/pages/api/v1/contents/[username]/[slug]/children/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/children/index.public.js
@@ -26,7 +26,6 @@ function getValidationHandler(request, response, next) {
   next();
 }
 
-// TODO: cache the response
 async function getHandler(request, response) {
   const userTryingToGet = user.createAnonymous();
 
@@ -48,7 +47,7 @@ async function getHandler(request, response) {
     });
   }
 
-  const childrenFound = await content.findChildrenTree({
+  const childrenFound = await content.findTree({
     where: {
       parent_id: contentFound.id,
     },

--- a/pages/api/v1/contents/[username]/[slug]/root/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/root/index.public.js
@@ -60,7 +60,7 @@ async function getHandler(request, response) {
 
   const rootContentFound = await content.findRootContent({
     where: {
-      id: contentFound.id,
+      id: contentFound.parent_id,
     },
   });
 


### PR DESCRIPTION
Foram realizadas diversas pequenas otimizações nas consultas dentro do model contents.

A maioria deve ser difícil de mensurar, pois só foram eliminados alguns passos desnecessários, mas que devem ter impacto na casa dos micro segundos. Por isso quis fazer essas modificações antes da criação do `root_id` e da criação de índices, assim temos como tentar medir se houve algum impacto.

A principal mudança é na criação das páginas estáticas de conteúdos root, e essa é possível medir o impacto da mudança, pois agora só é necessária uma única ida ao banco de dados para obter todos os dados da página.

Essa consulta é realizada dentro da função `findTree()`.

Em homologação a criação de uma página chegou a levar 128ms, mas no geral está ficando abaixo de 1s. 🎉