### PR TITLE
Quantidade mínima de 5 palavras, cada uma com no mínimo 5 letras, para poder ganhar TabCoins

### DIFF
--- a/models/content.js
+++ b/models/content.js
@@ -570,6 +570,10 @@ async function creditOrDebitTabCoins(oldContent, newContent, options = {}) {
       // We should not credit if the parent content is from the same user.
       if (parentContent.owner_id === newContent.owner_id) return;
     }
+
+    // We should not credit if the content has little or no value.
+    // Expected 5 or more words with 5 or more characters.
+    if (newContent.body.split(/[a-z]{5,}/i).length < 6) return;
   }
 
   if (userEarnings > 0) {

--- a/models/content.js
+++ b/models/content.js
@@ -496,23 +496,8 @@ function populatePublishedAtValue(oldContent, newContent) {
 }
 
 async function creditOrDebitTabCoins(oldContent, newContent, options = {}) {
-  const contentDefaultEarnings = 1;
-
-  // We should not credit or debit if the parent content is from the same user.
-  if (newContent.parent_id) {
-    const parentContent = await findOne(
-      {
-        where: {
-          id: newContent.parent_id,
-        },
-      },
-      options
-    );
-
-    if (parentContent.owner_id === newContent.owner_id) {
-      return;
-    }
-  }
+  let contentEarnings = 0;
+  let userEarnings = 0;
 
   // We should not credit or debit if the content has never been published before
   // and is being directly deleted, example: "draft" -> "deleted".
@@ -521,20 +506,21 @@ async function creditOrDebitTabCoins(oldContent, newContent, options = {}) {
   }
 
   // We should debit if the content was once "published", but now is being "deleted".
-  // 1) If content `tabcoins` is positive, we need to extract the `contentDefaultEarnings`
-  // from it and then debit all additional tabcoins from the user, including `userEarnings`.
+  // 1) If content `tabcoins` is positive, we need to debit all tabcoins earning by the user.
   // 2) If content `tabcoins` is negative, we should debit the original tabcoin gained from the
-  // creation of the content represented in `userEarnings`.
+  // creation of the content represented by `initialTabcoins`.
   if (oldContent && oldContent.published_at && newContent.status === 'deleted') {
     let amountToDebit;
 
-    const userEarnings = await prestige.getByContentId(oldContent.id, { transaction: options.transaction });
+    const userEarningsByContent = await prestige.getByContentId(oldContent.id, { transaction: options.transaction });
 
     if (oldContent.tabcoins > 0) {
-      amountToDebit = contentDefaultEarnings - oldContent.tabcoins - userEarnings;
+      amountToDebit = -userEarningsByContent.totalTabcoins;
     } else {
-      amountToDebit = -userEarnings;
+      amountToDebit = -userEarningsByContent.initialTabcoins;
     }
+
+    if (!amountToDebit) return;
 
     await balance.create(
       {
@@ -557,7 +543,8 @@ async function creditOrDebitTabCoins(oldContent, newContent, options = {}) {
     // We should credit if the content already existed and is now being published for the first time.
     (oldContent && !oldContent.published_at && newContent.status === 'published')
   ) {
-    const userEarnings = await prestige.getByUserId(newContent.owner_id, {
+    contentEarnings = 1;
+    userEarnings = await prestige.getByUserId(newContent.owner_id, {
       isRoot: !newContent.parent_id,
       transaction: options.transaction,
     });
@@ -570,6 +557,22 @@ async function creditOrDebitTabCoins(oldContent, newContent, options = {}) {
       });
     }
 
+    if (newContent.parent_id) {
+      const parentContent = await findOne(
+        {
+          where: {
+            id: newContent.parent_id,
+          },
+        },
+        options
+      );
+
+      // We should not credit if the parent content is from the same user.
+      if (parentContent.owner_id === newContent.owner_id) return;
+    }
+  }
+
+  if (userEarnings > 0) {
     await balance.create(
       {
         balanceType: 'user:tabcoin',
@@ -582,12 +585,14 @@ async function creditOrDebitTabCoins(oldContent, newContent, options = {}) {
         transaction: options.transaction,
       }
     );
+  }
 
+  if (contentEarnings > 0) {
     await balance.create(
       {
         balanceType: 'content:tabcoin',
         recipientId: newContent.id,
-        amount: contentDefaultEarnings,
+        amount: contentEarnings,
         originatorType: options.eventId ? 'event' : 'content',
         originatorId: options.eventId ? options.eventId : newContent.id,
       },
@@ -595,7 +600,6 @@ async function creditOrDebitTabCoins(oldContent, newContent, options = {}) {
         transaction: options.transaction,
       }
     );
-    return;
   }
 }
 

--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -73,7 +73,11 @@ export default function Post({ contentFound, rootContentFound, parentContentFoun
               p: 4,
               wordWrap: 'break-word',
             }}>
-            <Content key={contentFound.id} content={{ parent_id: contentFound.id }} mode="compact" />
+            <Content
+              key={contentFound.id}
+              content={{ owner_id: contentFound.owner_id, parent_id: contentFound.id }}
+              mode="compact"
+            />
           </Box>
 
           <RenderChildrenTree
@@ -176,7 +180,7 @@ function RenderChildrenTree({ childrenList, renderIntent, renderIncrement }) {
   const { filteredTree, handleCollapse, handleExpand } = useCollapse({ childrenList, renderIntent, renderIncrement });
 
   return filteredTree.map((child) => {
-    const { children = [], groupedCount, id, renderIntent, renderShowMore } = child;
+    const { children = [], groupedCount, id, owner_id, renderIntent, renderShowMore } = child;
     const labelShowMore = Math.min(renderIncrement, groupedCount);
     const plural = labelShowMore > 1 ? 's' : '';
 
@@ -253,7 +257,7 @@ function RenderChildrenTree({ childrenList, renderIntent, renderIncrement }) {
               <Content content={child} mode="view" />
 
               <Box sx={{ mt: 4 }}>
-                <Content content={{ parent_id: id }} mode="compact" viewFrame={true} />
+                <Content content={{ owner_id, parent_id: id }} mode="compact" viewFrame={true} />
               </Box>
 
               {children.length > 0 && (

--- a/tests/integration/api/v1/contents/[username]/[slug]/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/get.test.js
@@ -76,7 +76,7 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
       const defaultUserContent = await orchestrator.createContent({
         owner_id: defaultUser.id,
         title: 'Conteúdo publicamente disponível',
-        body: 'Deveria estar disponível para todos.',
+        body: 'Conteúdo relevante deveria estar disponível para todos.',
         status: 'published',
         source_url: 'https://www.tabnews.com.br/',
       });
@@ -94,7 +94,7 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
         parent_id: null,
         slug: 'conteudo-publicamente-disponivel',
         title: 'Conteúdo publicamente disponível',
-        body: 'Deveria estar disponível para todos.',
+        body: 'Conteúdo relevante deveria estar disponível para todos.',
         status: 'published',
         tabcoins: 1,
         source_url: 'https://www.tabnews.com.br/',
@@ -152,7 +152,7 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
       const rootContent = await orchestrator.createContent({
         owner_id: defaultUser.id,
         title: 'Conteúdo root',
-        body: 'Conteúdo root',
+        body: 'Body with relevant texts needs to contain a good amount of words',
         status: 'published',
       });
 
@@ -199,7 +199,7 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
         parent_id: null,
         slug: responseBody.slug,
         title: 'Conteúdo root',
-        body: 'Conteúdo root',
+        body: 'Body with relevant texts needs to contain a good amount of words',
         status: 'published',
         tabcoins: 1,
         source_url: null,

--- a/tests/integration/api/v1/contents/[username]/[slug]/parent/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/parent/get.test.js
@@ -196,7 +196,7 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
       const rootContent = await orchestrator.createContent({
         owner_id: firstUser.id,
         title: 'Root content title',
-        body: 'Root content body',
+        body: 'Root - Body with relevant texts needs to contain a good amount of words',
         status: 'published',
       });
 
@@ -204,7 +204,7 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
         owner_id: secondUser.id,
         parent_id: rootContent.id,
         title: 'Child content title Level 1',
-        body: 'Child content body Level 1',
+        body: 'Child content body Level 1 - relevant content',
         status: 'published',
       });
 
@@ -221,7 +221,7 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
         owner_id: firstUser.id,
         slug: 'root-content-title',
         title: 'Root content title',
-        body: 'Root content body',
+        body: 'Root - Body with relevant texts needs to contain a good amount of words',
         children_deep_count: 1,
         status: 'published',
         source_url: null,
@@ -257,7 +257,7 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
         owner_id: firstUser.id,
         parent_id: childContentLevel1.id,
         title: 'Child content title Level 2',
-        body: 'Child content body Level 2',
+        body: 'Child content body Level 2 - relevant content',
         status: 'published',
       });
 
@@ -282,7 +282,7 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
         owner_id: firstUser.id,
         slug: 'child-content-title-level-2',
         title: 'Child content title Level 2',
-        body: 'Child content body Level 2',
+        body: 'Child content body Level 2 - relevant content',
         children_deep_count: 1,
         status: 'published',
         source_url: null,
@@ -383,7 +383,7 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
         owner_id: firstUser.id,
         parent_id: childContentLevel1.id,
         title: 'Child content title Level 2',
-        body: 'Child content body Level 2',
+        body: 'Child content body Level 2 - deleted parent',
         status: 'published',
       });
 

--- a/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
@@ -397,7 +397,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         updated_at: responseBody.updated_at,
         published_at: responseBody.published_at,
         deleted_at: null,
-        tabcoins: 1,
+        tabcoins: 0,
         owner_username: firstUser.username,
       });
 
@@ -1002,7 +1002,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         title: 'Segundo conteúdo',
         body: 'Segundo conteúdo',
         status: 'published',
-        tabcoins: 1,
+        tabcoins: 0,
         source_url: null,
         created_at: responseBody.created_at,
         updated_at: responseBody.updated_at,
@@ -1613,7 +1613,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       const defaultUserContent = await orchestrator.createContent({
         owner_id: defaultUser.id,
         title: 'Título velho',
-        body: 'Body velho',
+        body: 'Body with relevant texts needs to contain a good amount of words',
         status: 'draft',
       });
 
@@ -1641,7 +1641,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         parent_id: null,
         slug: 'titulo-velho',
         title: 'Título velho',
-        body: 'Body velho',
+        body: 'Body with relevant texts needs to contain a good amount of words',
         status: 'published',
         source_url: null,
         created_at: responseBody.created_at,
@@ -1711,7 +1711,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       const defaultUserContent = await orchestrator.createContent({
         owner_id: defaultUser.id,
         title: 'Title',
-        body: 'Body',
+        body: 'Body with relevant texts needs to contain a good amount of words',
         status: 'published',
       });
 
@@ -1739,7 +1739,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         parent_id: null,
         slug: 'title',
         title: 'Title',
-        body: 'Body',
+        body: 'Body with relevant texts needs to contain a good amount of words',
         status: 'deleted',
         tabcoins: 1,
         source_url: null,
@@ -2732,7 +2732,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const defaultUserContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
           title: 'Title',
-          body: 'Body',
+          body: 'Body with relevant texts needs to contain a good amount of words',
           status: 'draft',
         });
 
@@ -2820,7 +2820,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const defaultUserContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
           title: 'Title',
-          body: 'Body',
+          body: 'Body with relevant texts needs to contain a good amount of words',
           status: 'published',
         });
 
@@ -2877,7 +2877,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const defaultUserContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
           title: 'Title',
-          body: 'Body',
+          body: 'Body with relevant texts needs to contain a good amount of words',
           status: 'published',
         });
 
@@ -2926,6 +2926,64 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         expect(userResponseBody.tabcash).toEqual(0);
       });
 
+      test('Deletion of "root" content that was first published without the minimum amount of relevant words', async () => {
+        const defaultUser = await orchestrator.createUser();
+        await orchestrator.activateUser(defaultUser);
+        const sessionObject = await orchestrator.createSession(defaultUser);
+        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: 4 });
+
+        const defaultUserContent = await orchestrator.createContent({
+          owner_id: defaultUser.id,
+          title: 'Title',
+          body: 'Body with no minimum amount of relevant words',
+          status: 'published',
+        });
+
+        const userResponseBefore = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+
+        const userResponseBodyBefore = await userResponseBefore.json();
+
+        expect(userResponseBodyBefore.tabcoins).toEqual(0);
+        expect(userResponseBodyBefore.tabcash).toEqual(0);
+
+        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: 1 });
+
+        const contentResponse = await fetch(
+          `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+          {
+            method: 'PATCH',
+            headers: {
+              'Content-Type': 'application/json',
+              cookie: `session_id=${sessionObject.token}`,
+            },
+            body: JSON.stringify({
+              status: 'deleted',
+            }),
+          }
+        );
+
+        const contentResponseBody = await contentResponse.json();
+
+        expect(contentResponseBody.tabcoins).toEqual(0);
+
+        const userResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+
+        const userResponseBody = await userResponse.json();
+
+        expect(userResponseBody.tabcoins).toEqual(0);
+        expect(userResponseBody.tabcash).toEqual(0);
+      });
+
       test('"root" content with positive tabcoins updated from "published" to "deleted" status (with prestige)', async () => {
         const defaultUser = await orchestrator.createUser();
         await orchestrator.activateUser(defaultUser);
@@ -2935,7 +2993,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const defaultUserContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
           title: 'Title',
-          body: 'Body',
+          body: 'Body with relevant texts needs to contain a good amount of words',
           status: 'published',
         });
 
@@ -2992,7 +3050,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const defaultUserContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
           title: 'Title',
-          body: 'Body',
+          body: 'Body with relevant texts needs to contain a good amount of words',
           status: 'published',
         });
 
@@ -3050,7 +3108,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const defaultUserContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
           title: 'Title',
-          body: 'Body',
+          body: 'Body with relevant texts needs to contain a good amount of words',
           status: 'published',
         });
 
@@ -3107,7 +3165,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const defaultUserContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
           title: 'Title',
-          body: 'Body',
+          body: 'Body with relevant texts needs to contain a good amount of words',
           status: 'published',
         });
 
@@ -3166,7 +3224,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const rootContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
           title: 'Root',
-          body: 'Body',
+          body: 'Body with relevant texts needs to contain a good amount of words',
           status: 'published',
         });
 
@@ -3174,7 +3232,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
           owner_id: defaultUser.id,
           parent_id: rootContent.id,
           title: 'Child',
-          body: 'Body',
+          body: 'Body with relevant texts needs to contain a good amount of words',
         });
 
         const contentResponse = await fetch(
@@ -3218,7 +3276,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const rootContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
           title: 'Root',
-          body: 'Body',
+          body: 'Body with relevant texts needs to contain a good amount of words',
           status: 'published',
         });
 
@@ -3226,7 +3284,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
           owner_id: defaultUser.id,
           parent_id: rootContent.id,
           title: 'Child',
-          body: 'Body',
+          body: 'Body with relevant texts needs to contain a good amount of words',
           status: 'draft',
         });
 
@@ -3272,7 +3330,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const rootContent = await orchestrator.createContent({
           owner_id: firstUser.id,
           title: 'Root',
-          body: 'Body',
+          body: 'Body with relevant texts needs to contain a good amount of words',
           status: 'published',
         });
 
@@ -3280,7 +3338,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
           owner_id: secondUser.id,
           parent_id: rootContent.id,
           title: 'Child',
-          body: 'Body',
+          body: 'Body with relevant texts needs to contain a good amount of words',
           status: 'draft',
         });
 
@@ -3337,7 +3395,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const rootContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
           title: 'Root',
-          body: 'Body',
+          body: 'Body with relevant texts needs to contain a good amount of words',
           status: 'published',
         });
 
@@ -3345,7 +3403,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
           owner_id: defaultUser.id,
           parent_id: rootContent.id,
           title: 'Child',
-          body: 'Body',
+          body: 'Body with relevant texts needs to contain a good amount of words',
           status: 'draft',
         });
 
@@ -3403,7 +3461,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const rootContent = await orchestrator.createContent({
           owner_id: firstUser.id,
           title: 'Root',
-          body: 'Body',
+          body: 'Body with relevant texts needs to contain a good amount of words',
           status: 'published',
         });
 
@@ -3411,7 +3469,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
           owner_id: secondUser.id,
           parent_id: rootContent.id,
           title: 'Child',
-          body: 'Body',
+          body: 'Body with relevant texts needs to contain a good amount of words',
           status: 'draft',
         });
 
@@ -3468,7 +3526,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const rootContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
           title: 'Root',
-          body: 'Body',
+          body: 'Body with relevant texts needs to contain a good amount of words',
           status: 'published',
         });
 
@@ -3476,7 +3534,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
           owner_id: defaultUser.id,
           parent_id: rootContent.id,
           title: 'Child',
-          body: 'Body',
+          body: 'Body with relevant texts needs to contain a good amount of words',
           status: 'published',
         });
 
@@ -3532,7 +3590,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const rootContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
           title: 'Root',
-          body: 'Body',
+          body: 'Body with relevant texts needs to contain a good amount of words',
           status: 'published',
         });
 
@@ -3540,7 +3598,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
           owner_id: defaultUser.id,
           parent_id: rootContent.id,
           title: 'Child',
-          body: 'Body',
+          body: 'Body with relevant texts needs to contain a good amount of words',
           status: 'published',
         });
 
@@ -3597,7 +3655,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const rootContent = await orchestrator.createContent({
           owner_id: firstUser.id,
           title: 'Root',
-          body: 'Body',
+          body: 'Body with relevant texts needs to contain a good amount of words',
           status: 'published',
         });
 
@@ -3605,7 +3663,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
           owner_id: secondUser.id,
           parent_id: rootContent.id,
           title: 'Child',
-          body: 'Body',
+          body: 'Body with relevant texts needs to contain a good amount of words',
           status: 'published',
         });
 
@@ -3661,7 +3719,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const rootContent = await orchestrator.createContent({
           owner_id: firstUser.id,
           title: 'Root',
-          body: 'Body',
+          body: 'Body with relevant texts needs to contain a good amount of words',
           status: 'published',
         });
 
@@ -3669,7 +3727,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
           owner_id: secondUser.id,
           parent_id: rootContent.id,
           title: 'Child',
-          body: 'Body',
+          body: 'Body with relevant texts needs to contain a good amount of words',
           status: 'published',
         });
 
@@ -3715,6 +3773,209 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         expect(secondUserResponse2Body.tabcoins).toEqual(0);
         expect(secondUserResponse2Body.tabcash).toEqual(0);
       });
+
+      test('Deletion of "child" content that was first published without the minimum amount of relevant words (without votes)', async () => {
+        const firstUser = await orchestrator.createUser();
+        const secondUser = await orchestrator.createUser();
+        await orchestrator.activateUser(secondUser);
+        const sessionObject = await orchestrator.createSession(secondUser);
+        await orchestrator.createPrestige(secondUser.id);
+
+        const rootContent = await orchestrator.createContent({
+          owner_id: firstUser.id,
+          title: 'Root',
+          body: 'Body with relevant texts needs to contain a good amount of words',
+          status: 'published',
+        });
+
+        const childContent = await orchestrator.createContent({
+          owner_id: secondUser.id,
+          parent_id: rootContent.id,
+          title: 'Child',
+          body: 'Body with no minimum amount of relevant words',
+          status: 'published',
+        });
+
+        const userResponse1 = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${secondUser.username}`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+
+        const userResponse1Body = await userResponse1.json();
+
+        expect(userResponse1Body.tabcoins).toEqual(0);
+        expect(userResponse1Body.tabcash).toEqual(0);
+
+        const contentResponse = await fetch(
+          `${orchestrator.webserverUrl}/api/v1/contents/${secondUser.username}/${childContent.slug}`,
+          {
+            method: 'PATCH',
+            headers: {
+              'Content-Type': 'application/json',
+              cookie: `session_id=${sessionObject.token}`,
+            },
+            body: JSON.stringify({
+              status: 'deleted',
+            }),
+          }
+        );
+
+        const contentResponseBody = await contentResponse.json();
+
+        expect(contentResponseBody.tabcoins).toEqual(0);
+
+        const userResponse2 = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${secondUser.username}`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+
+        const userResponse2Body = await userResponse2.json();
+
+        expect(userResponse2Body.tabcoins).toEqual(0);
+        expect(userResponse2Body.tabcash).toEqual(0);
+      });
+
+      test('Deletion of "child" content that was first published without the minimum amount of relevant words (with positive votes)', async () => {
+        const firstUser = await orchestrator.createUser();
+        const secondUser = await orchestrator.createUser();
+        await orchestrator.activateUser(secondUser);
+        const sessionObject = await orchestrator.createSession(secondUser);
+        await orchestrator.createPrestige(secondUser.id);
+
+        const rootContent = await orchestrator.createContent({
+          owner_id: firstUser.id,
+          title: 'Root',
+          body: 'Body with relevant texts needs to contain a good amount of words',
+          status: 'published',
+        });
+
+        const childContent = await orchestrator.createContent({
+          owner_id: secondUser.id,
+          parent_id: rootContent.id,
+          title: 'Child',
+          body: 'Body with no minimum amount of relevant words',
+          status: 'published',
+        });
+
+        await orchestrator.createPrestige(secondUser.id, { rootPrestigeNumerator: 10 });
+
+        await orchestrator.createRate(childContent, 10);
+
+        const userResponse1 = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${secondUser.username}`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+
+        const userResponse1Body = await userResponse1.json();
+
+        expect(userResponse1Body.tabcoins).toEqual(10);
+        expect(userResponse1Body.tabcash).toEqual(0);
+
+        const contentResponse = await fetch(
+          `${orchestrator.webserverUrl}/api/v1/contents/${secondUser.username}/${childContent.slug}`,
+          {
+            method: 'PATCH',
+            headers: {
+              'Content-Type': 'application/json',
+              cookie: `session_id=${sessionObject.token}`,
+            },
+            body: JSON.stringify({
+              status: 'deleted',
+            }),
+          }
+        );
+
+        const contentResponseBody = await contentResponse.json();
+
+        expect(contentResponseBody.tabcoins).toEqual(10);
+
+        const userResponse2 = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${secondUser.username}`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+
+        const userResponse2Body = await userResponse2.json();
+
+        expect(userResponse2Body.tabcoins).toEqual(0);
+        expect(userResponse2Body.tabcash).toEqual(0);
+      });
+
+      test('Deletion of "child" content that was first published without the minimum amount of relevant words (with negative votes)', async () => {
+        const firstUser = await orchestrator.createUser();
+        const secondUser = await orchestrator.createUser();
+        await orchestrator.activateUser(secondUser);
+        const sessionObject = await orchestrator.createSession(secondUser);
+        await orchestrator.createPrestige(secondUser.id);
+
+        const rootContent = await orchestrator.createContent({
+          owner_id: firstUser.id,
+          title: 'Root',
+          body: 'Body with relevant texts needs to contain a good amount of words',
+          status: 'published',
+        });
+
+        const childContent = await orchestrator.createContent({
+          owner_id: secondUser.id,
+          parent_id: rootContent.id,
+          title: 'Child',
+          body: 'Body with no minimum amount of relevant words',
+          status: 'published',
+        });
+
+        await orchestrator.createPrestige(secondUser.id, { rootPrestigeNumerator: 10 });
+
+        await orchestrator.createRate(childContent, -10);
+
+        const userResponse1 = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${secondUser.username}`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+
+        const userResponse1Body = await userResponse1.json();
+
+        expect(userResponse1Body.tabcoins).toEqual(-10);
+        expect(userResponse1Body.tabcash).toEqual(0);
+
+        const contentResponse = await fetch(
+          `${orchestrator.webserverUrl}/api/v1/contents/${secondUser.username}/${childContent.slug}`,
+          {
+            method: 'PATCH',
+            headers: {
+              'Content-Type': 'application/json',
+              cookie: `session_id=${sessionObject.token}`,
+            },
+            body: JSON.stringify({
+              status: 'deleted',
+            }),
+          }
+        );
+
+        const contentResponseBody = await contentResponse.json();
+
+        expect(contentResponseBody.tabcoins).toEqual(-10);
+
+        const userResponse2 = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${secondUser.username}`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+
+        const userResponse2Body = await userResponse2.json();
+
+        expect(userResponse2Body.tabcoins).toEqual(-10);
+        expect(userResponse2Body.tabcash).toEqual(0);
+      });
     });
   });
 
@@ -3729,7 +3990,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       const secondUserContent = await orchestrator.createContent({
         owner_id: secondUser.id,
         title: 'Conteúdo do Segundo Usuário antes do patch!',
-        body: 'Body antes do patch!',
+        body: 'Body antes do patch! - Body with relevant texts needs to contain a good amount of words',
         status: 'published',
       });
 

--- a/tests/integration/api/v1/contents/[username]/[slug]/root/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/root/get.test.js
@@ -196,7 +196,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
       const rootContent = await orchestrator.createContent({
         owner_id: firstUser.id,
         title: 'Root content title',
-        body: 'Root content body',
+        body: 'Body with relevant texts needs to contain a good amount of words',
         status: 'published',
       });
 
@@ -221,7 +221,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
         owner_id: firstUser.id,
         slug: 'root-content-title',
         title: 'Root content title',
-        body: 'Root content body',
+        body: 'Body with relevant texts needs to contain a good amount of words',
         children_deep_count: 1,
         status: 'published',
         source_url: null,
@@ -241,7 +241,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
       const rootContent = await orchestrator.createContent({
         owner_id: firstUser.id,
         title: 'Root content title',
-        body: 'Root content body',
+        body: 'Body with relevant texts needs to contain a good amount of words',
         status: 'published',
       });
 
@@ -282,7 +282,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
         owner_id: firstUser.id,
         slug: 'root-content-title',
         title: 'Root content title',
-        body: 'Root content body',
+        body: 'Body with relevant texts needs to contain a good amount of words',
         children_deep_count: 3,
         status: 'published',
         source_url: null,
@@ -302,7 +302,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
       const rootContent = await orchestrator.createContent({
         owner_id: firstUser.id,
         title: 'Root content title',
-        body: 'Root content body',
+        body: 'Body with relevant texts needs to contain a good amount of words',
         status: 'published',
       });
 
@@ -348,7 +348,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
         owner_id: firstUser.id,
         slug: 'root-content-title',
         title: 'Root content title',
-        body: 'Root content body',
+        body: 'Body with relevant texts needs to contain a good amount of words',
         children_deep_count: 2,
         status: 'published',
         source_url: null,
@@ -434,7 +434,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
       const rootContent = await orchestrator.createContent({
         owner_id: firstUser.id,
         title: 'Root content title',
-        body: 'Root content body',
+        body: 'Root - Body with relevant texts needs to contain a good amount of words',
         status: 'published',
         source_url: 'https://www.tabnews.com.br/',
       });

--- a/tests/integration/api/v1/contents/[username]/[slug]/tabcoins/post.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/tabcoins/post.test.js
@@ -143,7 +143,7 @@ describe('POST /api/v1/contents/tabcoins', () => {
       const firstUserContent = await orchestrator.createContent({
         owner_id: firstUser.id,
         title: 'Root',
-        body: 'Body',
+        body: 'Body with relevant texts needs to contain a good amount of words',
         status: 'published',
       });
 
@@ -209,7 +209,7 @@ describe('POST /api/v1/contents/tabcoins', () => {
       const firstUserContent = await orchestrator.createContent({
         owner_id: firstUser.id,
         title: 'Root',
-        body: 'Body',
+        body: 'Body with relevant texts needs to contain a good amount of words',
         status: 'published',
       });
 
@@ -519,7 +519,7 @@ describe('POST /api/v1/contents/tabcoins', () => {
       const firstUserContent = await orchestrator.createContent({
         owner_id: firstUser.id,
         title: 'Root',
-        body: 'Body',
+        body: 'Body with relevant texts needs to contain a good amount of words',
         status: 'published',
       });
 

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -864,7 +864,7 @@ describe('POST /api/v1/contents', () => {
         title: 'Conteúdo existente',
         body: 'Outro body',
         status: 'published',
-        tabcoins: 1,
+        tabcoins: 0,
         source_url: null,
         created_at: secondContentBody.created_at,
         updated_at: secondContentBody.updated_at,
@@ -1233,7 +1233,7 @@ describe('POST /api/v1/contents', () => {
         updated_at: responseBody.updated_at,
         published_at: responseBody.published_at,
         deleted_at: null,
-        tabcoins: 1,
+        tabcoins: 0,
         owner_username: defaultUser.username,
       });
 
@@ -2705,7 +2705,7 @@ describe('POST /api/v1/contents', () => {
           },
           body: JSON.stringify({
             title: 'Title',
-            body: 'Body',
+            body: 'Body with relevant text needs to contain a good amount of words.',
           }),
         });
 
@@ -2740,7 +2740,7 @@ describe('POST /api/v1/contents', () => {
           },
           body: JSON.stringify({
             title: 'Title',
-            body: 'Body',
+            body: 'Body with relevant text needs to contain a good amount of words.',
             status: 'published',
           }),
         });
@@ -2771,7 +2771,7 @@ describe('POST /api/v1/contents', () => {
         const rootContent = await orchestrator.createContent({
           owner_id: firstUser.id,
           title: 'Root',
-          body: 'Body',
+          body: 'Root - Body with relevant text needs to contain a good amount of words.',
           status: 'published',
         });
 
@@ -2782,7 +2782,7 @@ describe('POST /api/v1/contents', () => {
             cookie: `session_id=${sessionObject.token}`,
           },
           body: JSON.stringify({
-            body: 'Body',
+            body: 'Child - Body with relevant text needs to contain a good amount of words.',
             parent_id: rootContent.id,
             status: 'draft',
           }),
@@ -2815,7 +2815,7 @@ describe('POST /api/v1/contents', () => {
         const rootContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
           title: 'Root',
-          body: 'Body',
+          body: 'Root - Body with relevant text needs to contain a good amount of words.',
           status: 'published',
         });
 
@@ -2828,7 +2828,7 @@ describe('POST /api/v1/contents', () => {
             cookie: `session_id=${sessionObject.token}`,
           },
           body: JSON.stringify({
-            body: 'Body',
+            body: 'Child - Body with relevant text needs to contain a good amount of words.',
             parent_id: rootContent.id,
             status: 'published',
           }),
@@ -2861,7 +2861,7 @@ describe('POST /api/v1/contents', () => {
         const rootContent = await orchestrator.createContent({
           owner_id: firstUser.id,
           title: 'Root',
-          body: 'Body',
+          body: 'Root - Body with relevant text needs to contain a good amount of words.',
           status: 'published',
         });
 
@@ -2872,7 +2872,7 @@ describe('POST /api/v1/contents', () => {
             cookie: `session_id=${sessionObject.token}`,
           },
           body: JSON.stringify({
-            body: 'Body',
+            body: 'Child - Body with relevant text needs to contain a good amount of words.',
             parent_id: rootContent.id,
             status: 'published',
           }),
@@ -2911,7 +2911,7 @@ describe('POST /api/v1/contents', () => {
           },
           body: JSON.stringify({
             title: 'Title',
-            body: 'Body',
+            body: 'Body with relevant text needs to contain a good amount of words.',
             status: 'published',
           }),
         });
@@ -2993,7 +2993,7 @@ describe('POST /api/v1/contents', () => {
           },
           body: JSON.stringify({
             title: 'Title',
-            body: 'Body',
+            body: 'Body with relevant texts needs to contain a good amount of words',
             status: 'published',
           }),
         });
@@ -3008,7 +3008,7 @@ describe('POST /api/v1/contents', () => {
           parent_id: null,
           slug: 'title',
           title: 'Title',
-          body: 'Body',
+          body: 'Body with relevant texts needs to contain a good amount of words',
           status: 'published',
           source_url: null,
           created_at: responseBody.created_at,
@@ -3115,7 +3115,7 @@ describe('POST /api/v1/contents', () => {
           },
           body: JSON.stringify({
             title: 'Title',
-            body: 'Body',
+            body: 'Body with relevant texts needs to contain a good amount of words',
             status: 'published',
           }),
         });
@@ -3130,7 +3130,7 @@ describe('POST /api/v1/contents', () => {
           parent_id: null,
           slug: 'title',
           title: 'Title',
-          body: 'Body',
+          body: 'Body with relevant texts needs to contain a good amount of words',
           status: 'published',
           source_url: null,
           created_at: responseBody.created_at,
@@ -3179,7 +3179,7 @@ describe('POST /api/v1/contents', () => {
             cookie: `session_id=${sessionObject.token}`,
           },
           body: JSON.stringify({
-            body: 'Deve conseguir publicar, mas não deve ganhar TabCoins',
+            body: 'Deve conseguir publicar, mas não deve ganhar TabCoins sem prestígio suficiente.',
             parent_id: rootContent.id,
             status: 'published',
           }),
@@ -3195,7 +3195,7 @@ describe('POST /api/v1/contents', () => {
           parent_id: rootContent.id,
           slug: responseBody.slug,
           title: null,
-          body: 'Deve conseguir publicar, mas não deve ganhar TabCoins',
+          body: 'Deve conseguir publicar, mas não deve ganhar TabCoins sem prestígio suficiente.',
           status: 'published',
           source_url: null,
           created_at: responseBody.created_at,
@@ -3237,7 +3237,7 @@ describe('POST /api/v1/contents', () => {
           },
           body: JSON.stringify({
             title: 'Title',
-            body: 'Body',
+            body: 'Body with relevant texts needs to contain a good amount of words',
             status: 'published',
           }),
         });
@@ -3252,7 +3252,7 @@ describe('POST /api/v1/contents', () => {
           parent_id: null,
           slug: 'title',
           title: 'Title',
-          body: 'Body',
+          body: 'Body with relevant texts needs to contain a good amount of words',
           status: 'published',
           source_url: null,
           created_at: responseBody.created_at,
@@ -3301,7 +3301,7 @@ describe('POST /api/v1/contents', () => {
             cookie: `session_id=${sessionObject.token}`,
           },
           body: JSON.stringify({
-            body: 'Deve conseguir publicar e ganhar TabCoins.',
+            body: 'Deve conseguir publicar e ganhar TabCoins com esse texto.',
             parent_id: rootContent.id,
             status: 'published',
           }),
@@ -3317,7 +3317,292 @@ describe('POST /api/v1/contents', () => {
           parent_id: rootContent.id,
           slug: responseBody.slug,
           title: null,
-          body: 'Deve conseguir publicar e ganhar TabCoins.',
+          body: 'Deve conseguir publicar e ganhar TabCoins com esse texto.',
+          status: 'published',
+          source_url: null,
+          created_at: responseBody.created_at,
+          updated_at: responseBody.updated_at,
+          published_at: responseBody.published_at,
+          deleted_at: null,
+          tabcoins: 1,
+          owner_username: defaultUser.username,
+        });
+
+        expect(uuidVersion(responseBody.id)).toEqual(4);
+        expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+        expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+
+        const userResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+
+        const userResponseBody = await userResponse.json();
+
+        expect(userResponseBody.tabcoins).toEqual(1);
+        expect(userResponseBody.tabcash).toEqual(0);
+      });
+    });
+
+    describe('No minimum amount of relevant words', () => {
+      test('should not be able to create "root" content without prestige', async () => {
+        const defaultUser = await orchestrator.createUser();
+        await orchestrator.activateUser(defaultUser);
+        const sessionObject = await orchestrator.createSession(defaultUser);
+        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: -6, rootPrestigeDenominator: 10 });
+
+        const contentResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
+          method: 'post',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            title: 'Title',
+            body: 'Body',
+            status: 'published',
+          }),
+        });
+
+        const responseBody = await contentResponse.json();
+
+        expect(contentResponse.status).toEqual(403);
+        expect(responseBody.status_code).toEqual(403);
+        expect(responseBody.name).toEqual('ForbiddenError');
+        expect(responseBody.message).toEqual(
+          'Não é possível publicar porque há outras publicações mal avaliadas que ainda não foram excluídas.'
+        );
+        expect(responseBody.action).toEqual(
+          'Exclua seus conteúdos mais recentes que estiverem classificados como não relevantes.'
+        );
+        expect(uuidVersion(responseBody.error_id)).toEqual(4);
+        expect(uuidVersion(responseBody.request_id)).toEqual(4);
+        expect(responseBody.error_location_code).toEqual(
+          'MODEL:CONTENT:CREDIT_OR_DEBIT_TABCOINS:NEGATIVE_USER_EARNINGS'
+        );
+      });
+
+      test('Should not be able to earn tabcoins in "root" content', async () => {
+        const defaultUser = await orchestrator.createUser();
+        await orchestrator.activateUser(defaultUser);
+        const sessionObject = await orchestrator.createSession(defaultUser);
+        await orchestrator.createPrestige(defaultUser.id);
+
+        const contentResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
+          method: 'post',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            title: 'Title',
+            body: 'Body with no minimum amount of relevant words',
+            status: 'published',
+          }),
+        });
+
+        const responseBody = await contentResponse.json();
+
+        expect(contentResponse.status).toEqual(201);
+
+        expect(responseBody).toStrictEqual({
+          id: responseBody.id,
+          owner_id: defaultUser.id,
+          parent_id: null,
+          slug: 'title',
+          title: 'Title',
+          body: 'Body with no minimum amount of relevant words',
+          status: 'published',
+          source_url: null,
+          created_at: responseBody.created_at,
+          updated_at: responseBody.updated_at,
+          published_at: responseBody.published_at,
+          deleted_at: null,
+          tabcoins: 0,
+          owner_username: defaultUser.username,
+        });
+
+        expect(uuidVersion(responseBody.id)).toEqual(4);
+        expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+        expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+
+        const userResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+
+        const userResponseBody = await userResponse.json();
+
+        expect(userResponseBody.tabcoins).toEqual(0);
+        expect(userResponseBody.tabcash).toEqual(0);
+      });
+
+      test('Should not be able to earn tabcoins in "child" content', async () => {
+        const defaultUser = await orchestrator.createUser();
+        await orchestrator.activateUser(defaultUser);
+        const secondUser = await orchestrator.createUser();
+        await orchestrator.activateUser(secondUser);
+        const sessionObject = await orchestrator.createSession(defaultUser);
+        await orchestrator.createPrestige(defaultUser.id);
+
+        const rootContent = await orchestrator.createContent({
+          owner_id: secondUser.id,
+          title: 'Conteúdo raiz',
+          status: 'published',
+        });
+
+        const childResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
+          method: 'post',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            body: 'Body with no minimum amount of relevant words',
+            parent_id: rootContent.id,
+            status: 'published',
+          }),
+        });
+
+        const responseBody = await childResponse.json();
+
+        expect(childResponse.status).toEqual(201);
+
+        expect(responseBody).toStrictEqual({
+          id: responseBody.id,
+          owner_id: defaultUser.id,
+          parent_id: rootContent.id,
+          slug: responseBody.slug,
+          title: null,
+          body: 'Body with no minimum amount of relevant words',
+          status: 'published',
+          source_url: null,
+          created_at: responseBody.created_at,
+          updated_at: responseBody.updated_at,
+          published_at: responseBody.published_at,
+          deleted_at: null,
+          tabcoins: 0,
+          owner_username: defaultUser.username,
+        });
+
+        expect(uuidVersion(responseBody.id)).toEqual(4);
+        expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+        expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+
+        const userResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+
+        const userResponseBody = await userResponse.json();
+
+        expect(userResponseBody.tabcoins).toEqual(0);
+        expect(userResponseBody.tabcash).toEqual(0);
+      });
+    });
+
+    describe('With minimal amount of relevant words', () => {
+      test('Should be able to earn tabcoins in "root" content', async () => {
+        const defaultUser = await orchestrator.createUser();
+        await orchestrator.activateUser(defaultUser);
+        const sessionObject = await orchestrator.createSession(defaultUser);
+        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: 2, rootPrestigeDenominator: 10 });
+
+        const contentResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
+          method: 'post',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            title: 'Title',
+            body: 'Relevant text needs to contain a good amount of words',
+            status: 'published',
+          }),
+        });
+
+        const responseBody = await contentResponse.json();
+
+        expect(contentResponse.status).toEqual(201);
+
+        expect(responseBody).toStrictEqual({
+          id: responseBody.id,
+          owner_id: defaultUser.id,
+          parent_id: null,
+          slug: 'title',
+          title: 'Title',
+          body: 'Relevant text needs to contain a good amount of words',
+          status: 'published',
+          source_url: null,
+          created_at: responseBody.created_at,
+          updated_at: responseBody.updated_at,
+          published_at: responseBody.published_at,
+          deleted_at: null,
+          tabcoins: 1,
+          owner_username: defaultUser.username,
+        });
+
+        expect(uuidVersion(responseBody.id)).toEqual(4);
+        expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+        expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+
+        const userResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+
+        const userResponseBody = await userResponse.json();
+
+        expect(userResponseBody.tabcoins).toEqual(1);
+        expect(userResponseBody.tabcash).toEqual(0);
+      });
+
+      test('Should be able to earn tabcoins in "child" content', async () => {
+        const defaultUser = await orchestrator.createUser();
+        await orchestrator.activateUser(defaultUser);
+        const secondUser = await orchestrator.createUser();
+        await orchestrator.activateUser(secondUser);
+        const sessionObject = await orchestrator.createSession(defaultUser);
+        await orchestrator.createPrestige(defaultUser.id, { childPrestigeNumerator: 1, childPrestigeDenominator: 10 });
+
+        const rootContent = await orchestrator.createContent({
+          owner_id: secondUser.id,
+          title: 'Conteúdo raiz',
+          status: 'published',
+        });
+
+        const childResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
+          method: 'post',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            body: 'Relevant text needs to contain a good amount of words',
+            parent_id: rootContent.id,
+            status: 'published',
+          }),
+        });
+
+        const responseBody = await childResponse.json();
+
+        expect(childResponse.status).toEqual(201);
+
+        expect(responseBody).toStrictEqual({
+          id: responseBody.id,
+          owner_id: defaultUser.id,
+          parent_id: rootContent.id,
+          slug: responseBody.slug,
+          title: null,
+          body: 'Relevant text needs to contain a good amount of words',
           status: 'published',
           source_url: null,
           created_at: responseBody.created_at,

--- a/tests/integration/api/v1/users/[username]/delete.test.js
+++ b/tests/integration/api/v1/users/[username]/delete.test.js
@@ -183,7 +183,7 @@ describe('DELETE /api/v1/users/[username]', () => {
         },
         body: JSON.stringify({
           title: 'firstUserRootContent',
-          body: 'Body',
+          body: 'Body with relevant texts needs to contain a good amount of words',
           status: 'published',
         }),
       });
@@ -198,7 +198,7 @@ describe('DELETE /api/v1/users/[username]', () => {
         },
         body: JSON.stringify({
           parent_id: firstUserRootContentBody.id,
-          body: 'firstUserChildContent',
+          body: 'firstUserChildContent - Body with relevant texts needs to contain a good amount of words',
           status: 'published',
         }),
       });
@@ -214,7 +214,7 @@ describe('DELETE /api/v1/users/[username]', () => {
         },
         body: JSON.stringify({
           title: 'secondUserRootContent',
-          body: 'Body',
+          body: 'Body with relevant texts needs to contain a good amount of words',
           status: 'published',
         }),
       });
@@ -229,7 +229,7 @@ describe('DELETE /api/v1/users/[username]', () => {
         },
         body: JSON.stringify({
           parent_id: firstUserRootContentBody.id,
-          body: 'secondUserChildContent #1',
+          body: 'secondUserChildContent #1 - Body with relevant texts needs to contain a good amount of words',
           status: 'published',
         }),
       });
@@ -244,7 +244,7 @@ describe('DELETE /api/v1/users/[username]', () => {
         },
         body: JSON.stringify({
           parent_id: firstUserRootContentBody.id,
-          body: 'secondUserChildContent #2',
+          body: 'secondUserChildContent #2 - Body with relevant texts needs to contain a good amount of words',
           status: 'published',
         }),
       });
@@ -259,7 +259,7 @@ describe('DELETE /api/v1/users/[username]', () => {
         },
         body: JSON.stringify({
           title: 'Draft Content',
-          body: 'Draft Content',
+          body: 'Draft Content - Body with relevant texts needs to contain a good amount of words',
           status: 'draft',
         }),
       });
@@ -272,7 +272,7 @@ describe('DELETE /api/v1/users/[username]', () => {
         },
         body: JSON.stringify({
           title: 'Deleted Content',
-          body: 'Deleted Content',
+          body: 'Deleted Content - Body with relevant texts needs to contain a good amount of words',
           status: 'published',
         }),
       });


### PR DESCRIPTION
Como proposta de solução para a issue #1267, esse PR implementa uma verificação da quantidade de palavras presentes no conteúdo que está sendo publicado. Se a verificação a seguir retornar `true`, nem o usuário e nem o conteúdo ganharão TabCoins iniciais:

```js
newContent.body.split(/[a-z]{5,}/i).length < 6
```

Além de novos testes, esse PR exigiu a adequação de diversos dos testes já existentes. Seria uma boa ideia criar testes de unidade e diminuir os testes de integração.

-----

O PR também mostrou algumas inconsistências que ocorriam ao excluir conteúdos que não haviam ganho TabCoins iniciais, onde o valor de primeiro voto poderia ser considerado como se fosse o ganho inicial. Então o commit 48d220f4e33582ba91ca2ab7bfc8b4deaad4f388 é só para corrigir esse problema e criar os testes para evitar uma futura regressão.
