### PR TITLE
Cria funções para definir configurações de cache para endpoints/métodos da API

### DIFF
--- a/models/cache-control.js
+++ b/models/cache-control.js
@@ -1,0 +1,40 @@
+import { InternalServerError } from 'errors';
+
+function setCacheControl(res, cacheControl) {
+  const cacheControlHeader = res.getHeaders()['cache-control'];
+
+  if (cacheControlHeader?.toLowerCase() === cacheControl.toLowerCase()) return;
+
+  res.setHeader('Cache-Control', cacheControl);
+
+  const setHeader = res.setHeader;
+
+  res.setHeader = (name, value) => {
+    if (name.toLowerCase() === 'cache-control') {
+      throw new InternalServerError({
+        message: `Header Cache-Control já foi definido.`,
+        errorLocationCode: 'MODEL:CACHE_CONTROL:DIFFERENT_CACHE_CONTROL_ALREADY_DEFINED',
+      });
+    }
+    return setHeader(name, value);
+  };
+}
+
+function noCache(_, res, next) {
+  setCacheControl(res, 'no-cache, no-store, max-age=0, must-revalidate');
+  if (next) next();
+}
+
+function swrMaxAge(maxAge = 10) {
+  if (!Number.isInteger(maxAge)) throw new TypeError('maxAge must be an integer.');
+
+  return (_, res, next) => {
+    setCacheControl(res, `public, s-maxage=${maxAge.toString()}, stale-while-revalidate`);
+    if (next) next();
+  };
+}
+
+export default Object.freeze({
+  noCache,
+  swrMaxAge,
+});

--- a/models/controller.js
+++ b/models/controller.js
@@ -72,7 +72,13 @@ function onErrorHandler(error, request, response) {
     errorLocationCode: error.errorLocationCode,
   });
 
-  const privateErrorObject = { ...publicErrorObject, context: { ...request.context }, stack: error.stack };
+  const privateErrorObject = {
+    ...new InternalServerError({
+      ...error,
+      requestId: request.context?.requestId,
+    }),
+    context: { ...request.context },
+  };
 
   logger.error(snakeize(privateErrorObject));
 

--- a/models/session.js
+++ b/models/session.js
@@ -3,6 +3,7 @@ import cookie from 'cookie';
 import database from 'infra/database.js';
 import { UnauthorizedError } from 'errors/index.js';
 import validator from 'models/validator.js';
+import cacheControl from 'models/cache-control';
 
 const SESSION_EXPIRATION_IN_SECONDS = 60 * 60 * 24 * 30; // 30 days
 
@@ -21,6 +22,7 @@ async function create(userId) {
 }
 
 function setSessionIdCookieInResponse(sessionToken, response) {
+  cacheControl.noCache(undefined, response);
   response.setHeader('Set-Cookie', [
     cookie.serialize('session_id', sessionToken, {
       httpOnly: true,
@@ -74,6 +76,7 @@ async function expireAllFromUserId(userId, options = {}) {
 
 // TODO: mark session as invalid also in Database.
 function clearSessionIdCookie(response) {
+  cacheControl.noCache(undefined, response);
   response.setHeader('Set-Cookie', [
     cookie.serialize('session_id', 'invalid', {
       httpOnly: true,

--- a/pages/api/v1/activation/index.public.js
+++ b/pages/api/v1/activation/index.public.js
@@ -4,6 +4,7 @@ import activation from 'models/activation.js';
 import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
 import validator from 'models/validator.js';
+import cacheControl from 'models/cache-control';
 
 export default nextConnect({
   attachParams: true,
@@ -13,6 +14,7 @@ export default nextConnect({
   .use(controller.injectRequestMetadata)
   .use(authentication.injectAnonymousOrUser)
   .use(controller.logRequest)
+  .use(cacheControl.noCache)
   .patch(patchValidationHandler, authorization.canRequest('read:activation_token'), patchHandler);
 
 function patchValidationHandler(request, response, next) {

--- a/pages/api/v1/analytics/child-content-published/index.public.js
+++ b/pages/api/v1/analytics/child-content-published/index.public.js
@@ -1,6 +1,7 @@
 import nextConnect from 'next-connect';
 import controller from 'models/controller.js';
 import analytics from 'models/analytics.js';
+import cacheControl from 'models/cache-control';
 
 export default nextConnect({
   attachParams: true,
@@ -9,11 +10,11 @@ export default nextConnect({
 })
   .use(controller.injectRequestMetadata)
   .use(controller.logRequest)
+  .use(cacheControl.swrMaxAge(300))
   .get(getHandler);
 
 async function getHandler(request, response) {
   const contentsPublished = await analytics.getChildContentsPublished();
 
-  response.setHeader('Cache-Control', 'public, 300, stale-while-revalidate');
   return response.status(200).json(contentsPublished);
 }

--- a/pages/api/v1/analytics/root-content-published/index.public.js
+++ b/pages/api/v1/analytics/root-content-published/index.public.js
@@ -1,6 +1,7 @@
 import nextConnect from 'next-connect';
 import controller from 'models/controller.js';
 import analytics from 'models/analytics.js';
+import cacheControl from 'models/cache-control';
 
 export default nextConnect({
   attachParams: true,
@@ -9,11 +10,11 @@ export default nextConnect({
 })
   .use(controller.injectRequestMetadata)
   .use(controller.logRequest)
+  .use(cacheControl.swrMaxAge(300))
   .get(getHandler);
 
 async function getHandler(request, response) {
   const contentsPublished = await analytics.getRootContentsPublished();
 
-  response.setHeader('Cache-Control', 'public, 300, stale-while-revalidate');
   return response.status(200).json(contentsPublished);
 }

--- a/pages/api/v1/analytics/users-created/index.public.js
+++ b/pages/api/v1/analytics/users-created/index.public.js
@@ -1,6 +1,7 @@
 import nextConnect from 'next-connect';
 import controller from 'models/controller.js';
 import analytics from 'models/analytics.js';
+import cacheControl from 'models/cache-control';
 
 export default nextConnect({
   attachParams: true,
@@ -9,11 +10,11 @@ export default nextConnect({
 })
   .use(controller.injectRequestMetadata)
   .use(controller.logRequest)
+  .use(cacheControl.swrMaxAge(300))
   .get(getHandler);
 
 async function getHandler(request, response) {
   const usersCreated = await analytics.getUsersCreated();
 
-  response.setHeader('Cache-Control', 'public, 300, stale-while-revalidate');
   return response.status(200).json(usersCreated);
 }

--- a/pages/api/v1/contents/[username]/[slug]/children/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/children/index.public.js
@@ -1,6 +1,7 @@
 import nextConnect from 'next-connect';
 import controller from 'models/controller.js';
 import authorization from 'models/authorization.js';
+import cacheControl from 'models/cache-control';
 import validator from 'models/validator.js';
 import content from 'models/content.js';
 import { NotFoundError } from 'errors/index.js';
@@ -13,6 +14,7 @@ export default nextConnect({
 })
   .use(controller.injectRequestMetadata)
   .use(controller.logRequest)
+  .use(cacheControl.swrMaxAge(10))
   .get(getValidationHandler, getHandler);
 
 function getValidationHandler(request, response, next) {
@@ -54,8 +56,6 @@ async function getHandler(request, response) {
   });
 
   const secureOutputValues = authorization.filterOutput(userTryingToGet, 'read:content:list', childrenFound);
-
-  response.setHeader('Cache-Control', 'public, s-maxage=10, stale-while-revalidate');
 
   return response.status(200).json(secureOutputValues);
 }

--- a/pages/api/v1/contents/[username]/[slug]/parent/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/parent/index.public.js
@@ -2,6 +2,7 @@ import nextConnect from 'next-connect';
 import controller from 'models/controller.js';
 import user from 'models/user.js';
 import authorization from 'models/authorization.js';
+import cacheControl from 'models/cache-control';
 import validator from 'models/validator.js';
 import content from 'models/content.js';
 import { NotFoundError } from 'errors/index.js';
@@ -13,6 +14,7 @@ export default nextConnect({
 })
   .use(controller.injectRequestMetadata)
   .use(controller.logRequest)
+  .use(cacheControl.swrMaxAge(10))
   .get(getValidationHandler, getHandler);
 
 function getValidationHandler(request, response, next) {
@@ -65,8 +67,6 @@ async function getHandler(request, response) {
   });
 
   const secureParentContent = authorization.filterOutput(userTryingToGet, 'read:content', parentContentFound);
-
-  response.setHeader('Cache-Control', 'public, s-maxage=10, stale-while-revalidate');
 
   return response.status(200).json(secureParentContent);
 }

--- a/pages/api/v1/contents/[username]/[slug]/root/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/root/index.public.js
@@ -2,6 +2,7 @@ import nextConnect from 'next-connect';
 import controller from 'models/controller.js';
 import user from 'models/user.js';
 import authorization from 'models/authorization.js';
+import cacheControl from 'models/cache-control';
 import validator from 'models/validator.js';
 import content from 'models/content.js';
 import { NotFoundError } from 'errors/index.js';
@@ -13,6 +14,7 @@ export default nextConnect({
 })
   .use(controller.injectRequestMetadata)
   .use(controller.logRequest)
+  .use(cacheControl.swrMaxAge(10))
   .get(getValidationHandler, getHandler);
 
 function getValidationHandler(request, response, next) {
@@ -65,8 +67,6 @@ async function getHandler(request, response) {
   });
 
   const secureOutputValues = authorization.filterOutput(userTryingToGet, 'read:content', rootContentFound);
-
-  response.setHeader('Cache-Control', 'public, s-maxage=10, stale-while-revalidate');
 
   return response.status(200).json(secureOutputValues);
 }

--- a/pages/api/v1/contents/[username]/[slug]/tabcoins/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/tabcoins/index.public.js
@@ -2,6 +2,7 @@ import nextConnect from 'next-connect';
 import controller from 'models/controller.js';
 import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
+import cacheControl from 'models/cache-control';
 import validator from 'models/validator.js';
 import content from 'models/content.js';
 import event from 'models/event.js';
@@ -17,6 +18,7 @@ export default nextConnect({
   .use(controller.injectRequestMetadata)
   .use(authentication.injectAnonymousOrUser)
   .use(controller.logRequest)
+  .use(cacheControl.noCache)
   .post(postValidationHandler, authorization.canRequest('update:content'), postHandler);
 
 function postValidationHandler(request, response, next) {

--- a/pages/api/v1/contents/[username]/[slug]/thumbnail/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/thumbnail/index.public.js
@@ -1,4 +1,5 @@
 import nextConnect from 'next-connect';
+import cacheControl from 'models/cache-control';
 import controller from 'models/controller';
 import validator from 'models/validator.js';
 import content from 'models/content.js';
@@ -12,6 +13,7 @@ export default nextConnect({
 })
   .use(controller.injectRequestMetadata)
   .use(controller.logRequest)
+  .use(cacheControl.swrMaxAge(60))
   .get(getValidationHandler, getHandler);
 
 function getValidationHandler(request, response, next) {
@@ -48,6 +50,5 @@ async function getHandler(request, response) {
 
   response.statusCode = 200;
   response.setHeader('Content-Type', `image/png`);
-  response.setHeader('Cache-Control', 'public, s-maxage=60, stale-while-revalidate');
   response.end(thumbnailPng);
 }

--- a/pages/api/v1/contents/[username]/index.public.js
+++ b/pages/api/v1/contents/[username]/index.public.js
@@ -1,6 +1,7 @@
 import nextConnect from 'next-connect';
 import controller from 'models/controller.js';
 import authorization from 'models/authorization.js';
+import cacheControl from 'models/cache-control';
 import validator from 'models/validator.js';
 import content from 'models/content.js';
 import removeMarkdown from 'models/remove-markdown.js';
@@ -13,6 +14,7 @@ export default nextConnect({
 })
   .use(controller.injectRequestMetadata)
   .use(controller.logRequest)
+  .use(cacheControl.swrMaxAge(10))
   .get(getValidationHandler, getHandler);
 
 function getValidationHandler(request, response, next) {
@@ -53,8 +55,6 @@ async function getHandler(request, response) {
   }
 
   controller.injectPaginationHeaders(results.pagination, `/api/v1/contents/${request.query.username}`, response);
-
-  response.setHeader('Cache-Control', 'public, s-maxage=10, stale-while-revalidate');
 
   return response.status(200).json(secureOutputValues);
 }

--- a/pages/api/v1/contents/rss/index.public.js
+++ b/pages/api/v1/contents/rss/index.public.js
@@ -1,6 +1,7 @@
 import nextConnect from 'next-connect';
 import controller from 'models/controller.js';
 import authorization from 'models/authorization.js';
+import cacheControl from 'models/cache-control';
 import user from 'models/user.js';
 import rss from 'models/rss';
 import content from 'models/content.js';
@@ -12,6 +13,7 @@ export default nextConnect({
 })
   .use(controller.injectRequestMetadata)
   .use(controller.logRequest)
+  .use(cacheControl.swrMaxAge(60))
   .get(handleRequest);
 
 async function handleRequest(request, response) {
@@ -33,6 +35,5 @@ async function handleRequest(request, response) {
   const rss2 = rss.generateRss2(secureContentListFound);
 
   response.setHeader('Content-Type', 'text/xml; charset=utf-8');
-  response.setHeader('Cache-Control', 'public, s-maxage=60, stale-while-revalidate');
   response.status(200).send(rss2);
 }

--- a/pages/api/v1/email-confirmation/index.public.js
+++ b/pages/api/v1/email-confirmation/index.public.js
@@ -2,6 +2,7 @@ import nextConnect from 'next-connect';
 import controller from 'models/controller.js';
 import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
+import cacheControl from 'models/cache-control';
 import emailConfirmation from 'models/email-confirmation.js';
 import validator from 'models/validator.js';
 
@@ -13,6 +14,7 @@ export default nextConnect({
   .use(controller.injectRequestMetadata)
   .use(authentication.injectAnonymousOrUser)
   .use(controller.logRequest)
+  .use(cacheControl.noCache)
   .patch(patchValidationHandler, patchHandler);
 
 function patchValidationHandler(request, response, next) {

--- a/pages/api/v1/migrations/index.public.js
+++ b/pages/api/v1/migrations/index.public.js
@@ -3,6 +3,7 @@ import controller from 'models/controller.js';
 import migrator from 'infra/migrator.js';
 import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
+import cacheControl from 'models/cache-control';
 
 export default nextConnect({
   attachParams: true,
@@ -12,6 +13,7 @@ export default nextConnect({
   .use(controller.injectRequestMetadata)
   .use(authentication.injectAnonymousOrUser)
   .use(controller.logRequest)
+  .use(cacheControl.noCache)
   .get(authorization.canRequest('read:migration'), getHandler)
   .post(authorization.canRequest('create:migration'), postHandler);
 

--- a/pages/api/v1/recovery/index.public.js
+++ b/pages/api/v1/recovery/index.public.js
@@ -2,6 +2,7 @@ import nextConnect from 'next-connect';
 import controller from 'models/controller.js';
 import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
+import cacheControl from 'models/cache-control';
 import recovery from 'models/recovery.js';
 import validator from 'models/validator.js';
 import { ForbiddenError } from 'errors';
@@ -14,6 +15,7 @@ export default nextConnect({
   .use(controller.injectRequestMetadata)
   .use(authentication.injectAnonymousOrUser)
   .use(controller.logRequest)
+  .use(cacheControl.noCache)
   .post(postValidationHandler, postHandler)
   .patch(patchValidationHandler, patchHandler);
 

--- a/pages/api/v1/sessions/index.public.js
+++ b/pages/api/v1/sessions/index.public.js
@@ -3,6 +3,7 @@ import controller from 'models/controller.js';
 import user from 'models/user';
 import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
+import cacheControl from 'models/cache-control';
 import { UnauthorizedError, ForbiddenError } from '/errors/index.js';
 import activation from 'models/activation.js';
 import validator from 'models/validator.js';
@@ -16,6 +17,7 @@ export default nextConnect({
   .use(controller.injectRequestMetadata)
   .use(authentication.injectAnonymousOrUser)
   .use(controller.logRequest)
+  .use(cacheControl.noCache)
   .delete(authorization.canRequest('read:session'), deleteHandler)
   .post(postValidationHandler, authorization.canRequest('create:session'), postHandler);
 

--- a/pages/api/v1/status/index.public.js
+++ b/pages/api/v1/status/index.public.js
@@ -1,5 +1,6 @@
 import nextConnect from 'next-connect';
 import { formatISO } from 'date-fns';
+import cacheControl from 'models/cache-control';
 import controller from 'models/controller.js';
 import health from 'models/health.js';
 
@@ -10,6 +11,7 @@ export default nextConnect({
 })
   .use(controller.injectRequestMetadata)
   .use(controller.logRequest)
+  .use(cacheControl.swrMaxAge(5))
   .get(getHandler);
 
 async function getHandler(request, response) {
@@ -20,8 +22,6 @@ async function getHandler(request, response) {
   if (checkedDependencies.database.status === 'unhealthy') {
     statusCode = 503;
   }
-
-  response.setHeader('Cache-Control', 'public, s-maxage=5, stale-while-revalidate');
 
   return response.status(statusCode).json({
     updated_at: formatISO(Date.now()),

--- a/pages/api/v1/user/index.public.js
+++ b/pages/api/v1/user/index.public.js
@@ -2,6 +2,7 @@ import nextConnect from 'next-connect';
 import controller from 'models/controller.js';
 import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
+import cacheControl from 'models/cache-control';
 import session from 'models/session';
 
 export default nextConnect({
@@ -12,6 +13,7 @@ export default nextConnect({
   .use(controller.injectRequestMetadata)
   .use(injectUserWithBalance)
   .use(controller.logRequest)
+  .use(cacheControl.noCache)
   .get(authorization.canRequest('read:session'), renewSessionIfNecessary, getHandler);
 
 async function getHandler(request, response) {

--- a/pages/api/v1/users/[username]/index.public.js
+++ b/pages/api/v1/users/[username]/index.public.js
@@ -1,4 +1,5 @@
 import nextConnect from 'next-connect';
+import cacheControl from 'models/cache-control';
 import controller from 'models/controller.js';
 import user from 'models/user.js';
 import ban from 'models/ban.js';
@@ -16,14 +17,16 @@ export default nextConnect({
 })
   .use(controller.injectRequestMetadata)
   .use(controller.logRequest)
-  .get(getValidationHandler, getHandler)
+  .get(cacheControl.swrMaxAge(10), getValidationHandler, getHandler)
   .patch(
+    cacheControl.noCache,
     authentication.injectAnonymousOrUser,
     patchValidationHandler,
     authorization.canRequest('update:user'),
     patchHandler
   )
   .delete(
+    cacheControl.noCache,
     authentication.injectAnonymousOrUser,
     deleteValidationHandler,
     authorization.canRequest('ban:user'),
@@ -47,8 +50,6 @@ async function getHandler(request, response) {
   });
 
   const secureOutputValues = authorization.filterOutput(userTryingToGet, 'read:user', userStoredFromDatabase);
-
-  response.setHeader('Cache-Control', 'public, s-maxage=10, stale-while-revalidate');
 
   return response.status(200).json(secureOutputValues);
 }

--- a/pages/api/v1/users/index.public.js
+++ b/pages/api/v1/users/index.public.js
@@ -5,6 +5,7 @@ import user from 'models/user.js';
 import activation from 'models/activation.js';
 import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
+import cacheControl from 'models/cache-control';
 import validator from 'models/validator.js';
 import event from 'models/event.js';
 import firewall from 'models/firewall.js';
@@ -17,6 +18,7 @@ export default nextConnect({
   .use(controller.injectRequestMetadata)
   .use(authentication.injectAnonymousOrUser)
   .use(controller.logRequest)
+  .use(cacheControl.noCache)
   .get(authorization.canRequest('read:user:list'), getHandler)
   .post(
     postValidationHandler,


### PR DESCRIPTION
Agora temos as funções `noCache` e `swrMaxAge(maxAge)` que devem ser chamadas em todos os endpoints da API. Assim definimos explicitamente onde queremos e onde não queremos armazenar cache.

Já adicionei as funções em quase todos os endpoints e não foi necessária nenhuma modificação em testes. Os únicos endpoints em que não defini o funcionamento do cache foram os que estão dentro de `/_responses`, pois, por serem acessados via redirecionamentos temporários, acho que pode haver algum conflito se enviarmos cabeçalhos de controle de cache ali.

As duas funções utilizam uma mesma função interna, a `setCacheControl` que modifica o funcionamento de `res.setHeader` para que dispare um erro caso os headers de controle de cache sejam definidos mais de uma vez (de maneiras diferentes) em uma mesma requisição.

Com isso será mais fácil saber se algum controle de cache for modificado em um endpoint que retorna o set-cookie, pois antes de definir o cabeçalho set-cookie, os controles de cache já são definidos para não armazenar nenhum cache, e não será possível modificá-los na mesma requisição.

Mas isso não elimina a necessidade de criarmos os testes citados em #1405, pois são coisas complementares.