### PR TITLE
Acelera um pouco mais o aumento de ganhos, mas sem precisar afrouxar os freios para usuários negativados

### DIFF
--- a/models/prestige.js
+++ b/models/prestige.js
@@ -62,15 +62,19 @@ async function getByUserId(
 
   if (isRoot) {
     if (0.4 >= mean) return -1;
-    if (1.2 >= mean) return 0;
-    if (1.7 >= mean) return 1;
+    if (1.1 >= mean) return 0;
+    if (1.4 >= mean) return 1;
+    if (1.6 >= mean) return 2;
+    if (1.8 >= mean) return 3;
   } else {
     if (0.2 >= mean) return -1;
     if (1.0 >= mean) return 0;
-    if (1.5 >= mean) return 1;
+    if (1.2 >= mean) return 1;
+    if (1.5 >= mean) return 2;
+    if (1.7 >= mean) return 3;
   }
 
-  return Math.ceil(mean);
+  return Math.ceil(mean + 2);
 }
 
 const queryByUserId = `

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -3105,7 +3105,7 @@ describe('POST /api/v1/contents', () => {
         const defaultUser = await orchestrator.createUser();
         await orchestrator.activateUser(defaultUser);
         const sessionObject = await orchestrator.createSession(defaultUser);
-        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: 1, rootPrestigeDenominator: 5 });
+        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: 1, rootPrestigeDenominator: 10 });
 
         const contentResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
           method: 'post',
@@ -3227,7 +3227,7 @@ describe('POST /api/v1/contents', () => {
         const defaultUser = await orchestrator.createUser();
         await orchestrator.activateUser(defaultUser);
         const sessionObject = await orchestrator.createSession(defaultUser);
-        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: 3, rootPrestigeDenominator: 10 });
+        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: 2, rootPrestigeDenominator: 10 });
 
         const contentResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
           method: 'post',

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -188,9 +188,9 @@ async function createPrestige(
   userId,
   {
     rootPrestigeNumerator = 1,
-    rootPrestigeDenominator = 1,
+    rootPrestigeDenominator = 2,
     childPrestigeNumerator = 1,
-    childPrestigeDenominator = 1,
+    childPrestigeDenominator = 2,
   } = {}
 ) {
   if (


### PR DESCRIPTION
No PR #1440 a equação que calculava os ganhos de TabCoins no ato de publicar foi substituída por alguns condicionais. Isso permitiu fazer ajustes mais precisos em cada faixa sem precisar adotar uma equação complexa.

Então nesse PR vamos acelerar ainda mais os ganhos de quem está publicando conteúdos relevantes, e sem precisar afrouxar os freios para os usuários que estão sendo muito negativados.

Os ganhos conforme a média (m) de saldo das últimas publicações ficarão assim:

root | comentário | ganho ao publicar
:--: | :--: | :--:
m <= 0,4 | m <= 0,2 | precisa apagar negativados
0,4 < m <= 1,1 |  0,2 < m <= 1,0 | 0
1,1 < m <= 1,4 |  1,0 < m <= 1,2 | 1
1,4 < m <= 1,6 |  1,2 < m <= 1,5 | 2
1,6 < m <= 1,8 |  1,5 < m <= 1,7 | 3
1,8 < m | 1,7 < m | m + 2 (e arredonda para cima)

Exemplos:
* Um usuário que possui metade das últimas publicações com 1 voto positivo (saldo de 2 TabCoins), já pode ganhar 2 TabCoins ao publicar
* Um usuário com média de 1 voto positivo por publicação irá ganhar 4 TabCoins ao publicar.
* Um usuário com 1 voto positivo em qualquer das últimas publicações (e sem negativos) já está habilitado a ganhar 1 TabCoin ao publicar.
* Um usuário com 8 comentários negativados entre os últimos 10, precisará adequar as publicações para poder continuar comentando.