### PR TITLE
Acelera a transição entre não ganhar TabCoins até passar a ganhar 2 TabCoins por conteúdo

### DIFF
--- a/models/prestige.js
+++ b/models/prestige.js
@@ -1,8 +1,5 @@
 import database from 'infra/database';
 
-const THRESHOLD_PERCENTAGE_TO_EARN_TABCOINS_WITH_ROOT_CONTENT = 0.39;
-const THRESHOLD_PERCENTAGE_TO_EARN_TABCOINS_WITH_CHILD_CONTENT = 0.19;
-
 async function getByContentId(contentId, { transaction } = {}) {
   const result = await database.query(
     {
@@ -46,10 +43,6 @@ async function getByUserId(
     transaction,
   } = {}
 ) {
-  const thresholdPercentage = isRoot
-    ? THRESHOLD_PERCENTAGE_TO_EARN_TABCOINS_WITH_ROOT_CONTENT
-    : THRESHOLD_PERCENTAGE_TO_EARN_TABCOINS_WITH_CHILD_CONTENT;
-
   const result = await database.query(
     {
       text: queryByUserId,
@@ -65,8 +58,19 @@ async function getByUserId(
   }
 
   const tabcoins = result.rows.reduce((acc, { tabcoins }) => acc + tabcoins, 0);
+  const mean = tabcoins / length;
 
-  return Math.floor(tabcoins / length - thresholdPercentage);
+  if (isRoot) {
+    if (0.4 >= mean) return -1;
+    if (1.2 >= mean) return 0;
+    if (1.7 >= mean) return 1;
+  } else {
+    if (0.2 >= mean) return -1;
+    if (1.0 >= mean) return 0;
+    if (1.5 >= mean) return 1;
+  }
+
+  return Math.ceil(mean);
 }
 
 const queryByUserId = `

--- a/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
@@ -2815,7 +2815,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const defaultUser = await orchestrator.createUser();
         await orchestrator.activateUser(defaultUser);
         const sessionObject = await orchestrator.createSession(defaultUser);
-        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: 5 });
+        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: 4 });
 
         const defaultUserContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
@@ -3172,7 +3172,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
 
         const userResponse2Body = await userResponse2.json();
 
-        expect(userResponse2Body.tabcoins).toEqual(1);
+        expect(userResponse2Body.tabcoins).toEqual(2);
         expect(userResponse2Body.tabcash).toEqual(0);
       });
 
@@ -3377,7 +3377,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const secondUser = await orchestrator.createUser();
         await orchestrator.activateUser(secondUser);
         const sessionObject = await orchestrator.createSession(secondUser);
-        await orchestrator.createPrestige(secondUser.id, { childPrestigeNumerator: 2 });
+        await orchestrator.createPrestige(secondUser.id);
 
         const rootContent = await orchestrator.createContent({
           owner_id: firstUser.id,

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -2891,7 +2891,7 @@ describe('POST /api/v1/contents', () => {
 
         const userResponseBody = await userResponse.json();
 
-        expect(userResponseBody.tabcoins).toEqual(1);
+        expect(userResponseBody.tabcoins).toEqual(2);
         expect(userResponseBody.tabcash).toEqual(0);
       });
     });
@@ -2901,7 +2901,7 @@ describe('POST /api/v1/contents', () => {
         const defaultUser = await orchestrator.createUser();
         await orchestrator.activateUser(defaultUser);
         const sessionObject = await orchestrator.createSession(defaultUser);
-        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: -6, rootPrestigeDenominator: 9 });
+        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: -6, rootPrestigeDenominator: 10 });
 
         const contentResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
           method: 'post',
@@ -2940,7 +2940,7 @@ describe('POST /api/v1/contents', () => {
         const secondUser = await orchestrator.createUser();
         await orchestrator.activateUser(secondUser);
         const sessionObject = await orchestrator.createSession(defaultUser);
-        await orchestrator.createPrestige(defaultUser.id, { childPrestigeNumerator: -9, childPrestigeDenominator: 10 });
+        await orchestrator.createPrestige(defaultUser.id, { childPrestigeNumerator: -4, childPrestigeDenominator: 5 });
 
         const rootContent = await orchestrator.createContent({
           owner_id: secondUser.id,
@@ -2983,7 +2983,7 @@ describe('POST /api/v1/contents', () => {
         const defaultUser = await orchestrator.createUser();
         await orchestrator.activateUser(defaultUser);
         const sessionObject = await orchestrator.createSession(defaultUser);
-        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: -6, rootPrestigeDenominator: 10 });
+        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: -1, rootPrestigeDenominator: 2 });
 
         const contentResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
           method: 'post',
@@ -3042,7 +3042,7 @@ describe('POST /api/v1/contents', () => {
         const secondUser = await orchestrator.createUser();
         await orchestrator.activateUser(secondUser);
         const sessionObject = await orchestrator.createSession(defaultUser);
-        await orchestrator.createPrestige(defaultUser.id, { childPrestigeNumerator: -8, childPrestigeDenominator: 10 });
+        await orchestrator.createPrestige(defaultUser.id, { childPrestigeNumerator: -7, childPrestigeDenominator: 10 });
 
         const rootContent = await orchestrator.createContent({
           owner_id: secondUser.id,
@@ -3105,7 +3105,7 @@ describe('POST /api/v1/contents', () => {
         const defaultUser = await orchestrator.createUser();
         await orchestrator.activateUser(defaultUser);
         const sessionObject = await orchestrator.createSession(defaultUser);
-        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: 1, rootPrestigeDenominator: 3 });
+        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: 1, rootPrestigeDenominator: 5 });
 
         const contentResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
           method: 'post',
@@ -3164,7 +3164,7 @@ describe('POST /api/v1/contents', () => {
         const secondUser = await orchestrator.createUser();
         await orchestrator.activateUser(secondUser);
         const sessionObject = await orchestrator.createSession(defaultUser);
-        await orchestrator.createPrestige(defaultUser.id, { childPrestigeNumerator: 1, childPrestigeDenominator: 6 });
+        await orchestrator.createPrestige(defaultUser.id, { childPrestigeNumerator: 0 });
 
         const rootContent = await orchestrator.createContent({
           owner_id: secondUser.id,
@@ -3227,7 +3227,7 @@ describe('POST /api/v1/contents', () => {
         const defaultUser = await orchestrator.createUser();
         await orchestrator.activateUser(defaultUser);
         const sessionObject = await orchestrator.createSession(defaultUser);
-        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: 4, rootPrestigeDenominator: 10 });
+        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: 3, rootPrestigeDenominator: 10 });
 
         const contentResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
           method: 'post',
@@ -3286,7 +3286,7 @@ describe('POST /api/v1/contents', () => {
         const secondUser = await orchestrator.createUser();
         await orchestrator.activateUser(secondUser);
         const sessionObject = await orchestrator.createSession(defaultUser);
-        await orchestrator.createPrestige(defaultUser.id, { childPrestigeNumerator: 2, childPrestigeDenominator: 10 });
+        await orchestrator.createPrestige(defaultUser.id, { childPrestigeNumerator: 1, childPrestigeDenominator: 10 });
 
         const rootContent = await orchestrator.createContent({
           owner_id: secondUser.id,

--- a/tests/integration/api/v1/users/[username]/delete.test.js
+++ b/tests/integration/api/v1/users/[username]/delete.test.js
@@ -172,7 +172,7 @@ describe('DELETE /api/v1/users/[username]', () => {
       const secondUser = await orchestrator.createUser();
       await orchestrator.activateUser(secondUser);
       const secondUserSession = await orchestrator.createSession(secondUser);
-      await orchestrator.createPrestige(secondUser.id, { childPrestigeNumerator: 2 });
+      await orchestrator.createPrestige(secondUser.id);
 
       // 2) CREATE CONTENTS FOR FIRST USER
       const firstUserRootContent = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -187,7 +187,7 @@ async function createFirewallTestFunctions() {
 async function createPrestige(
   userId,
   {
-    rootPrestigeNumerator = 2,
+    rootPrestigeNumerator = 1,
     rootPrestigeDenominator = 1,
     childPrestigeNumerator = 1,
     childPrestigeDenominator = 1,


### PR DESCRIPTION
Considerando que afrouxamos as regras recentemente e não tivemos nenhum problema de abuso, então vamos dar mais uma relaxada nas regras.

Esse PR facilita ainda mais atingir os limiares para ganhar TabCoins já no ato de publicar conteúdos, e acrescenta um novo patamar bem próximo do primeiro, onde já se chega no ganho de 2 TabCoins. Acima disso, os ganhos serão iguais ao arredondamento para cima nas médias de saldos das publicações, então os ganhos estão subindo em todas as faixas.

### Conteúdos "root"

Basta ter saldo de 3 votos positivos, ao somar os votos dos 10 últimos conteúdos, para habilitar a ganhar 1 TabCoin extra no ato da publicação. Com 8 já passa a ganhar 2 TabCoins extras por publicação.

### Comentários

Basta ter pelo menos saldo de 1 voto positivo na soma de todas as últimas 10 publicações para começar a ganhar TabCoins. Se metade dos comentários tiver pelo menos 1 voto, então já passa a ganhar 2 TabCoins por publicação.
