### PR TITLE
Continuação da implementação do caminho materializado

### DIFF
--- a/models/notification.js
+++ b/models/notification.js
@@ -22,11 +22,14 @@ async function sendReplyEmailToParentUser(createdContent) {
     }
 
     const childContendUrl = getChildContendUrl(secureCreatedContent);
-    const rootContent = await content.findRootContent({
-      where: {
-        id: secureCreatedContent.id,
-      },
-    });
+    const rootContent = parentContent.parent_id
+      ? await content.findOne({
+          where: {
+            id: parentContent.path[0],
+          },
+          attributes: { exclude: ['body'] },
+        })
+      : parentContent;
 
     const secureRootContent = authorization.filterOutput(anonymousUser, 'read:content', rootContent);
 

--- a/pages/api/v1/contents/[username]/[slug]/children/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/children/index.public.js
@@ -35,15 +35,14 @@ async function getHandler(request, response) {
   const getChildrenStartTime = performance.now();
   const userTryingToGet = user.createAnonymous();
 
-  const contentFound = await content.findOne({
+  const contentTreeFound = await content.findTree({
     where: {
       owner_username: request.query.username,
       slug: request.query.slug,
-      status: 'published',
     },
   });
 
-  if (!contentFound) {
+  if (!contentTreeFound?.length) {
     throw new NotFoundError({
       message: `O conteúdo informado não foi encontrado no sistema.`,
       action: 'Verifique se o "slug" está digitado corretamente.',
@@ -53,11 +52,7 @@ async function getHandler(request, response) {
     });
   }
 
-  const childrenFound = await content.findTree({
-    where: {
-      parent_id: contentFound.id,
-    },
-  });
+  const childrenFound = contentTreeFound[0].children;
 
   const filterOutputStartTime = performance.now();
   const secureOutputValues = authorization.filterOutput(userTryingToGet, 'read:content:list', childrenFound);

--- a/pages/api/v1/contents/[username]/[slug]/root/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/root/index.public.js
@@ -60,9 +60,9 @@ async function getHandler(request, response) {
     });
   }
 
-  const rootContentFound = await content.findRootContent({
+  const rootContentFound = await content.findOne({
     where: {
-      id: contentFound.parent_id,
+      id: contentFound.path[0],
     },
   });
 

--- a/tests/integration/api/v1/contents/[username]/[slug]/root/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/root/get.test.js
@@ -349,7 +349,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
         slug: 'root-content-title',
         title: 'Root content title',
         body: 'Root content body',
-        children_deep_count: 1,
+        children_deep_count: 2,
         status: 'published',
         source_url: null,
         published_at: rootContent.published_at.toISOString(),

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -1,6 +1,7 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
 import orchestrator from 'tests/orchestrator.js';
+import database from 'infra/database';
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();
@@ -1913,6 +1914,13 @@ describe('POST /api/v1/contents', () => {
       expect(uuidVersion(responseBody.id)).toEqual(4);
       expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
       expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+
+      const contentInDatabase = await database.query({
+        text: 'SELECT * FROM contents WHERE id = $1',
+        values: [responseBody.id],
+      });
+
+      expect(contentInDatabase.rows[0].path).toEqual([]);
     });
 
     test('"root" content with "title" containing custom slug special characters', async () => {
@@ -2063,6 +2071,13 @@ describe('POST /api/v1/contents', () => {
       expect(uuidVersion(responseBody.slug)).toEqual(4);
       expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
       expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+
+      const contentInDatabase = await database.query({
+        text: 'SELECT * FROM contents WHERE id = $1',
+        values: [responseBody.id],
+      });
+
+      expect(contentInDatabase.rows[0].path).toEqual([rootContent.id]);
     });
 
     test('"child" content with "title" containing Null value', async () => {


### PR DESCRIPTION
Removi do PR anterior (#1419) as modificações que dependiam do campo `path` já estar populado e trouxe para esse aqui.

Criei um roteiro do que acredito que deve ser feito para popular `path` sem chances de termos inconsistências. Já testei essa sequência localmente.

Em homologação já podemos executar tudo (Bora?!), mas acho melhor não fazer o último passo por enquanto, por causa dos outros PRs com deploy em homologação, conforme explicado no final.

## Procedimento

1) Rodar a migration que cria a coluna path.

2) Para evitarmos inconsistências, antes de executar a query que vai popular o path, criar a função a seguir, pois ela é uma redundância que preenche o `path` ao inserir ou atualizar um registro, assim não vai haver inconsistência se algum registro for modificado por algum usuário ao mesmo tempo que estamos populando o `path`.

```sql
CREATE OR REPLACE FUNCTION update_path() RETURNS trigger AS $$
BEGIN
  IF NEW.parent_id IS NOT NULL THEN
    WITH RECURSIVE cte AS (
      SELECT parent_id, ARRAY[id] AS path
      FROM contents
      WHERE id = NEW.parent_id
    UNION ALL
      SELECT c.parent_id, c.id || cte.path
      FROM contents c
      JOIN cte ON cte.parent_id = c.id
    )
    SELECT cte.path INTO NEW.path
    FROM cte
    WHERE cte.parent_id IS NULL;
  END IF;

  RETURN NEW;
END;
$$ LANGUAGE plpgsql;
```

3) Criar o trigger que vai chamar a função acima.

```sql
CREATE TRIGGER update_path_trigger
BEFORE INSERT OR UPDATE ON contents
FOR EACH ROW EXECUTE PROCEDURE update_path();
```

4) Executar a query que vai popular o `path`.

```sql
WITH RECURSIVE cte AS (
  SELECT id, parent_id, ARRAY[]::uuid[] AS path
  FROM contents
  WHERE parent_id IS NULL
  UNION ALL
  SELECT c.id, c.parent_id, cte.path || cte.id
  FROM contents c
  JOIN cte ON cte.id = c.parent_id
)
UPDATE contents c
SET path = cte.path
FROM cte
WHERE c.id = cte.id;
```

5) Conferir se a query funcionou corretamente (deve retornar 0).

```sql
SELECT COUNT(*) AS count
FROM contents
WHERE parent_id IS NOT NULL
AND path = ARRAY[]::uuid[];
```

6) Talvez fazer essa conferência mais pesada. Vamos ver primeiro como ela se comporta com o banco de homologação para decidir se rodamos em produção.

```sql
SELECT COUNT(*) AS count
FROM contents
WHERE (
  parent_id IS NOT NULL AND (
    array_length(path, 1) < 1 OR
    path[array_length(path, 1)] <> parent_id
  )
) OR (
  parent_id IS NULL AND path <> ARRAY[]::uuid[]
);
```

7) Modificar a função chamada pelo trigger para uma mais simples, que só pode funcionar agora que `path` já está corretamente preenchido em todos os conteúdos. Em produção imagino que todos os passos serão dados em sequência, então podemos pular essa etapa 7, já que ela só é necessária para melhorar a performance das inserções enquanto não fizermos o deploy final da modificação (esse PR aqui).

```sql
CREATE OR REPLACE FUNCTION update_path() RETURNS TRIGGER AS $$
BEGIN
  IF NEW.parent_id IS NOT NULL AND NEW.path = ARRAY[]::uuid[]
  THEN
    NEW.path := (
      SELECT c.path FROM contents c WHERE c.id = NEW.parent_id
    ) || NEW.parent_id;
  END IF;
  
  RETURN NEW;
END;
$$ LANGUAGE plpgsql;
```

8) Fazer o deploy desse PR, eliminando assim a necessidade do trigger e da função.

9) Remover o trigger e a função em produção. Obs. Em homologação considere manter o trigger por enquanto, conforme explicações abaixo.

```sql
DROP TRIGGER IF EXISTS update_path_trigger ON contents;
DROP FUNCTION IF EXISTS update_path();
```
FIM 🚀

Em homologação precisamos manter o trigger como redundância por um tempo, pois senão conteúdos criados por outras branchs não terão o `path` preenchido corretamente.

Mantendo o trigger no banco de homologação, caso queira garantir e testar o comportamento das inserções sem o trigger antes de enviar para produção, podemos usar um outro banco de homologação provisório, como do Supabase, Neon etc.

Outra opção é removermos todos os deploys ativos em homologação, já que de qualquer forma os PRs deles precisarão ser atualizados.

Eu não acho que seja essencial testar sem o trigger em homologação, já que os testes de integração executados localmente, e também no CI do PR #1419 enquanto as modificações daqui ainda estavam lá, mostraram que o trigger não é necessário.