### PR TITLE
[Analytics] Remover das páginas '/' (home) e '/publicar'

### DIFF
--- a/pages/_app.public.js
+++ b/pages/_app.public.js
@@ -21,7 +21,15 @@ function MyApp({ Component, pageProps }) {
             <Component {...pageProps} />
           </RevalidateProvider>
         </SWRConfig>
-        <Analytics />
+        <Analytics
+          beforeSend={(event) => {
+            const { pathname } = new URL(event.url);
+            if (['/', '/publicar'].includes(pathname)) {
+              return null;
+            }
+            return event;
+          }}
+        />
       </UserProvider>
     </ThemeProvider>
   );


### PR DESCRIPTION
Mensalmente nós estamos gerando eventos de analytics em quantidade acima do limite do nosso plano (500k), então esse PR busca nos manter dentro do limite, já que vai parar de gerar eventos da página mais acessada, que é a "home".

Além disso, também removemos da página `/publicar`, pois ela também aparece entre as mais acessadas.

Obs.: Nós temos outras formar de medir o volume de acessos à páginas específicas, mas vamos parar de computar, como visitantes únicos, os usuários que visitarem exclusivamente a página inicial do TabNews sem clicar em nenhuma publicação ou demais links internos.