### PR TITLE
Mensagem na página de status usando a Edge Config da Vercel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@upstash/ratelimit": "0.4.2",
         "@upstash/redis": "1.20.4",
         "@vercel/analytics": "1.0.0",
+        "@vercel/edge-config": "0.2.0",
         "async-retry": "1.3.3",
         "bcryptjs": "2.4.3",
         "cookie": "0.5.0",
@@ -45,7 +46,7 @@
         "react-icons": "4.8.0",
         "react-rewards": "2.0.4",
         "recharts": "2.5.0",
-        "satori": "^0.9.1",
+        "satori": "0.9.1",
         "set-cookie-parser": "2.6.0",
         "slug": "8.2.2",
         "snakeize": "0.1.0",
@@ -3020,6 +3021,22 @@
       "peerDependencies": {
         "react": "^16.8||^17||^18"
       }
+    },
+    "node_modules/@vercel/edge-config": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/edge-config/-/edge-config-0.2.0.tgz",
+      "integrity": "sha512-gHs5dqhyOOU+Gh5kLLe6FVXKQr5D9Igb0w8xby0DSgCCY2VNv4cm+mHRtCbgQoD4MyMw7tgGFQme4DkJUNAmEg==",
+      "dependencies": {
+        "@vercel/edge-config-fs": "0.1.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@vercel/edge-config-fs": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/edge-config-fs/-/edge-config-fs-0.1.0.tgz",
+      "integrity": "sha512-NRIBwfcS0bUoUbRWlNGetqjvLSwgYH/BqKqDN7vK1g32p7dN96k0712COgaz6VFizAm9b0g6IG6hR6+hc0KCPg=="
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -15986,6 +16003,19 @@
       "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.0.0.tgz",
       "integrity": "sha512-RQmj7pv82JwGDHrnKeRc6TtSw2U7rWNubc2IH0ernTzWTj02yr9zvIYiYJeztsBzrJtWv7m8Nz6vxxb+cdEtJw==",
       "requires": {}
+    },
+    "@vercel/edge-config": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/edge-config/-/edge-config-0.2.0.tgz",
+      "integrity": "sha512-gHs5dqhyOOU+Gh5kLLe6FVXKQr5D9Igb0w8xby0DSgCCY2VNv4cm+mHRtCbgQoD4MyMw7tgGFQme4DkJUNAmEg==",
+      "requires": {
+        "@vercel/edge-config-fs": "0.1.0"
+      }
+    },
+    "@vercel/edge-config-fs": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/edge-config-fs/-/edge-config-fs-0.1.0.tgz",
+      "integrity": "sha512-NRIBwfcS0bUoUbRWlNGetqjvLSwgYH/BqKqDN7vK1g32p7dN96k0712COgaz6VFizAm9b0g6IG6hR6+hc0KCPg=="
     },
     "abort-controller": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@upstash/ratelimit": "0.4.2",
     "@upstash/redis": "1.20.4",
     "@vercel/analytics": "1.0.0",
+    "@vercel/edge-config": "0.2.0",
     "async-retry": "1.3.3",
     "bcryptjs": "2.4.3",
     "cookie": "0.5.0",


### PR DESCRIPTION
Iniciando a implementação citada na issue #1181, mas inicialmente mostrando a mensagem apenas na página de status. 

![image](https://github.com/filipedeschamps/tabnews.com.br/assets/77860630/c71ac417-1a88-40ef-bade-77270c7308f2)

E em desenvolvimento deixei mensagens fixas, mas qualquer um pode adicionar a variável de ambiente `EDGE_CONFIG` e mostrar mensagens criadas em suas contas na Vercel.

![image](https://github.com/filipedeschamps/tabnews.com.br/assets/77860630/8ac891c0-31bc-4a27-ab51-6dcb620d7c46)

Uma única mensagem pode ser adicionada como texto simples:

```json
{
  "announcements": "Agora podemos inserir avisos na página de status."
}
```

Mas eu recomendo sempre adicionarmos como um `array` em que opcionalmente podemos escolher a cor do aviso através da propriedade `type`, sendo que as opções são as mesmas do componente `Flash` do Primer React (`default`, `success`, `warning` ou `danger`):

```json
{
  "announcements": [
    {
      "text": "Agora podemos inserir avisos na página de status.",
      "type": "success"
    }
  ]
}
