### PR TITLE
Feat reading time on posts

### DIFF
--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -11,6 +11,7 @@ import {
   IconButton,
   Link,
   PublishedSince,
+  ReadTime,
   Text,
   TextInput,
   useConfirm,
@@ -180,6 +181,7 @@ function ViewMode({ setComponentMode, contentObject, viewFrame }) {
             <BranchName as={Link} href={`/${contentObject.owner_username}`}>
               {contentObject.owner_username}
             </BranchName>
+            <ReadTime text={contentObject.body} />
             <Link
               href={`/${contentObject.owner_username}/${contentObject.slug}`}
               prefetch={false}

--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -177,7 +177,7 @@ function ViewMode({ setComponentMode, contentObject, viewFrame }) {
 
         <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
           <Box
-            sx={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', whiteSpace: 'nowrap', gap: 1, mt: '2px' }}>
+            sx={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', whiteSpace: 'nowrap', gap: 2, mt: '2px' }}>
             <BranchName as={Link} href={`/${contentObject.owner_username}`}>
               {contentObject.owner_username}
             </BranchName>

--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -177,7 +177,15 @@ function ViewMode({ setComponentMode, contentObject, viewFrame }) {
 
         <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
           <Box
-            sx={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', whiteSpace: 'nowrap', gap: 2, mt: '2px' }}>
+            sx={{
+              display: 'flex',
+              flexWrap: 'wrap',
+              alignItems: 'center',
+              whiteSpace: 'nowrap',
+              gap: 1,
+              mt: '2px',
+              color: 'fg.muted',
+            }}>
             <BranchName as={Link} href={`/${contentObject.owner_username}`}>
               {contentObject.owner_username}
             </BranchName>
@@ -190,7 +198,7 @@ function ViewMode({ setComponentMode, contentObject, viewFrame }) {
             <Link
               href={`/${contentObject.owner_username}/${contentObject.slug}`}
               prefetch={false}
-              sx={{ fontSize: 0, color: 'fg.muted', mr: '100px', py: '1px', height: '22px' }}>
+              sx={{ fontSize: 0, color: 'fg.muted', mr: '100px', py: '2px', height: '22px' }}>
               <PublishedSince direction="n" date={contentObject.published_at} />
             </Link>
           </Box>

--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -181,7 +181,12 @@ function ViewMode({ setComponentMode, contentObject, viewFrame }) {
             <BranchName as={Link} href={`/${contentObject.owner_username}`}>
               {contentObject.owner_username}
             </BranchName>
-            <ReadTime text={contentObject.body} />
+            {!contentObject.parent_id && (
+              <>
+                <ReadTime text={contentObject.body} />
+                {' · '}
+              </>
+            )}
             <Link
               href={`/${contentObject.owner_username}/${contentObject.slug}`}
               prefetch={false}

--- a/pages/interface/components/ContentList/index.js
+++ b/pages/interface/components/ContentList/index.js
@@ -119,7 +119,7 @@ export default function ContentList({ contentList: list, pagination, paginationB
             </Link>
             {' · '}
             <Text>
-              <PublishedSince direction="nw" date={contentObject.published_at} />
+              <PublishedSince direction="nw" date={contentObject.published_at} sx={{ position: 'absolute', ml: 1 }} />
             </Text>
           </Box>
         </Box>,

--- a/pages/interface/components/PublishedSince/index.js
+++ b/pages/interface/components/PublishedSince/index.js
@@ -33,7 +33,7 @@ export default function PublishedSince({ date, ...props }) {
   }, [date]);
 
   return (
-    <Tooltip sx={{ position: 'absolute', ml: 1 }} aria-label={tooltipLabel} suppressHydrationWarning {...props}>
+    <Tooltip sx={{ position: 'absolute' }} aria-label={tooltipLabel} suppressHydrationWarning {...props}>
       <span style={{ whiteSpace: 'nowrap' }} suppressHydrationWarning>
         {formatPublishedSince(date)}
       </span>

--- a/pages/interface/components/ReadTime/index.js
+++ b/pages/interface/components/ReadTime/index.js
@@ -4,13 +4,13 @@ import { useMemo } from 'react';
 export default function ReadTime({ text, ...props }) {
   const readTimeInMinutes = useMemo(() => {
     const wpm = 260;
-    const wordsQuantity = text.split(' ').length;
-    return Math.ceil(wordsQuantity / wpm);
+    const wordsQuantity = text.split(/[^A-Za-z]+/).length;
+    return `${Math.ceil(wordsQuantity / wpm)} min de leitura`;
   }, [text]);
 
   return (
     <Text sx={{ fontSize: 0, color: 'fg.muted', py: '1px', height: '22px' }} {...props}>
-      {`${readTimeInMinutes} ${readTimeInMinutes === 1 ? 'minuto' : 'minutos'} de leitura`}
+      {readTimeInMinutes}
     </Text>
   );
 }

--- a/pages/interface/components/ReadTime/index.js
+++ b/pages/interface/components/ReadTime/index.js
@@ -9,7 +9,7 @@ export default function ReadTime({ text, ...props }) {
   }, [text]);
 
   return (
-    <Text sx={{ fontSize: 0, color: 'fg.muted', py: '1px', height: '22px' }} {...props}>
+    <Text sx={{ fontSize: 0, color: 'fg.muted', py: '2px', height: '22px' }} {...props}>
       {readTimeInMinutes}
     </Text>
   );

--- a/pages/interface/components/ReadTime/index.js
+++ b/pages/interface/components/ReadTime/index.js
@@ -1,0 +1,14 @@
+import { Text } from '@/TabNewsUI';
+
+function getReadTime(text, wpm = 260) {
+  const wordsQuantity = text.split(' ').length;
+  return Math.ceil((wordsQuantity * 60) / wpm / 60);
+}
+
+export default function ReadTime({ text, ...props }) {
+  return (
+    <Text sx={{ fontSize: 0, color: 'fg.muted', py: '1px', height: '22px' }} {...props}>
+      {`${getReadTime(text)} ${getReadTime(text) === 1 ? 'minuto' : 'minutos'} de leitura`}
+    </Text>
+  );
+}

--- a/pages/interface/components/ReadTime/index.js
+++ b/pages/interface/components/ReadTime/index.js
@@ -1,14 +1,16 @@
 import { Text } from '@/TabNewsUI';
-
-function getReadTime(text, wpm = 260) {
-  const wordsQuantity = text.split(' ').length;
-  return Math.ceil(wordsQuantity / wpm);
-}
+import { useMemo } from 'react';
 
 export default function ReadTime({ text, ...props }) {
+  const readTimeInMinutes = useMemo(() => {
+    const wpm = 260;
+    const wordsQuantity = text.split(' ').length;
+    return Math.ceil(wordsQuantity / wpm);
+  }, [text]);
+
   return (
     <Text sx={{ fontSize: 0, color: 'fg.muted', py: '1px', height: '22px' }} {...props}>
-      {`${getReadTime(text)} ${getReadTime(text) === 1 ? 'minuto' : 'minutos'} de leitura`}
+      {`${readTimeInMinutes} ${readTimeInMinutes === 1 ? 'minuto' : 'minutos'} de leitura`}
     </Text>
   );
 }

--- a/pages/interface/components/ReadTime/index.js
+++ b/pages/interface/components/ReadTime/index.js
@@ -2,7 +2,7 @@ import { Text } from '@/TabNewsUI';
 
 function getReadTime(text, wpm = 260) {
   const wordsQuantity = text.split(' ').length;
-  return Math.ceil((wordsQuantity * 60) / wpm / 60);
+  return Math.ceil(wordsQuantity / wpm);
 }
 
 export default function ReadTime({ text, ...props }) {

--- a/pages/interface/components/TabNewsUI/index.js
+++ b/pages/interface/components/TabNewsUI/index.js
@@ -12,6 +12,7 @@ export { EditorColors, EditorStyles, ViewerStyles } from '@/Markdown/styles/inde
 export { default as PasswordInput } from '@/PasswordInput/index.js';
 export { default as NextNProgress } from '@/Progressbar/index.js';
 export { default as PublishedSince } from '@/PublishedSince/index.js';
+export { default as ReadTime } from '@/ReadTime/index.js';
 export { default as TabCoinButtons } from '@/TabCoinButtons/index.js';
 export { default as ThemeProvider } from '@/ThemeProvider/index.js';
 export { default as ThemeSelector, ThemeSwitcher } from '@/ThemeSelector/index.js';


### PR DESCRIPTION
Esse pr adiciona a feature de tempo de leitura estimado a cada post ao entrar no post.

Como base, segui o que o [medium.com](url) utiliza, 260/270 wpm(words per minute) e arrendondar para cima os segundos restantes.

Artigo base do medium: 
https://blog.medium.com/read-time-and-you-bc2048ab620c

![Captura de tela 2023-06-13 181737](https://github.com/filipedeschamps/tabnews.com.br/assets/112519905/c64c5d27-608e-41d2-accf-56aed131a574)
