### PR TITLE
[`comentário` e `tabcoin`]: corrige a formatação de `singular` ou `plural`

### DIFF
--- a/pages/interface/components/ContentList/index.js
+++ b/pages/interface/components/ContentList/index.js
@@ -63,11 +63,11 @@ export default function ContentList({ contentList: list, pagination, paginationB
 
   function RenderItems() {
     function ChildrenDeepCountText({ count }) {
-      return count !== 1 ? `${count} comentários` : `${count} comentário`;
+      return count > 1 ? `${count} comentários` : `${count} comentário`;
     }
 
     function TabCoinsText({ count }) {
-      return Math.abs(count) !== 1 ? `${count} tabcoins` : `${count} tabcoin`;
+      return count > 1 || count < -1 ? `${count} tabcoins` : `${count} tabcoin`;
     }
 
     return list.map((contentObject, index) => {


### PR DESCRIPTION
Esta PR corrige o detalhe de formatação notado pelo @cesarcanoff na issue #1458 :handshake: 

Na issue, ele sugere a correção para a label de `comentário` mas ela também é aplicável à label de `tabcoin` e como as funções que fazem essa formatação são vizinhas, aproveitei para ajustar nas duas logo:+1: 

https://github.com/filipedeschamps/tabnews.com.br/blob/c0c0c346fe94c11fa2ce6e24029dd87fc7d3c63e/pages/interface/components/ContentList/index.js#L65-L71

## Preview

| `0` comentário | `1` comentário  | `1` comentário |
|--------|--------|--------|
| ![image](https://github.com/filipedeschamps/tabnews.com.br/assets/57193392/d647d120-6a8d-463a-b9d1-a9e04a6b1357) | ![image](https://github.com/filipedeschamps/tabnews.com.br/assets/57193392/62aaa5c8-b9d1-447e-88fb-a89d4af88f26) | ![image](https://github.com/filipedeschamps/tabnews.com.br/assets/57193392/2f847829-ada7-4316-96c1-b2433e859f8f) |

| `2` comentários | `2` comentários |
|--------|--------|
| ![image](https://github.com/filipedeschamps/tabnews.com.br/assets/57193392/c487e85f-fc66-4fc4-a72c-d2c241c590a1) | ![image](https://github.com/filipedeschamps/tabnews.com.br/assets/57193392/10377ac5-6a82-48c3-a4c8-40d80d307d8a) | 