### PR TITLE
Configurações do ESLint (importações, exportações e JSX)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,7 +15,6 @@
     }
   },
   "rules": {
-    "import/no-anonymous-default-export": "off",
     "import/newline-after-import": "error",
     "import/no-duplicates": "error",
     "import/no-useless-path-segments": [

--- a/.eslintrc
+++ b/.eslintrc
@@ -15,7 +15,6 @@
     }
   },
   "rules": {
-    "react/no-unescaped-entities": "off",
     "import/no-anonymous-default-export": "off",
     "import/newline-after-import": "error",
     "import/no-duplicates": "error",

--- a/.eslintrc
+++ b/.eslintrc
@@ -7,9 +7,49 @@
     "plugin:jsx-a11y/recommended"
   ],
   "plugins": ["jsx-a11y"],
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "paths": ["."]
+      }
+    }
+  },
   "rules": {
     "react/no-unescaped-entities": "off",
     "import/no-anonymous-default-export": "off",
+    "import/newline-after-import": "error",
+    "import/no-duplicates": "error",
+    "import/no-useless-path-segments": [
+      "error",
+      {
+        "noUselessIndex": true
+      }
+    ],
+    "import/order": [
+      "error",
+      {
+        "alphabetize": {
+          "order": "asc",
+          "caseInsensitive": true
+        },
+        "groups": [["builtin", "external"], "internal", ["parent", "sibling", "index"]],
+        "newlines-between": "always",
+        "pathGroups": [
+          {
+            "pattern": "@/**",
+            "group": "internal"
+          }
+        ]
+      }
+    ],
+    "sort-imports": [
+      "error",
+      {
+        "allowSeparatedGroups": true,
+        "ignoreCase": true,
+        "ignoreDeclarationSort": true
+      }
+    ],
     "no-unused-vars": [
       "error",
       {

--- a/infra/database.js
+++ b/infra/database.js
@@ -1,9 +1,10 @@
-import { Pool, Client } from 'pg';
 import retry from 'async-retry';
-import { ServiceError } from 'errors/index.js';
+import { Client, Pool } from 'pg';
+import snakeize from 'snakeize';
+
+import { ServiceError } from 'errors';
 import logger from 'infra/logger.js';
 import webserver from 'infra/webserver.js';
-import snakeize from 'snakeize';
 
 const configurations = {
   user: process.env.POSTGRES_USER,

--- a/infra/email.js
+++ b/infra/email.js
@@ -1,7 +1,8 @@
-const nodemailer = require('nodemailer');
-import { ServiceError } from 'errors/index.js';
+import nodemailer from 'nodemailer';
+
+import { ServiceError } from 'errors';
+import logger from 'infra/logger.js';
 import webserver from 'infra/webserver.js';
-import logger from './logger.js';
 
 const transporterConfiguration = {
   host: process.env.EMAIL_SMTP_HOST,

--- a/infra/migrator.js
+++ b/infra/migrator.js
@@ -1,6 +1,7 @@
-const { join, resolve } = require('path');
-import database from 'infra/database.js';
 import migrationRunner from 'node-pg-migrate';
+import { join, resolve } from 'node:path';
+
+import database from 'infra/database.js';
 import logger from 'infra/logger.js';
 
 const defaultConfigurations = {

--- a/infra/migrator.js
+++ b/infra/migrator.js
@@ -54,7 +54,9 @@ async function runPendingMigrations() {
   }
 }
 
-export default {
+const migrator = {
   listPendingMigrations,
   runPendingMigrations,
 };
+
+export default migrator;

--- a/infra/rate-limit.js
+++ b/infra/rate-limit.js
@@ -1,6 +1,7 @@
 import { Ratelimit } from '@upstash/ratelimit';
 import { Redis } from '@upstash/redis';
-import { ServiceError } from 'errors/index.js';
+
+import { ServiceError } from 'errors';
 import webserver from 'infra/webserver.js';
 import ip from 'models/ip.js';
 

--- a/infra/scripts/seed-database.js
+++ b/infra/scripts/seed-database.js
@@ -1,7 +1,7 @@
 const fs = require('node:fs');
-const { join, resolve } = require('path');
-
+const { join, resolve } = require('node:path');
 const { Client } = require('pg');
+
 const client = new Client({
   connectionString: process.env.DATABASE_URL,
   connectionTimeoutMillis: 5000,

--- a/infra/scripts/wait-for-db-connection-ready.js
+++ b/infra/scripts/wait-for-db-connection-ready.js
@@ -1,5 +1,5 @@
-const { exec } = require('node:child_process');
 const retry = require('async-retry');
+const { exec } = require('node:child_process');
 
 /**
  * Check Postgres database connection status

--- a/middleware.public.js
+++ b/middleware.public.js
@@ -1,10 +1,11 @@
 import { NextResponse } from 'next/server';
+import snakeize from 'snakeize';
+
+import { UnauthorizedError } from 'errors';
 import logger from 'infra/logger.js';
 import rateLimit from 'infra/rate-limit.js';
-import snakeize from 'snakeize';
-import { UnauthorizedError } from '/errors/index.js';
-import ip from 'models/ip.js';
 import webserver from 'infra/webserver.js';
+import ip from 'models/ip.js';
 
 export const config = {
   matcher: ['/((?!_next/static|va/|favicon|manifest).*)'],

--- a/models/activation.js
+++ b/models/activation.js
@@ -1,9 +1,9 @@
-import email from 'infra/email.js';
+import { ForbiddenError, NotFoundError } from 'errors';
 import database from 'infra/database.js';
+import email from 'infra/email.js';
 import webserver from 'infra/webserver.js';
-import user from 'models/user.js';
 import authorization from 'models/authorization.js';
-import { NotFoundError, ForbiddenError } from 'errors/index.js';
+import user from 'models/user.js';
 
 async function createAndSendActivationEmail(user) {
   const tokenObject = await create(user);

--- a/models/authentication.js
+++ b/models/authentication.js
@@ -1,9 +1,10 @@
 import setCookieParser from 'set-cookie-parser';
-import session from 'models/session.js';
-import user from 'models/user.js';
+
+import { ForbiddenError, UnauthorizedError } from 'errors';
 import authorization from 'models/authorization.js';
 import password from 'models/password.js';
-import { ForbiddenError, UnauthorizedError } from 'errors/index.js';
+import session from 'models/session.js';
+import user from 'models/user.js';
 import validator from 'models/validator.js';
 
 async function hashPassword(unhashedPassword) {

--- a/models/authorization.js
+++ b/models/authorization.js
@@ -1,5 +1,5 @@
+import { ForbiddenError, ValidationError } from 'errors';
 import validator from 'models/validator.js';
-import { ValidationError, ForbiddenError } from 'errors/index.js';
 
 const availableFeatures = new Set([
   // USER

--- a/models/balance.js
+++ b/models/balance.js
@@ -1,5 +1,5 @@
+import { UnprocessableEntityError } from 'errors';
 import database from 'infra/database.js';
-import { UnprocessableEntityError } from 'errors/index.js';
 
 async function findOne(operationId, options = {}) {
   const query = {

--- a/models/ban.js
+++ b/models/ban.js
@@ -1,8 +1,8 @@
 import database from 'infra/database.js';
-import user from 'models/user.js';
-import content from 'models/content.js';
 import balance from 'models/balance.js';
+import content from 'models/content.js';
 import session from 'models/session.js';
+import user from 'models/user.js';
 
 async function nuke(userId, options = {}) {
   await user.removeFeatures(userId, null, options);

--- a/models/content.js
+++ b/models/content.js
@@ -1,12 +1,13 @@
-import { ForbiddenError, ValidationError } from 'errors/index.js';
+import slug from 'slug';
+import { v4 as uuidV4 } from 'uuid';
+
+import { ForbiddenError, ValidationError } from 'errors';
 import database from 'infra/database.js';
 import balance from 'models/balance.js';
 import prestige from 'models/prestige';
 import user from 'models/user.js';
 import validator from 'models/validator.js';
 import queries from 'queries/rankingQueries';
-import slug from 'slug';
-import { v4 as uuidV4 } from 'uuid';
 
 async function findAll(values = {}, options = {}) {
   values = validateValues(values);

--- a/models/controller.js
+++ b/models/controller.js
@@ -1,20 +1,19 @@
-import { v4 as uuidV4 } from 'uuid';
 import snakeize from 'snakeize';
-
-import ip from 'models/ip.js';
-import session from 'models/session.js';
-import logger from 'infra/logger.js';
-import webserver from 'infra/webserver.js';
+import { v4 as uuidV4 } from 'uuid';
 
 import {
+  ForbiddenError,
   InternalServerError,
   NotFoundError,
-  ValidationError,
-  ForbiddenError,
-  UnauthorizedError,
   TooManyRequestsError,
+  UnauthorizedError,
   UnprocessableEntityError,
-} from '/errors/index.js';
+  ValidationError,
+} from 'errors';
+import logger from 'infra/logger.js';
+import webserver from 'infra/webserver.js';
+import ip from 'models/ip.js';
+import session from 'models/session.js';
 
 async function injectRequestMetadata(request, response, next) {
   request.context = {

--- a/models/email-confirmation.js
+++ b/models/email-confirmation.js
@@ -1,8 +1,8 @@
-import email from 'infra/email.js';
+import { NotFoundError } from 'errors';
 import database from 'infra/database.js';
+import email from 'infra/email.js';
 import webserver from 'infra/webserver.js';
 import user from 'models/user.js';
-import { NotFoundError } from 'errors/index.js';
 
 async function createAndSendEmail(userId, newEmail) {
   const userFound = await user.findOneById(userId);

--- a/models/firewall.js
+++ b/models/firewall.js
@@ -1,6 +1,6 @@
+import { TooManyRequestsError } from 'errors';
 import database from 'infra/database.js';
 import event from 'models/event.js';
-import { TooManyRequestsError } from 'errors/index.js';
 
 const rules = {
   'create:user': createUserRule,

--- a/models/health.js
+++ b/models/health.js
@@ -1,5 +1,6 @@
-import database from 'infra/database';
 import { performance } from 'perf_hooks';
+
+import database from 'infra/database';
 import logger from 'infra/logger';
 
 async function getDependencies() {

--- a/models/ip.js
+++ b/models/ip.js
@@ -1,5 +1,6 @@
-import webserver from 'infra/webserver';
 import { isInSubnet, isIP } from 'is-in-subnet';
+
+import webserver from 'infra/webserver';
 
 function extractFromRequest(request) {
   if (isRequestFromCloudflare(request)) {

--- a/models/notification.js
+++ b/models/notification.js
@@ -1,8 +1,8 @@
-import user from 'models/user.js';
-import content from 'models/content.js';
-import authorization from 'models/authorization.js';
-import webserver from 'infra/webserver.js';
 import email from 'infra/email.js';
+import webserver from 'infra/webserver.js';
+import authorization from 'models/authorization.js';
+import content from 'models/content.js';
+import user from 'models/user.js';
 
 async function sendReplyEmailToParentUser(createdContent) {
   const anonymousUser = user.createAnonymous();

--- a/models/password.js
+++ b/models/password.js
@@ -1,4 +1,5 @@
 import bcryptjs from 'bcryptjs';
+
 import webserver from 'infra/webserver.js';
 
 async function hash(password) {

--- a/models/recovery.js
+++ b/models/recovery.js
@@ -1,9 +1,9 @@
-import email from 'infra/email.js';
+import { NotFoundError, ValidationError } from 'errors';
 import database from 'infra/database.js';
+import email from 'infra/email.js';
 import webserver from 'infra/webserver.js';
-import user from 'models/user.js';
 import session from 'models/session';
-import { NotFoundError, ValidationError } from 'errors/index.js';
+import user from 'models/user.js';
 
 async function createAndSendRecoveryEmail(secureInputValues) {
   const userFound = await findUserByUsernameOrEmail(secureInputValues);

--- a/models/rss.js
+++ b/models/rss.js
@@ -1,9 +1,9 @@
-import { Viewer } from '@/TabNewsUI';
-import removeMarkdown from 'models/remove-markdown';
+import { Feed } from 'feed';
 import { renderToStaticMarkup } from 'react-dom/server';
 
-import { Feed } from 'feed';
+import { Viewer } from '@/TabNewsUI';
 import webserver from 'infra/webserver.js';
+import removeMarkdown from 'models/remove-markdown';
 
 function generateRss2(contentList) {
   const webserverHost = webserver.host;

--- a/models/session.js
+++ b/models/session.js
@@ -1,9 +1,10 @@
-import crypto from 'crypto';
 import cookie from 'cookie';
+import crypto from 'crypto';
+
+import { UnauthorizedError } from 'errors';
 import database from 'infra/database.js';
-import { UnauthorizedError } from 'errors/index.js';
-import validator from 'models/validator.js';
 import cacheControl from 'models/cache-control';
+import validator from 'models/validator.js';
 
 const SESSION_EXPIRATION_IN_SECONDS = 60 * 60 * 24 * 30; // 30 days
 

--- a/models/thumbnail.js
+++ b/models/thumbnail.js
@@ -1,9 +1,10 @@
 /* eslint-disable jsx-a11y/alt-text */
 /* eslint-disable @next/next/no-img-element */
+import { renderAsync } from '@resvg/resvg-js';
 import fs from 'node:fs';
 import { join, resolve } from 'node:path';
-import { renderAsync } from '@resvg/resvg-js';
 import satori from 'satori';
+
 import content from 'models/content.js';
 import removeMarkdown from 'models/remove-markdown';
 

--- a/models/user.js
+++ b/models/user.js
@@ -1,9 +1,9 @@
+import { NotFoundError, ValidationError } from 'errors';
 import database from 'infra/database.js';
 import authentication from 'models/authentication.js';
-import validator from 'models/validator.js';
 import balance from 'models/balance.js';
 import emailConfirmation from 'models/email-confirmation.js';
-import { ValidationError, NotFoundError } from 'errors/index.js';
+import validator from 'models/validator.js';
 
 async function findAll() {
   const query = {

--- a/models/validator.js
+++ b/models/validator.js
@@ -1,7 +1,8 @@
 import Joi from 'joi';
-import { ValidationError } from 'errors/index.js';
-import removeMarkdown from 'models/remove-markdown';
+
+import { ValidationError } from 'errors';
 import webserver from 'infra/webserver';
+import removeMarkdown from 'models/remove-markdown';
 
 export default function validator(object, keys) {
   // Force the clean up of "undefined" values since JSON

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "lint": "npm run lint:next && npm run lint:prettier",
     "lint:next": "next lint --max-warnings=0 --dir .",
     "lint:prettier": "prettier --check .",
-    "lint:fix": "eslint --fix && prettier --write .",
+    "lint:fix": "eslint --fix . && prettier --write .",
     "commit": "cz",
     "migration:create": "node-pg-migrate --migrations-dir ./infra/migrations create",
     "migration:run": "node -r dotenv-expand/config infra/scripts/wait-for-db-connection-ready.js && node-pg-migrate up --envPath ./.env -m infra/migrations/ 2>migrations.log",

--- a/pages/404.public.js
+++ b/pages/404.public.js
@@ -1,5 +1,6 @@
-import { Box, DefaultLayout, Link } from '@/TabNewsUI';
 import Image from 'next/image';
+
+import { Box, DefaultLayout, Link } from '@/TabNewsUI';
 import botSleepyFaceDarkTransparent from 'public/brand/bot-sleepy-face-dark-transparent.svg';
 
 export default function Custom404() {

--- a/pages/500.public.js
+++ b/pages/500.public.js
@@ -1,5 +1,6 @@
-import { Box, DefaultLayout, Link } from '@/TabNewsUI';
 import Image from 'next/image';
+
+import { Box, DefaultLayout, Link } from '@/TabNewsUI';
 import botDeadFaceDarkTransparent from 'public/brand/bot-dead-face-dark-transparent.svg';
 
 export default function Custom500() {

--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -1,14 +1,15 @@
+import { getStaticPropsRevalidate } from 'next-swr';
+import { useEffect, useState } from 'react';
+
 import { Box, Button, Confetti, Content, DefaultLayout, Link, TabCoinButtons, Tooltip } from '@/TabNewsUI';
 import { CommentDiscussionIcon, CommentIcon, FoldIcon, UnfoldIcon } from '@/TabNewsUI/icons';
-import { NotFoundError, ValidationError } from 'errors/index.js';
+import { NotFoundError, ValidationError } from 'errors';
 import webserver from 'infra/webserver.js';
 import authorization from 'models/authorization.js';
 import content from 'models/content.js';
 import removeMarkdown from 'models/remove-markdown.js';
 import user from 'models/user.js';
-import { getStaticPropsRevalidate } from 'next-swr';
 import { useCollapse } from 'pages/interface';
-import { useEffect, useState } from 'react';
 
 export default function Post({ contentFound, rootContentFound, parentContentFound, contentMetadata }) {
   const [childrenToShow, setChildrenToShow] = useState(108);

--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -146,7 +146,7 @@ function InReplyToLinks({ content, parentContent, rootContent }) {
             Respondendo a{' '}
             {parentContent.status === 'published' && (
               <Link href={`/${parentContent.owner_username}/${parentContent.slug}`}>
-                <strong>"{parentContent.body}..."</strong>{' '}
+                <strong>{`"${parentContent.body}"`}</strong>{' '}
               </Link>
             )}
             {parentContent.status !== 'published' && (

--- a/pages/[username]/index.public.js
+++ b/pages/[username]/index.public.js
@@ -1,3 +1,8 @@
+import { useRouter } from 'next/router';
+import { getStaticPropsRevalidate } from 'next-swr';
+import { useState } from 'react';
+import useSWR from 'swr';
+
 import {
   ActionList,
   ActionMenu,
@@ -9,21 +14,17 @@ import {
   Label,
   LabelGroup,
   Pagehead,
-  Viewer,
   useConfirm,
+  Viewer,
 } from '@/TabNewsUI';
 import { FaUser, KebabHorizontalIcon, TrashIcon } from '@/TabNewsUI/icons';
-import { NotFoundError } from 'errors/index.js';
+import { NotFoundError } from 'errors';
 import authorization from 'models/authorization.js';
 import content from 'models/content.js';
 import removeMarkdown from 'models/remove-markdown.js';
 import user from 'models/user.js';
 import validator from 'models/validator.js';
-import { getStaticPropsRevalidate } from 'next-swr';
-import { useRouter } from 'next/router';
 import { useUser } from 'pages/interface';
-import { useState } from 'react';
-import useSWR from 'swr';
 
 export default function Home({ contentListFound, pagination, userFound: userFoundFallback }) {
   const { data: userFound, mutate: userFoundMutate } = useSWR(`/api/v1/users/${userFoundFallback.username}`, {

--- a/pages/[username]/pagina/[page]/index.public.js
+++ b/pages/[username]/pagina/[page]/index.public.js
@@ -1,11 +1,12 @@
-import { DefaultLayout, ContentList } from '@/TabNewsUI';
-import user from 'models/user.js';
-import content from 'models/content.js';
-import authorization from 'models/authorization.js';
-import validator from 'models/validator.js';
-import removeMarkdown from 'models/remove-markdown.js';
-import { NotFoundError } from 'errors/index.js';
 import { getStaticPropsRevalidate } from 'next-swr';
+
+import { ContentList, DefaultLayout } from '@/TabNewsUI';
+import { NotFoundError } from 'errors';
+import authorization from 'models/authorization.js';
+import content from 'models/content.js';
+import removeMarkdown from 'models/remove-markdown.js';
+import user from 'models/user.js';
+import validator from 'models/validator.js';
 
 export default function Home({ contentListFound, pagination, username }) {
   return (

--- a/pages/_app.public.js
+++ b/pages/_app.public.js
@@ -1,8 +1,9 @@
-import { ThemeProvider } from '@/TabNewsUI';
 import { Analytics } from '@vercel/analytics/react';
 import { RevalidateProvider } from 'next-swr';
-import { DefaultHead, UserProvider } from 'pages/interface';
 import { SWRConfig } from 'swr';
+
+import { ThemeProvider } from '@/TabNewsUI';
+import { DefaultHead, UserProvider } from 'pages/interface';
 
 async function SWRFetcher(resource, init) {
   const response = await fetch(resource, init);

--- a/pages/api/v1/_responses/rate-limit-reached-sessions.public.js
+++ b/pages/api/v1/_responses/rate-limit-reached-sessions.public.js
@@ -1,11 +1,12 @@
 import nextConnect from 'next-connect';
-import { v4 as uuidV4 } from 'uuid';
 import snakeize from 'snakeize';
+import { v4 as uuidV4 } from 'uuid';
+
+import { ForbiddenError, TooManyRequestsError, UnauthorizedError } from 'errors';
 import logger from 'infra/logger.js';
 import controller from 'models/controller.js';
-import validator from 'models/validator.js';
 import ip from 'models/ip.js';
-import { UnauthorizedError, ForbiddenError, TooManyRequestsError } from 'errors/index.js';
+import validator from 'models/validator.js';
 
 export default nextConnect({
   onError: controller.onErrorHandler,

--- a/pages/api/v1/_responses/rate-limit-reached.public.js
+++ b/pages/api/v1/_responses/rate-limit-reached.public.js
@@ -1,7 +1,8 @@
 import snakeize from 'snakeize';
+
+import { TooManyRequestsError } from 'errors';
 import logger from 'infra/logger.js';
 import ip from 'models/ip.js';
-import { TooManyRequestsError } from 'errors/index.js';
 
 export default function handler(request, response) {
   const error = new TooManyRequestsError({

--- a/pages/api/v1/activation/index.public.js
+++ b/pages/api/v1/activation/index.public.js
@@ -1,10 +1,11 @@
 import nextConnect from 'next-connect';
-import controller from 'models/controller.js';
+
 import activation from 'models/activation.js';
 import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
-import validator from 'models/validator.js';
 import cacheControl from 'models/cache-control';
+import controller from 'models/controller.js';
+import validator from 'models/validator.js';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/api/v1/analytics/child-content-published/index.public.js
+++ b/pages/api/v1/analytics/child-content-published/index.public.js
@@ -1,7 +1,8 @@
 import nextConnect from 'next-connect';
-import controller from 'models/controller.js';
+
 import analytics from 'models/analytics.js';
 import cacheControl from 'models/cache-control';
+import controller from 'models/controller.js';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/api/v1/analytics/root-content-published/index.public.js
+++ b/pages/api/v1/analytics/root-content-published/index.public.js
@@ -1,7 +1,8 @@
 import nextConnect from 'next-connect';
-import controller from 'models/controller.js';
+
 import analytics from 'models/analytics.js';
 import cacheControl from 'models/cache-control';
+import controller from 'models/controller.js';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/api/v1/analytics/users-created/index.public.js
+++ b/pages/api/v1/analytics/users-created/index.public.js
@@ -1,7 +1,8 @@
 import nextConnect from 'next-connect';
-import controller from 'models/controller.js';
+
 import analytics from 'models/analytics.js';
 import cacheControl from 'models/cache-control';
+import controller from 'models/controller.js';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/api/v1/contents/[username]/[slug]/children/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/children/index.public.js
@@ -1,11 +1,12 @@
 import nextConnect from 'next-connect';
-import controller from 'models/controller.js';
+
+import { NotFoundError } from 'errors';
 import authorization from 'models/authorization.js';
 import cacheControl from 'models/cache-control';
-import validator from 'models/validator.js';
 import content from 'models/content.js';
-import { NotFoundError } from 'errors/index.js';
+import controller from 'models/controller.js';
 import user from 'models/user.js';
+import validator from 'models/validator.js';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/api/v1/contents/[username]/[slug]/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/index.public.js
@@ -1,14 +1,15 @@
 import nextConnect from 'next-connect';
-import controller from 'models/controller.js';
+
+import { ForbiddenError, NotFoundError } from 'errors';
+import database from 'infra/database.js';
 import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
 import cacheControl from 'models/cache-control';
-import validator from 'models/validator.js';
 import content from 'models/content.js';
-import database from 'infra/database.js';
+import controller from 'models/controller.js';
 import event from 'models/event.js';
-import { ForbiddenError, NotFoundError } from 'errors/index.js';
 import user from 'models/user.js';
+import validator from 'models/validator.js';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/api/v1/contents/[username]/[slug]/parent/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/parent/index.public.js
@@ -1,11 +1,12 @@
 import nextConnect from 'next-connect';
-import controller from 'models/controller.js';
-import user from 'models/user.js';
+
+import { NotFoundError } from 'errors';
 import authorization from 'models/authorization.js';
 import cacheControl from 'models/cache-control';
-import validator from 'models/validator.js';
 import content from 'models/content.js';
-import { NotFoundError } from 'errors/index.js';
+import controller from 'models/controller.js';
+import user from 'models/user.js';
+import validator from 'models/validator.js';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/api/v1/contents/[username]/[slug]/root/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/root/index.public.js
@@ -1,11 +1,12 @@
 import nextConnect from 'next-connect';
-import controller from 'models/controller.js';
-import user from 'models/user.js';
+
+import { NotFoundError } from 'errors';
 import authorization from 'models/authorization.js';
 import cacheControl from 'models/cache-control';
-import validator from 'models/validator.js';
 import content from 'models/content.js';
-import { NotFoundError } from 'errors/index.js';
+import controller from 'models/controller.js';
+import user from 'models/user.js';
+import validator from 'models/validator.js';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/api/v1/contents/[username]/[slug]/tabcoins/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/tabcoins/index.public.js
@@ -1,14 +1,15 @@
 import nextConnect from 'next-connect';
-import controller from 'models/controller.js';
+
+import { NotFoundError, UnprocessableEntityError, ValidationError } from 'errors';
+import database from 'infra/database.js';
 import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
-import cacheControl from 'models/cache-control';
-import validator from 'models/validator.js';
-import content from 'models/content.js';
-import event from 'models/event.js';
-import database from 'infra/database.js';
 import balance from 'models/balance.js';
-import { NotFoundError, UnprocessableEntityError, ValidationError } from 'errors/index.js';
+import cacheControl from 'models/cache-control';
+import content from 'models/content.js';
+import controller from 'models/controller.js';
+import event from 'models/event.js';
+import validator from 'models/validator.js';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/api/v1/contents/[username]/[slug]/thumbnail/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/thumbnail/index.public.js
@@ -1,10 +1,11 @@
 import nextConnect from 'next-connect';
+
+import { NotFoundError } from 'errors';
 import cacheControl from 'models/cache-control';
-import controller from 'models/controller';
-import validator from 'models/validator.js';
 import content from 'models/content.js';
+import controller from 'models/controller';
 import thumbnail from 'models/thumbnail.js';
-import { NotFoundError } from 'errors/index.js';
+import validator from 'models/validator.js';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/api/v1/contents/[username]/index.public.js
+++ b/pages/api/v1/contents/[username]/index.public.js
@@ -1,11 +1,12 @@
 import nextConnect from 'next-connect';
-import controller from 'models/controller.js';
+
 import authorization from 'models/authorization.js';
 import cacheControl from 'models/cache-control';
-import validator from 'models/validator.js';
 import content from 'models/content.js';
+import controller from 'models/controller.js';
 import removeMarkdown from 'models/remove-markdown.js';
 import user from 'models/user.js';
+import validator from 'models/validator.js';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/api/v1/contents/index.public.js
+++ b/pages/api/v1/contents/index.public.js
@@ -1,16 +1,17 @@
 import nextConnect from 'next-connect';
-import controller from 'models/controller.js';
+
+import { ForbiddenError } from 'errors';
+import database from 'infra/database.js';
 import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
 import cacheControl from 'models/cache-control';
-import validator from 'models/validator.js';
 import content from 'models/content.js';
-import notification from 'models/notification.js';
+import controller from 'models/controller.js';
 import event from 'models/event.js';
 import firewall from 'models/firewall.js';
+import notification from 'models/notification.js';
 import user from 'models/user.js';
-import database from 'infra/database.js';
-import { ForbiddenError } from 'errors/index.js';
+import validator from 'models/validator.js';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/api/v1/contents/rss/index.public.js
+++ b/pages/api/v1/contents/rss/index.public.js
@@ -1,10 +1,11 @@
 import nextConnect from 'next-connect';
-import controller from 'models/controller.js';
+
 import authorization from 'models/authorization.js';
 import cacheControl from 'models/cache-control';
-import user from 'models/user.js';
-import rss from 'models/rss';
 import content from 'models/content.js';
+import controller from 'models/controller.js';
+import rss from 'models/rss';
+import user from 'models/user.js';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/api/v1/email-confirmation/index.public.js
+++ b/pages/api/v1/email-confirmation/index.public.js
@@ -1,8 +1,9 @@
 import nextConnect from 'next-connect';
-import controller from 'models/controller.js';
+
 import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
 import cacheControl from 'models/cache-control';
+import controller from 'models/controller.js';
 import emailConfirmation from 'models/email-confirmation.js';
 import validator from 'models/validator.js';
 

--- a/pages/api/v1/migrations/index.public.js
+++ b/pages/api/v1/migrations/index.public.js
@@ -1,9 +1,10 @@
 import nextConnect from 'next-connect';
-import controller from 'models/controller.js';
+
 import migrator from 'infra/migrator.js';
 import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
 import cacheControl from 'models/cache-control';
+import controller from 'models/controller.js';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/api/v1/recovery/index.public.js
+++ b/pages/api/v1/recovery/index.public.js
@@ -1,11 +1,12 @@
 import nextConnect from 'next-connect';
-import controller from 'models/controller.js';
+
+import { ForbiddenError } from 'errors';
 import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
 import cacheControl from 'models/cache-control';
+import controller from 'models/controller.js';
 import recovery from 'models/recovery.js';
 import validator from 'models/validator.js';
-import { ForbiddenError } from 'errors';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/api/v1/sessions/index.public.js
+++ b/pages/api/v1/sessions/index.public.js
@@ -1,13 +1,14 @@
 import nextConnect from 'next-connect';
-import controller from 'models/controller.js';
-import user from 'models/user';
+
+import { ForbiddenError, UnauthorizedError } from 'errors';
+import activation from 'models/activation.js';
 import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
 import cacheControl from 'models/cache-control';
-import { UnauthorizedError, ForbiddenError } from '/errors/index.js';
-import activation from 'models/activation.js';
-import validator from 'models/validator.js';
+import controller from 'models/controller.js';
 import session from 'models/session';
+import user from 'models/user';
+import validator from 'models/validator.js';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/api/v1/status/index.public.js
+++ b/pages/api/v1/status/index.public.js
@@ -1,5 +1,6 @@
-import nextConnect from 'next-connect';
 import { formatISO } from 'date-fns';
+import nextConnect from 'next-connect';
+
 import cacheControl from 'models/cache-control';
 import controller from 'models/controller.js';
 import health from 'models/health.js';

--- a/pages/api/v1/user/index.public.js
+++ b/pages/api/v1/user/index.public.js
@@ -1,8 +1,9 @@
 import nextConnect from 'next-connect';
-import controller from 'models/controller.js';
+
 import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
 import cacheControl from 'models/cache-control';
+import controller from 'models/controller.js';
 import session from 'models/session';
 
 export default nextConnect({

--- a/pages/api/v1/users/[username]/index.public.js
+++ b/pages/api/v1/users/[username]/index.public.js
@@ -1,14 +1,15 @@
 import nextConnect from 'next-connect';
-import cacheControl from 'models/cache-control';
-import controller from 'models/controller.js';
-import user from 'models/user.js';
-import ban from 'models/ban.js';
+
+import { ForbiddenError, UnprocessableEntityError } from 'errors';
+import database from 'infra/database.js';
 import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
-import validator from 'models/validator.js';
+import ban from 'models/ban.js';
+import cacheControl from 'models/cache-control';
+import controller from 'models/controller.js';
 import event from 'models/event.js';
-import database from 'infra/database.js';
-import { ForbiddenError, UnprocessableEntityError } from 'errors/index.js';
+import user from 'models/user.js';
+import validator from 'models/validator.js';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/api/v1/users/index.public.js
+++ b/pages/api/v1/users/index.public.js
@@ -1,14 +1,14 @@
 import nextConnect from 'next-connect';
 
-import controller from 'models/controller.js';
-import user from 'models/user.js';
 import activation from 'models/activation.js';
 import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
 import cacheControl from 'models/cache-control';
-import validator from 'models/validator.js';
+import controller from 'models/controller.js';
 import event from 'models/event.js';
 import firewall from 'models/firewall.js';
+import user from 'models/user.js';
+import validator from 'models/validator.js';
 
 export default nextConnect({
   attachParams: true,

--- a/pages/cadastro/ativar/[token].public.js
+++ b/pages/cadastro/ativar/[token].public.js
@@ -1,7 +1,8 @@
-import { Box, Confetti, DefaultLayout, Flash } from '@/TabNewsUI';
 import fetch from 'cross-fetch';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
+
+import { Box, Confetti, DefaultLayout, Flash } from '@/TabNewsUI';
 
 export default function ActiveUser() {
   const router = useRouter();

--- a/pages/cadastro/confirmar/index.public.js
+++ b/pages/cadastro/confirmar/index.public.js
@@ -1,5 +1,6 @@
-import { Box, DefaultLayout, Heading, Text } from '@/TabNewsUI';
 import { useEffect, useState } from 'react';
+
+import { Box, DefaultLayout, Heading, Text } from '@/TabNewsUI';
 
 export default function ConfirmSignup() {
   const [email, setEmail] = useState('');

--- a/pages/cadastro/index.public.js
+++ b/pages/cadastro/index.public.js
@@ -1,3 +1,6 @@
+import { useRouter } from 'next/router';
+import { useRef, useState } from 'react';
+
 import {
   Box,
   Button,
@@ -12,8 +15,6 @@ import {
   TextInput,
 } from '@/TabNewsUI';
 import { suggestEmail } from 'pages/interface';
-import { useRouter } from 'next/router';
-import { useRef, useState } from 'react';
 
 export default function Register() {
   return (

--- a/pages/cadastro/recuperar/[token].public.js
+++ b/pages/cadastro/recuperar/[token].public.js
@@ -1,7 +1,8 @@
-import { Box, Button, DefaultLayout, Flash, FormControl, Heading, PasswordInput } from '@/TabNewsUI';
 import fetch from 'cross-fetch';
 import { useRouter } from 'next/router';
 import { useRef, useState } from 'react';
+
+import { Box, Button, DefaultLayout, Flash, FormControl, Heading, PasswordInput } from '@/TabNewsUI';
 
 export default function RecoverPassword() {
   return (

--- a/pages/cadastro/recuperar/index.public.js
+++ b/pages/cadastro/recuperar/index.public.js
@@ -1,7 +1,8 @@
-import { Box, Button, DefaultLayout, Flash, FormControl, Heading, TextInput } from '@/TabNewsUI';
 import { useRouter } from 'next/router';
-import { useUser } from 'pages/interface';
 import { useEffect, useRef, useState } from 'react';
+
+import { Box, Button, DefaultLayout, Flash, FormControl, Heading, TextInput } from '@/TabNewsUI';
+import { useUser } from 'pages/interface';
 
 export default function RecoverPassword() {
   return (

--- a/pages/cadastro/recuperar/index.public.js
+++ b/pages/cadastro/recuperar/index.public.js
@@ -151,12 +151,12 @@ function RecoverPasswordForm() {
               block={true}
               aria-label="Seu e-mail"
             />
-            {['userInput', 'email', 'username'].includes(errorObject?.key) && (
+            {['userInput', 'email'].includes(errorObject?.key) && (
               <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
             )}
 
-            {errorObject?.type === 'string.alphanum' && (
-              <FormControl.Validation variant="error">"email" deve conter um endereço válido.</FormControl.Validation>
+            {errorObject?.key === 'username' && (
+              <FormControl.Validation variant="error">Insira um endereço de email válido.</FormControl.Validation>
             )}
           </FormControl>
         )}

--- a/pages/index.public.js
+++ b/pages/index.public.js
@@ -1,10 +1,11 @@
+import { getStaticPropsRevalidate } from 'next-swr';
+
 import { ContentList, DefaultLayout } from '@/TabNewsUI';
+import { FaTree } from '@/TabNewsUI/icons';
 import authorization from 'models/authorization.js';
 import content from 'models/content.js';
 import user from 'models/user.js';
 import validator from 'models/validator.js';
-import { getStaticPropsRevalidate } from 'next-swr';
-import { FaTree } from '@/TabNewsUI/icons';
 
 export default function Home({ contentListFound, pagination }) {
   return (

--- a/pages/interface/components/Confetti/index.js
+++ b/pages/interface/components/Confetti/index.js
@@ -1,5 +1,5 @@
-import ReactConfetti from 'react-confetti';
 import { useEffect, useState } from 'react';
+import ReactConfetti from 'react-confetti';
 
 export default function Confetti({
   width = 0,

--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -1,3 +1,6 @@
+import { useRouter } from 'next/router';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
 import {
   ActionList,
   ActionMenu,
@@ -18,9 +21,7 @@ import {
   Viewer,
 } from '@/TabNewsUI';
 import { KebabHorizontalIcon, LinkIcon, PencilIcon, TrashIcon } from '@/TabNewsUI/icons';
-import { useRouter } from 'next/router';
 import { useUser } from 'pages/interface';
-import { useCallback, useEffect, useMemo, useState } from 'react';
 
 export default function Content({ content, mode = 'view', viewFrame = false }) {
   const [componentMode, setComponentMode] = useState(mode);

--- a/pages/interface/components/ContentList/index.js
+++ b/pages/interface/components/ContentList/index.js
@@ -97,7 +97,8 @@ export default function ContentList({ contentList: list, pagination, paginationB
               <Link
                 sx={{ wordWrap: 'break-word', fontStyle: 'italic', fontWeight: 'normal' }}
                 href={`/${contentObject.owner_username}/${contentObject.slug}`}>
-                <CommentIcon verticalAlign="middle" size="small" /> "{contentObject.body}"
+                <CommentIcon verticalAlign="middle" size="small" />
+                {` "${contentObject.body}"`}
               </Link>
             ) : (
               <Link sx={{ wordWrap: 'break-word' }} href={`/${contentObject.owner_username}/${contentObject.slug}`}>

--- a/pages/interface/components/GoToTopButton/index.js
+++ b/pages/interface/components/GoToTopButton/index.js
@@ -1,6 +1,7 @@
+import { useEffect, useState } from 'react';
+
 import { IconButton } from '@/TabNewsUI';
 import { ChevronUpIcon } from '@/TabNewsUI/icons';
-import { useEffect, useState } from 'react';
 
 export default function GoToTopButton() {
   const [showButton, setShowButton] = useState(false);

--- a/pages/interface/components/Head/index.js
+++ b/pages/interface/components/Head/index.js
@@ -1,7 +1,8 @@
-import { useMediaQuery } from 'pages/interface';
-import webserver from 'infra/webserver.js';
 import NextHead from 'next/head';
 import { useRouter } from 'next/router';
+
+import webserver from 'infra/webserver.js';
+import { useMediaQuery } from 'pages/interface';
 
 const webserverHost = webserver.host;
 

--- a/pages/interface/components/Header/index.js
+++ b/pages/interface/components/Header/index.js
@@ -1,3 +1,5 @@
+import { useRouter } from 'next/router';
+
 import {
   ActionList,
   ActionMenu,
@@ -14,7 +16,6 @@ import {
   Truncate,
 } from '@/TabNewsUI';
 import { CgTab, HomeIcon, PersonFillIcon, PlusIcon, SquareFillIcon } from '@/TabNewsUI/icons';
-import { useRouter } from 'next/router';
 import { useUser } from 'pages/interface';
 
 export default function HeaderComponent() {

--- a/pages/interface/components/Link/index.js
+++ b/pages/interface/components/Link/index.js
@@ -1,6 +1,7 @@
-import { NavList, PrimerHeader, PrimerLink } from '@/TabNewsUI';
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
+
+import { NavList, PrimerHeader, PrimerLink } from '@/TabNewsUI';
 
 export function Link({ href, children, ...props }) {
   return (

--- a/pages/interface/components/Markdown/index.js
+++ b/pages/interface/components/Markdown/index.js
@@ -1,8 +1,3 @@
-import { Box, EditorColors, EditorStyles, useTheme } from '@/TabNewsUI';
-import { Editor as ByteMdEditor, Viewer as ByteMdViewer } from '@bytemd/react';
-import { useEffect, useMemo, useRef, useState } from 'react';
-
-// ByteMD dependencies:
 import breaksPlugin from '@bytemd/plugin-breaks';
 import gemojiPlugin from '@bytemd/plugin-gemoji';
 import gfmPlugin from '@bytemd/plugin-gfm';
@@ -12,8 +7,12 @@ import mathPlugin from '@bytemd/plugin-math';
 import mathLocale from '@bytemd/plugin-math/locales/pt_BR.json';
 import mermaidPlugin from '@bytemd/plugin-mermaid';
 import mermaidLocale from '@bytemd/plugin-mermaid/locales/pt_BR.json';
+import { Editor as ByteMdEditor, Viewer as ByteMdViewer } from '@bytemd/react';
 import byteMDLocale from 'bytemd/locales/pt_BR.json';
 import 'katex/dist/katex.css';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import { Box, EditorColors, EditorStyles, useTheme } from '@/TabNewsUI';
 
 const bytemdPluginBaseList = [
   gfmPlugin({ locale: gfmLocale }),

--- a/pages/interface/components/PasswordInput/index.js
+++ b/pages/interface/components/PasswordInput/index.js
@@ -1,6 +1,7 @@
+import { useEffect, useState } from 'react';
+
 import { FormControl, TextInput } from '@/TabNewsUI';
 import { EyeClosedIcon, EyeIcon } from '@/TabNewsUI/icons';
-import { useEffect, useState } from 'react';
 
 export default function PasswordInput({ inputRef, id, name, label, errorObject, setErrorObject, ...props }) {
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);

--- a/pages/interface/components/PublishedSince/index.js
+++ b/pages/interface/components/PublishedSince/index.js
@@ -1,7 +1,8 @@
-import { Tooltip } from '@/TabNewsUI';
 import { format, formatDistanceToNowStrict } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { useEffect, useState } from 'react';
+
+import { Tooltip } from '@/TabNewsUI';
 
 function formatPublishedSince(date) {
   try {

--- a/pages/interface/components/ReadTime/index.js
+++ b/pages/interface/components/ReadTime/index.js
@@ -1,5 +1,6 @@
-import { Text } from '@/TabNewsUI';
 import { useMemo } from 'react';
+
+import { Text } from '@/TabNewsUI';
 
 export default function ReadTime({ text, ...props }) {
   const readTimeInMinutes = useMemo(() => {

--- a/pages/interface/components/SearchBox/index.js
+++ b/pages/interface/components/SearchBox/index.js
@@ -1,6 +1,7 @@
-import { SearchIcon, XCircleFillIcon } from '@/TabNewsUI/icons';
-import { Box, Button, Heading, IconButton, Overlay, Spinner } from '@/TabNewsUI';
 import { useEffect, useRef, useState } from 'react';
+
+import { Box, Button, Heading, IconButton, Overlay, Spinner } from '@/TabNewsUI';
+import { SearchIcon, XCircleFillIcon } from '@/TabNewsUI/icons';
 
 const searchURL = process.env.NEXT_PUBLIC_SEARCH_URL + process.env.NEXT_PUBLIC_SEARCH_ID;
 

--- a/pages/interface/components/TabCoinButtons/index.js
+++ b/pages/interface/components/TabCoinButtons/index.js
@@ -1,10 +1,11 @@
-import { Box, IconButton, Text, Tooltip } from '@/TabNewsUI';
-import { ChevronDownIcon, ChevronUpIcon } from '@/TabNewsUI/icons';
-import { useRevalidate } from 'next-swr';
 import { useRouter } from 'next/router';
-import { useUser } from 'pages/interface';
+import { useRevalidate } from 'next-swr';
 import { useEffect, useState } from 'react';
 import { useReward } from 'react-rewards';
+
+import { Box, IconButton, Text, Tooltip } from '@/TabNewsUI';
+import { ChevronDownIcon, ChevronUpIcon } from '@/TabNewsUI/icons';
+import { useUser } from 'pages/interface';
 
 export default function TabCoinButtons({ content }) {
   const router = useRouter();

--- a/pages/interface/components/TabNewsUI/index.js
+++ b/pages/interface/components/TabNewsUI/index.js
@@ -1,22 +1,22 @@
-export { default as Confetti } from '@/Confetti/index.js';
-export { default as Content } from '@/Content/index.js';
-export { default as ContentList } from '@/ContentList/index.js';
-export { default as DefaultLayout } from '@/DefaultLayout/index.js';
-export { default as EmptyState } from '@/EmptyState/index.js';
-export { default as Footer } from '@/Footer/index.js';
-export { default as GoToTopButton } from '@/GoToTopButton/index.js';
-export { default as Header } from '@/Header/index.js';
-export { default as NextLink, HeaderLink, Link, NavItem } from '@/Link';
-export { default as Viewer, Editor } from '@/Markdown/index.js';
-export { EditorColors, EditorStyles, ViewerStyles } from '@/Markdown/styles/index.js';
-export { default as PasswordInput } from '@/PasswordInput/index.js';
-export { default as NextNProgress } from '@/Progressbar/index.js';
-export { default as PublishedSince } from '@/PublishedSince/index.js';
-export { default as ReadTime } from '@/ReadTime/index.js';
-export { default as SearchBox } from '@/SearchBox/index.js';
-export { default as TabCoinButtons } from '@/TabCoinButtons/index.js';
-export { default as ThemeProvider } from '@/ThemeProvider/index.js';
-export { default as ThemeSelector, ThemeSwitcher } from '@/ThemeSelector/index.js';
+export { default as Confetti } from '@/Confetti';
+export { default as Content } from '@/Content';
+export { default as ContentList } from '@/ContentList';
+export { default as DefaultLayout } from '@/DefaultLayout';
+export { default as EmptyState } from '@/EmptyState';
+export { default as Footer } from '@/Footer';
+export { default as GoToTopButton } from '@/GoToTopButton';
+export { default as Header } from '@/Header';
+export { HeaderLink, Link, NavItem, default as NextLink } from '@/Link';
+export { Editor, default as Viewer } from '@/Markdown';
+export { EditorColors, EditorStyles, ViewerStyles } from '@/Markdown/styles';
+export { default as PasswordInput } from '@/PasswordInput';
+export { default as NextNProgress } from '@/Progressbar';
+export { default as PublishedSince } from '@/PublishedSince';
+export { default as ReadTime } from '@/ReadTime';
+export { default as SearchBox } from '@/SearchBox';
+export { default as TabCoinButtons } from '@/TabCoinButtons';
+export { default as ThemeProvider } from '@/ThemeProvider';
+export { default as ThemeSelector, ThemeSwitcher } from '@/ThemeSelector';
 export {
   ActionList,
   ActionMenu,
@@ -27,21 +27,21 @@ export {
   Checkbox,
   Flash,
   FormControl,
-  Header as PrimerHeader,
   Heading,
   IconButton,
   Label,
   LabelGroup,
-  Link as PrimerLink,
   NavList,
   Overlay,
   Pagehead,
+  Header as PrimerHeader,
+  Link as PrimerLink,
+  ThemeProvider as PrimerThemeProvider,
+  SSRProvider,
   SegmentedControl,
   Spinner,
-  SSRProvider,
   Text,
   TextInput,
-  ThemeProvider as PrimerThemeProvider,
   Tooltip,
   Truncate,
   useConfirm,

--- a/pages/interface/components/ThemeProvider/index.js
+++ b/pages/interface/components/ThemeProvider/index.js
@@ -1,5 +1,6 @@
-import { BaseStyles, NextNProgress, PrimerThemeProvider, SSRProvider, ViewerStyles, useTheme } from '@/TabNewsUI';
 import { useEffect, useLayoutEffect, useState } from 'react';
+
+import { BaseStyles, NextNProgress, PrimerThemeProvider, SSRProvider, useTheme, ViewerStyles } from '@/TabNewsUI';
 
 // script to be called before interactive in _document.js
 // if (['auto','night'].includes(localStorage.getItem('colorMode')))

--- a/pages/interface/hooks/useMediaQuery/index.js
+++ b/pages/interface/hooks/useMediaQuery/index.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 export default function useMediaQuery(query) {
   const [matches, setMatches] = useState(false);

--- a/pages/interface/hooks/useUser/index.js
+++ b/pages/interface/hooks/useUser/index.js
@@ -1,6 +1,7 @@
-import webserver from 'infra/webserver';
 import { useRouter } from 'next/router';
 import { createContext, useCallback, useContext, useEffect, useState } from 'react';
+
+import webserver from 'infra/webserver';
 
 const userEndpoint = '/api/v1/user';
 const sessionEndpoint = '/api/v1/sessions';

--- a/pages/interface/index.js
+++ b/pages/interface/index.js
@@ -1,5 +1,5 @@
-export { default as Head, DefaultHead } from './components/Head/index.js';
-export { default as useCollapse } from './hooks/useCollapse/index.js';
-export { default as useMediaQuery } from './hooks/useMediaQuery/index.js';
-export { default as useUser, UserProvider } from './hooks/useUser/index.js';
+export { DefaultHead, default as Head } from './components/Head';
+export { default as useCollapse } from './hooks/useCollapse';
+export { default as useMediaQuery } from './hooks/useMediaQuery';
+export { UserProvider, default as useUser } from './hooks/useUser';
 export { default as suggestEmail } from './utils/email-suggestion';

--- a/pages/login/index.public.js
+++ b/pages/login/index.public.js
@@ -1,3 +1,5 @@
+import { useRef, useState } from 'react';
+
 import {
   Box,
   Button,
@@ -11,7 +13,6 @@ import {
   TextInput,
 } from '@/TabNewsUI';
 import { useUser } from 'pages/interface';
-import { useRef, useState } from 'react';
 
 export default function Login() {
   return (

--- a/pages/pagina/[page]/index.public.js
+++ b/pages/pagina/[page]/index.public.js
@@ -1,9 +1,10 @@
+import { getStaticPropsRevalidate } from 'next-swr';
+
 import { ContentList, DefaultLayout } from '@/TabNewsUI';
 import authorization from 'models/authorization.js';
 import content from 'models/content.js';
 import user from 'models/user.js';
 import validator from 'models/validator.js';
-import { getStaticPropsRevalidate } from 'next-swr';
 
 export default function Home({ contentListFound, pagination }) {
   return (

--- a/pages/perfil/confirmar-email/[token].public.js
+++ b/pages/perfil/confirmar-email/[token].public.js
@@ -1,7 +1,8 @@
-import { Box, Confetti, DefaultLayout, Flash } from '@/TabNewsUI';
 import fetch from 'cross-fetch';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
+
+import { Box, Confetti, DefaultLayout, Flash } from '@/TabNewsUI';
 
 export default function ActiveUser() {
   const router = useRouter();

--- a/pages/perfil/index.public.js
+++ b/pages/perfil/index.public.js
@@ -1,3 +1,6 @@
+import { useRouter } from 'next/router';
+import { useEffect, useRef, useState } from 'react';
+
 import {
   Box,
   Button,
@@ -11,9 +14,7 @@ import {
   TextInput,
   useConfirm,
 } from '@/TabNewsUI';
-import { useUser, suggestEmail } from 'pages/interface';
-import { useRouter } from 'next/router';
-import { useEffect, useRef, useState } from 'react';
+import { suggestEmail, useUser } from 'pages/interface';
 
 export default function EditProfile() {
   return (

--- a/pages/publicar/index.public.js
+++ b/pages/publicar/index.public.js
@@ -1,8 +1,9 @@
-import { Box, Content, DefaultLayout, Flash, Heading, Link } from '@/TabNewsUI';
 import { useRouter } from 'next/router';
-import { useUser } from 'pages/interface';
 import { useEffect } from 'react';
 import useSWR from 'swr';
+
+import { Box, Content, DefaultLayout, Flash, Heading, Link } from '@/TabNewsUI';
+import { useUser } from 'pages/interface';
 
 export default function Post() {
   const router = useRouter();

--- a/pages/recentes/index.public.js
+++ b/pages/recentes/index.public.js
@@ -1,9 +1,10 @@
+import { getStaticPropsRevalidate } from 'next-swr';
+
 import { ContentList, DefaultLayout } from '@/TabNewsUI';
 import authorization from 'models/authorization.js';
 import content from 'models/content.js';
 import user from 'models/user.js';
 import validator from 'models/validator.js';
-import { getStaticPropsRevalidate } from 'next-swr';
 
 export default function Home({ contentListFound, pagination }) {
   return (

--- a/pages/recentes/pagina/[page]/index.public.js
+++ b/pages/recentes/pagina/[page]/index.public.js
@@ -1,9 +1,10 @@
+import { getStaticPropsRevalidate } from 'next-swr';
+
 import { ContentList, DefaultLayout } from '@/TabNewsUI';
 import authorization from 'models/authorization.js';
 import content from 'models/content.js';
 import user from 'models/user.js';
 import validator from 'models/validator.js';
-import { getStaticPropsRevalidate } from 'next-swr';
 
 export default function Home({ contentListFound, pagination }) {
   return (

--- a/pages/status/index.public.js
+++ b/pages/status/index.public.js
@@ -1,8 +1,9 @@
-import { Box, DefaultLayout, Heading, Label, LabelGroup, Truncate } from '@/TabNewsUI';
-import analytics from 'models/analytics.js';
 import { getStaticPropsRevalidate } from 'next-swr';
 import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis } from 'recharts';
 import useSWR from 'swr';
+
+import { Box, DefaultLayout, Heading, Label, LabelGroup, Truncate } from '@/TabNewsUI';
+import analytics from 'models/analytics.js';
 
 export default function Page({ usersCreated, rootContentPublished, childContentPublished }) {
   const { data: statusObject, isLoading: statusObjectIsLoading } = useSWR('/api/v1/status', {

--- a/tests/integration/api/v1/_use-cases/registration-flow.test.js
+++ b/tests/integration/api/v1/_use-cases/registration-flow.test.js
@@ -1,11 +1,12 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
-import orchestrator from 'tests/orchestrator.js';
-import user from 'models/user.js';
-import authentication from 'models/authentication';
+
 import activation from 'models/activation.js';
-import session from 'models/session.js';
+import authentication from 'models/authentication';
 import password from 'models/password.js';
+import session from 'models/session.js';
+import user from 'models/user.js';
+import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();

--- a/tests/integration/api/v1/activation/patch.test.js
+++ b/tests/integration/api/v1/activation/patch.test.js
@@ -1,7 +1,8 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
-import orchestrator from 'tests/orchestrator.js';
+
 import activation from 'models/activation.js';
+import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();

--- a/tests/integration/api/v1/contents/[username]/[slug]/children/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/children/get.test.js
@@ -1,5 +1,6 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/contents/[username]/[slug]/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/get.test.js
@@ -1,5 +1,6 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/contents/[username]/[slug]/parent/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/parent/get.test.js
@@ -1,5 +1,6 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
@@ -1,5 +1,6 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/contents/[username]/[slug]/root/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/root/get.test.js
@@ -1,5 +1,6 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/contents/[username]/[slug]/tabcoins/post.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/tabcoins/post.test.js
@@ -1,4 +1,5 @@
 import fetch from 'cross-fetch';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/contents/[username]/[slug]/thumbnail/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/thumbnail/get.test.js
@@ -1,7 +1,8 @@
-const { join, resolve } = require('path');
-import { readFileSync } from 'fs';
 import fetch from 'cross-fetch';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
 import { version as uuidVersion } from 'uuid';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/contents/[username]/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/get.test.js
@@ -1,6 +1,7 @@
 import fetch from 'cross-fetch';
-import { version as uuidVersion } from 'uuid';
 import parseLinkHeader from 'parse-link-header';
+import { version as uuidVersion } from 'uuid';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/contents/firewall.post.test.js
+++ b/tests/integration/api/v1/contents/firewall.post.test.js
@@ -1,8 +1,9 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
-import orchestrator from 'tests/orchestrator.js';
+
 import content from 'models/content.js';
 import event from 'models/event.js';
+import orchestrator from 'tests/orchestrator.js';
 
 beforeEach(async () => {
   await orchestrator.waitForAllServices();

--- a/tests/integration/api/v1/contents/get.test.js
+++ b/tests/integration/api/v1/contents/get.test.js
@@ -1,6 +1,7 @@
 import fetch from 'cross-fetch';
-import { version as uuidVersion } from 'uuid';
 import parseLinkHeader from 'parse-link-header';
+import { version as uuidVersion } from 'uuid';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -1,7 +1,8 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
-import orchestrator from 'tests/orchestrator.js';
+
 import database from 'infra/database';
+import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();

--- a/tests/integration/api/v1/contents/rss/get.test.js
+++ b/tests/integration/api/v1/contents/rss/get.test.js
@@ -1,4 +1,5 @@
 import fetch from 'cross-fetch';
+
 import orchestrator from 'tests/orchestrator.js';
 
 describe('GET /recentes/rss', () => {

--- a/tests/integration/api/v1/email-confirmation/patch.test.js
+++ b/tests/integration/api/v1/email-confirmation/patch.test.js
@@ -1,8 +1,9 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
-import orchestrator from 'tests/orchestrator.js';
-import user from 'models/user.js';
+
 import emailConfirmation from 'models/email-confirmation.js';
+import user from 'models/user.js';
+import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();

--- a/tests/integration/api/v1/events/get.test.js
+++ b/tests/integration/api/v1/events/get.test.js
@@ -1,8 +1,8 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
 
-import orchestrator from 'tests/orchestrator.js';
 import event from 'models/event.js';
+import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();

--- a/tests/integration/api/v1/migrations/get.test.js
+++ b/tests/integration/api/v1/migrations/get.test.js
@@ -1,5 +1,6 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/migrations/post.test.js
+++ b/tests/integration/api/v1/migrations/post.test.js
@@ -1,5 +1,6 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/recovery/patch.test.js
+++ b/tests/integration/api/v1/recovery/patch.test.js
@@ -1,8 +1,9 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
-import orchestrator from 'tests/orchestrator.js';
-import user from 'models/user.js';
+
 import recovery from 'models/recovery.js';
+import user from 'models/user.js';
+import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();

--- a/tests/integration/api/v1/recovery/post.test.js
+++ b/tests/integration/api/v1/recovery/post.test.js
@@ -1,7 +1,8 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
-import orchestrator from 'tests/orchestrator.js';
+
 import recovery from 'models/recovery.js';
+import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();

--- a/tests/integration/api/v1/sessions/delete.test.js
+++ b/tests/integration/api/v1/sessions/delete.test.js
@@ -1,5 +1,6 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/sessions/get.test.js
+++ b/tests/integration/api/v1/sessions/get.test.js
@@ -1,5 +1,6 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/sessions/post.test.js
+++ b/tests/integration/api/v1/sessions/post.test.js
@@ -1,8 +1,9 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
-import orchestrator from 'tests/orchestrator.js';
-import session from 'models/session';
+
 import authentication from 'models/authentication';
+import session from 'models/session';
+import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();

--- a/tests/integration/api/v1/status/get.test.js
+++ b/tests/integration/api/v1/status/get.test.js
@@ -1,4 +1,5 @@
 import fetch from 'cross-fetch';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/swr/get.test.js
+++ b/tests/integration/api/v1/swr/get.test.js
@@ -1,4 +1,5 @@
 import fetch from 'cross-fetch';
+
 import orchestrator from 'tests/orchestrator.js';
 
 describe('GET /swr', () => {

--- a/tests/integration/api/v1/user/get.test.js
+++ b/tests/integration/api/v1/user/get.test.js
@@ -1,7 +1,8 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
-import orchestrator from 'tests/orchestrator.js';
+
 import authentication from 'models/authentication';
+import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();

--- a/tests/integration/api/v1/user/post.test.js
+++ b/tests/integration/api/v1/user/post.test.js
@@ -1,5 +1,6 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/users/[username]/delete.test.js
+++ b/tests/integration/api/v1/users/[username]/delete.test.js
@@ -1,5 +1,6 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/users/[username]/get.test.js
+++ b/tests/integration/api/v1/users/[username]/get.test.js
@@ -1,5 +1,6 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/users/[username]/patch.test.js
+++ b/tests/integration/api/v1/users/[username]/patch.test.js
@@ -1,9 +1,10 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
-import orchestrator from 'tests/orchestrator.js';
-import user from 'models/user.js';
-import password from 'models/password.js';
+
 import emailConfirmation from 'models/email-confirmation.js';
+import password from 'models/password.js';
+import user from 'models/user.js';
+import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();

--- a/tests/integration/api/v1/users/firewall.post.test.js
+++ b/tests/integration/api/v1/users/firewall.post.test.js
@@ -1,8 +1,9 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
-import orchestrator from 'tests/orchestrator.js';
-import user from 'models/user.js';
+
 import event from 'models/event.js';
+import user from 'models/user.js';
+import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();

--- a/tests/integration/api/v1/users/get.test.js
+++ b/tests/integration/api/v1/users/get.test.js
@@ -1,5 +1,6 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
+
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/users/post.test.js
+++ b/tests/integration/api/v1/users/post.test.js
@@ -1,8 +1,9 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
-import orchestrator from 'tests/orchestrator.js';
-import user from 'models/user.js';
+
 import password from 'models/password.js';
+import user from 'models/user.js';
+import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -1,17 +1,18 @@
-import fs from 'node:fs';
-import fetch from 'cross-fetch';
-import retry from 'async-retry';
 import { faker } from '@faker-js/faker';
+import retry from 'async-retry';
+import fetch from 'cross-fetch';
+import fs from 'node:fs';
+
 import database from 'infra/database.js';
 import migrator from 'infra/migrator.js';
-import user from 'models/user.js';
-import activation from 'models/activation.js';
-import session from 'models/session.js';
-import content from 'models/content.js';
-import recovery from 'models/recovery.js';
-import balance from 'models/balance.js';
-import event from 'models/event.js';
 import webserver from 'infra/webserver.js';
+import activation from 'models/activation.js';
+import balance from 'models/balance.js';
+import content from 'models/content.js';
+import event from 'models/event.js';
+import recovery from 'models/recovery.js';
+import session from 'models/session.js';
+import user from 'models/user.js';
 
 const webserverUrl = webserver.host;
 const emailServiceUrl = `http://${process.env.EMAIL_HTTP_HOST}:${process.env.EMAIL_HTTP_PORT}`;

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -321,7 +321,7 @@ async function createPrestige(
   return [...rootContents, ...childContents];
 }
 
-export default {
+const orchestrator = {
   waitForAllServices,
   dropAllTables,
   runPendingMigrations,
@@ -342,3 +342,5 @@ export default {
   createPrestige,
   createRate,
 };
+
+export default orchestrator;

--- a/tests/unit/models/prestige.test.js
+++ b/tests/unit/models/prestige.test.js
@@ -1,5 +1,6 @@
-import prestige from 'models/prestige';
 import { v4 as uuidV4 } from 'uuid';
+
+import prestige from 'models/prestige';
 
 describe('prestige model', () => {
   describe('getByContentId', () => {


### PR DESCRIPTION
Configura o ESLint para organizar todas as importações do projeto.

Não foi necessário adicionar nenhum novo plugin, mas apenas configurar os parâmetros no `.eslintrc` e corrigir o script `lint:fix` no `package.json`, onde faltava o "ponto" (`.`) em `eslint --fix .`:

#### package.json
```diff
- "lint:fix": "eslint --fix && prettier --write .",
+ "lint:fix": "eslint --fix . && prettier --write .",
```


#### .eslintrc
```json
{
  ...
  "settings": {
    "import/resolver": {
      "node": {
        "paths": ["."]
      }
    }
  },
  "rules": {
    "import/newline-after-import": "error",
    "import/no-duplicates": "error",
    "import/no-useless-path-segments": [
      "error",
      {
        "noUselessIndex": true
      }
    ],
    "import/order": [
      "error",
      {
        "alphabetize": {
          "order": "asc",
          "caseInsensitive": true
        },
        "groups": [["builtin", "external"], "internal", ["parent", "sibling", "index"]],
        "newlines-between": "always",
        "pathGroups": [
          {
            "pattern": "@/**",
            "group": "internal"
          }
        ]
      }
    ],
    "sort-imports": [
      "error",
      {
        "allowSeparatedGroups": true,
        "ignoreCase": true,
        "ignoreDeclarationSort": true
      }
    ],
    "no-unused-vars": [
      "error",
      {
        "vars": "all",
        "args": "after-used"
      }
    ]
  }
}
```

Os critérios de configuração tiveram foco em manter a compatibilidade com a organização automática feita pelo VS Code, onde apenas dois arquivos (`pages/[username]` e `TabCoinsButtons`) não ficaram 100% compatíveis, pois possuem essas duas linhas:

```js
import { ... } from 'next/router';
import { ... } from 'next-swr';
```

Onde o ESLint deixa na ordem acima, já que `next` vem antes de `next-swr`, mas o VS Code leva em consideração `next/router` com a barra sendo um caractere e não um divisor, o que inverte a ordem de classificação.

Continuando na adequação do ESLint, habilitei duas regras que estavam suprimidas e já adequei o código:

- (9912ab020ef7392b07245d3d99bf75f4deee7fc8) `react/no-unescaped-entities`
- (c6380b6fd5fb128c9e34fd30abab2f9d75d4c652) `import/no-anonymous-default-export`

Ao adequar o código para a regra `react/no-unescaped-entities`, nos pontos que exigiam mudanças, notei erros não relacionados com a regra, mas por serem pequenos detalhes, já aproveitei para corrigir.

#### pages/[username]/[slug]/index.public.js

Removi `...`, pois já está presente em `parentContent.body` sempre que for necessário (é inserido pelo `removeMarkdown`):

```diff
- <strong>"{parentContent.body}..."</strong>{' '}
+ <strong>{`"${parentContent.body}"`}</strong>{' '}
```

#### pages/cadastro/recuperar/index.public.js

Corrigi a validação, pois nunca seria mostrada a mensagem de que deve ser inserido um email válido:

```diff
- {['userInput', 'email', 'username'].includes(errorObject?.key) && (
+ {['userInput', 'email'].includes(errorObject?.key) && (
    <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
            )}
-            {errorObject?.type === 'string.alphanum' && (
+            {errorObject?.key === 'username' && (
-              <FormControl.Validation variant="error">"email" deve conter um endereço válido.</FormControl.Validation>
+              <FormControl.Validation variant="error">Insira um endereço de email válido.</FormControl.Validation>
```

### Resumindo

As modificações relevantes estão nos arquivos `.eslintrc` e `package.json`.