### PR TITLE
Adiciona ícone de carregamento no botão de publicar

### DIFF
--- a/pages/cadastro/index.public.js
+++ b/pages/cadastro/index.public.js
@@ -7,6 +7,7 @@ import {
   FormControl,
   Heading,
   Link,
+  ButtonWithLoading,
   PasswordInput,
   Text,
   TextInput,
@@ -195,15 +196,15 @@ function SignUpForm() {
 
         <FormControl>
           <FormControl.Label visuallyHidden>Criar cadastro</FormControl.Label>
-          <Button
+          <ButtonWithLoading
             variant="primary"
             size="large"
             type="submit"
-            disabled={isLoading || !isTermsAccepted}
             sx={{ width: '100%' }}
-            aria-label="Criar cadastro">
+            aria-label="Criar cadastro"
+            isLoading={isLoading || !isTermsAccepted}>
             Criar cadastro
-          </Button>
+          </ButtonWithLoading>
         </FormControl>
       </Box>
     </form>

--- a/pages/cadastro/index.public.js
+++ b/pages/cadastro/index.public.js
@@ -4,7 +4,7 @@ import { useRef, useState } from 'react';
 import {
   Box,
   Button,
-  ButtonWithLoading,
+  ButtonWithLoader,
   Checkbox,
   DefaultLayout,
   Flash,
@@ -197,7 +197,7 @@ function SignUpForm() {
 
         <FormControl>
           <FormControl.Label visuallyHidden>Criar cadastro</FormControl.Label>
-          <ButtonWithLoading
+          <ButtonWithLoader
             variant="primary"
             size="large"
             type="submit"
@@ -205,7 +205,7 @@ function SignUpForm() {
             aria-label="Criar cadastro"
             isLoading={isLoading || !isTermsAccepted}>
             Criar cadastro
-          </ButtonWithLoading>
+          </ButtonWithLoader>
         </FormControl>
       </Box>
     </form>

--- a/pages/cadastro/index.public.js
+++ b/pages/cadastro/index.public.js
@@ -203,7 +203,8 @@ function SignUpForm() {
             type="submit"
             sx={{ width: '100%' }}
             aria-label="Criar cadastro"
-            isLoading={isLoading || !isTermsAccepted}>
+            disabled={!isTermsAccepted}
+            isLoading={isLoading}>
             Criar cadastro
           </ButtonWithLoader>
         </FormControl>

--- a/pages/cadastro/recuperar/[token].public.js
+++ b/pages/cadastro/recuperar/[token].public.js
@@ -1,4 +1,4 @@
-import { Box, Button, DefaultLayout, Flash, FormControl, Heading, PasswordInput } from '@/TabNewsUI';
+import { Box, DefaultLayout, Flash, FormControl, Heading, ButtonWithLoading, PasswordInput } from '@/TabNewsUI';
 import fetch from 'cross-fetch';
 import { useRouter } from 'next/router';
 import { useRef, useState } from 'react';
@@ -110,15 +110,15 @@ function RecoverPasswordForm() {
         />
         <FormControl>
           <FormControl.Label visuallyHidden>Alterar senha</FormControl.Label>
-          <Button
+          <ButtonWithLoading
             variant="primary"
             size="large"
             type="submit"
-            disabled={isLoading}
             sx={{ width: '100%' }}
-            aria-label="Alterar senha">
+            aria-label="Alterar senha"
+            isLoading={isLoading}>
             Alterar senha
-          </Button>
+          </ButtonWithLoading>
         </FormControl>
       </Box>
     </form>

--- a/pages/cadastro/recuperar/[token].public.js
+++ b/pages/cadastro/recuperar/[token].public.js
@@ -2,7 +2,7 @@ import fetch from 'cross-fetch';
 import { useRouter } from 'next/router';
 import { useRef, useState } from 'react';
 
-import { Box, ButtonWithLoading, DefaultLayout, Flash, FormControl, Heading, PasswordInput } from '@/TabNewsUI';
+import { Box, ButtonWithLoader, DefaultLayout, Flash, FormControl, Heading, PasswordInput } from '@/TabNewsUI';
 
 export default function RecoverPassword() {
   return (
@@ -111,7 +111,7 @@ function RecoverPasswordForm() {
         />
         <FormControl>
           <FormControl.Label visuallyHidden>Alterar senha</FormControl.Label>
-          <ButtonWithLoading
+          <ButtonWithLoader
             variant="primary"
             size="large"
             type="submit"
@@ -119,7 +119,7 @@ function RecoverPasswordForm() {
             aria-label="Alterar senha"
             isLoading={isLoading}>
             Alterar senha
-          </ButtonWithLoading>
+          </ButtonWithLoader>
         </FormControl>
       </Box>
     </form>

--- a/pages/cadastro/recuperar/index.public.js
+++ b/pages/cadastro/recuperar/index.public.js
@@ -1,4 +1,4 @@
-import { Box, Button, DefaultLayout, Flash, FormControl, Heading, TextInput } from '@/TabNewsUI';
+import { Box, DefaultLayout, Flash, FormControl, Heading, ButtonWithLoading, TextInput } from '@/TabNewsUI';
 import { useRouter } from 'next/router';
 import { useUser } from 'pages/interface';
 import { useEffect, useRef, useState } from 'react';
@@ -162,15 +162,15 @@ function RecoverPasswordForm() {
 
         <FormControl>
           <FormControl.Label visuallyHidden>Recuperar</FormControl.Label>
-          <Button
+          <ButtonWithLoading
             variant="primary"
             size="large"
             type="submit"
-            disabled={isLoading}
             sx={{ width: '100%' }}
-            aria-label="Recuperar">
+            aria-label="Recuperar"
+            isLoading={isLoading}>
             Recuperar
-          </Button>
+          </ButtonWithLoading>
         </FormControl>
       </Box>
     </form>

--- a/pages/cadastro/recuperar/index.public.js
+++ b/pages/cadastro/recuperar/index.public.js
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router';
 import { useEffect, useRef, useState } from 'react';
 
-import { Box, ButtonWithLoading, DefaultLayout, Flash, FormControl, Heading, TextInput } from '@/TabNewsUI';
+import { Box, ButtonWithLoader, DefaultLayout, Flash, FormControl, Heading, TextInput } from '@/TabNewsUI';
 import { useUser } from 'pages/interface';
 
 export default function RecoverPassword() {
@@ -163,7 +163,7 @@ function RecoverPasswordForm() {
 
         <FormControl>
           <FormControl.Label visuallyHidden>Recuperar</FormControl.Label>
-          <ButtonWithLoading
+          <ButtonWithLoader
             variant="primary"
             size="large"
             type="submit"
@@ -171,7 +171,7 @@ function RecoverPasswordForm() {
             aria-label="Recuperar"
             isLoading={isLoading}>
             Recuperar
-          </ButtonWithLoading>
+          </ButtonWithLoader>
         </FormControl>
       </Box>
     </form>

--- a/pages/interface/components/ButtonWithLoader/index.js
+++ b/pages/interface/components/ButtonWithLoader/index.js
@@ -20,7 +20,7 @@ function SpinnerWrapper({ children, isLoading }) {
   );
 }
 
-export default function ButtonWithLoading({ children, isLoading, ...props }) {
+export default function ButtonWithLoader({ children, isLoading, ...props }) {
   return (
     <Button {...props} disabled={isLoading}>
       <SpinnerWrapper isLoading={isLoading}>{children}</SpinnerWrapper>

--- a/pages/interface/components/ButtonWithLoader/index.js
+++ b/pages/interface/components/ButtonWithLoader/index.js
@@ -20,9 +20,9 @@ function SpinnerWrapper({ children, isLoading }) {
   );
 }
 
-export default function ButtonWithLoader({ children, isLoading, ...props }) {
+export default function ButtonWithLoader({ children, disabled, isLoading, ...props }) {
   return (
-    <Button {...props} disabled={isLoading}>
+    <Button {...props} disabled={isLoading || disabled}>
       <SpinnerWrapper isLoading={isLoading}>{children}</SpinnerWrapper>
     </Button>
   );

--- a/pages/interface/components/ButtonWithLoading/index.js
+++ b/pages/interface/components/ButtonWithLoading/index.js
@@ -1,0 +1,29 @@
+import { Box, Button, Spinner } from '@/TabNewsUI';
+
+function SpinnerWrapper({ children, isLoading }) {
+  const scaleValue = isLoading ? 1 : 0;
+  const transformValue = isLoading ? 'translateX(0)' : 'translateX(-12px)';
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          marginRight: '8px',
+          transform: `scale(${scaleValue})`,
+          transition: 'all 500ms ease',
+        }}>
+        <Spinner size="small" />
+      </Box>
+      <Box sx={{ transform: transformValue, transition: 'transform 500ms ease' }}>{children}</Box>
+    </Box>
+  );
+}
+
+export default function ButtonWithLoading({ children, isLoading, ...props }) {
+  return (
+    <Button {...props} disabled={isLoading}>
+      <SpinnerWrapper isLoading={isLoading}>{children}</SpinnerWrapper>
+    </Button>
+  );
+}

--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -10,8 +10,8 @@ import {
   Heading,
   IconButton,
   Link,
+  ButtonWithLoading,
   PublishedSince,
-  Spinner,
   ReadTime,
   Text,
   TextInput,
@@ -518,14 +518,13 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
                 Cancelar
               </Button>
             )}
-            <Button
-              leadingIcon={isPosting && (() => <Spinner size="small" />)}
+            <ButtonWithLoading
               variant="primary"
               type="submit"
-              disabled={isPosting}
-              aria-label={isPosting ? 'Enviando publicação' : 'Publicar'}>
+              aria-label={isPosting ? 'Carregando...' : contentObject?.id ? 'Atualizar' : 'Publicar'}
+              isLoading={isPosting}>
               {contentObject?.id ? 'Atualizar' : 'Publicar'}
-            </Button>
+            </ButtonWithLoading>
           </Box>
         </Box>
       </form>

--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -519,7 +519,7 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
               </Button>
             )}
             <Button
-              leadingIcon={isPosting ? () => <Spinner size="small" /> : null}
+              leadingIcon={isPosting && (() => <Spinner size="small" />)}
               variant="primary"
               type="submit"
               disabled={isPosting}

--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -7,7 +7,7 @@ import {
   Box,
   BranchName,
   Button,
-  ButtonWithLoading,
+  ButtonWithLoader,
   Editor,
   Flash,
   FormControl,
@@ -519,13 +519,13 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
                 Cancelar
               </Button>
             )}
-            <ButtonWithLoading
+            <ButtonWithLoader
               variant="primary"
               type="submit"
               aria-label={isPosting ? 'Carregando...' : contentObject?.id ? 'Atualizar' : 'Publicar'}
               isLoading={isPosting}>
               {contentObject?.id ? 'Atualizar' : 'Publicar'}
-            </ButtonWithLoading>
+            </ButtonWithLoader>
           </Box>
         </Box>
       </form>

--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -11,6 +11,7 @@ import {
   IconButton,
   Link,
   PublishedSince,
+  Spinner,
   ReadTime,
   Text,
   TextInput,
@@ -517,7 +518,12 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
                 Cancelar
               </Button>
             )}
-            <Button variant="primary" type="submit" disabled={isPosting} aria-label="Publicar">
+            <Button
+              leadingIcon={isPosting ? () => <Spinner size="small" /> : null}
+              variant="primary"
+              type="submit"
+              disabled={isPosting}
+              aria-label={isPosting ? 'Enviando publicação' : 'Publicar'}>
               {contentObject?.id ? 'Atualizar' : 'Publicar'}
             </Button>
           </Box>

--- a/pages/interface/components/TabNewsUI/index.js
+++ b/pages/interface/components/TabNewsUI/index.js
@@ -1,4 +1,4 @@
-export { default as ButtonWithLoading } from '@/ButtonWithLoading/index.js';
+export { default as ButtonWithLoader } from '@/ButtonWithLoader';
 export { default as Confetti } from '@/Confetti';
 export { default as Content } from '@/Content';
 export { default as ContentList } from '@/ContentList';

--- a/pages/interface/components/TabNewsUI/index.js
+++ b/pages/interface/components/TabNewsUI/index.js
@@ -1,3 +1,4 @@
+export { default as ButtonWithLoading } from '@/ButtonWithLoading/index.js';
 export { default as Confetti } from '@/Confetti/index.js';
 export { default as Content } from '@/Content/index.js';
 export { default as ContentList } from '@/ContentList/index.js';

--- a/pages/login/index.public.js
+++ b/pages/login/index.public.js
@@ -2,7 +2,7 @@ import { useRef, useState } from 'react';
 
 import {
   Box,
-  ButtonWithLoading,
+  ButtonWithLoader,
   DefaultLayout,
   Flash,
   FormControl,
@@ -122,7 +122,7 @@ function LoginForm() {
           />
           <FormControl>
             <FormControl.Label visuallyHidden>Login</FormControl.Label>
-            <ButtonWithLoading
+            <ButtonWithLoader
               variant="primary"
               size="large"
               type="submit"
@@ -130,7 +130,7 @@ function LoginForm() {
               aria-label="Login"
               isLoading={isLoading}>
               Login
-            </ButtonWithLoading>
+            </ButtonWithLoader>
           </FormControl>
         </Box>
       </form>

--- a/pages/login/index.public.js
+++ b/pages/login/index.public.js
@@ -1,11 +1,11 @@
 import {
   Box,
-  Button,
   DefaultLayout,
   Flash,
   FormControl,
   Heading,
   Link,
+  ButtonWithLoading,
   PasswordInput,
   Text,
   TextInput,
@@ -121,15 +121,15 @@ function LoginForm() {
           />
           <FormControl>
             <FormControl.Label visuallyHidden>Login</FormControl.Label>
-            <Button
+            <ButtonWithLoading
               variant="primary"
               size="large"
               type="submit"
-              disabled={isLoading}
               sx={{ width: '100%' }}
-              aria-label="Login">
+              aria-label="Login"
+              isLoading={isLoading}>
               Login
-            </Button>
+            </ButtonWithLoading>
           </FormControl>
         </Box>
       </form>

--- a/pages/perfil/index.public.js
+++ b/pages/perfil/index.public.js
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import {
   Box,
   Button,
-  ButtonWithLoading,
+  ButtonWithLoader,
   Checkbox,
   DefaultLayout,
   Editor,
@@ -285,7 +285,7 @@ function EditProfileForm() {
 
         <FormControl>
           <FormControl.Label visuallyHidden>Salvar</FormControl.Label>
-          <ButtonWithLoading
+          <ButtonWithLoader
             variant="primary"
             size="large"
             type="submit"
@@ -293,7 +293,7 @@ function EditProfileForm() {
             aria-label="Salvar"
             isLoading={isLoading}>
             Salvar
-          </ButtonWithLoading>
+          </ButtonWithLoader>
         </FormControl>
       </Box>
     </form>

--- a/pages/perfil/index.public.js
+++ b/pages/perfil/index.public.js
@@ -8,6 +8,7 @@ import {
   FormControl,
   Heading,
   Link,
+  ButtonWithLoading,
   TextInput,
   useConfirm,
 } from '@/TabNewsUI';
@@ -283,15 +284,15 @@ function EditProfileForm() {
 
         <FormControl>
           <FormControl.Label visuallyHidden>Salvar</FormControl.Label>
-          <Button
+          <ButtonWithLoading
             variant="primary"
             size="large"
             type="submit"
-            disabled={isLoading}
             sx={{ width: '100%' }}
-            aria-label="Salvar">
+            aria-label="Salvar"
+            isLoading={isLoading}>
             Salvar
-          </Button>
+          </ButtonWithLoading>
         </FormControl>
       </Box>
     </form>


### PR DESCRIPTION
Implementação do componente de botão com status de carregamento para os botões de publicar, salvar etc, considerando o que foi sugerido na issue #788.

| Antes | Depois |
|-------|--------|
|   <img width="100" alt="antes" src="https://github.com/filipedeschamps/tabnews.com.br/assets/32906579/ed73719e-e1be-42c4-bfc4-ee35723c8c6d">   |  <img width="124" alt="Screenshot 2023-09-12 at 02 15 42" src="https://github.com/filipedeschamps/tabnews.com.br/assets/32906579/13343eeb-50c1-4454-8a3b-3846d257879a"><img width="124" alt="depois-carregando" src="https://github.com/filipedeschamps/tabnews.com.br/assets/32906579/8edc24d4-9ac2-4988-8ae7-9dc0909221c8"> |

https://github.com/filipedeschamps/tabnews.com.br/assets/32906579/8777d7e7-e014-4f9b-940c-e5538378a829
