### PR TITLE
refactor(icon imports): change icon imports to TabNewsUI/icons

### DIFF
--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -1,5 +1,5 @@
 import { Box, Button, Confetti, Content, DefaultLayout, Link, TabCoinButtons, Tooltip } from '@/TabNewsUI';
-import { CommentDiscussionIcon, CommentIcon, FoldIcon, UnfoldIcon } from '@primer/octicons-react';
+import { CommentDiscussionIcon, CommentIcon, FoldIcon, UnfoldIcon } from '@/TabNewsUI/icons';
 import { NotFoundError, ValidationError } from 'errors/index.js';
 import webserver from 'infra/webserver.js';
 import authorization from 'models/authorization.js';

--- a/pages/[username]/index.public.js
+++ b/pages/[username]/index.public.js
@@ -12,7 +12,7 @@ import {
   Viewer,
   useConfirm,
 } from '@/TabNewsUI';
-import { KebabHorizontalIcon, TrashIcon } from '@/TabNewsUI/icons';
+import { FaUser, KebabHorizontalIcon, TrashIcon } from '@/TabNewsUI/icons';
 import { NotFoundError } from 'errors/index.js';
 import authorization from 'models/authorization.js';
 import content from 'models/content.js';
@@ -23,7 +23,6 @@ import { getStaticPropsRevalidate } from 'next-swr';
 import { useRouter } from 'next/router';
 import { useUser } from 'pages/interface';
 import { useState } from 'react';
-import { FaUser } from '@/TabNewsUI/icons';
 import useSWR from 'swr';
 
 export default function Home({ contentListFound, pagination, userFound: userFoundFallback }) {

--- a/pages/[username]/index.public.js
+++ b/pages/[username]/index.public.js
@@ -11,7 +11,7 @@ import {
   Pagehead,
   useConfirm,
 } from '@/TabNewsUI';
-import { KebabHorizontalIcon, TrashIcon } from '@primer/octicons-react';
+import { KebabHorizontalIcon, TrashIcon } from '@/TabNewsUI/icons';
 import { NotFoundError } from 'errors/index.js';
 import authorization from 'models/authorization.js';
 import content from 'models/content.js';
@@ -22,7 +22,7 @@ import { getStaticPropsRevalidate } from 'next-swr';
 import { useRouter } from 'next/router';
 import { useUser } from 'pages/interface';
 import { useState } from 'react';
-import { FaUser } from 'react-icons/fa';
+import { FaUser } from '@/TabNewsUI/icons';
 import useSWR from 'swr';
 
 export default function Home({ contentListFound, pagination, userFound: userFoundFallback }) {

--- a/pages/index.public.js
+++ b/pages/index.public.js
@@ -4,7 +4,7 @@ import content from 'models/content.js';
 import user from 'models/user.js';
 import validator from 'models/validator.js';
 import { getStaticPropsRevalidate } from 'next-swr';
-import { FaTree } from 'react-icons/fa';
+import { FaTree } from '@/TabNewsUI/icons';
 
 export default function Home({ contentListFound, pagination }) {
   return (

--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -17,7 +17,7 @@ import {
   useConfirm,
   Viewer,
 } from '@/TabNewsUI';
-import { KebabHorizontalIcon, LinkIcon, PencilIcon, TrashIcon } from '@primer/octicons-react';
+import { KebabHorizontalIcon, LinkIcon, PencilIcon, TrashIcon } from '@/TabNewsUI/icons';
 import { useRouter } from 'next/router';
 import { useUser } from 'pages/interface';
 import { useCallback, useEffect, useMemo, useState } from 'react';

--- a/pages/interface/components/ContentList/index.js
+++ b/pages/interface/components/ContentList/index.js
@@ -1,5 +1,5 @@
 import { Box, EmptyState, Link, PublishedSince, Text } from '@/TabNewsUI';
-import { ChevronLeftIcon, ChevronRightIcon, CommentIcon } from '@primer/octicons-react';
+import { ChevronLeftIcon, ChevronRightIcon, CommentIcon } from '@/TabNewsUI/icons';
 
 export default function ContentList({ contentList: list, pagination, paginationBasePath, emptyStateProps }) {
   const listNumberOffset = pagination.perPage * (pagination.currentPage - 1);

--- a/pages/interface/components/EmptyState/index.js
+++ b/pages/interface/components/EmptyState/index.js
@@ -1,5 +1,5 @@
 import { Box, Button, Heading, Text } from '@/TabNewsUI';
-import { PlusIcon } from '@primer/octicons-react';
+import { PlusIcon } from '@/TabNewsUI/icons';
 
 export default function EmptyState(props) {
   const { title, description, action, icon: Icon, isLoading } = props;

--- a/pages/interface/components/Footer/index.js
+++ b/pages/interface/components/Footer/index.js
@@ -1,5 +1,5 @@
 import { Box, Link } from '@/TabNewsUI';
-import { CgTab } from 'react-icons/cg';
+import { CgTab } from '@/TabNewsUI/icons';
 
 export default function Footer(props) {
   return (

--- a/pages/interface/components/GoToTopButton/index.js
+++ b/pages/interface/components/GoToTopButton/index.js
@@ -1,5 +1,5 @@
 import { IconButton } from '@/TabNewsUI';
-import { ChevronUpIcon } from '@primer/octicons-react';
+import { ChevronUpIcon } from '@/TabNewsUI/icons';
 import { useEffect, useState } from 'react';
 
 export default function GoToTopButton() {

--- a/pages/interface/components/Header/index.js
+++ b/pages/interface/components/Header/index.js
@@ -13,10 +13,10 @@ import {
   Tooltip,
   Truncate,
 } from '@/TabNewsUI';
-import { HomeIcon, PersonFillIcon, SquareFillIcon, PlusIcon } from '@primer/octicons-react';
+import { HomeIcon, PersonFillIcon, SquareFillIcon, PlusIcon } from '@/TabNewsUI/icons';
 import { useRouter } from 'next/router';
 import { useUser } from 'pages/interface';
-import { CgTab } from 'react-icons/cg';
+import { CgTab } from '@/TabNewsUI/icons';
 
 export default function HeaderComponent() {
   const { user, isLoading, logout } = useUser();

--- a/pages/interface/components/Header/index.js
+++ b/pages/interface/components/Header/index.js
@@ -13,10 +13,9 @@ import {
   Tooltip,
   Truncate,
 } from '@/TabNewsUI';
-import { HomeIcon, PersonFillIcon, SquareFillIcon, PlusIcon } from '@/TabNewsUI/icons';
+import { CgTab, HomeIcon, PersonFillIcon, PlusIcon, SquareFillIcon } from '@/TabNewsUI/icons';
 import { useRouter } from 'next/router';
 import { useUser } from 'pages/interface';
-import { CgTab } from '@/TabNewsUI/icons';
 
 export default function HeaderComponent() {
   const { user, isLoading, logout } = useUser();

--- a/pages/interface/components/PasswordInput/index.js
+++ b/pages/interface/components/PasswordInput/index.js
@@ -1,5 +1,5 @@
 import { FormControl, TextInput } from '@/TabNewsUI';
-import { EyeClosedIcon, EyeIcon } from '@primer/octicons-react';
+import { EyeClosedIcon, EyeIcon } from '@/TabNewsUI/icons';
 import { useEffect, useState } from 'react';
 
 export default function PasswordInput({ inputRef, id, name, label, errorObject, setErrorObject, ...props }) {

--- a/pages/interface/components/SearchBox/index.js
+++ b/pages/interface/components/SearchBox/index.js
@@ -1,4 +1,4 @@
-import { SearchIcon, XCircleFillIcon } from '@primer/octicons-react';
+import { SearchIcon, XCircleFillIcon } from '@/TabNewsUI/icons';
 import { Box, Button, Heading, IconButton, Overlay, Spinner } from '@/TabNewsUI';
 import { useEffect, useRef, useState } from 'react';
 

--- a/pages/interface/components/TabCoinButtons/index.js
+++ b/pages/interface/components/TabCoinButtons/index.js
@@ -1,5 +1,5 @@
 import { Box, IconButton, Text, Tooltip } from '@/TabNewsUI';
-import { ChevronDownIcon, ChevronUpIcon } from '@primer/octicons-react';
+import { ChevronDownIcon, ChevronUpIcon } from '@/TabNewsUI/icons';
 import { useRevalidate } from 'next-swr';
 import { useRouter } from 'next/router';
 import { useUser } from 'pages/interface';

--- a/pages/interface/components/TabNewsUI/icons/index.js
+++ b/pages/interface/components/TabNewsUI/icons/index.js
@@ -1,0 +1,25 @@
+export { CgTab } from 'react-icons/cg';
+export { FaUser, FaTree } from 'react-icons/fa';
+export {
+  ChevronDownIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  ChevronUpIcon,
+  CommentDiscussionIcon,
+  EyeClosedIcon,
+  EyeIcon,
+  FoldIcon,
+  HomeIcon,
+  KebabHorizontalIcon,
+  LinkIcon,
+  MoonIcon,
+  PencilIcon,
+  PersonFillIcon,
+  PlusIcon,
+  SearchIcon,
+  SquareFillIcon,
+  SunIcon,
+  TrashIcon,
+  UnfoldIcon,
+  XCircleFillIcon,
+} from '@primer/octicons-react';

--- a/pages/interface/components/TabNewsUI/icons/index.js
+++ b/pages/interface/components/TabNewsUI/icons/index.js
@@ -6,6 +6,7 @@ export {
   ChevronRightIcon,
   ChevronUpIcon,
   CommentDiscussionIcon,
+  CommentIcon,
   EyeClosedIcon,
   EyeIcon,
   FoldIcon,

--- a/pages/interface/components/ThemeSelector/index.js
+++ b/pages/interface/components/ThemeSelector/index.js
@@ -1,5 +1,5 @@
 import { Box, Button, SegmentedControl, useTheme } from '@/TabNewsUI';
-import { MoonIcon, SunIcon } from '@primer/octicons-react';
+import { MoonIcon, SunIcon } from '@/TabNewsUI/icons';
 
 export default function ThemeSelector({ ...props }) {
   const { colorMode, setColorMode } = useTheme();


### PR DESCRIPTION
• Esse pr refatora a importação dos icones para um só lugar, `/TabNewsUI/icons`.

• a subpasta icons é para não misturar a importação de `componentes` e `icones` tudo dentro de `TabNewsUI` 