### PR TITLE
feat: Adicionando rss para as rotas da api

### DIFF
--- a/models/rss.js
+++ b/models/rss.js
@@ -5,12 +5,8 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { Feed } from 'feed';
 import webserver from 'infra/webserver.js';
 
-function generateRss2(contentList) {
+function generateRss2(contentList, feedURL) {
   const webserverHost = webserver.host;
-
-  // TODO: make this property flexible in the future to
-  // support things like: `/[username]/rss`
-  const feedURL = `${webserverHost}/recentes/rss`;
 
   const feed = new Feed({
     title: 'TabNews',

--- a/next.config.js
+++ b/next.config.js
@@ -25,9 +25,39 @@ module.exports = {
   },
   async rewrites() {
     return [
+      //direct rss
       {
         source: '/recentes/rss',
-        destination: '/api/v1/contents/rss',
+        destination: '/api/v1/contents/rss?strategy=new',
+      },
+      {
+        source: '/relevantes/rss',
+        destination: '/api/v1/contents/rss?strategy=relevant',
+      },
+      {
+        source: '/:user/rss',
+        destination: '/api/v1/contents/:user/rss',
+      },
+      {
+        source: '/:user/:slug/rss',
+        destination: '/api/v1/contents/:user/:slug/rss',
+      },
+      //.xml rss
+      {
+        source: '/recentes/rss.xml',
+        destination: '/api/v1/contents/rss?strategy=new',
+      },
+      {
+        source: '/relevantes/rss.xml',
+        destination: '/api/v1/contents/rss?strategy=relevant',
+      },
+      {
+        source: '/:user/rss.xml',
+        destination: '/api/v1/contents/:user/rss',
+      },
+      {
+        source: '/:user/:slug/rss.xml',
+        destination: '/api/v1/contents/:user/:slug/rss',
       },
     ];
   },

--- a/pages/api/v1/contents/[username]/[slug]/rss/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/rss/index.public.js
@@ -1,0 +1,62 @@
+import nextConnect from 'next-connect';
+import controller from 'models/controller.js';
+import authorization from 'models/authorization.js';
+import cacheControl from 'models/cache-control';
+import validator from 'models/validator.js';
+import content from 'models/content.js';
+import user from 'models/user.js';
+import rss from 'models/rss.js';
+import webserver from 'infra/webserver.js';
+
+export default nextConnect({
+  attachParams: true,
+  onNoMatch: controller.onNoMatchHandler,
+  onError: controller.onErrorHandler,
+})
+  .use(controller.injectRequestMetadata)
+  .use(controller.logRequest)
+  .use(cacheControl.swrMaxAge(10))
+  .get(getValidationHandler, getHandler);
+
+function getValidationHandler(request, response, next) {
+  const cleanValues = validator(request.query, {
+    username: 'required',
+    slug: 'required',
+  });
+
+  request.query = cleanValues;
+
+  next();
+}
+
+async function getHandler(request, response) {
+  const userTryingToGet = user.createAnonymous();
+
+  const contentFound = await content.findOne({
+    where: {
+      owner_username: request.query.username,
+      slug: request.query.slug,
+      status: 'published',
+    },
+  });
+
+  if (!contentFound) {
+    throw new NotFoundError({
+      message: `O conteúdo informado não foi encontrado no sistema.`,
+      action: 'Verifique se o "slug" está digitado corretamente.',
+      stack: new Error().stack,
+      errorLocationCode: 'CONTROLLER:CONTENT:GET_HANDLER:SLUG_NOT_FOUND',
+      key: 'slug',
+    });
+  }
+
+  const secureOutputValues = authorization.filterOutput(userTryingToGet, 'read:content', contentFound);
+
+  const rss2 = rss.generateRss2(
+    [secureOutputValues],
+    `${webserver.host}/${request.query.username}/${request.query.slug}/rss`
+  );
+
+  response.setHeader('Content-Type', 'text/xml; charset=utf-8');
+  return response.status(200).send(rss2);
+}

--- a/tests/integration/api/v1/contents/[username]/[slug]/rss/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/rss/get.test.js
@@ -1,0 +1,63 @@
+import fetch from 'cross-fetch';
+import orchestrator from 'tests/orchestrator.js';
+
+describe('GET /recentes/rss', () => {
+  beforeEach(async () => {
+    await orchestrator.waitForAllServices();
+    await orchestrator.dropAllTables();
+    await orchestrator.runPendingMigrations();
+  });
+
+  describe('Anonymous user', () => {
+    test('With no content', async () => {
+      const defaultUser = await orchestrator.createUser();
+
+      const response = await fetch(`${orchestrator.webserverUrl}/${defaultUser.username}/inexists/rss`);
+
+      expect(response.status).toEqual(500);
+    });
+
+    test('With content passed', async () => {
+      const defaultUser = await orchestrator.createUser();
+
+      const firstRootContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Conteúdo #1 (mais antigo)',
+        status: 'published',
+        body: `# Corpo com HTML
+  
+  É **importante** lidar corretamente com o \`HTML\`, incluindo estilos ~~especiais~~ do \`GFM\`.`,
+      });
+
+      const response = await fetch(`${orchestrator.webserverUrl}/${defaultUser.username}/${firstRootContent.slug}/rss`);
+      const responseBody = await response.text();
+
+      expect(response.status).toEqual(200);
+      expect(responseBody).toStrictEqual(`<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+    <channel>
+        <title>TabNews</title>
+        <link>http://localhost:3000/${defaultUser.username}/${firstRootContent.slug}/rss</link>
+        <description>Conteúdos para quem trabalha com Programação e Tecnologia</description>
+        <lastBuildDate>${new Date(firstRootContent.published_at).toUTCString()}</lastBuildDate>
+        <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
+        <generator>https://github.com/jpmonette/feed</generator>
+        <language>pt</language>
+        <image>
+            <title>TabNews</title>
+            <url>http://localhost:3000/favicon-mobile.png</url>
+            <link>http://localhost:3000/${defaultUser.username}/${firstRootContent.slug}/rss</link>
+        </image>
+        <item>
+            <title><![CDATA[Conteúdo #1 (mais antigo)]]></title>
+            <link>http://localhost:3000/${firstRootContent.owner_username}/${firstRootContent.slug}</link>
+            <guid>http://localhost:3000/${firstRootContent.owner_username}/${firstRootContent.slug}</guid>
+            <pubDate>${new Date(firstRootContent.published_at).toUTCString()}</pubDate>
+            <description><![CDATA[Corpo com HTML É importante lidar corretamente com o HTML, incluindo estilos especiais do GFM.]]></description>
+            <content:encoded><![CDATA[<div class="markdown-body"><h1>Corpo com HTML</h1><p>É <strong>importante</strong> lidar corretamente com o <code>HTML</code>, incluindo estilos <del>especiais</del> do <code>GFM</code>.</p></div>]]></content:encoded>
+        </item>
+    </channel>
+</rss>`);
+    });
+  });
+});

--- a/tests/integration/api/v1/contents/[username]/rss/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/rss/get.test.js
@@ -1,0 +1,109 @@
+import fetch from 'cross-fetch';
+import orchestrator from 'tests/orchestrator.js';
+
+describe('GET /recentes/rss', () => {
+  beforeEach(async () => {
+    await orchestrator.waitForAllServices();
+    await orchestrator.dropAllTables();
+    await orchestrator.runPendingMigrations();
+  });
+
+  describe('Anonymous user', () => {
+    test('With 0 contents', async () => {
+      const defaultUser = await orchestrator.createUser();
+
+      const response = await fetch(`${orchestrator.webserverUrl}/${defaultUser.username}/rss`);
+      const responseBody = await response.text();
+
+      const lastBuildDateFromResponseBody = /<lastBuildDate>(.*?)<\/lastBuildDate>/.exec(responseBody, 'g')[1];
+
+      expect(response.status).toEqual(200);
+
+      expect(responseBody).toStrictEqual(`<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0">
+    <channel>
+        <title>TabNews</title>
+        <link>http://localhost:3000/${defaultUser.username}/rss</link>
+        <description>Conteúdos para quem trabalha com Programação e Tecnologia</description>
+        <lastBuildDate>${lastBuildDateFromResponseBody}</lastBuildDate>
+        <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
+        <generator>https://github.com/jpmonette/feed</generator>
+        <language>pt</language>
+        <image>
+            <title>TabNews</title>
+            <url>http://localhost:3000/favicon-mobile.png</url>
+            <link>http://localhost:3000/${defaultUser.username}/rss</link>
+        </image>
+    </channel>
+</rss>`);
+    });
+
+    test('With 3 contents, 2 `published` and 1 with `draft` status', async () => {
+      const defaultUser = await orchestrator.createUser();
+
+      const firstRootContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Conteúdo #1 (mais antigo)',
+        status: 'published',
+        body: `# Corpo com HTML
+  
+  É **importante** lidar corretamente com o \`HTML\`, incluindo estilos ~~especiais~~ do \`GFM\`.`,
+      });
+
+      const secondRootContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Conteúdo #2 (mais novo)',
+        body: 'Este é um corpo bastante longo, vamos ver como que a propriedade description irá reagir, pois por padrão ela deverá cortar após um número X de caracteres. Não vou tomar nota aqui da quantidade exata de caracteres, pois isso pode mudar ao longo do tempo.',
+        status: 'published',
+      });
+
+      // thirdRootContent
+      await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Conteúdo #3 (mais novo, mas no status "draft")',
+        body: `Este conteúdo não deverá aparecer na lista retornada pelo rss,
+                 porque quando um conteúdo possui o "status" como "draft", ele não
+                 esta pronto para ser listado publicamente.`,
+        status: 'draft',
+      });
+
+      const response = await fetch(`${orchestrator.webserverUrl}/${defaultUser.username}/rss`);
+      const responseBody = await response.text();
+
+      expect(response.status).toEqual(200);
+      expect(responseBody).toStrictEqual(`<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+    <channel>
+        <title>TabNews</title>
+        <link>http://localhost:3000/${defaultUser.username}/rss</link>
+        <description>Conteúdos para quem trabalha com Programação e Tecnologia</description>
+        <lastBuildDate>${new Date(secondRootContent.published_at).toUTCString()}</lastBuildDate>
+        <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
+        <generator>https://github.com/jpmonette/feed</generator>
+        <language>pt</language>
+        <image>
+            <title>TabNews</title>
+            <url>http://localhost:3000/favicon-mobile.png</url>
+            <link>http://localhost:3000/${defaultUser.username}/rss</link>
+        </image>
+        <item>
+            <title><![CDATA[Conteúdo #2 (mais novo)]]></title>
+            <link>http://localhost:3000/${secondRootContent.owner_username}/${secondRootContent.slug}</link>
+            <guid>http://localhost:3000/${secondRootContent.owner_username}/${secondRootContent.slug}</guid>
+            <pubDate>${new Date(secondRootContent.published_at).toUTCString()}</pubDate>
+            <description><![CDATA[Este é um corpo bastante longo, vamos ver como que a propriedade description irá reagir, pois por padrão ela deverá cortar após um número X de caracteres. Não vou tomar nota aqui da quant...]]></description>
+            <content:encoded><![CDATA[<div class="markdown-body"><p>Este é um corpo bastante longo, vamos ver como que a propriedade description irá reagir, pois por padrão ela deverá cortar após um número X de caracteres. Não vou tomar nota aqui da quantidade exata de caracteres, pois isso pode mudar ao longo do tempo.</p></div>]]></content:encoded>
+        </item>
+        <item>
+            <title><![CDATA[Conteúdo #1 (mais antigo)]]></title>
+            <link>http://localhost:3000/${firstRootContent.owner_username}/${firstRootContent.slug}</link>
+            <guid>http://localhost:3000/${firstRootContent.owner_username}/${firstRootContent.slug}</guid>
+            <pubDate>${new Date(firstRootContent.published_at).toUTCString()}</pubDate>
+            <description><![CDATA[Corpo com HTML É importante lidar corretamente com o HTML, incluindo estilos especiais do GFM.]]></description>
+            <content:encoded><![CDATA[<div class="markdown-body"><h1>Corpo com HTML</h1><p>É <strong>importante</strong> lidar corretamente com o <code>HTML</code>, incluindo estilos <del>especiais</del> do <code>GFM</code>.</p></div>]]></content:encoded>
+        </item>
+    </channel>
+</rss>`);
+    });
+  });
+});

--- a/tests/integration/api/v1/contents/rss/get.test.js
+++ b/tests/integration/api/v1/contents/rss/get.test.js
@@ -2,32 +2,33 @@ import fetch from 'cross-fetch';
 import orchestrator from 'tests/orchestrator.js';
 
 describe('GET /recentes/rss', () => {
-  beforeAll(async () => {
+  beforeEach(async () => {
     await orchestrator.waitForAllServices();
     await orchestrator.dropAllTables();
     await orchestrator.runPendingMigrations();
   });
 
   describe('Anonymous user', () => {
-    test('With `/rss` alias`', async () => {
-      const response = await fetch(`${orchestrator.webserverUrl}/rss`);
-      expect(response.status).toEqual(200);
-    });
+    describe('Recentes', () => {
+      test('With `/rss` alias`', async () => {
+        const response = await fetch(`${orchestrator.webserverUrl}/rss`);
+        expect(response.status).toEqual(200);
+      });
 
-    test('With `/rss.xml` alias`', async () => {
-      const response = await fetch(`${orchestrator.webserverUrl}/rss.xml`);
-      expect(response.status).toEqual(200);
-    });
+      test('With `/rss.xml` alias`', async () => {
+        const response = await fetch(`${orchestrator.webserverUrl}/rss.xml`);
+        expect(response.status).toEqual(200);
+      });
 
-    test('With 0 contents', async () => {
-      const response = await fetch(`${orchestrator.webserverUrl}/recentes/rss`);
-      const responseBody = await response.text();
+      test('With 0 contents', async () => {
+        const response = await fetch(`${orchestrator.webserverUrl}/recentes/rss`);
+        const responseBody = await response.text();
 
-      const lastBuildDateFromResponseBody = /<lastBuildDate>(.*?)<\/lastBuildDate>/.exec(responseBody, 'g')[1];
+        const lastBuildDateFromResponseBody = /<lastBuildDate>(.*?)<\/lastBuildDate>/.exec(responseBody, 'g')[1];
 
-      expect(response.status).toEqual(200);
+        expect(response.status).toEqual(200);
 
-      expect(responseBody).toStrictEqual(`<?xml version="1.0" encoding="utf-8"?>
+        expect(responseBody).toStrictEqual(`<?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0">
     <channel>
         <title>TabNews</title>
@@ -44,42 +45,42 @@ describe('GET /recentes/rss', () => {
         </image>
     </channel>
 </rss>`);
-    });
-
-    test('With 3 contents, 2 `published` and 1 with `draft` status', async () => {
-      const defaultUser = await orchestrator.createUser();
-
-      const firstRootContent = await orchestrator.createContent({
-        owner_id: defaultUser.id,
-        title: 'Conteúdo #1 (mais antigo)',
-        status: 'published',
-        body: `# Corpo com HTML
-
-É **importante** lidar corretamente com o \`HTML\`, incluindo estilos ~~especiais~~ do \`GFM\`.`,
       });
 
-      const secondRootContent = await orchestrator.createContent({
-        owner_id: defaultUser.id,
-        title: 'Conteúdo #2 (mais novo)',
-        body: 'Este é um corpo bastante longo, vamos ver como que a propriedade description irá reagir, pois por padrão ela deverá cortar após um número X de caracteres. Não vou tomar nota aqui da quantidade exata de caracteres, pois isso pode mudar ao longo do tempo.',
-        status: 'published',
-      });
+      test('With 3 contents, 2 `published` and 1 with `draft` status', async () => {
+        const defaultUser = await orchestrator.createUser();
 
-      // thirdRootContent
-      await orchestrator.createContent({
-        owner_id: defaultUser.id,
-        title: 'Conteúdo #3 (mais novo, mas no status "draft")',
-        body: `Este conteúdo não deverá aparecer na lista retornada pelo rss,
-               porque quando um conteúdo possui o "status" como "draft", ele não
-               esta pronto para ser listado publicamente.`,
-        status: 'draft',
-      });
+        const firstRootContent = await orchestrator.createContent({
+          owner_id: defaultUser.id,
+          title: 'Conteúdo #1 (mais antigo)',
+          status: 'published',
+          body: `# Corpo com HTML
+  
+  É **importante** lidar corretamente com o \`HTML\`, incluindo estilos ~~especiais~~ do \`GFM\`.`,
+        });
 
-      const response = await fetch(`${orchestrator.webserverUrl}/rss`);
-      const responseBody = await response.text();
+        const secondRootContent = await orchestrator.createContent({
+          owner_id: defaultUser.id,
+          title: 'Conteúdo #2 (mais novo)',
+          body: 'Este é um corpo bastante longo, vamos ver como que a propriedade description irá reagir, pois por padrão ela deverá cortar após um número X de caracteres. Não vou tomar nota aqui da quantidade exata de caracteres, pois isso pode mudar ao longo do tempo.',
+          status: 'published',
+        });
 
-      expect(response.status).toEqual(200);
-      expect(responseBody).toStrictEqual(`<?xml version="1.0" encoding="utf-8"?>
+        // thirdRootContent
+        await orchestrator.createContent({
+          owner_id: defaultUser.id,
+          title: 'Conteúdo #3 (mais novo, mas no status "draft")',
+          body: `Este conteúdo não deverá aparecer na lista retornada pelo rss,
+                 porque quando um conteúdo possui o "status" como "draft", ele não
+                 esta pronto para ser listado publicamente.`,
+          status: 'draft',
+        });
+
+        const response = await fetch(`${orchestrator.webserverUrl}/recentes/rss`);
+        const responseBody = await response.text();
+
+        expect(response.status).toEqual(200);
+        expect(responseBody).toStrictEqual(`<?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/">
     <channel>
         <title>TabNews</title>
@@ -112,6 +113,102 @@ describe('GET /recentes/rss', () => {
         </item>
     </channel>
 </rss>`);
+      });
+    });
+
+    describe('Relevantes', () => {
+      test('With 0 contents', async () => {
+        const response = await fetch(`${orchestrator.webserverUrl}/relevantes/rss`);
+        const responseBody = await response.text();
+
+        const lastBuildDateFromResponseBody = /<lastBuildDate>(.*?)<\/lastBuildDate>/.exec(responseBody, 'g')[1];
+
+        expect(response.status).toEqual(200);
+
+        expect(responseBody).toStrictEqual(`<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0">
+    <channel>
+        <title>TabNews</title>
+        <link>http://localhost:3000/relevantes/rss</link>
+        <description>Conteúdos para quem trabalha com Programação e Tecnologia</description>
+        <lastBuildDate>${lastBuildDateFromResponseBody}</lastBuildDate>
+        <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
+        <generator>https://github.com/jpmonette/feed</generator>
+        <language>pt</language>
+        <image>
+            <title>TabNews</title>
+            <url>http://localhost:3000/favicon-mobile.png</url>
+            <link>http://localhost:3000/relevantes/rss</link>
+        </image>
+    </channel>
+</rss>`);
+      });
+
+      test('With 3 contents, 2 `published` and 1 with `draft` status', async () => {
+        const defaultUser = await orchestrator.createUser();
+
+        const firstRootContent = await orchestrator.createContent({
+          owner_id: defaultUser.id,
+          title: 'Conteúdo #1 (mais antigo)',
+          status: 'published',
+          body: `# Corpo com HTML
+  
+  É **importante** lidar corretamente com o \`HTML\`, incluindo estilos ~~especiais~~ do \`GFM\`.`,
+        });
+
+        const secondRootContent = await orchestrator.createContent({
+          owner_id: defaultUser.id,
+          title: 'Conteúdo #2 (mais novo)',
+          body: 'Este é um corpo bastante longo, vamos ver como que a propriedade description irá reagir, pois por padrão ela deverá cortar após um número X de caracteres. Não vou tomar nota aqui da quantidade exata de caracteres, pois isso pode mudar ao longo do tempo.',
+          status: 'published',
+        });
+
+        // thirdRootContent
+        await orchestrator.createContent({
+          owner_id: defaultUser.id,
+          title: 'Conteúdo #3 (mais novo, mas no status "draft")',
+          body: `Este conteúdo não deverá aparecer na lista retornada pelo rss,
+                 porque quando um conteúdo possui o "status" como "draft", ele não
+                 esta pronto para ser listado publicamente.`,
+          status: 'draft',
+        });
+
+        const response = await fetch(`${orchestrator.webserverUrl}/relevantes/rss`);
+        const responseBody = await response.text();
+
+        expect(response.status).toEqual(200);
+        expect(responseBody).toStrictEqual(`<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+    <channel>
+        <title>TabNews</title>
+        <link>http://localhost:3000/relevantes/rss</link>
+        <description>Conteúdos para quem trabalha com Programação e Tecnologia</description>
+        <lastBuildDate>${new Date(secondRootContent.published_at).toUTCString()}</lastBuildDate>
+        <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
+        <generator>https://github.com/jpmonette/feed</generator>
+        <language>pt</language>
+        <image>
+            <title>TabNews</title>
+            <url>http://localhost:3000/favicon-mobile.png</url>
+            <link>http://localhost:3000/relevantes/rss</link>
+        </image>
+        <item>
+            <title><![CDATA[Conteúdo #2 (mais novo)]]></title>
+            <link>http://localhost:3000/${secondRootContent.owner_username}/${secondRootContent.slug}</link>
+            <guid>http://localhost:3000/${secondRootContent.owner_username}/${secondRootContent.slug}</guid>
+            <pubDate>${new Date(secondRootContent.published_at).toUTCString()}</pubDate>
+            <content:encoded><![CDATA[<div class="markdown-body"></div>]]></content:encoded>
+        </item>
+        <item>
+            <title><![CDATA[Conteúdo #1 (mais antigo)]]></title>
+            <link>http://localhost:3000/${firstRootContent.owner_username}/${firstRootContent.slug}</link>
+            <guid>http://localhost:3000/${firstRootContent.owner_username}/${firstRootContent.slug}</guid>
+            <pubDate>${new Date(firstRootContent.published_at).toUTCString()}</pubDate>
+            <content:encoded><![CDATA[<div class="markdown-body"></div>]]></content:encoded>
+        </item>
+    </channel>
+</rss>`);
+      });
     });
   });
 });


### PR DESCRIPTION
Esse pull request tras a implementação do feed rss para as demais rotas, além da rota "recentes" já implementada, como sugerido por @filipedeschamps  em: [TabNews: A diferença entre "Relevantes" e "Recentes"](https://www.tabnews.com.br/filipedeschamps/tabnews-a-diferenca-entre-revelantes-e-recentes)
A função do model RSS foi atualizada para permitir que as rotas fossem criadas.

As rotas são:

- [x]  relevantes/rss
- [x]  username/rss
- [x]  username/slug/rss
 ---
- [x] Testes incluidos.

@aprendendofelipe 