### PR TITLE
[Draft] Mantém os botões de qualificação visíveis enquanto o conteúdo estiver visível

### DIFF
--- a/pages/interface/components/TabCoinButtons/index.js
+++ b/pages/interface/components/TabCoinButtons/index.js
@@ -86,6 +86,10 @@ export default function TabCoinButtons({ content }) {
     <Box
       sx={{
         display: 'flex',
+        position: 'sticky',
+        top: '0px',
+        backgroundColor: 'canvas.default',
+        zIndex: 1,
         flexDirection: 'column',
         alignItems: 'center',
         mt: contentObject.title ? '9px' : '0px',


### PR DESCRIPTION
Sugestão de solução para o problema relatado neste comentário (https://github.com/filipedeschamps/tabnews.com.br/issues/540#issuecomment-1605791934), onde é citado um problema de UX para qualificar o conteúdo logo após o término da leitura de textos longos.

Deixei como draft, pois precisa de ajustes para funcionar bem com os diferentes níveis de comentários, mas já dá para avaliarem se a ideia faz sentido, pois está funcionando para o root, e parcialmente para o primeiro nível de comentários.

Vejam esse exemplo, de preferência em tela pequena:

https://tabnews-jomry90yh-tabnews.vercel.app/filipedeschamps/testando-pr-do-darkmode