### PR TITLE
Transforma `/contents` em um ponto capaz de fornecer todos os tipos de dados sobre os conteúdos públicos

### DIFF
--- a/models/notification.js
+++ b/models/notification.js
@@ -22,11 +22,13 @@ async function sendReplyEmailToParentUser(createdContent) {
     }
 
     const childContendUrl = getChildContendUrl(secureCreatedContent);
-    const rootContent = await content.findRootContent({
-      where: {
-        id: secureCreatedContent.id,
-      },
-    });
+    const rootContent = parentContent.parent_id
+      ? await content.findRootContent({
+          where: {
+            id: parentContent.parent_id,
+          },
+        })
+      : parentContent;
 
     const secureRootContent = authorization.filterOutput(anonymousUser, 'read:content', rootContent);
 

--- a/models/validator.js
+++ b/models/validator.js
@@ -503,6 +503,7 @@ const schemas = {
       'username',
       'owner_username',
       '$or',
+      '$not_null',
       'attributes',
     ]) {
       const keyValidationFunction = schemas[key];
@@ -548,6 +549,15 @@ const schemas = {
     });
   },
 
+  $not_null: function () {
+    return Joi.object({
+      $not_null: Joi.array().optional().items(Joi.string().valid('parent_id')).messages({
+        'array.base': `"#not_null" deve ser do tipo Array.`,
+        'any.only': `"#not_null" deve conter um dos seguintes valores: "parent_id".`,
+      }),
+    });
+  },
+
   attributes: function () {
     return Joi.object({
       attributes: Joi.object({
@@ -585,6 +595,8 @@ const schemas = {
       children: Joi.array().optional().items(Joi.link('#content')).messages({
         'array.base': `"children" deve ser do tipo Array.`,
       }),
+      parent: Joi.link('#content').optional(),
+      root: Joi.link('#content').optional(),
     })
       .required()
       .min(1)
@@ -780,6 +792,96 @@ const schemas = {
           'any.only': `"ban_type" deve possuir um dos seguintes valores: "nuke".`,
         }),
     });
+  },
+
+  with_children: function () {
+    return Joi.object({
+      with_children: Joi.boolean()
+        .allow(false)
+        .when('$required.with_children', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
+        .messages({
+          'any.required': `"with_children" é um campo obrigatório.`,
+          'string.empty': `"with_children" não pode estar em branco.`,
+          'boolean.base': `"with_children" deve ser do tipo Boolean.`,
+        }),
+    });
+  },
+
+  with_parent: function () {
+    return Joi.object({
+      with_parent: Joi.boolean()
+        .allow(false)
+        .when('$required.with_parent', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
+        .messages({
+          'any.required': `"with_parent" é um campo obrigatório.`,
+          'string.empty': `"with_parent" não pode estar em branco.`,
+          'boolean.base': `"with_parent" deve ser do tipo Boolean.`,
+        }),
+    });
+  },
+
+  with_root: function () {
+    return Joi.object({
+      with_root: Joi.boolean()
+        .allow(false)
+        .when('$required.with_root', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
+        .messages({
+          'any.required': `"with_root" é um campo obrigatório.`,
+          'string.empty': `"with_root" não pode estar em branco.`,
+          'boolean.base': `"with_root" deve ser do tipo Boolean.`,
+        }),
+    });
+  },
+
+  published_before: function () {
+    return Joi.object({
+      published_before: Joi.date()
+        .when('$required.published_before', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
+        .messages({
+          'any.required': `"published_before" é um campo obrigatório.`,
+          'string.empty': `"published_before" não pode estar em branco.`,
+          'string.base': `"published_before" deve ser do tipo Date.`,
+        }),
+    });
+  },
+
+  published_after: function () {
+    return Joi.object({
+      published_after: Joi.date()
+        .when('$required.published_after', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
+        .messages({
+          'any.required': `"published_after" é um campo obrigatório.`,
+          'string.empty': `"published_after" não pode estar em branco.`,
+          'string.base': `"published_after" deve ser do tipo Date.`,
+        }),
+    });
+  },
+
+  contents_query_string: function () {
+    let contentsQueryStringSchema = Joi.object({}).messages({
+      'object.base': `"contents_query_string" deve ser do tipo Object.`,
+    });
+
+    for (const key of [
+      'page',
+      'per_page',
+      'strategy',
+      'id',
+      'parent_id',
+      'slug',
+      'owner_id',
+      'owner_username',
+      'with_children',
+      'with_parent',
+      'with_root',
+      'published_before',
+      'published_after',
+    ]) {
+      const keyValidationFunction = schemas[key];
+      contentsQueryStringSchema = contentsQueryStringSchema.concat(keyValidationFunction());
+    }
+
+    return contentsQueryStringSchema;
   },
 };
 

--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -312,6 +312,7 @@ export async function getStaticPaths() {
 }
 
 export const getStaticProps = getStaticPropsRevalidate(async (context) => {
+  const contentPageStartTime = performance.now();
   const userTryingToGet = user.createAnonymous();
 
   let contentTreeFound;
@@ -389,6 +390,8 @@ export const getStaticProps = getStaticPropsRevalidate(async (context) => {
     parentContentFound.body = removeMarkdown(parentContentFound.body, { maxLength: 50 });
     secureParentContentFound = authorization.filterOutput(userTryingToGet, 'read:content', parentContentFound);
   }
+
+  console.log({ contentPageTime: performance.now() - contentPageStartTime });
 
   return {
     props: {

--- a/pages/api/v1/contents/[username]/[slug]/children/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/children/index.public.js
@@ -18,6 +18,7 @@ export default nextConnect({
   .get(getValidationHandler, getHandler);
 
 function getValidationHandler(request, response, next) {
+  const validatorStartTime = performance.now();
   const cleanValues = validator(request.query, {
     username: 'required',
     slug: 'required',
@@ -25,10 +26,13 @@ function getValidationHandler(request, response, next) {
 
   request.query = cleanValues;
 
+  console.log({ getChildrenValidationDuration: performance.now() - validatorStartTime, query: request.query });
+
   next();
 }
 
 async function getHandler(request, response) {
+  const getChildrenStartTime = performance.now();
   const userTryingToGet = user.createAnonymous();
 
   const contentTreeFound = await content.findTree({
@@ -50,7 +54,15 @@ async function getHandler(request, response) {
 
   const childrenFound = contentTreeFound[0].children;
 
+  const filterOutputStartTime = performance.now();
   const secureOutputValues = authorization.filterOutput(userTryingToGet, 'read:content:list', childrenFound);
+
+  const getChildrenEndTime = performance.now();
+  console.log({
+    getChildrenDuration: getChildrenEndTime - getChildrenStartTime,
+    filterOutputDuration: getChildrenEndTime - filterOutputStartTime,
+    query: request.query,
+  });
 
   return response.status(200).json(secureOutputValues);
 }

--- a/pages/api/v1/contents/[username]/[slug]/children/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/children/index.public.js
@@ -31,29 +31,24 @@ function getValidationHandler(request, response, next) {
 async function getHandler(request, response) {
   const userTryingToGet = user.createAnonymous();
 
-  const contentFound = await content.findOne({
+  const contentTreeFound = await content.findTree({
     where: {
       owner_username: request.query.username,
       slug: request.query.slug,
-      status: 'published',
     },
   });
 
-  if (!contentFound) {
+  if (!contentTreeFound?.length) {
     throw new NotFoundError({
       message: `O conteúdo informado não foi encontrado no sistema.`,
-      action: 'Verifique se o "slug" está digitado corretamente.',
+      action: 'Verifique se os dados foram digitados corretamente.',
       stack: new Error().stack,
-      errorLocationCode: 'CONTROLLER:CONTENT:CHILDREN:GET_HANDLER:SLUG_NOT_FOUND',
+      errorLocationCode: 'CONTROLLER:CONTENT:CHILDREN:GET_HANDLER:CONTENT_NOT_FOUND',
       key: 'slug',
     });
   }
 
-  const childrenFound = await content.findTree({
-    where: {
-      parent_id: contentFound.id,
-    },
-  });
+  const childrenFound = contentTreeFound[0].children;
 
   const secureOutputValues = authorization.filterOutput(userTryingToGet, 'read:content:list', childrenFound);
 

--- a/pages/api/v1/contents/[username]/[slug]/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/index.public.js
@@ -51,9 +51,9 @@ async function getHandler(request, response) {
   if (!contentFound) {
     throw new NotFoundError({
       message: `O conteúdo informado não foi encontrado no sistema.`,
-      action: 'Verifique se o "slug" está digitado corretamente.',
+      action: 'Verifique se os dados foram digitados corretamente.',
       stack: new Error().stack,
-      errorLocationCode: 'CONTROLLER:CONTENT:GET_HANDLER:SLUG_NOT_FOUND',
+      errorLocationCode: 'CONTROLLER:CONTENT:GET_HANDLER:CONTENT_NOT_FOUND',
       key: 'slug',
     });
   }
@@ -100,9 +100,9 @@ async function patchHandler(request, response) {
   if (!contentToBeUpdated) {
     throw new NotFoundError({
       message: `O conteúdo informado não foi encontrado no sistema.`,
-      action: 'Verifique se o "slug" está digitado corretamente.',
+      action: 'Verifique se os dados foram digitados corretamente.',
       stack: new Error().stack,
-      errorLocationCode: 'CONTROLLER:CONTENT:PATCH_HANDLER:SLUG_NOT_FOUND',
+      errorLocationCode: 'CONTROLLER:CONTENT:PATCH_HANDLER:CONTENT_NOT_FOUND',
       key: 'slug',
     });
   }

--- a/pages/api/v1/contents/[username]/[slug]/parent/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/parent/index.public.js
@@ -42,9 +42,9 @@ async function getHandler(request, response) {
   if (!contentFound) {
     throw new NotFoundError({
       message: `O conteúdo informado não foi encontrado no sistema.`,
-      action: 'Verifique se o "slug" está digitado corretamente.',
+      action: 'Verifique se os dados foram digitados corretamente.',
       stack: new Error().stack,
-      errorLocationCode: 'CONTROLLER:CONTENT:PARENT:GET_HANDLER:SLUG_NOT_FOUND',
+      errorLocationCode: 'CONTROLLER:CONTENT:PARENT:GET_HANDLER:CONTENT_NOT_FOUND',
       key: 'slug',
     });
   }

--- a/pages/api/v1/contents/[username]/[slug]/root/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/root/index.public.js
@@ -42,9 +42,9 @@ async function getHandler(request, response) {
   if (!contentFound) {
     throw new NotFoundError({
       message: `O conteúdo informado não foi encontrado no sistema.`,
-      action: 'Verifique se o "slug" está digitado corretamente.',
+      action: 'Verifique se os dados foram digitados corretamente.',
       stack: new Error().stack,
-      errorLocationCode: 'CONTROLLER:CONTENT:ROOT:GET_HANDLER:SLUG_NOT_FOUND',
+      errorLocationCode: 'CONTROLLER:CONTENT:ROOT:GET_HANDLER:CONTENT_NOT_FOUND',
       key: 'slug',
     });
   }

--- a/pages/api/v1/contents/[username]/[slug]/tabcoins/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/tabcoins/index.public.js
@@ -52,7 +52,7 @@ async function postHandler(request, response) {
   if (!contentFound) {
     throw new NotFoundError({
       message: `O conteúdo informado não foi encontrado no sistema.`,
-      action: 'Verifique se o "slug" está digitado corretamente.',
+      action: 'Verifique se os dados foram digitados corretamente.',
       stack: new Error().stack,
       errorLocationCode: 'CONTROLLER:CONTENT:TABCOINS:CONTENT_NOT_FOUND',
       key: 'slug',

--- a/pages/api/v1/contents/[username]/[slug]/thumbnail/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/thumbnail/index.public.js
@@ -39,9 +39,9 @@ async function getHandler(request, response) {
   if (!contentFound) {
     throw new NotFoundError({
       message: `Este conteúdo não está disponível.`,
-      action: 'Verifique se o "slug" está digitado corretamente ou considere o fato do conteúdo ter sido despublicado.',
+      action: 'Verifique se o endereço foi digitado corretamente ou considere o fato do conteúdo ter sido excluído.',
       stack: new Error().stack,
-      errorLocationCode: 'CONTROLLER:CONTENT:THUMBNAIL:GET_HANDLER:SLUG_NOT_FOUND',
+      errorLocationCode: 'CONTROLLER:CONTENT:THUMBNAIL:GET_HANDLER:CONTENT_NOT_FOUND',
       key: 'slug',
     });
   }

--- a/pages/api/v1/contents/index.public.js
+++ b/pages/api/v1/contents/index.public.js
@@ -40,6 +40,7 @@ function getValidationHandler(request, response, next) {
 }
 
 async function getHandler(request, response) {
+  const getContentStartTime = performance.now();
   const userTryingToGet = user.createAnonymous();
 
   let feature = request.query.parent_id ? 'read:content:list' : 'read:content';
@@ -52,7 +53,16 @@ async function getHandler(request, response) {
     feature = 'read:content:list';
   }
 
+  const filterOutputStartTime = performance.now();
   const secureOutputValues = authorization.filterOutput(userTryingToGet, feature, results);
+
+  const getContentsEndTime = performance.now();
+
+  console.log({
+    getContentTotalTime: getContentsEndTime - getContentStartTime,
+    filterOutputTotalTime: getContentsEndTime - filterOutputStartTime,
+    query: request.query,
+  });
 
   return response.status(200).json(secureOutputValues);
 }

--- a/pages/interface/hooks/useCollapse/index.js
+++ b/pages/interface/hooks/useCollapse/index.js
@@ -1,55 +1,108 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export default function useCollapse({
+  id,
+  childrenDeepCount = 0,
   childrenList,
   renderIntent = 20,
   renderIncrement = 10,
-  flatten = false,
   minimalSubTree = 3,
 }) {
-  const flattenedTree = useMemo(flattenTree, [childrenList, flatten]);
-  const [childrenState, setChildrenState] = useState(() =>
-    computeStates(flattenedTree, renderIntent, [], minimalSubTree)
+  const [eldestChildDate, setEldestChildDate] = useState();
+  const [extraChildrenList, setExtraChildrenList] = useState([]);
+  const [childrenWithState, setChildrenWithState] = useState(() =>
+    computeStates({
+      children: [...childrenList, ...extraChildrenList],
+      renderIntent,
+      childrenDeepCount,
+      minimalSubTree,
+    })
   );
 
   useEffect(() => {
-    setChildrenState((lastState) => computeStates(flattenedTree, renderIntent, lastState, minimalSubTree));
-  }, [flattenedTree, minimalSubTree, renderIntent]);
+    const newChildrenList = [
+      ...childrenList,
+      ...extraChildrenList.filter((newChild) => !childrenList.some((child) => child.id === newChild.id)),
+    ];
 
-  const filteredTree = useMemo(() => {
-    let merged = [];
+    setChildrenWithState((lastState) =>
+      computeStates({ children: newChildrenList, renderIntent, childrenDeepCount, lastState, minimalSubTree })
+    );
 
-    flattenedTree.forEach((child, index) => {
-      if (!child.id) return;
-      if (child.id !== childrenState[index]?.id) return;
-      if (child.renderIntent < 1 && !child.renderShowMore) return;
-      merged.push({ ...childrenState[index], ...child });
+    setEldestChildDate((previousEldestChildDate) => {
+      let eldestChildDate = newChildrenList.at(-1)?.published_at || previousEldestChildDate;
+
+      newChildrenList.forEach((child) => {
+        if (new Date(child.published_at) < new Date(eldestChildDate)) {
+          eldestChildDate = child.published_at;
+        }
+      });
+
+      return eldestChildDate;
     });
+  }, [childrenDeepCount, minimalSubTree, renderIntent, childrenList, extraChildrenList]);
 
-    return merged;
-  }, [childrenState, flattenedTree]);
+  async function handleExpand(id) {
+    if (id !== 'needToFetch') {
+      setChildrenWithState((previousState) => {
+        const childIndex = previousState.findIndex((child) => child.id === id);
+        let grouperIndex = childIndex;
+        let childrenToExpand = [];
 
-  function handleExpand(id) {
-    setChildrenState((lastState) => {
-      const childIndex = lastState.findIndex((child) => child.id === id);
-      let grouperIndex = childIndex;
-      let childrenToExpand = [];
+        while (previousState[grouperIndex]?.renderIntent === 0) {
+          childrenToExpand.push(previousState[grouperIndex]);
+          grouperIndex += 1;
+        }
 
-      while (lastState[grouperIndex]?.renderIntent === 0) {
-        childrenToExpand.push(flattenedTree[grouperIndex]);
-        grouperIndex += 1;
-      }
+        return [
+          ...previousState.slice(0, childIndex),
+          ...computeStates({
+            children: childrenToExpand,
+            renderIntent: renderIncrement,
+            childrenDeepCount: previousState[childIndex].groupedCount,
+          }),
+          ...previousState.slice(grouperIndex),
+        ];
+      });
+    }
 
-      return [
-        ...lastState.slice(0, childIndex),
-        ...computeStates(childrenToExpand, renderIncrement),
-        ...lastState.slice(grouperIndex),
-      ];
-    });
+    const extraChildren = (await getMoreChildren()) || [];
+
+    if (id === 'needToFetch') {
+      setChildrenWithState((previousState) => {
+        const filteredExtraChildren = extraChildren.filter(
+          (newChild) => !previousState.some((child) => child.id === newChild.id)
+        );
+        return [
+          ...previousState.slice(0, -1),
+          ...computeStates({
+            children: filteredExtraChildren,
+            renderIntent: renderIncrement,
+            childrenDeepCount: previousState.at(-1).groupedCount,
+          }),
+        ];
+      });
+    }
+
+    setExtraChildrenList((lastExtraChildrenList) => [
+      ...lastExtraChildrenList,
+      ...extraChildren
+        .filter((newChild) => !lastExtraChildrenList.some((child) => child.id === newChild.id))
+        .filter((newChild) => !childrenList.some((child) => child.id === newChild.id)),
+    ]);
+  }
+
+  async function getMoreChildren() {
+    const published_before = eldestChildDate ? `&published_before=${eldestChildDate}` : '';
+    const response = await fetch(`/api/v1/contents?parent_id=${id}&per_page=${renderIncrement}${published_before}`);
+
+    if (!response.ok) return;
+
+    return await response.json();
   }
 
   function handleCollapse(id) {
-    setChildrenState((lastState) => {
+    setChildrenWithState((lastState) => {
       const childIndex = lastState.findIndex((child) => child.id === id);
       let children = [...lastState];
 
@@ -57,9 +110,11 @@ export default function useCollapse({
 
       children[childIndex].renderIntent = 0;
       children[childIndex].renderShowMore = true;
+      children[childIndex].hiddenAvailable = countAvailable(lastState[childIndex]);
 
       if (lastState[childIndex + 1]?.renderIntent === 0) {
         children[childIndex].groupedCount += lastState[childIndex + 1].groupedCount;
+        children[childIndex].hiddenAvailable += lastState[childIndex + 1].hiddenAvailable;
         children[childIndex + 1].renderShowMore = false;
       }
 
@@ -71,6 +126,7 @@ export default function useCollapse({
         }
 
         children[groupedIndex].groupedCount += children[childIndex].groupedCount;
+        children[groupedIndex].hiddenAvailable += children[childIndex].hiddenAvailable;
         groupedIndex -= 1;
       }
 
@@ -78,52 +134,47 @@ export default function useCollapse({
     });
   }
 
-  function flattenTree() {
-    if (!childrenList?.length) return [];
-    if (!flatten) return childrenList;
-
-    let flattenTree = [...childrenList];
-
-    while (flattenTree.at(-1)?.children?.length === 1) {
-      flattenTree = [
-        ...flattenTree.slice(0, -1),
-        { ...flattenTree.at(-1), children: [], children_deep_count: 0 },
-        ...flattenTree.at(-1).children,
-      ];
-    }
-
-    return flattenTree;
-  }
-
   return {
-    filteredTree,
+    childrenWithState,
     handleCollapse,
     handleExpand,
   };
 }
 
-function computeStates(children, renderIntent, lastState = [], minimalSubTree) {
-  let newStates = [];
+function computeStates({ children, renderIntent, childrenDeepCount, lastState = [], minimalSubTree = 3 }) {
+  if (!children?.length && childrenDeepCount === 0) return [];
+
   let remaining = renderIntent;
   let treeIntent = minimalSubTree;
   let grouperIndex = null;
+  let groupedCount = 0;
   let deltaIndex = 0;
+  let needToFetch = childrenDeepCount;
+  let hiddenAvailable = 0;
 
-  children.forEach((child, index) => {
-    if (lastState.length > 0) {
+  const newStates = children.map((child, index) => {
+    needToFetch -= 1 + child.children_deep_count;
+
+    if (lastState.length > 0 && lastState[0]?.id !== 'needToFetch') {
       if (lastState[index + deltaIndex]?.id === child.id && child.id) {
-        newStates.push(lastState[index + deltaIndex]);
-        remaining -= lastState[index + deltaIndex].renderIntent;
-        return;
+        const childLastState = lastState[index + deltaIndex];
+        remaining -= childLastState.renderIntent;
+        if (childLastState.renderShowMore) grouperIndex = index;
+        if (childLastState.renderIntent) grouperIndex = null;
+
+        return { ...childLastState, ...child };
       }
 
+      // in case any child has changed order
       const childLastStateIndex = lastState.findIndex((childLastState) => childLastState.id === child.id && child.id);
 
       if (childLastStateIndex > -1) {
         deltaIndex = childLastStateIndex - index;
-        newStates.push(lastState[childLastStateIndex]);
         remaining -= lastState[childLastStateIndex].renderIntent;
-        return;
+        if (lastState[childLastStateIndex].renderShowMore) grouperIndex = index;
+        if (lastState[childLastStateIndex].renderIntent) grouperIndex = null;
+
+        return { ...lastState[childLastStateIndex], ...child };
       }
     }
 
@@ -134,34 +185,35 @@ function computeStates(children, renderIntent, lastState = [], minimalSubTree) {
       const renderIntent = treeIntent > child.children_deep_count ? 1 + child.children_deep_count : treeIntent;
       remaining -= renderIntent;
 
-      newStates.push({
-        id: child.id,
+      return {
+        ...child,
         renderIntent: renderIntent,
         groupedCount: 1 + child.children_deep_count,
         renderShowMore: false,
-      });
-    } else if (grouperIndex === null) {
+      };
+    }
+
+    groupedCount += 1 + child.children_deep_count;
+    hiddenAvailable += countAvailable(child);
+
+    if (grouperIndex === null) {
       grouperIndex = index;
       remaining -= 1;
 
-      newStates.push({
-        id: child.id,
+      return {
+        ...child,
         renderIntent: 0,
         groupedCount: 1 + child.children_deep_count,
         renderShowMore: true,
-      });
-    } else {
-      if (newStates[grouperIndex]) {
-        newStates[grouperIndex].groupedCount += 1 + child.children_deep_count;
-      }
-
-      newStates.push({
-        id: child.id,
-        renderIntent: 0,
-        groupedCount: 1 + child.children_deep_count,
-        renderShowMore: false,
-      });
+      };
     }
+
+    return {
+      ...child,
+      renderIntent: 0,
+      groupedCount: 1 + child.children_deep_count,
+      renderShowMore: false,
+    };
   });
 
   for (const child of newStates) {
@@ -176,5 +228,39 @@ function computeStates(children, renderIntent, lastState = [], minimalSubTree) {
     }
   }
 
+  if (grouperIndex !== null) {
+    const grouper = newStates[grouperIndex];
+
+    if (grouper.hiddenAvailable !== undefined) {
+      grouper.hiddenAvailable += hiddenAvailable;
+      grouper.groupedCount += groupedCount;
+    } else {
+      grouper.hiddenAvailable = hiddenAvailable;
+      grouper.groupedCount = groupedCount + needToFetch;
+    }
+  }
+
+  if (needToFetch > 0 && grouperIndex === null) {
+    newStates.push({
+      id: 'needToFetch',
+      renderIntent: 0,
+      groupedCount: groupedCount + needToFetch,
+      renderShowMore: true,
+      hiddenAvailable: hiddenAvailable,
+    });
+  }
+
   return newStates;
+}
+
+function countAvailable(child) {
+  let available = 1;
+
+  if (child.children?.length > 0) {
+    child.children.forEach((subChild) => {
+      available += countAvailable(subChild);
+    });
+  }
+
+  return available;
 }

--- a/tests/integration/api/v1/contents/[username]/[slug]/children/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/children/get.test.js
@@ -27,10 +27,10 @@ describe('GET /api/v1/contents/[username]/[slug]/children', () => {
       expect(responseBody.status_code).toEqual(404);
       expect(responseBody.name).toEqual('NotFoundError');
       expect(responseBody.message).toEqual('O conteúdo informado não foi encontrado no sistema.');
-      expect(responseBody.action).toEqual('Verifique se o "slug" está digitado corretamente.');
+      expect(responseBody.action).toEqual('Verifique se os dados foram digitados corretamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('CONTROLLER:CONTENT:CHILDREN:GET_HANDLER:SLUG_NOT_FOUND');
+      expect(responseBody.error_location_code).toEqual('CONTROLLER:CONTENT:CHILDREN:GET_HANDLER:CONTENT_NOT_FOUND');
     });
 
     test('From "root" content with "deleted" status', async () => {
@@ -52,10 +52,10 @@ describe('GET /api/v1/contents/[username]/[slug]/children', () => {
       expect(responseBody.status_code).toEqual(404);
       expect(responseBody.name).toEqual('NotFoundError');
       expect(responseBody.message).toEqual('O conteúdo informado não foi encontrado no sistema.');
-      expect(responseBody.action).toEqual('Verifique se o "slug" está digitado corretamente.');
+      expect(responseBody.action).toEqual('Verifique se os dados foram digitados corretamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('CONTROLLER:CONTENT:CHILDREN:GET_HANDLER:SLUG_NOT_FOUND');
+      expect(responseBody.error_location_code).toEqual('CONTROLLER:CONTENT:CHILDREN:GET_HANDLER:CONTENT_NOT_FOUND');
     });
 
     test('From "root" content with "published" status with no children', async () => {

--- a/tests/integration/api/v1/contents/[username]/[slug]/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/get.test.js
@@ -17,11 +17,11 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
       expect(response.status).toEqual(404);
       expect(responseBody.status_code).toEqual(404);
       expect(responseBody.name).toEqual('NotFoundError');
-      expect(responseBody.message).toEqual('O "username" informado não foi encontrado no sistema.');
-      expect(responseBody.action).toEqual('Verifique se o "username" está digitado corretamente.');
+      expect(responseBody.message).toEqual('O conteúdo informado não foi encontrado no sistema.');
+      expect(responseBody.action).toEqual('Verifique se os dados foram digitados corretamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:USER:FIND_ONE_BY_USERNAME:NOT_FOUND');
+      expect(responseBody.error_location_code).toEqual('CONTROLLER:CONTENT:GET_HANDLER:CONTENT_NOT_FOUND');
     });
 
     test('Content with "username" existent, but "slug" non-existent', async () => {
@@ -37,10 +37,10 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
       expect(responseBody.status_code).toEqual(404);
       expect(responseBody.name).toEqual('NotFoundError');
       expect(responseBody.message).toEqual('O conteúdo informado não foi encontrado no sistema.');
-      expect(responseBody.action).toEqual('Verifique se o "slug" está digitado corretamente.');
+      expect(responseBody.action).toEqual('Verifique se os dados foram digitados corretamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('CONTROLLER:CONTENT:GET_HANDLER:SLUG_NOT_FOUND');
+      expect(responseBody.error_location_code).toEqual('CONTROLLER:CONTENT:GET_HANDLER:CONTENT_NOT_FOUND');
     });
 
     test('Content "root" with "status" set to "draft"', async () => {
@@ -63,10 +63,10 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
       expect(responseBody.status_code).toEqual(404);
       expect(responseBody.name).toEqual('NotFoundError');
       expect(responseBody.message).toEqual('O conteúdo informado não foi encontrado no sistema.');
-      expect(responseBody.action).toEqual('Verifique se o "slug" está digitado corretamente.');
+      expect(responseBody.action).toEqual('Verifique se os dados foram digitados corretamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('CONTROLLER:CONTENT:GET_HANDLER:SLUG_NOT_FOUND');
+      expect(responseBody.error_location_code).toEqual('CONTROLLER:CONTENT:GET_HANDLER:CONTENT_NOT_FOUND');
     });
 
     test('Content "root" with "status" set to "published"', async () => {
@@ -133,11 +133,11 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
         message: 'O conteúdo informado não foi encontrado no sistema.',
-        action: 'Verifique se o "slug" está digitado corretamente.',
+        action: 'Verifique se os dados foram digitados corretamente.',
         status_code: 404,
         error_id: responseBody.error_id,
         request_id: responseBody.request_id,
-        error_location_code: 'CONTROLLER:CONTENT:GET_HANDLER:SLUG_NOT_FOUND',
+        error_location_code: 'CONTROLLER:CONTENT:GET_HANDLER:CONTENT_NOT_FOUND',
         key: 'slug',
       });
 
@@ -242,10 +242,10 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
       expect(responseBody.status_code).toEqual(404);
       expect(responseBody.name).toEqual('NotFoundError');
       expect(responseBody.message).toEqual('O conteúdo informado não foi encontrado no sistema.');
-      expect(responseBody.action).toEqual('Verifique se o "slug" está digitado corretamente.');
+      expect(responseBody.action).toEqual('Verifique se os dados foram digitados corretamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('CONTROLLER:CONTENT:GET_HANDLER:SLUG_NOT_FOUND');
+      expect(responseBody.error_location_code).toEqual('CONTROLLER:CONTENT:GET_HANDLER:CONTENT_NOT_FOUND');
     });
 
     test('Content "child" with "status" set to "published"', async () => {
@@ -391,11 +391,11 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
         message: 'O conteúdo informado não foi encontrado no sistema.',
-        action: 'Verifique se o "slug" está digitado corretamente.',
+        action: 'Verifique se os dados foram digitados corretamente.',
         status_code: 404,
         error_id: responseBody.error_id,
         request_id: responseBody.request_id,
-        error_location_code: 'CONTROLLER:CONTENT:GET_HANDLER:SLUG_NOT_FOUND',
+        error_location_code: 'CONTROLLER:CONTENT:GET_HANDLER:CONTENT_NOT_FOUND',
         key: 'slug',
       });
 

--- a/tests/integration/api/v1/contents/[username]/[slug]/parent/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/parent/get.test.js
@@ -28,11 +28,11 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
         message: 'O conteúdo informado não foi encontrado no sistema.',
-        action: 'Verifique se o "slug" está digitado corretamente.',
+        action: 'Verifique se os dados foram digitados corretamente.',
         status_code: 404,
         error_id: responseBody.error_id,
         request_id: responseBody.request_id,
-        error_location_code: 'CONTROLLER:CONTENT:PARENT:GET_HANDLER:SLUG_NOT_FOUND',
+        error_location_code: 'CONTROLLER:CONTENT:PARENT:GET_HANDLER:CONTENT_NOT_FOUND',
         key: 'slug',
       });
 
@@ -60,11 +60,11 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
         message: 'O conteúdo informado não foi encontrado no sistema.',
-        action: 'Verifique se o "slug" está digitado corretamente.',
+        action: 'Verifique se os dados foram digitados corretamente.',
         status_code: 404,
         error_id: responseBody.error_id,
         request_id: responseBody.request_id,
-        error_location_code: 'CONTROLLER:CONTENT:PARENT:GET_HANDLER:SLUG_NOT_FOUND',
+        error_location_code: 'CONTROLLER:CONTENT:PARENT:GET_HANDLER:CONTENT_NOT_FOUND',
         key: 'slug',
       });
 
@@ -132,11 +132,11 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
         message: 'O conteúdo informado não foi encontrado no sistema.',
-        action: 'Verifique se o "slug" está digitado corretamente.',
+        action: 'Verifique se os dados foram digitados corretamente.',
         status_code: 404,
         error_id: responseBody.error_id,
         request_id: responseBody.request_id,
-        error_location_code: 'CONTROLLER:CONTENT:PARENT:GET_HANDLER:SLUG_NOT_FOUND',
+        error_location_code: 'CONTROLLER:CONTENT:PARENT:GET_HANDLER:CONTENT_NOT_FOUND',
         key: 'slug',
       });
 
@@ -177,11 +177,11 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
         message: 'O conteúdo informado não foi encontrado no sistema.',
-        action: 'Verifique se o "slug" está digitado corretamente.',
+        action: 'Verifique se os dados foram digitados corretamente.',
         status_code: 404,
         error_id: responseBody.error_id,
         request_id: responseBody.request_id,
-        error_location_code: 'CONTROLLER:CONTENT:PARENT:GET_HANDLER:SLUG_NOT_FOUND',
+        error_location_code: 'CONTROLLER:CONTENT:PARENT:GET_HANDLER:CONTENT_NOT_FOUND',
         key: 'slug',
       });
 

--- a/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
@@ -264,11 +264,11 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       expect(response.status).toEqual(404);
       expect(responseBody.status_code).toEqual(404);
       expect(responseBody.name).toEqual('NotFoundError');
-      expect(responseBody.message).toEqual('O "username" informado não foi encontrado no sistema.');
-      expect(responseBody.action).toEqual('Verifique se o "username" está digitado corretamente.');
+      expect(responseBody.message).toEqual('O conteúdo informado não foi encontrado no sistema.');
+      expect(responseBody.action).toEqual('Verifique se os dados foram digitados corretamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:USER:FIND_ONE_BY_USERNAME:NOT_FOUND');
+      expect(responseBody.error_location_code).toEqual('CONTROLLER:CONTENT:PATCH_HANDLER:CONTENT_NOT_FOUND');
     });
 
     test('Content with "username" existent, but "slug" non-existent', async () => {
@@ -303,10 +303,10 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       expect(responseBody.status_code).toEqual(404);
       expect(responseBody.name).toEqual('NotFoundError');
       expect(responseBody.message).toEqual('O conteúdo informado não foi encontrado no sistema.');
-      expect(responseBody.action).toEqual('Verifique se o "slug" está digitado corretamente.');
+      expect(responseBody.action).toEqual('Verifique se os dados foram digitados corretamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('CONTROLLER:CONTENT:PATCH_HANDLER:SLUG_NOT_FOUND');
+      expect(responseBody.error_location_code).toEqual('CONTROLLER:CONTENT:PATCH_HANDLER:CONTENT_NOT_FOUND');
     });
 
     test('Content with "username" and "slug" pointing to content from another user', async () => {
@@ -1304,11 +1304,11 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
         message: 'O conteúdo informado não foi encontrado no sistema.',
-        action: 'Verifique se o "slug" está digitado corretamente.',
+        action: 'Verifique se os dados foram digitados corretamente.',
         status_code: 404,
         error_id: responseBody.error_id,
         request_id: responseBody.request_id,
-        error_location_code: 'CONTROLLER:CONTENT:PATCH_HANDLER:SLUG_NOT_FOUND',
+        error_location_code: 'CONTROLLER:CONTENT:PATCH_HANDLER:CONTENT_NOT_FOUND',
         key: 'slug',
       });
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
@@ -1803,11 +1803,11 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       expect(republishedResponseBody).toStrictEqual({
         name: 'NotFoundError',
         message: 'O conteúdo informado não foi encontrado no sistema.',
-        action: 'Verifique se o "slug" está digitado corretamente.',
+        action: 'Verifique se os dados foram digitados corretamente.',
         status_code: 404,
         error_id: republishedResponseBody.error_id,
         request_id: republishedResponseBody.request_id,
-        error_location_code: 'CONTROLLER:CONTENT:PATCH_HANDLER:SLUG_NOT_FOUND',
+        error_location_code: 'CONTROLLER:CONTENT:PATCH_HANDLER:CONTENT_NOT_FOUND',
         key: 'slug',
       });
       expect(uuidVersion(republishedResponseBody.error_id)).toEqual(4);

--- a/tests/integration/api/v1/contents/[username]/[slug]/root/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/root/get.test.js
@@ -28,11 +28,11 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
         message: 'O conteúdo informado não foi encontrado no sistema.',
-        action: 'Verifique se o "slug" está digitado corretamente.',
+        action: 'Verifique se os dados foram digitados corretamente.',
         status_code: 404,
         error_id: responseBody.error_id,
         request_id: responseBody.request_id,
-        error_location_code: 'CONTROLLER:CONTENT:ROOT:GET_HANDLER:SLUG_NOT_FOUND',
+        error_location_code: 'CONTROLLER:CONTENT:ROOT:GET_HANDLER:CONTENT_NOT_FOUND',
         key: 'slug',
       });
 
@@ -60,11 +60,11 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
         message: 'O conteúdo informado não foi encontrado no sistema.',
-        action: 'Verifique se o "slug" está digitado corretamente.',
+        action: 'Verifique se os dados foram digitados corretamente.',
         status_code: 404,
         error_id: responseBody.error_id,
         request_id: responseBody.request_id,
-        error_location_code: 'CONTROLLER:CONTENT:ROOT:GET_HANDLER:SLUG_NOT_FOUND',
+        error_location_code: 'CONTROLLER:CONTENT:ROOT:GET_HANDLER:CONTENT_NOT_FOUND',
         key: 'slug',
       });
 
@@ -132,11 +132,11 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
         message: 'O conteúdo informado não foi encontrado no sistema.',
-        action: 'Verifique se o "slug" está digitado corretamente.',
+        action: 'Verifique se os dados foram digitados corretamente.',
         status_code: 404,
         error_id: responseBody.error_id,
         request_id: responseBody.request_id,
-        error_location_code: 'CONTROLLER:CONTENT:ROOT:GET_HANDLER:SLUG_NOT_FOUND',
+        error_location_code: 'CONTROLLER:CONTENT:ROOT:GET_HANDLER:CONTENT_NOT_FOUND',
         key: 'slug',
       });
 
@@ -177,11 +177,11 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
         message: 'O conteúdo informado não foi encontrado no sistema.',
-        action: 'Verifique se o "slug" está digitado corretamente.',
+        action: 'Verifique se os dados foram digitados corretamente.',
         status_code: 404,
         error_id: responseBody.error_id,
         request_id: responseBody.request_id,
-        error_location_code: 'CONTROLLER:CONTENT:ROOT:GET_HANDLER:SLUG_NOT_FOUND',
+        error_location_code: 'CONTROLLER:CONTENT:ROOT:GET_HANDLER:CONTENT_NOT_FOUND',
         key: 'slug',
       });
 

--- a/tests/integration/api/v1/contents/[username]/[slug]/thumbnail/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/thumbnail/get.test.js
@@ -30,12 +30,11 @@ describe('GET /api/v1/contents/[username]/[slug]/thumbnail', () => {
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
         message: 'Este conteúdo não está disponível.',
-        action:
-          'Verifique se o "slug" está digitado corretamente ou considere o fato do conteúdo ter sido despublicado.',
+        action: 'Verifique se o endereço foi digitado corretamente ou considere o fato do conteúdo ter sido excluído.',
         status_code: 404,
         error_id: responseBody.error_id,
         request_id: responseBody.request_id,
-        error_location_code: 'CONTROLLER:CONTENT:THUMBNAIL:GET_HANDLER:SLUG_NOT_FOUND',
+        error_location_code: 'CONTROLLER:CONTENT:THUMBNAIL:GET_HANDLER:CONTENT_NOT_FOUND',
         key: 'slug',
       });
 
@@ -63,12 +62,11 @@ describe('GET /api/v1/contents/[username]/[slug]/thumbnail', () => {
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
         message: 'Este conteúdo não está disponível.',
-        action:
-          'Verifique se o "slug" está digitado corretamente ou considere o fato do conteúdo ter sido despublicado.',
+        action: 'Verifique se o endereço foi digitado corretamente ou considere o fato do conteúdo ter sido excluído.',
         status_code: 404,
         error_id: responseBody.error_id,
         request_id: responseBody.request_id,
-        error_location_code: 'CONTROLLER:CONTENT:THUMBNAIL:GET_HANDLER:SLUG_NOT_FOUND',
+        error_location_code: 'CONTROLLER:CONTENT:THUMBNAIL:GET_HANDLER:CONTENT_NOT_FOUND',
         key: 'slug',
       });
 

--- a/tests/integration/api/v1/contents/[username]/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/get.test.js
@@ -15,14 +15,8 @@ describe('GET /api/v1/contents/[username]', () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents/ThisUserDoesNotExists`);
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(404);
-      expect(responseBody.status_code).toEqual(404);
-      expect(responseBody.name).toEqual('NotFoundError');
-      expect(responseBody.message).toEqual('O "username" informado não foi encontrado no sistema.');
-      expect(responseBody.action).toEqual('Verifique se o "username" está digitado corretamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:USER:FIND_ONE_BY_USERNAME:NOT_FOUND');
+      expect(response.status).toEqual(200);
+      expect(responseBody).toEqual([]);
     });
 
     test('"username" existent, but with no content at all', async () => {


### PR DESCRIPTION
São tantas possibilidades de combinações que fica até difícil de listar. Então vou só dar uma visão geral de cada parâmetro aceito, e a maioria das coisas que vocês imaginarem deve funcionar, ou seja, vai existir uma configuração perfeita para cada sistema que usar a API:

**page e per_page**: Paginação das listas de conteúdos (pais e/ou filhos). Usando junto com `strategy` é o mesmo funcionamento atual, mas para qualquer dos tipos de listas retornadas. Em breve servirá também para a paginação dos comentários na árvore de conteúdo.
**strategy**: Para listas, define a estratégia de ranqueamento dos conteúdos (seja root ou children). No caso de consultas que retornam a árvore, define a forma de classificação dos comentários em cada nível da árvore.
**id**: Busca um conteúdo pelo `id` e pode trazer mais informações de acordo com `with_children`, `with_parent` e `with_root`.
**parent_id**: Busca a lista de conteúdos abaixo de um conteúdo dono do `id` fornecido, incluindo todas as árvores abaixo.
**slug**: Busca um conteúdo através do `slug` junto de mais algum parâmetro do autor. Pode ser o `owner_id` ou o `owner_username`.
**owner_id**: Sem `slug` retorna a lista de conteúdos e/ou comentários de um autor. Com `slug` retorna um conteúdo específico.
**owner_username**: Forma um pouco mais custosa de obter o mesmo retorno que com `owner_id`.
**with_root**: Booleano que define os tipos de conteúdos retornados. Nas listas de conteúdo é `true` por padrão, o que devolve os conteúdos "root". Nas consultas de árvores define se o conteúdo raiz estará incluída no objeto retornado. Nesse caso o padrão é `false`.
**with_parent**: Booleano para definir se o conteúdo pai do conteúdo pesquisado deve ser incluído na resposta. O padrão é `false`.
**with_children**: Mesma coisa que `with_root`, mas para os comentários. Só que o padrão é `false` para todos os casos. Os três últimos podem ser combinados conforme a necessidade para retornar todos os dados necessários em uma única requisição.

Vou deixar algumas consultas interessantes:

**O mesmo padrão atual**
https://tabnews-esor3rk95-tabnews.vercel.app/api/v1/contents?strategy=new

**Buscando também os comentários**
https://tabnews-esor3rk95-tabnews.vercel.app/api/v1/contents?strategy=relevant&with_children=true
Notem que a classificação acima mistura os conteúdos, por isso é do mesmo tipo de classificação de relevantes de comentários. Apenas no modo padrão, sem children, é que a classificação usa o mesmo método da página de relevantes.

**Buscando uma árvore a partir de um comentário**
https://tabnews-esor3rk95-tabnews.vercel.app/api/v1/contents?id=a55d96c8-3fda-44b5-917b-065c1f1a580e&with_root=true&with_parent=true&with_children=true

## Mais sobre o PR

* Só mudei os testes porque modifiquei as mensagens para serem mais coerentes com um endpoint de conteúdos. Quando um conteúdo não é encontrado será avisado de que não foi encontrado (ou vai retornar a lista vazia dependendo se a consulta é de árvore ou lista), mas não vai avisar se um username ou id de usuário fornecido não for localizado, independentemente do usuário fornecido existir ou não no banco. Isso porque é um endpoint de conteúdos.
* Fiz mais alguma otimizações, então será eliminada uma das recursividades ao enviar o email de notificação, pois já vai começar um nível acima. Além de eliminar um segunda consulta recursiva desnecessária quando o conteúdo pai e root é o mesmo.
* Todas as consultas que usam owner_username agora conseguem buscar o id do usuário na mesma ida ao banco.
* Podemos escolher a forma de classificação dos comentários.
* Podemos retornar os conteúdos de um usuário da forma que acharmos melhor, seja só comentários, só conteúdos root ou tudo misturado.
* Seja pela performance melhor, seja pela ajuda do cache, está tudo muito rápido 🚀

## O mais importante

Eu só adequei algumas mensagem de resposta, então foi só isso que alterei nos testes. Mas, com as últimas modificações, acho que tudo que usamos no front-end está passando pelos testes que já existiam, inclusive o que tinha ficado de fora por causa do PR #1400.

Só que foram criadas inúmeras novas possibilidades, então vamos precisar de uma boa estratégia para elaborar todos os novos testes sem adicionar um quantidade tendendo ao infinito. 😅