### PR TITLE
Implementa a estratégia de caminho materializado adicionando a coluna `path` com índice ao `contents`

### DIFF
--- a/infra/migrations/1684412419408_alter-contents-table-add-root-id-array.js
+++ b/infra/migrations/1684412419408_alter-contents-table-add-root-id-array.js
@@ -1,0 +1,16 @@
+exports.up = async (pgm) => {
+  await pgm.addColumns('contents', {
+    path: {
+      type: 'uuid[]',
+      notNull: true,
+      default: '{}',
+    },
+  });
+
+  await pgm.createIndex('contents', 'path', {
+    name: 'contents_path_idx',
+    method: 'gin',
+  });
+};
+
+exports.down = false;

--- a/models/content.js
+++ b/models/content.js
@@ -213,13 +213,28 @@ async function findOne(values, options = {}) {
 }
 
 async function findWithStrategy(options = {}) {
+  const findAllInitTime = performance.now();
+  let rankStartTime, rankEndTime;
+  let strategy = options.strategy;
+
   const strategies = {
     new: getNew,
     old: getOld,
     relevant: getRelevant,
   };
 
-  return await strategies[options.strategy](options);
+  const queryReturn = await strategies[options.strategy](options);
+
+  const findAllEndTime = performance.now();
+
+  console.log({
+    findWithStrategyTime: findAllEndTime - findAllInitTime,
+    rankTime: rankEndTime - rankStartTime,
+    ...options,
+    strategy,
+  });
+
+  return queryReturn;
 
   async function getNew(options = {}) {
     const results = {};
@@ -257,7 +272,9 @@ async function findWithStrategy(options = {}) {
     if (options.strategy === 'relevant_global') {
       results.rows = contentList;
     } else {
+      rankStartTime = performance.now();
       results.rows = rankContentListByRelevance(contentList);
+      rankEndTime = performance.now();
     }
 
     values.totalRows = results.rows[0]?.total_rows;
@@ -767,6 +784,7 @@ function throwIfContentPublishedIsChangedToDraft(oldContent, newContent) {
 }
 
 async function findTree(options) {
+  const findTreeStartTime = performance.now();
   options.where = validateWhereSchema(options?.where);
   let values;
   if (options.where.parent_id) {
@@ -777,8 +795,19 @@ async function findTree(options) {
     values = [options.where.owner_username, options.where.slug];
   }
 
+  const queryStartTime = performance.now();
   const flatList = await recursiveDatabaseLookup(options);
-  return flatListToTree(flatList);
+  const queryEndTime = performance.now();
+  const tree = flatListToTree(flatList);
+  const findTreeEndTime = performance.now();
+  console.log({
+    findTreeTime: findTreeEndTime - findTreeStartTime,
+    validateTime: queryStartTime - findTreeStartTime,
+    queryTime: queryEndTime - queryStartTime,
+    flatListToTreeTime: findTreeEndTime - queryEndTime,
+    ...options,
+  });
+  return tree;
 
   async function recursiveDatabaseLookup(options) {
     const query = {

--- a/models/content.js
+++ b/models/content.js
@@ -660,15 +660,14 @@ async function update(contentId, postedContent, options = {}) {
       WITH
         updated_content as (
           UPDATE contents SET
-            parent_id = $2,
-            slug = $3,
-            title = $4,
-            body = $5,
-            status = $6,
-            source_url = $7,
-            published_at = $8,
+            slug = $2,
+            title = $3,
+            body = $4,
+            status = $5,
+            source_url = $6,
+            published_at = $7,
             updated_at = (now() at time zone 'utc'),
-            deleted_at = $9
+            deleted_at = $8
           WHERE
             id = $1
           RETURNING *
@@ -694,7 +693,6 @@ async function update(contentId, postedContent, options = {}) {
       ;`,
       values: [
         content.id,
-        content.parent_id,
         content.slug,
         content.title,
         content.body,

--- a/pages/api/v1/contents/[username]/[slug]/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/index.public.js
@@ -72,7 +72,6 @@ function patchValidationHandler(request, response, next) {
   request.query = cleanQueryValues;
 
   const cleanBodyValues = validator(request.body, {
-    parent_id: 'optional',
     slug: 'optional',
     title: 'optional',
     body: 'optional',


### PR DESCRIPTION
A estratégia de caminho materializado envolve armazenar um array com os IDs de todos os ancestrais do conteúdo. Isso permite consultar a árvore de comentários abaixo de qualquer conteúdo, filtrando apenas os conteúdos que possuem o ID do conteúdo desejado na coluna `path`.

Essa estratégia elimina as consultas recursivas para obter as árvores de comentários dos conteúdos, resolvendo a issue #1169. Além disso, o uso do índice GIN na coluna `path` deve melhorar ainda mais o desempenho dessas consultas.

Esse PR assume que o `parent_id` não pode ser alterado. O bloqueio dessa alteração já foi realizado anteriormente (d0b8d00ba34af1bdba40e542f88eff08c8f3874b), mas nesse PR foi realizada uma refatoração e remoção de testes relacionados que não são mais necessários.

No commit 7ca271ed356b33ad9900df961e1a93fda97bb71d foram adicionados alguns logs para monitorarmos a performance das alterações.

Após rodar a migration, devemos executar a seguinte query para popular a coluna `path`:

```sql
WITH RECURSIVE cte AS (
  SELECT id, parent_id, ARRAY[]::uuid[] AS path
  FROM contents
  WHERE parent_id IS NULL
  UNION ALL
  SELECT c.id, c.parent_id, cte.path || cte.id
  FROM contents c
  JOIN cte ON cte.id = c.parent_id
)
UPDATE contents c
SET path = cte.path
FROM cte
WHERE c.id = cte.id;