### PR TITLE
feat(notifications): send URL based on parent content and fragment identifier

### DIFF
--- a/models/notification.js
+++ b/models/notification.js
@@ -21,7 +21,7 @@ async function sendReplyEmailToParentUser(createdContent) {
       return;
     }
 
-    const childContendUrl = getChildContendUrl(secureCreatedContent);
+    const childContendUrl = getChildContendUrl(parentContent, secureCreatedContent);
     const rootContent = parentContent.parent_id
       ? await content.findOne({
           where: {
@@ -78,8 +78,8 @@ function getBodyReplyLine({ createdContent, rootContent }) {
   return `"${createdContent.owner_username}" respondeu ao seu comentário na publicação "${rootContent.title}". Para ler a resposta, utilize o link abaixo:`;
 }
 
-function getChildContendUrl({ owner_username, slug }) {
-  return `${webserver.host}/${owner_username}/${slug}`;
+function getChildContendUrl({ owner_username, slug }, { id }) {
+  return `${webserver.host}/${owner_username}/${slug}#${id}`;
 }
 
 export default Object.freeze({

--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -156,6 +156,7 @@ function ViewMode({ setComponentMode, contentObject, viewFrame }) {
 
   return (
     <Box
+      id={contentObject.id}
       sx={{
         display: 'flex',
         flexDirection: 'column',

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -2398,7 +2398,7 @@ describe('POST /api/v1/contents', () => {
 
         const getLastEmail = await orchestrator.getLastEmail();
 
-        const childContentUrl = `${orchestrator.webserverUrl}/${secondUser.username}/${responseBody.slug}`;
+        const childContentUrl = `${orchestrator.webserverUrl}/${firstUser.username}/${rootContent.slug}#${responseBody.id}`;
 
         expect(response.status).toBe(201);
         expect(responseBody.parent_id).toBe(rootContent.id);
@@ -2443,7 +2443,7 @@ describe('POST /api/v1/contents', () => {
 
         const getLastEmail = await orchestrator.getLastEmail();
 
-        const childContentUrl = `${orchestrator.webserverUrl}/${secondUser.username}/${responseBody.slug}`;
+        const childContentUrl = `${orchestrator.webserverUrl}/${firstUser.username}/${rootContent.slug}#${responseBody.id}`;
 
         expect(response.status).toBe(201);
         expect(responseBody.parent_id).toBe(rootContent.id);
@@ -2496,7 +2496,7 @@ describe('POST /api/v1/contents', () => {
 
         const getLastEmail = await orchestrator.getLastEmail();
 
-        const childContentUrl = `${orchestrator.webserverUrl}/${firstUser.username}/${responseBody.slug}`;
+        const childContentUrl = `${orchestrator.webserverUrl}/${secondUser.username}/${childContentFromSecondUser.slug}#${responseBody.id}`;
 
         expect(response.status).toBe(201);
         expect(responseBody.parent_id).toBe(childContentFromSecondUser.id);
@@ -2553,7 +2553,7 @@ describe('POST /api/v1/contents', () => {
 
         const getLastEmail = await orchestrator.getLastEmail();
 
-        const childContentUrl = `${orchestrator.webserverUrl}/${firstUser.username}/${responseBody.slug}`;
+        const childContentUrl = `${orchestrator.webserverUrl}/${secondUser.username}/${childContentFromSecondUser.slug}#${responseBody.id}`;
 
         expect(response.status).toBe(201);
         expect(responseBody.parent_id).toBe(childContentFromSecondUser.id);
@@ -2678,7 +2678,7 @@ describe('POST /api/v1/contents', () => {
         // 8) CHECK IF FIRST USER RECEIVED ANY EMAIL
         const getLastEmail2 = await orchestrator.getLastEmail();
 
-        const childContentUrl = `${orchestrator.webserverUrl}/${secondUser.username}/${contentResponse2Body.slug}`;
+        const childContentUrl = `${orchestrator.webserverUrl}/${firstUser.username}/${rootContent.slug}#${contentResponse2Body.id}`;
 
         expect(getLastEmail2.recipients[0].includes(firstUser.email)).toBe(true);
         expect(getLastEmail2.subject).toBe(`"${secondUser.username}" comentou em "Testando sistema de notificação"`);


### PR DESCRIPTION
Altera o link que é enviado no email de notificação de nova resposta. Assim recebemos um link que direciona para a página do conteúdo original que foi respondido, mas que rola a página até a nova resposta.

Com isso a nova resposta abre em uma página com um contexto melhor.

O que acham?