### PR TITLE
[Fix] Retorna 404 em caso de erro na validação de username ou slug

### DIFF
--- a/models/validator.js
+++ b/models/validator.js
@@ -99,6 +99,7 @@ const schemas = {
         .max(30)
         .trim()
         .invalid(null)
+        .custom(checkReservedUsernames, 'check if username is reserved')
         .when('$required.owner_username', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
           'any.required': `"owner_username" é um campo obrigatório.`,
@@ -108,6 +109,7 @@ const schemas = {
           'string.min': `"owner_username" deve conter no mínimo {#limit} caracteres.`,
           'string.max': `"owner_username" deve conter no máximo {#limit} caracteres.`,
           'any.invalid': `"owner_username" possui o valor inválido "null".`,
+          'username.reserved': `Este nome de usuário não está disponível para uso.`,
         }),
     });
   },

--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -1,6 +1,6 @@
 import { Box, Button, Confetti, Content, DefaultLayout, Link, TabCoinButtons, Tooltip } from '@/TabNewsUI';
 import { CommentDiscussionIcon, CommentIcon, FoldIcon, UnfoldIcon } from '@primer/octicons-react';
-import { NotFoundError } from 'errors/index.js';
+import { NotFoundError, ValidationError } from 'errors/index.js';
 import webserver from 'infra/webserver.js';
 import authorization from 'models/authorization.js';
 import content from 'models/content.js';
@@ -328,6 +328,12 @@ export const getStaticProps = getStaticPropsRevalidate(async (context) => {
       });
     }
   } catch (error) {
+    if (error instanceof ValidationError) {
+      return {
+        notFound: true,
+      };
+    }
+
     if (error instanceof NotFoundError) {
       return {
         notFound: true,


### PR DESCRIPTION
No PR #1400 eu modifiquei a validação para ocorrer por dentro do `findTree` e não mais diretamente em `getStaticProps`.

Só que não estava sendo capturado corretamente o erro de validação e não era retornado o erro 404. Apenas era disparado o erro, o que levava para a página de erro 500.

Apenas para conteúdos realmente não encontrados no banco de dados o erro estava sendo capturado corretamente e direcionando para a página 404.

Agora o erro de validação está sendo capturado corretamente e a validação do `owner_username` ficou igual ao do `username`.