### PR TITLE
Aumenta a frequência de revalidação da página de conteúdos

### DIFF
--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -406,7 +406,7 @@ export const getStaticProps = getStaticPropsRevalidate(async (context) => {
       parentContentFound: JSON.parse(JSON.stringify(secureParentContentFound)),
       contentMetadata: JSON.parse(JSON.stringify(contentMetadata)),
     },
-    revalidate: 10,
+    revalidate: 1,
     swr: { revalidateOnFocus: false },
   };
 });


### PR DESCRIPTION
Volta o valor de revalidação de 10s para 1s, que era a configuração de antes do lançamento oficial do TabNews.

Acredito que essa modificação nas páginas de conteúdos não deve causar uma aumento significativo no número de revalidações, então pode valer a pena ser trouxer alguma melhora de UX, já que qualquer nova qualificação ou edição de conteúdo será propagado para o cache da CDN mais rapidamente.

Um momento importante para sabermos se houve algum impacto negativo será na próxima vez que houver um aumento significativo de acessos simultâneos, como ocorre sempre que o TabNews é citado em algum canal de grande exposição, como em vídeos do @filipedeschamps.

Vamos monitorar 🤝