### PR TITLE
Remove variável que ainda não é passada por `useCollapse`

### DIFF
--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -181,9 +181,8 @@ function RenderChildrenTree({ childrenList, renderIntent, renderIncrement }) {
   const { childrenState, handleCollapse, handleExpand } = useCollapse({ childrenList, renderIntent, renderIncrement });
 
   return childrenState.map((child) => {
-    const { children, children_deep_count, groupedCount, hiddenAvailable, id, owner_id, renderIntent, renderShowMore } =
-      child;
-    const labelShowMore = Math.min(groupedCount, hiddenAvailable, renderIncrement) || '';
+    const { children, children_deep_count, groupedCount, id, owner_id, renderIntent, renderShowMore } = child;
+    const labelShowMore = Math.min(groupedCount, renderIncrement) || '';
     const plural = labelShowMore != 1 ? 's' : '';
 
     return !renderIntent && !renderShowMore ? null : (


### PR DESCRIPTION
A variável `hiddenAvailable` só será necessária quando for implementada a paginação dos comentários. Por enquanto estou removendo ela para que volte a aparecer a quantidade de comentários que serão expandidos ao clicar no botão de ver mais respostas.

Acabei copiando indevidamente essa variável ao trazer algumas alterações do PR #1413 para o #1483 