### PR TITLE
refactor(authorization): use early return on can method

### DIFF
--- a/models/authorization.js
+++ b/models/authorization.js
@@ -43,30 +43,23 @@ function can(user, feature, resource) {
   validateUser(user);
   validateFeature(feature);
 
-  let authorized = false;
+  if (!user.features.includes(feature)) return false;
 
-  if (user.features.includes(feature)) {
-    authorized = true;
+  if (!resource) return true;
+
+  switch (feature) {
+    case 'update:user':
+      return user.id === resource.id;
+
+    case 'update:content':
+      return user.id === resource.owner_id || user.features.includes('update:content:others');
+
+    case 'create:content:text_root':
+    case 'create:content:text_child':
+      return true;
   }
 
-  // TODO: Double check if this is right and covered by tests
-  if (feature === 'update:user' && resource) {
-    authorized = false;
-
-    if (user.id === resource.id && user.features.includes('update:user')) {
-      authorized = true;
-    }
-  }
-
-  if (feature === 'update:content' && resource) {
-    authorized = false;
-
-    if (user.id === resource.owner_id || user.features.includes('update:content:others')) {
-      authorized = true;
-    }
-  }
-
-  return authorized;
+  return false;
 }
 
 function filterInput(user, feature, input) {


### PR DESCRIPTION
Uma sugestão de refatoração para o método `can`  que verifica se o usuário possui determinada feature,  em casos de edição de usuário além de validar se o usuário possui essa feature também valida se o usuário que está editando é o mesmo que está sendo editado, e em casos de edição de conteúdo valida se o usuário é o dono do conteúdo ou se possui a feature de editar conteúdo de terceiros. Rodei os testes antes e depois das alterações, todos os testes continuaram passando.
O objetivo da refatoração é  ajudar na legibilidade do código, foi umas das primeiras funções que parei para estudar no código e levei um tempinho para entender.
Edit: um amigo sugeriu algumas alterações que inclui no commit [b203ac3](https://github.com/filipedeschamps/tabnews.com.br/pull/1427/commits/b203ac325f40851919ff636af645bfdcd5f0b69b), melhorei os nomes da variáveis, inclui um early return caso a função `can` não receba o argumento resource, e também inclui a validação se o usuário possui a feature de atualizar o conteúdo