### PR TITLE
style/imports sort

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,9 @@
 {
   "printWidth": 120,
   "singleQuote": true,
-  "bracketSameLine": true
+  "bracketSameLine": true,
+  "importOrder": ["^(errors|fonts|infra|models|queries|tests|pages)/(.*)$", "^[./]"],
+  "importOrderSeparation": true,
+  "importOrderSortSpecifiers": true,
+  "importOrderGroupNamespaceSpecifiers": true
 }

--- a/infra/database.js
+++ b/infra/database.js
@@ -1,9 +1,10 @@
-import { Pool, Client } from 'pg';
 import retry from 'async-retry';
+import { Client, Pool } from 'pg';
+import snakeize from 'snakeize';
+
 import { ServiceError } from 'errors/index.js';
 import logger from 'infra/logger.js';
 import webserver from 'infra/webserver.js';
-import snakeize from 'snakeize';
 
 const configurations = {
   user: process.env.POSTGRES_USER,

--- a/infra/email.js
+++ b/infra/email.js
@@ -1,7 +1,9 @@
-const nodemailer = require('nodemailer');
 import { ServiceError } from 'errors/index.js';
 import webserver from 'infra/webserver.js';
+
 import logger from './logger.js';
+
+const nodemailer = require('nodemailer');
 
 const transporterConfiguration = {
   host: process.env.EMAIL_SMTP_HOST,

--- a/infra/migrator.js
+++ b/infra/migrator.js
@@ -1,7 +1,9 @@
-const { join, resolve } = require('path');
-import database from 'infra/database.js';
 import migrationRunner from 'node-pg-migrate';
+
+import database from 'infra/database.js';
 import logger from 'infra/logger.js';
+
+const { join, resolve } = require('path');
 
 const defaultConfigurations = {
   dir: join(resolve('.'), 'infra', 'migrations'),

--- a/infra/migrator.js
+++ b/infra/migrator.js
@@ -1,9 +1,8 @@
 import migrationRunner from 'node-pg-migrate';
+import { join, resolve } from 'node:path';
 
 import database from 'infra/database.js';
 import logger from 'infra/logger.js';
-
-const { join, resolve } = require('path');
 
 const defaultConfigurations = {
   dir: join(resolve('.'), 'infra', 'migrations'),

--- a/infra/rate-limit.js
+++ b/infra/rate-limit.js
@@ -1,5 +1,6 @@
 import { Ratelimit } from '@upstash/ratelimit';
 import { Redis } from '@upstash/redis';
+
 import { ServiceError } from 'errors/index.js';
 import webserver from 'infra/webserver.js';
 import ip from 'models/ip.js';

--- a/infra/scripts/seed-database.js
+++ b/infra/scripts/seed-database.js
@@ -1,7 +1,7 @@
 const fs = require('node:fs');
-const { join, resolve } = require('path');
-
+const { join, resolve } = require('node:path');
 const { Client } = require('pg');
+
 const client = new Client({
   connectionString: process.env.DATABASE_URL,
   connectionTimeoutMillis: 5000,

--- a/middleware.public.js
+++ b/middleware.public.js
@@ -1,10 +1,12 @@
 import { NextResponse } from 'next/server';
+import snakeize from 'snakeize';
+
 import logger from 'infra/logger.js';
 import rateLimit from 'infra/rate-limit.js';
-import snakeize from 'snakeize';
-import { UnauthorizedError } from '/errors/index.js';
-import ip from 'models/ip.js';
 import webserver from 'infra/webserver.js';
+import ip from 'models/ip.js';
+
+import { UnauthorizedError } from '/errors/index.js';
 
 export const config = {
   matcher: ['/((?!_next/static|va/|favicon|manifest).*)'],

--- a/models/activation.js
+++ b/models/activation.js
@@ -1,9 +1,9 @@
-import email from 'infra/email.js';
+import { ForbiddenError, NotFoundError } from 'errors/index.js';
 import database from 'infra/database.js';
+import email from 'infra/email.js';
 import webserver from 'infra/webserver.js';
-import user from 'models/user.js';
 import authorization from 'models/authorization.js';
-import { NotFoundError, ForbiddenError } from 'errors/index.js';
+import user from 'models/user.js';
 
 async function createAndSendActivationEmail(user) {
   const tokenObject = await create(user);

--- a/models/authentication.js
+++ b/models/authentication.js
@@ -1,9 +1,10 @@
 import setCookieParser from 'set-cookie-parser';
-import session from 'models/session.js';
-import user from 'models/user.js';
+
+import { ForbiddenError, UnauthorizedError } from 'errors/index.js';
 import authorization from 'models/authorization.js';
 import password from 'models/password.js';
-import { ForbiddenError, UnauthorizedError } from 'errors/index.js';
+import session from 'models/session.js';
+import user from 'models/user.js';
 import validator from 'models/validator.js';
 
 async function hashPassword(unhashedPassword) {

--- a/models/authorization.js
+++ b/models/authorization.js
@@ -1,5 +1,5 @@
+import { ForbiddenError, ValidationError } from 'errors/index.js';
 import validator from 'models/validator.js';
-import { ValidationError, ForbiddenError } from 'errors/index.js';
 
 const availableFeatures = new Set([
   // USER

--- a/models/balance.js
+++ b/models/balance.js
@@ -1,5 +1,5 @@
-import database from 'infra/database.js';
 import { UnprocessableEntityError } from 'errors/index.js';
+import database from 'infra/database.js';
 
 async function findOne(operationId, options = {}) {
   const query = {

--- a/models/ban.js
+++ b/models/ban.js
@@ -1,8 +1,8 @@
 import database from 'infra/database.js';
-import user from 'models/user.js';
-import content from 'models/content.js';
 import balance from 'models/balance.js';
+import content from 'models/content.js';
 import session from 'models/session.js';
+import user from 'models/user.js';
 
 async function nuke(userId, options = {}) {
   await user.removeFeatures(userId, null, options);

--- a/models/content.js
+++ b/models/content.js
@@ -1,3 +1,6 @@
+import slug from 'slug';
+import { v4 as uuidV4 } from 'uuid';
+
 import { ForbiddenError, ValidationError } from 'errors/index.js';
 import database from 'infra/database.js';
 import balance from 'models/balance.js';
@@ -5,8 +8,6 @@ import prestige from 'models/prestige';
 import user from 'models/user.js';
 import validator from 'models/validator.js';
 import queries from 'queries/rankingQueries';
-import slug from 'slug';
-import { v4 as uuidV4 } from 'uuid';
 
 async function findAll(values = {}, options = {}) {
   values = validateValues(values);

--- a/models/controller.js
+++ b/models/controller.js
@@ -1,19 +1,19 @@
-import { v4 as uuidV4 } from 'uuid';
 import snakeize from 'snakeize';
+import { v4 as uuidV4 } from 'uuid';
 
-import ip from 'models/ip.js';
-import session from 'models/session.js';
 import logger from 'infra/logger.js';
 import webserver from 'infra/webserver.js';
+import ip from 'models/ip.js';
+import session from 'models/session.js';
 
 import {
+  ForbiddenError,
   InternalServerError,
   NotFoundError,
-  ValidationError,
-  ForbiddenError,
-  UnauthorizedError,
   TooManyRequestsError,
+  UnauthorizedError,
   UnprocessableEntityError,
+  ValidationError,
 } from '/errors/index.js';
 
 async function injectRequestMetadata(request, response, next) {

--- a/models/email-confirmation.js
+++ b/models/email-confirmation.js
@@ -1,8 +1,8 @@
-import email from 'infra/email.js';
+import { NotFoundError } from 'errors/index.js';
 import database from 'infra/database.js';
+import email from 'infra/email.js';
 import webserver from 'infra/webserver.js';
 import user from 'models/user.js';
-import { NotFoundError } from 'errors/index.js';
 
 async function createAndSendEmail(userId, newEmail) {
   const userFound = await user.findOneById(userId);

--- a/models/firewall.js
+++ b/models/firewall.js
@@ -1,6 +1,6 @@
+import { TooManyRequestsError } from 'errors/index.js';
 import database from 'infra/database.js';
 import event from 'models/event.js';
-import { TooManyRequestsError } from 'errors/index.js';
 
 const rules = {
   'create:user': createUserRule,

--- a/models/health.js
+++ b/models/health.js
@@ -1,5 +1,6 @@
-import database from 'infra/database';
 import { performance } from 'perf_hooks';
+
+import database from 'infra/database';
 import logger from 'infra/logger';
 
 async function getDependencies() {

--- a/models/ip.js
+++ b/models/ip.js
@@ -1,5 +1,6 @@
+import { isIP, isInSubnet } from 'is-in-subnet';
+
 import webserver from 'infra/webserver';
-import { isInSubnet, isIP } from 'is-in-subnet';
 
 function extractFromRequest(request) {
   if (isRequestFromCloudflare(request)) {

--- a/models/notification.js
+++ b/models/notification.js
@@ -1,8 +1,8 @@
-import user from 'models/user.js';
-import content from 'models/content.js';
-import authorization from 'models/authorization.js';
-import webserver from 'infra/webserver.js';
 import email from 'infra/email.js';
+import webserver from 'infra/webserver.js';
+import authorization from 'models/authorization.js';
+import content from 'models/content.js';
+import user from 'models/user.js';
 
 async function sendReplyEmailToParentUser(createdContent) {
   const anonymousUser = user.createAnonymous();

--- a/models/password.js
+++ b/models/password.js
@@ -1,4 +1,5 @@
 import bcryptjs from 'bcryptjs';
+
 import webserver from 'infra/webserver.js';
 
 async function hash(password) {

--- a/models/recovery.js
+++ b/models/recovery.js
@@ -1,9 +1,9 @@
-import email from 'infra/email.js';
-import database from 'infra/database.js';
-import webserver from 'infra/webserver.js';
-import user from 'models/user.js';
-import session from 'models/session';
 import { NotFoundError, ValidationError } from 'errors/index.js';
+import database from 'infra/database.js';
+import email from 'infra/email.js';
+import webserver from 'infra/webserver.js';
+import session from 'models/session';
+import user from 'models/user.js';
 
 async function createAndSendRecoveryEmail(secureInputValues) {
   const userFound = await findUserByUsernameOrEmail(secureInputValues);

--- a/models/rss.js
+++ b/models/rss.js
@@ -1,9 +1,9 @@
 import { Viewer } from '@/TabNewsUI';
-import removeMarkdown from 'models/remove-markdown';
+import { Feed } from 'feed';
 import { renderToStaticMarkup } from 'react-dom/server';
 
-import { Feed } from 'feed';
 import webserver from 'infra/webserver.js';
+import removeMarkdown from 'models/remove-markdown';
 
 function generateRss2(contentList) {
   const webserverHost = webserver.host;

--- a/models/session.js
+++ b/models/session.js
@@ -1,9 +1,10 @@
-import crypto from 'crypto';
 import cookie from 'cookie';
-import database from 'infra/database.js';
+import crypto from 'crypto';
+
 import { UnauthorizedError } from 'errors/index.js';
-import validator from 'models/validator.js';
+import database from 'infra/database.js';
 import cacheControl from 'models/cache-control';
+import validator from 'models/validator.js';
 
 const SESSION_EXPIRATION_IN_SECONDS = 60 * 60 * 24 * 30; // 30 days
 

--- a/models/thumbnail.js
+++ b/models/thumbnail.js
@@ -1,9 +1,11 @@
 /* eslint-disable jsx-a11y/alt-text */
+
 /* eslint-disable @next/next/no-img-element */
+import { renderAsync } from '@resvg/resvg-js';
 import fs from 'node:fs';
 import { join, resolve } from 'node:path';
-import { renderAsync } from '@resvg/resvg-js';
 import satori from 'satori';
+
 import content from 'models/content.js';
 import removeMarkdown from 'models/remove-markdown';
 

--- a/models/user.js
+++ b/models/user.js
@@ -1,9 +1,9 @@
+import { NotFoundError, ValidationError } from 'errors/index.js';
 import database from 'infra/database.js';
 import authentication from 'models/authentication.js';
-import validator from 'models/validator.js';
 import balance from 'models/balance.js';
 import emailConfirmation from 'models/email-confirmation.js';
-import { ValidationError, NotFoundError } from 'errors/index.js';
+import validator from 'models/validator.js';
 
 async function findAll() {
   const query = {

--- a/models/validator.js
+++ b/models/validator.js
@@ -1,7 +1,8 @@
 import Joi from 'joi';
+
 import { ValidationError } from 'errors/index.js';
-import removeMarkdown from 'models/remove-markdown';
 import webserver from 'infra/webserver';
+import removeMarkdown from 'models/remove-markdown';
 
 export default function validator(object, keys) {
   // Force the clean up of "undefined" values since JSON

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "@commitlint/cli": "17.6.1",
         "@commitlint/config-conventional": "17.6.1",
         "@faker-js/faker": "7.6.0",
+        "@trivago/prettier-plugin-sort-imports": "^4.2.0",
         "autoprefixer": "10.4.14",
         "concurrently": "8.0.1",
         "cz-conventional-changelog": "3.3.0",
@@ -2411,6 +2412,95 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@trivago/prettier-plugin-sort-imports": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-4.2.0.tgz",
+      "integrity": "sha512-YBepjbt+ZNBVmN3ev1amQH3lWCmHyt5qTbLCp/syXJRu/Kw2koXh44qayB1gMRxcL/gV8egmjN5xWSrYyfUtyw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/generator": "7.17.7",
+        "@babel/parser": "^7.20.5",
+        "@babel/traverse": "7.17.3",
+        "@babel/types": "7.17.0",
+        "javascript-natural-sort": "0.7.1",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "@vue/compiler-sfc": "3.x",
+        "prettier": "2.x - 3.x"
+      },
+      "peerDependenciesMeta": {
+        "@vue/compiler-sfc": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/generator": {
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
+      "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.17.0",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/traverse": {
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
+      "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.16.7",
+        "@babel/generator": "^7.17.3",
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-function-name": "^7.16.7",
+        "@babel/helper-hoist-variables": "^7.16.7",
+        "@babel/helper-split-export-declaration": "^7.16.7",
+        "@babel/parser": "^7.17.3",
+        "@babel/types": "^7.17.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/types": {
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+      "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.16.7",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -3219,6 +3309,25 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/array.prototype.findlastindex": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.2.tgz",
+      "integrity": "sha512-tb5thFFlUcp7NdNF6/MpDk/1r/4awWG1FIz3YqDf+/zJSTezBb+/5WViH41obXULHVpDzoiCLpJ/ZO9YbJMsdw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0",
+        "get-intrinsic": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array.prototype.flat": {
@@ -5655,26 +5764,29 @@
       }
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.27.5",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz",
-      "integrity": "sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.28.0.tgz",
+      "integrity": "sha512-B8s/n+ZluN7sxj9eUf7/pRFERX0r5bnFA2dCaLHy2ZeaQEAz0k+ZZkFWRFHJAqxfxQDx6KLv9LeIki7cFdwW+Q==",
       "dev": true,
       "dependencies": {
         "array-includes": "^3.1.6",
+        "array.prototype.findlastindex": "^1.2.2",
         "array.prototype.flat": "^1.3.1",
         "array.prototype.flatmap": "^1.3.1",
         "debug": "^3.2.7",
         "doctrine": "^2.1.0",
         "eslint-import-resolver-node": "^0.3.7",
-        "eslint-module-utils": "^2.7.4",
+        "eslint-module-utils": "^2.8.0",
         "has": "^1.0.3",
-        "is-core-module": "^2.11.0",
+        "is-core-module": "^2.12.1",
         "is-glob": "^4.0.3",
         "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.6",
+        "object.groupby": "^1.0.0",
         "object.values": "^1.1.6",
-        "resolve": "^1.22.1",
-        "semver": "^6.3.0",
-        "tsconfig-paths": "^3.14.1"
+        "resolve": "^1.22.3",
+        "semver": "^6.3.1",
+        "tsconfig-paths": "^3.14.2"
       },
       "engines": {
         "node": ">=4"
@@ -5705,9 +5817,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -6475,13 +6587,14 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
-      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
       "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
+        "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3"
       },
       "funding": {
@@ -7374,9 +7487,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
-      "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
+      "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
@@ -7824,6 +7937,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+      "dev": true
     },
     "node_modules/jest": {
       "version": "29.5.0",
@@ -10546,6 +10665,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object.groupby": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.0.tgz",
+      "integrity": "sha512-70MWG6NfRH9GnbZOikuhPPYzpUpof9iW2J9E4dW7FXTqPNb6rllE6u39SKwwiNh8lCwX3DDb5OgcKGiEBrTTyw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.21.2",
+        "get-intrinsic": "^1.2.1"
+      }
+    },
     "node_modules/object.hasown": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.2.tgz",
@@ -11873,12 +12004,12 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
-      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+      "version": "1.22.4",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
+      "integrity": "sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==",
       "dev": true,
       "dependencies": {
-        "is-core-module": "^2.11.0",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -15478,6 +15609,73 @@
         "tslib": "^2.4.0"
       }
     },
+    "@trivago/prettier-plugin-sort-imports": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-4.2.0.tgz",
+      "integrity": "sha512-YBepjbt+ZNBVmN3ev1amQH3lWCmHyt5qTbLCp/syXJRu/Kw2koXh44qayB1gMRxcL/gV8egmjN5xWSrYyfUtyw==",
+      "dev": true,
+      "requires": {
+        "@babel/generator": "7.17.7",
+        "@babel/parser": "^7.20.5",
+        "@babel/traverse": "7.17.3",
+        "@babel/types": "7.17.0",
+        "javascript-natural-sort": "0.7.1",
+        "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "@babel/generator": {
+          "version": "7.17.7",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
+          "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.17.0",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.17.3",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
+          "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.16.7",
+            "@babel/generator": "^7.17.3",
+            "@babel/helper-environment-visitor": "^7.16.7",
+            "@babel/helper-function-name": "^7.16.7",
+            "@babel/helper-hoist-variables": "^7.16.7",
+            "@babel/helper-split-export-declaration": "^7.16.7",
+            "@babel/parser": "^7.17.3",
+            "@babel/types": "^7.17.0",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.17.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+          "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.16.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+          "dev": true
+        }
+      }
+    },
     "@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -16131,6 +16329,19 @@
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true
+    },
+    "array.prototype.findlastindex": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.2.tgz",
+      "integrity": "sha512-tb5thFFlUcp7NdNF6/MpDk/1r/4awWG1FIz3YqDf+/zJSTezBb+/5WViH41obXULHVpDzoiCLpJ/ZO9YbJMsdw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0",
+        "get-intrinsic": "^1.1.3"
+      }
     },
     "array.prototype.flat": {
       "version": "1.3.1",
@@ -17940,26 +18151,29 @@
       "requires": {}
     },
     "eslint-plugin-import": {
-      "version": "2.27.5",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz",
-      "integrity": "sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.28.0.tgz",
+      "integrity": "sha512-B8s/n+ZluN7sxj9eUf7/pRFERX0r5bnFA2dCaLHy2ZeaQEAz0k+ZZkFWRFHJAqxfxQDx6KLv9LeIki7cFdwW+Q==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.6",
+        "array.prototype.findlastindex": "^1.2.2",
         "array.prototype.flat": "^1.3.1",
         "array.prototype.flatmap": "^1.3.1",
         "debug": "^3.2.7",
         "doctrine": "^2.1.0",
         "eslint-import-resolver-node": "^0.3.7",
-        "eslint-module-utils": "^2.7.4",
+        "eslint-module-utils": "^2.8.0",
         "has": "^1.0.3",
-        "is-core-module": "^2.11.0",
+        "is-core-module": "^2.12.1",
         "is-glob": "^4.0.3",
         "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.6",
+        "object.groupby": "^1.0.0",
         "object.values": "^1.1.6",
-        "resolve": "^1.22.1",
-        "semver": "^6.3.0",
-        "tsconfig-paths": "^3.14.1"
+        "resolve": "^1.22.3",
+        "semver": "^6.3.1",
+        "tsconfig-paths": "^3.14.2"
       },
       "dependencies": {
         "debug": {
@@ -17981,9 +18195,9 @@
           }
         },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -18539,13 +18753,14 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-intrinsic": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
-      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
+        "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3"
       }
     },
@@ -19176,9 +19391,9 @@
       "dev": true
     },
     "is-core-module": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
-      "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
+      "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -19484,6 +19699,12 @@
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
       }
+    },
+    "javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+      "dev": true
     },
     "jest": {
       "version": "29.5.0",
@@ -21390,6 +21611,18 @@
         "es-abstract": "^1.20.4"
       }
     },
+    "object.groupby": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.0.tgz",
+      "integrity": "sha512-70MWG6NfRH9GnbZOikuhPPYzpUpof9iW2J9E4dW7FXTqPNb6rllE6u39SKwwiNh8lCwX3DDb5OgcKGiEBrTTyw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.21.2",
+        "get-intrinsic": "^1.2.1"
+      }
+    },
     "object.hasown": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.2.tgz",
@@ -22345,12 +22578,12 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
-      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+      "version": "1.22.4",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
+      "integrity": "sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==",
       "dev": true,
       "requires": {
-        "is-core-module": "^2.11.0",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@commitlint/cli": "17.6.1",
     "@commitlint/config-conventional": "17.6.1",
     "@faker-js/faker": "7.6.0",
+    "@trivago/prettier-plugin-sort-imports": "^4.2.0",
     "autoprefixer": "10.4.14",
     "concurrently": "8.0.1",
     "cz-conventional-changelog": "3.3.0",

--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -1,14 +1,15 @@
 import { Box, Button, Confetti, Content, DefaultLayout, Link, TabCoinButtons, Tooltip } from '@/TabNewsUI';
 import { CommentDiscussionIcon, CommentIcon, FoldIcon, UnfoldIcon } from '@/TabNewsUI/icons';
+import { getStaticPropsRevalidate } from 'next-swr';
+import { useEffect, useState } from 'react';
+
 import { NotFoundError, ValidationError } from 'errors/index.js';
 import webserver from 'infra/webserver.js';
 import authorization from 'models/authorization.js';
 import content from 'models/content.js';
 import removeMarkdown from 'models/remove-markdown.js';
 import user from 'models/user.js';
-import { getStaticPropsRevalidate } from 'next-swr';
 import { useCollapse } from 'pages/interface';
-import { useEffect, useState } from 'react';
 
 export default function Post({ contentFound, rootContentFound, parentContentFound, contentMetadata }) {
   const [childrenToShow, setChildrenToShow] = useState(108);

--- a/pages/[username]/index.public.js
+++ b/pages/[username]/index.public.js
@@ -13,17 +13,18 @@ import {
   useConfirm,
 } from '@/TabNewsUI';
 import { FaUser, KebabHorizontalIcon, TrashIcon } from '@/TabNewsUI/icons';
+import { getStaticPropsRevalidate } from 'next-swr';
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+import useSWR from 'swr';
+
 import { NotFoundError } from 'errors/index.js';
 import authorization from 'models/authorization.js';
 import content from 'models/content.js';
 import removeMarkdown from 'models/remove-markdown.js';
 import user from 'models/user.js';
 import validator from 'models/validator.js';
-import { getStaticPropsRevalidate } from 'next-swr';
-import { useRouter } from 'next/router';
 import { useUser } from 'pages/interface';
-import { useState } from 'react';
-import useSWR from 'swr';
 
 export default function Home({ contentListFound, pagination, userFound: userFoundFallback }) {
   const { data: userFound, mutate: userFoundMutate } = useSWR(`/api/v1/users/${userFoundFallback.username}`, {

--- a/pages/[username]/pagina/[page]/index.public.js
+++ b/pages/[username]/pagina/[page]/index.public.js
@@ -1,11 +1,12 @@
-import { DefaultLayout, ContentList } from '@/TabNewsUI';
-import user from 'models/user.js';
-import content from 'models/content.js';
-import authorization from 'models/authorization.js';
-import validator from 'models/validator.js';
-import removeMarkdown from 'models/remove-markdown.js';
-import { NotFoundError } from 'errors/index.js';
+import { ContentList, DefaultLayout } from '@/TabNewsUI';
 import { getStaticPropsRevalidate } from 'next-swr';
+
+import { NotFoundError } from 'errors/index.js';
+import authorization from 'models/authorization.js';
+import content from 'models/content.js';
+import removeMarkdown from 'models/remove-markdown.js';
+import user from 'models/user.js';
+import validator from 'models/validator.js';
 
 export default function Home({ contentListFound, pagination, username }) {
   return (

--- a/pages/_app.public.js
+++ b/pages/_app.public.js
@@ -1,8 +1,9 @@
 import { ThemeProvider } from '@/TabNewsUI';
 import { Analytics } from '@vercel/analytics/react';
 import { RevalidateProvider } from 'next-swr';
-import { DefaultHead, UserProvider } from 'pages/interface';
 import { SWRConfig } from 'swr';
+
+import { DefaultHead, UserProvider } from 'pages/interface';
 
 async function SWRFetcher(resource, init) {
   const response = await fetch(resource, init);

--- a/pages/api/v1/_responses/rate-limit-reached-sessions.public.js
+++ b/pages/api/v1/_responses/rate-limit-reached-sessions.public.js
@@ -1,11 +1,12 @@
 import nextConnect from 'next-connect';
-import { v4 as uuidV4 } from 'uuid';
 import snakeize from 'snakeize';
+import { v4 as uuidV4 } from 'uuid';
+
+import { ForbiddenError, TooManyRequestsError, UnauthorizedError } from 'errors/index.js';
 import logger from 'infra/logger.js';
 import controller from 'models/controller.js';
-import validator from 'models/validator.js';
 import ip from 'models/ip.js';
-import { UnauthorizedError, ForbiddenError, TooManyRequestsError } from 'errors/index.js';
+import validator from 'models/validator.js';
 
 export default nextConnect({
   onError: controller.onErrorHandler,

--- a/pages/api/v1/_responses/rate-limit-reached.public.js
+++ b/pages/api/v1/_responses/rate-limit-reached.public.js
@@ -1,7 +1,8 @@
 import snakeize from 'snakeize';
+
+import { TooManyRequestsError } from 'errors/index.js';
 import logger from 'infra/logger.js';
 import ip from 'models/ip.js';
-import { TooManyRequestsError } from 'errors/index.js';
 
 export default function handler(request, response) {
   const error = new TooManyRequestsError({

--- a/pages/api/v1/activation/index.public.js
+++ b/pages/api/v1/activation/index.public.js
@@ -1,10 +1,11 @@
 import nextConnect from 'next-connect';
-import controller from 'models/controller.js';
+
 import activation from 'models/activation.js';
 import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
-import validator from 'models/validator.js';
 import cacheControl from 'models/cache-control';
+import controller from 'models/controller.js';
+import validator from 'models/validator.js';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/api/v1/analytics/child-content-published/index.public.js
+++ b/pages/api/v1/analytics/child-content-published/index.public.js
@@ -1,7 +1,8 @@
 import nextConnect from 'next-connect';
-import controller from 'models/controller.js';
+
 import analytics from 'models/analytics.js';
 import cacheControl from 'models/cache-control';
+import controller from 'models/controller.js';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/api/v1/analytics/root-content-published/index.public.js
+++ b/pages/api/v1/analytics/root-content-published/index.public.js
@@ -1,7 +1,8 @@
 import nextConnect from 'next-connect';
-import controller from 'models/controller.js';
+
 import analytics from 'models/analytics.js';
 import cacheControl from 'models/cache-control';
+import controller from 'models/controller.js';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/api/v1/analytics/users-created/index.public.js
+++ b/pages/api/v1/analytics/users-created/index.public.js
@@ -1,7 +1,8 @@
 import nextConnect from 'next-connect';
-import controller from 'models/controller.js';
+
 import analytics from 'models/analytics.js';
 import cacheControl from 'models/cache-control';
+import controller from 'models/controller.js';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/api/v1/contents/[username]/[slug]/children/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/children/index.public.js
@@ -1,11 +1,12 @@
 import nextConnect from 'next-connect';
-import controller from 'models/controller.js';
+
+import { NotFoundError } from 'errors/index.js';
 import authorization from 'models/authorization.js';
 import cacheControl from 'models/cache-control';
-import validator from 'models/validator.js';
 import content from 'models/content.js';
-import { NotFoundError } from 'errors/index.js';
+import controller from 'models/controller.js';
 import user from 'models/user.js';
+import validator from 'models/validator.js';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/api/v1/contents/[username]/[slug]/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/index.public.js
@@ -1,14 +1,15 @@
 import nextConnect from 'next-connect';
-import controller from 'models/controller.js';
+
+import { ForbiddenError, NotFoundError } from 'errors/index.js';
+import database from 'infra/database.js';
 import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
 import cacheControl from 'models/cache-control';
-import validator from 'models/validator.js';
 import content from 'models/content.js';
-import database from 'infra/database.js';
+import controller from 'models/controller.js';
 import event from 'models/event.js';
-import { ForbiddenError, NotFoundError } from 'errors/index.js';
 import user from 'models/user.js';
+import validator from 'models/validator.js';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/api/v1/contents/[username]/[slug]/parent/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/parent/index.public.js
@@ -1,11 +1,12 @@
 import nextConnect from 'next-connect';
-import controller from 'models/controller.js';
-import user from 'models/user.js';
+
+import { NotFoundError } from 'errors/index.js';
 import authorization from 'models/authorization.js';
 import cacheControl from 'models/cache-control';
-import validator from 'models/validator.js';
 import content from 'models/content.js';
-import { NotFoundError } from 'errors/index.js';
+import controller from 'models/controller.js';
+import user from 'models/user.js';
+import validator from 'models/validator.js';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/api/v1/contents/[username]/[slug]/root/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/root/index.public.js
@@ -1,11 +1,12 @@
 import nextConnect from 'next-connect';
-import controller from 'models/controller.js';
-import user from 'models/user.js';
+
+import { NotFoundError } from 'errors/index.js';
 import authorization from 'models/authorization.js';
 import cacheControl from 'models/cache-control';
-import validator from 'models/validator.js';
 import content from 'models/content.js';
-import { NotFoundError } from 'errors/index.js';
+import controller from 'models/controller.js';
+import user from 'models/user.js';
+import validator from 'models/validator.js';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/api/v1/contents/[username]/[slug]/tabcoins/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/tabcoins/index.public.js
@@ -1,14 +1,15 @@
 import nextConnect from 'next-connect';
-import controller from 'models/controller.js';
+
+import { NotFoundError, UnprocessableEntityError, ValidationError } from 'errors/index.js';
+import database from 'infra/database.js';
 import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
-import cacheControl from 'models/cache-control';
-import validator from 'models/validator.js';
-import content from 'models/content.js';
-import event from 'models/event.js';
-import database from 'infra/database.js';
 import balance from 'models/balance.js';
-import { NotFoundError, UnprocessableEntityError, ValidationError } from 'errors/index.js';
+import cacheControl from 'models/cache-control';
+import content from 'models/content.js';
+import controller from 'models/controller.js';
+import event from 'models/event.js';
+import validator from 'models/validator.js';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/api/v1/contents/[username]/[slug]/thumbnail/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/thumbnail/index.public.js
@@ -1,10 +1,11 @@
 import nextConnect from 'next-connect';
-import cacheControl from 'models/cache-control';
-import controller from 'models/controller';
-import validator from 'models/validator.js';
-import content from 'models/content.js';
-import thumbnail from 'models/thumbnail.js';
+
 import { NotFoundError } from 'errors/index.js';
+import cacheControl from 'models/cache-control';
+import content from 'models/content.js';
+import controller from 'models/controller';
+import thumbnail from 'models/thumbnail.js';
+import validator from 'models/validator.js';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/api/v1/contents/[username]/index.public.js
+++ b/pages/api/v1/contents/[username]/index.public.js
@@ -1,11 +1,12 @@
 import nextConnect from 'next-connect';
-import controller from 'models/controller.js';
+
 import authorization from 'models/authorization.js';
 import cacheControl from 'models/cache-control';
-import validator from 'models/validator.js';
 import content from 'models/content.js';
+import controller from 'models/controller.js';
 import removeMarkdown from 'models/remove-markdown.js';
 import user from 'models/user.js';
+import validator from 'models/validator.js';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/api/v1/contents/index.public.js
+++ b/pages/api/v1/contents/index.public.js
@@ -1,16 +1,17 @@
 import nextConnect from 'next-connect';
-import controller from 'models/controller.js';
+
+import { ForbiddenError } from 'errors/index.js';
+import database from 'infra/database.js';
 import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
 import cacheControl from 'models/cache-control';
-import validator from 'models/validator.js';
 import content from 'models/content.js';
-import notification from 'models/notification.js';
+import controller from 'models/controller.js';
 import event from 'models/event.js';
 import firewall from 'models/firewall.js';
+import notification from 'models/notification.js';
 import user from 'models/user.js';
-import database from 'infra/database.js';
-import { ForbiddenError } from 'errors/index.js';
+import validator from 'models/validator.js';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/api/v1/contents/rss/index.public.js
+++ b/pages/api/v1/contents/rss/index.public.js
@@ -1,10 +1,11 @@
 import nextConnect from 'next-connect';
-import controller from 'models/controller.js';
+
 import authorization from 'models/authorization.js';
 import cacheControl from 'models/cache-control';
-import user from 'models/user.js';
-import rss from 'models/rss';
 import content from 'models/content.js';
+import controller from 'models/controller.js';
+import rss from 'models/rss';
+import user from 'models/user.js';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/api/v1/email-confirmation/index.public.js
+++ b/pages/api/v1/email-confirmation/index.public.js
@@ -1,8 +1,9 @@
 import nextConnect from 'next-connect';
-import controller from 'models/controller.js';
+
 import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
 import cacheControl from 'models/cache-control';
+import controller from 'models/controller.js';
 import emailConfirmation from 'models/email-confirmation.js';
 import validator from 'models/validator.js';
 

--- a/pages/api/v1/migrations/index.public.js
+++ b/pages/api/v1/migrations/index.public.js
@@ -1,9 +1,10 @@
 import nextConnect from 'next-connect';
-import controller from 'models/controller.js';
+
 import migrator from 'infra/migrator.js';
 import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
 import cacheControl from 'models/cache-control';
+import controller from 'models/controller.js';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/api/v1/recovery/index.public.js
+++ b/pages/api/v1/recovery/index.public.js
@@ -1,11 +1,12 @@
+import { ForbiddenError } from 'errors';
 import nextConnect from 'next-connect';
-import controller from 'models/controller.js';
+
 import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
 import cacheControl from 'models/cache-control';
+import controller from 'models/controller.js';
 import recovery from 'models/recovery.js';
 import validator from 'models/validator.js';
-import { ForbiddenError } from 'errors';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/api/v1/sessions/index.public.js
+++ b/pages/api/v1/sessions/index.public.js
@@ -1,13 +1,15 @@
 import nextConnect from 'next-connect';
-import controller from 'models/controller.js';
-import user from 'models/user';
+
+import activation from 'models/activation.js';
 import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
 import cacheControl from 'models/cache-control';
-import { UnauthorizedError, ForbiddenError } from '/errors/index.js';
-import activation from 'models/activation.js';
-import validator from 'models/validator.js';
+import controller from 'models/controller.js';
 import session from 'models/session';
+import user from 'models/user';
+import validator from 'models/validator.js';
+
+import { ForbiddenError, UnauthorizedError } from '/errors/index.js';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/api/v1/status/index.public.js
+++ b/pages/api/v1/status/index.public.js
@@ -1,5 +1,6 @@
-import nextConnect from 'next-connect';
 import { formatISO } from 'date-fns';
+import nextConnect from 'next-connect';
+
 import cacheControl from 'models/cache-control';
 import controller from 'models/controller.js';
 import health from 'models/health.js';

--- a/pages/api/v1/user/index.public.js
+++ b/pages/api/v1/user/index.public.js
@@ -1,8 +1,9 @@
 import nextConnect from 'next-connect';
-import controller from 'models/controller.js';
+
 import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
 import cacheControl from 'models/cache-control';
+import controller from 'models/controller.js';
 import session from 'models/session';
 
 export default nextConnect({

--- a/pages/api/v1/users/[username]/index.public.js
+++ b/pages/api/v1/users/[username]/index.public.js
@@ -1,14 +1,15 @@
 import nextConnect from 'next-connect';
-import cacheControl from 'models/cache-control';
-import controller from 'models/controller.js';
-import user from 'models/user.js';
-import ban from 'models/ban.js';
+
+import { ForbiddenError, UnprocessableEntityError } from 'errors/index.js';
+import database from 'infra/database.js';
 import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
-import validator from 'models/validator.js';
+import ban from 'models/ban.js';
+import cacheControl from 'models/cache-control';
+import controller from 'models/controller.js';
 import event from 'models/event.js';
-import database from 'infra/database.js';
-import { ForbiddenError, UnprocessableEntityError } from 'errors/index.js';
+import user from 'models/user.js';
+import validator from 'models/validator.js';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/api/v1/users/index.public.js
+++ b/pages/api/v1/users/index.public.js
@@ -1,14 +1,14 @@
 import nextConnect from 'next-connect';
 
-import controller from 'models/controller.js';
-import user from 'models/user.js';
 import activation from 'models/activation.js';
 import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
 import cacheControl from 'models/cache-control';
-import validator from 'models/validator.js';
+import controller from 'models/controller.js';
 import event from 'models/event.js';
 import firewall from 'models/firewall.js';
+import user from 'models/user.js';
+import validator from 'models/validator.js';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/cadastro/index.public.js
+++ b/pages/cadastro/index.public.js
@@ -1,7 +1,8 @@
 import { Box, Button, DefaultLayout, Flash, FormControl, Heading, PasswordInput, TextInput } from '@/TabNewsUI';
-import { suggestEmail } from 'pages/interface';
 import { useRouter } from 'next/router';
 import { useRef, useState } from 'react';
+
+import { suggestEmail } from 'pages/interface';
 
 export default function Register() {
   return (

--- a/pages/cadastro/recuperar/index.public.js
+++ b/pages/cadastro/recuperar/index.public.js
@@ -1,7 +1,8 @@
 import { Box, Button, DefaultLayout, Flash, FormControl, Heading, TextInput } from '@/TabNewsUI';
 import { useRouter } from 'next/router';
-import { useUser } from 'pages/interface';
 import { useEffect, useRef, useState } from 'react';
+
+import { useUser } from 'pages/interface';
 
 export default function RecoverPassword() {
   return (

--- a/pages/index.public.js
+++ b/pages/index.public.js
@@ -1,10 +1,11 @@
 import { ContentList, DefaultLayout } from '@/TabNewsUI';
+import { FaTree } from '@/TabNewsUI/icons';
+import { getStaticPropsRevalidate } from 'next-swr';
+
 import authorization from 'models/authorization.js';
 import content from 'models/content.js';
 import user from 'models/user.js';
 import validator from 'models/validator.js';
-import { getStaticPropsRevalidate } from 'next-swr';
-import { FaTree } from '@/TabNewsUI/icons';
 
 export default function Home({ contentListFound, pagination }) {
   return (

--- a/pages/interface/components/Confetti/index.js
+++ b/pages/interface/components/Confetti/index.js
@@ -1,5 +1,5 @@
-import ReactConfetti from 'react-confetti';
 import { useEffect, useState } from 'react';
+import ReactConfetti from 'react-confetti';
 
 export default function Confetti({
   width = 0,

--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -14,13 +14,14 @@ import {
   ReadTime,
   Text,
   TextInput,
-  useConfirm,
   Viewer,
+  useConfirm,
 } from '@/TabNewsUI';
 import { KebabHorizontalIcon, LinkIcon, PencilIcon, TrashIcon } from '@/TabNewsUI/icons';
 import { useRouter } from 'next/router';
-import { useUser } from 'pages/interface';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useUser } from 'pages/interface';
 
 export default function Content({ content, mode = 'view', viewFrame = false }) {
   const [componentMode, setComponentMode] = useState(mode);

--- a/pages/interface/components/DefaultLayout/index.js
+++ b/pages/interface/components/DefaultLayout/index.js
@@ -1,4 +1,5 @@
 import { Box, Footer, GoToTopButton, Header } from '@/TabNewsUI';
+
 import { Head } from 'pages/interface';
 
 export default function DefaultLayout({ children, containerWidth = 'large', metadata }) {

--- a/pages/interface/components/Head/index.js
+++ b/pages/interface/components/Head/index.js
@@ -1,7 +1,8 @@
-import { useMediaQuery } from 'pages/interface';
-import webserver from 'infra/webserver.js';
 import NextHead from 'next/head';
 import { useRouter } from 'next/router';
+
+import webserver from 'infra/webserver.js';
+import { useMediaQuery } from 'pages/interface';
 
 const webserverHost = webserver.host;
 

--- a/pages/interface/components/Header/index.js
+++ b/pages/interface/components/Header/index.js
@@ -15,6 +15,7 @@ import {
 } from '@/TabNewsUI';
 import { CgTab, HomeIcon, PersonFillIcon, PlusIcon, SquareFillIcon } from '@/TabNewsUI/icons';
 import { useRouter } from 'next/router';
+
 import { useUser } from 'pages/interface';
 
 export default function HeaderComponent() {

--- a/pages/interface/components/Markdown/index.js
+++ b/pages/interface/components/Markdown/index.js
@@ -1,7 +1,4 @@
 import { Box, EditorColors, EditorStyles, useTheme } from '@/TabNewsUI';
-import { Editor as ByteMdEditor, Viewer as ByteMdViewer } from '@bytemd/react';
-import { useEffect, useMemo, useRef, useState } from 'react';
-
 // ByteMD dependencies:
 import breaksPlugin from '@bytemd/plugin-breaks';
 import gemojiPlugin from '@bytemd/plugin-gemoji';
@@ -12,8 +9,10 @@ import mathPlugin from '@bytemd/plugin-math';
 import mathLocale from '@bytemd/plugin-math/locales/pt_BR.json';
 import mermaidPlugin from '@bytemd/plugin-mermaid';
 import mermaidLocale from '@bytemd/plugin-mermaid/locales/pt_BR.json';
+import { Editor as ByteMdEditor, Viewer as ByteMdViewer } from '@bytemd/react';
 import byteMDLocale from 'bytemd/locales/pt_BR.json';
 import 'katex/dist/katex.css';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 const bytemdPluginBaseList = [
   gfmPlugin({ locale: gfmLocale }),

--- a/pages/interface/components/Progressbar/index.js
+++ b/pages/interface/components/Progressbar/index.js
@@ -1,5 +1,4 @@
 // Original code from: https://github.com/apal21/nextjs-progressbar
-
 import Router from 'next/router';
 import NProgress from 'nprogress';
 import { useEffect } from 'react';

--- a/pages/interface/components/SearchBox/index.js
+++ b/pages/interface/components/SearchBox/index.js
@@ -1,5 +1,5 @@
-import { SearchIcon, XCircleFillIcon } from '@/TabNewsUI/icons';
 import { Box, Button, Heading, IconButton, Overlay, Spinner } from '@/TabNewsUI';
+import { SearchIcon, XCircleFillIcon } from '@/TabNewsUI/icons';
 import { useEffect, useRef, useState } from 'react';
 
 const searchURL = process.env.NEXT_PUBLIC_SEARCH_URL + process.env.NEXT_PUBLIC_SEARCH_ID;

--- a/pages/interface/components/TabCoinButtons/index.js
+++ b/pages/interface/components/TabCoinButtons/index.js
@@ -2,9 +2,10 @@ import { Box, IconButton, Text, Tooltip } from '@/TabNewsUI';
 import { ChevronDownIcon, ChevronUpIcon } from '@/TabNewsUI/icons';
 import { useRevalidate } from 'next-swr';
 import { useRouter } from 'next/router';
-import { useUser } from 'pages/interface';
 import { useEffect, useState } from 'react';
 import { useReward } from 'react-rewards';
+
+import { useUser } from 'pages/interface';
 
 export default function TabCoinButtons({ content }) {
   const router = useRouter();

--- a/pages/interface/hooks/useMediaQuery/index.js
+++ b/pages/interface/hooks/useMediaQuery/index.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 export default function useMediaQuery(query) {
   const [matches, setMatches] = useState(false);

--- a/pages/interface/hooks/useUser/index.js
+++ b/pages/interface/hooks/useUser/index.js
@@ -1,6 +1,7 @@
-import webserver from 'infra/webserver';
 import { useRouter } from 'next/router';
 import { createContext, useCallback, useContext, useEffect, useState } from 'react';
+
+import webserver from 'infra/webserver';
 
 const userEndpoint = '/api/v1/user';
 const sessionEndpoint = '/api/v1/sessions';

--- a/pages/login/index.public.js
+++ b/pages/login/index.public.js
@@ -10,8 +10,9 @@ import {
   Text,
   TextInput,
 } from '@/TabNewsUI';
-import { useUser } from 'pages/interface';
 import { useRef, useState } from 'react';
+
+import { useUser } from 'pages/interface';
 
 export default function Login() {
   return (

--- a/pages/pagina/[page]/index.public.js
+++ b/pages/pagina/[page]/index.public.js
@@ -1,9 +1,10 @@
 import { ContentList, DefaultLayout } from '@/TabNewsUI';
+import { getStaticPropsRevalidate } from 'next-swr';
+
 import authorization from 'models/authorization.js';
 import content from 'models/content.js';
 import user from 'models/user.js';
 import validator from 'models/validator.js';
-import { getStaticPropsRevalidate } from 'next-swr';
 
 export default function Home({ contentListFound, pagination }) {
   return (

--- a/pages/perfil/index.public.js
+++ b/pages/perfil/index.public.js
@@ -11,9 +11,10 @@ import {
   TextInput,
   useConfirm,
 } from '@/TabNewsUI';
-import { useUser, suggestEmail } from 'pages/interface';
 import { useRouter } from 'next/router';
 import { useEffect, useRef, useState } from 'react';
+
+import { suggestEmail, useUser } from 'pages/interface';
 
 export default function EditProfile() {
   return (

--- a/pages/publicar/index.public.js
+++ b/pages/publicar/index.public.js
@@ -1,8 +1,9 @@
 import { Box, Content, DefaultLayout, Flash, Heading, Link } from '@/TabNewsUI';
 import { useRouter } from 'next/router';
-import { useUser } from 'pages/interface';
 import { useEffect } from 'react';
 import useSWR from 'swr';
+
+import { useUser } from 'pages/interface';
 
 export default function Post() {
   const router = useRouter();

--- a/pages/recentes/index.public.js
+++ b/pages/recentes/index.public.js
@@ -1,9 +1,10 @@
 import { ContentList, DefaultLayout } from '@/TabNewsUI';
+import { getStaticPropsRevalidate } from 'next-swr';
+
 import authorization from 'models/authorization.js';
 import content from 'models/content.js';
 import user from 'models/user.js';
 import validator from 'models/validator.js';
-import { getStaticPropsRevalidate } from 'next-swr';
 
 export default function Home({ contentListFound, pagination }) {
   return (

--- a/pages/recentes/pagina/[page]/index.public.js
+++ b/pages/recentes/pagina/[page]/index.public.js
@@ -1,9 +1,10 @@
 import { ContentList, DefaultLayout } from '@/TabNewsUI';
+import { getStaticPropsRevalidate } from 'next-swr';
+
 import authorization from 'models/authorization.js';
 import content from 'models/content.js';
 import user from 'models/user.js';
 import validator from 'models/validator.js';
-import { getStaticPropsRevalidate } from 'next-swr';
 
 export default function Home({ contentListFound, pagination }) {
   return (

--- a/pages/status/index.public.js
+++ b/pages/status/index.public.js
@@ -1,8 +1,9 @@
 import { Box, DefaultLayout, Heading, Label, LabelGroup, Truncate } from '@/TabNewsUI';
-import analytics from 'models/analytics.js';
 import { getStaticPropsRevalidate } from 'next-swr';
 import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis } from 'recharts';
 import useSWR from 'swr';
+
+import analytics from 'models/analytics.js';
 
 export default function Page({ usersCreated, rootContentPublished, childContentPublished }) {
   const { data: statusObject, isLoading: statusObjectIsLoading } = useSWR('/api/v1/status', {

--- a/tests/integration/api/v1/_use-cases/registration-flow.test.js
+++ b/tests/integration/api/v1/_use-cases/registration-flow.test.js
@@ -1,11 +1,12 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
-import orchestrator from 'tests/orchestrator.js';
-import user from 'models/user.js';
-import authentication from 'models/authentication';
+
 import activation from 'models/activation.js';
-import session from 'models/session.js';
+import authentication from 'models/authentication';
 import password from 'models/password.js';
+import session from 'models/session.js';
+import user from 'models/user.js';
+import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();

--- a/tests/integration/api/v1/activation/patch.test.js
+++ b/tests/integration/api/v1/activation/patch.test.js
@@ -1,7 +1,8 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
-import orchestrator from 'tests/orchestrator.js';
+
 import activation from 'models/activation.js';
+import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();

--- a/tests/integration/api/v1/contents/[username]/[slug]/children/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/children/get.test.js
@@ -1,5 +1,6 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/contents/[username]/[slug]/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/get.test.js
@@ -1,5 +1,6 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/contents/[username]/[slug]/parent/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/parent/get.test.js
@@ -1,5 +1,6 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
@@ -1,5 +1,6 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/contents/[username]/[slug]/root/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/root/get.test.js
@@ -1,5 +1,6 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/contents/[username]/[slug]/tabcoins/post.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/tabcoins/post.test.js
@@ -1,4 +1,5 @@
 import fetch from 'cross-fetch';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/contents/[username]/[slug]/thumbnail/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/thumbnail/get.test.js
@@ -1,10 +1,9 @@
 import fetch from 'cross-fetch';
-import { readFileSync } from 'fs';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
 import { version as uuidVersion } from 'uuid';
 
 import orchestrator from 'tests/orchestrator.js';
-
-const { join, resolve } = require('path');
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();

--- a/tests/integration/api/v1/contents/[username]/[slug]/thumbnail/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/thumbnail/get.test.js
@@ -1,8 +1,10 @@
-const { join, resolve } = require('path');
-import { readFileSync } from 'fs';
 import fetch from 'cross-fetch';
+import { readFileSync } from 'fs';
 import { version as uuidVersion } from 'uuid';
+
 import orchestrator from 'tests/orchestrator.js';
+
+const { join, resolve } = require('path');
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();

--- a/tests/integration/api/v1/contents/[username]/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/get.test.js
@@ -1,6 +1,7 @@
 import fetch from 'cross-fetch';
-import { version as uuidVersion } from 'uuid';
 import parseLinkHeader from 'parse-link-header';
+import { version as uuidVersion } from 'uuid';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/contents/firewall.post.test.js
+++ b/tests/integration/api/v1/contents/firewall.post.test.js
@@ -1,8 +1,9 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
-import orchestrator from 'tests/orchestrator.js';
+
 import content from 'models/content.js';
 import event from 'models/event.js';
+import orchestrator from 'tests/orchestrator.js';
 
 beforeEach(async () => {
   await orchestrator.waitForAllServices();

--- a/tests/integration/api/v1/contents/get.test.js
+++ b/tests/integration/api/v1/contents/get.test.js
@@ -1,6 +1,7 @@
 import fetch from 'cross-fetch';
-import { version as uuidVersion } from 'uuid';
 import parseLinkHeader from 'parse-link-header';
+import { version as uuidVersion } from 'uuid';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -1,7 +1,8 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
-import orchestrator from 'tests/orchestrator.js';
+
 import database from 'infra/database';
+import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();

--- a/tests/integration/api/v1/contents/rss/get.test.js
+++ b/tests/integration/api/v1/contents/rss/get.test.js
@@ -1,4 +1,5 @@
 import fetch from 'cross-fetch';
+
 import orchestrator from 'tests/orchestrator.js';
 
 describe('GET /recentes/rss', () => {

--- a/tests/integration/api/v1/email-confirmation/patch.test.js
+++ b/tests/integration/api/v1/email-confirmation/patch.test.js
@@ -1,8 +1,9 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
-import orchestrator from 'tests/orchestrator.js';
-import user from 'models/user.js';
+
 import emailConfirmation from 'models/email-confirmation.js';
+import user from 'models/user.js';
+import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();

--- a/tests/integration/api/v1/events/get.test.js
+++ b/tests/integration/api/v1/events/get.test.js
@@ -1,8 +1,8 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
 
-import orchestrator from 'tests/orchestrator.js';
 import event from 'models/event.js';
+import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();

--- a/tests/integration/api/v1/migrations/get.test.js
+++ b/tests/integration/api/v1/migrations/get.test.js
@@ -1,5 +1,6 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/migrations/post.test.js
+++ b/tests/integration/api/v1/migrations/post.test.js
@@ -1,5 +1,6 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/recovery/patch.test.js
+++ b/tests/integration/api/v1/recovery/patch.test.js
@@ -1,8 +1,9 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
-import orchestrator from 'tests/orchestrator.js';
-import user from 'models/user.js';
+
 import recovery from 'models/recovery.js';
+import user from 'models/user.js';
+import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();

--- a/tests/integration/api/v1/recovery/post.test.js
+++ b/tests/integration/api/v1/recovery/post.test.js
@@ -1,7 +1,8 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
-import orchestrator from 'tests/orchestrator.js';
+
 import recovery from 'models/recovery.js';
+import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();

--- a/tests/integration/api/v1/sessions/delete.test.js
+++ b/tests/integration/api/v1/sessions/delete.test.js
@@ -1,5 +1,6 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/sessions/get.test.js
+++ b/tests/integration/api/v1/sessions/get.test.js
@@ -1,5 +1,6 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/sessions/post.test.js
+++ b/tests/integration/api/v1/sessions/post.test.js
@@ -1,8 +1,9 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
-import orchestrator from 'tests/orchestrator.js';
-import session from 'models/session';
+
 import authentication from 'models/authentication';
+import session from 'models/session';
+import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();

--- a/tests/integration/api/v1/status/get.test.js
+++ b/tests/integration/api/v1/status/get.test.js
@@ -1,4 +1,5 @@
 import fetch from 'cross-fetch';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/swr/get.test.js
+++ b/tests/integration/api/v1/swr/get.test.js
@@ -1,4 +1,5 @@
 import fetch from 'cross-fetch';
+
 import orchestrator from 'tests/orchestrator.js';
 
 describe('GET /swr', () => {

--- a/tests/integration/api/v1/user/get.test.js
+++ b/tests/integration/api/v1/user/get.test.js
@@ -1,7 +1,8 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
-import orchestrator from 'tests/orchestrator.js';
+
 import authentication from 'models/authentication';
+import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();

--- a/tests/integration/api/v1/user/post.test.js
+++ b/tests/integration/api/v1/user/post.test.js
@@ -1,5 +1,6 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/users/[username]/delete.test.js
+++ b/tests/integration/api/v1/users/[username]/delete.test.js
@@ -1,5 +1,6 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/users/[username]/get.test.js
+++ b/tests/integration/api/v1/users/[username]/get.test.js
@@ -1,5 +1,6 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/users/[username]/patch.test.js
+++ b/tests/integration/api/v1/users/[username]/patch.test.js
@@ -1,9 +1,10 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
-import orchestrator from 'tests/orchestrator.js';
-import user from 'models/user.js';
-import password from 'models/password.js';
+
 import emailConfirmation from 'models/email-confirmation.js';
+import password from 'models/password.js';
+import user from 'models/user.js';
+import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();

--- a/tests/integration/api/v1/users/firewall.post.test.js
+++ b/tests/integration/api/v1/users/firewall.post.test.js
@@ -1,8 +1,9 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
-import orchestrator from 'tests/orchestrator.js';
-import user from 'models/user.js';
+
 import event from 'models/event.js';
+import user from 'models/user.js';
+import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();

--- a/tests/integration/api/v1/users/get.test.js
+++ b/tests/integration/api/v1/users/get.test.js
@@ -1,5 +1,6 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/users/post.test.js
+++ b/tests/integration/api/v1/users/post.test.js
@@ -1,8 +1,9 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
-import orchestrator from 'tests/orchestrator.js';
-import user from 'models/user.js';
+
 import password from 'models/password.js';
+import user from 'models/user.js';
+import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -1,17 +1,18 @@
-import fs from 'node:fs';
-import fetch from 'cross-fetch';
-import retry from 'async-retry';
 import { faker } from '@faker-js/faker';
+import retry from 'async-retry';
+import fetch from 'cross-fetch';
+import fs from 'node:fs';
+
 import database from 'infra/database.js';
 import migrator from 'infra/migrator.js';
-import user from 'models/user.js';
-import activation from 'models/activation.js';
-import session from 'models/session.js';
-import content from 'models/content.js';
-import recovery from 'models/recovery.js';
-import balance from 'models/balance.js';
-import event from 'models/event.js';
 import webserver from 'infra/webserver.js';
+import activation from 'models/activation.js';
+import balance from 'models/balance.js';
+import content from 'models/content.js';
+import event from 'models/event.js';
+import recovery from 'models/recovery.js';
+import session from 'models/session.js';
+import user from 'models/user.js';
 
 const webserverUrl = webserver.host;
 const emailServiceUrl = `http://${process.env.EMAIL_HTTP_HOST}:${process.env.EMAIL_HTTP_PORT}`;

--- a/tests/unit/models/prestige.test.js
+++ b/tests/unit/models/prestige.test.js
@@ -1,5 +1,6 @@
-import prestige from 'models/prestige';
 import { v4 as uuidV4 } from 'uuid';
+
+import prestige from 'models/prestige';
 
 describe('prestige model', () => {
   describe('getByContentId', () => {


### PR DESCRIPTION
Salve galera!!

Esse PR faz a reimplementação do #552 e que foi levandado novamente pelo @aprendendofelipe  em #1494.

Nesse PR foi adicionado um novo plugin do prettier, o [@trivago/prettier-plugin-sort-imports](https://www.npmjs.com/package/@trivago/prettier-plugin-sort-imports), e, em [5dfb0df](https://github.com/filipedeschamps/tabnews.com.br/pull/1496/commits/5dfb0df2d08fcf3db73b2687adb0c303ff666107) aproveitei e transformei alguns imports que estavam no padrão commonJS para ESModules.
