### PR TITLE
Adiciona recompensas diárias em TabCoins

### DIFF
--- a/infra/migrations/1693859094620_alter-table-users-add-rewarded-at.js
+++ b/infra/migrations/1693859094620_alter-table-users-add-rewarded-at.js
@@ -1,0 +1,13 @@
+exports.up = (pgm) => {
+  pgm.addColumns('users', {
+    rewarded_at: {
+      type: 'timestamp with time zone',
+      notNull: true,
+      default: pgm.func("(now() at time zone 'utc')"),
+    },
+  });
+};
+
+exports.down = (pgm) => {
+  pgm.dropColumns('users', ['rewarded_at']);
+};

--- a/models/prestige.js
+++ b/models/prestige.js
@@ -29,8 +29,9 @@ async function getByUserId(
   userId,
   {
     timeOffset = new Date(Date.now() - 1000 * 60 * 60 * 24 * 2), // 2 days ago
+    offset = 3,
     isRoot,
-    limit = 10,
+    limit = 20,
     transaction,
     database = db,
   } = {}
@@ -38,7 +39,7 @@ async function getByUserId(
   const result = await database.query(
     {
       text: query.byUserId,
-      values: [userId, timeOffset, isRoot, limit],
+      values: [userId, timeOffset, isRoot, limit, offset],
     },
     { transaction }
   );
@@ -62,7 +63,7 @@ function calcTabcoinsAverage(tabcoinsObjectArray) {
 
 function calcPrestigeLevel(mean, isRoot) {
   if (isRoot) {
-    if (0.4 >= mean) return -1;
+    if (0.5 >= mean) return -1;
     if (1.1 >= mean) return 0;
     if (1.2 >= mean) return 1;
     if (1.3 >= mean) return 2;
@@ -72,7 +73,7 @@ function calcPrestigeLevel(mean, isRoot) {
     if (2.1 >= mean) return 6;
     if (2.4 >= mean) return 7;
   } else {
-    if (0.2 >= mean) return -1;
+    if (0.4 >= mean) return -1;
     if (1.0 >= mean) return 0;
     if (1.1 >= mean) return 1;
     if (1.2 >= mean) return 2;

--- a/models/reward.js
+++ b/models/reward.js
@@ -1,0 +1,133 @@
+import database from 'infra/database';
+import balance from 'models/balance';
+import content from 'models/content.js';
+import event from 'models/event';
+import prestige from 'models/prestige';
+import user from 'models/user';
+
+const tabcoinsBase = 20;
+const contentAgeBase = 604_800_000; // one week in milliseconds
+
+export default async function reward(request, dbOptions = {}) {
+  if (request?.context?.user?.tabcoins === undefined) return 0;
+
+  const { id: userId, username, tabcoins, rewarded_at: rewardedAt } = request.context.user;
+
+  if (!userId || !username || !rewardedAt) return 0;
+
+  const utcZeroHourToday = new Date().setUTCHours(0, 0, 0, 0);
+
+  if (rewardedAt >= utcZeroHourToday) return 0;
+
+  const prestigeFactor = await prestige.getByUserId(userId, dbOptions);
+  const tabcoinsFactor = calcTabcoinsFactor(tabcoins);
+
+  let reward = 0;
+
+  if (tabcoinsFactor <= prestigeFactor) {
+    const contentAgeFactor = await getContentAgeFactor(userId);
+    reward = calcReward(prestigeFactor, tabcoinsFactor, contentAgeFactor);
+  }
+
+  reward = await saveReward(request, reward, dbOptions);
+
+  return reward;
+}
+
+function calcTabcoinsFactor(tabcoins) {
+  if (tabcoins <= 0) return 0;
+
+  const tabcoinsFactor = Math.floor((tabcoins / tabcoinsBase) ** 2);
+
+  return tabcoinsFactor;
+}
+
+async function getContentAgeFactor(owner_id) {
+  const contents = await content.findWithStrategy({
+    strategy: 'new',
+    where: {
+      owner_id,
+      status: 'published',
+    },
+    per_page: 1,
+  });
+
+  const lastContent = contents?.rows?.[0];
+
+  if (!lastContent) return 0;
+
+  const lastContentAge = new Date() - new Date(lastContent.created_at);
+
+  return Math.ceil(lastContentAge / contentAgeBase);
+}
+
+function calcReward(prestige, tabcoinsFactor, contentAgeFactor) {
+  if (!contentAgeFactor || prestige <= tabcoinsFactor) return 0;
+
+  const reward = Math.ceil((prestige - tabcoinsFactor) / contentAgeFactor);
+
+  return reward;
+}
+
+async function saveReward(request, reward, { transaction }) {
+  transaction = transaction || (await database.transaction());
+
+  try {
+    await transaction.query('BEGIN');
+    await transaction.query('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ');
+
+    if (reward > 0) {
+      const currentUser = await user.findOneById(request.context.user.id, { transaction });
+
+      const utcZeroHourToday = new Date().setUTCHours(0, 0, 0, 0);
+
+      if (currentUser.rewarded_at >= utcZeroHourToday) {
+        throw new Error('User already rewarded today');
+      }
+
+      const currentEvent = await event.create(
+        {
+          type: 'reward:user:tabcoins',
+          originatorUserId: request.context.user.id,
+          originatorIp: request.context.clientIp,
+          metadata: {
+            reward_type: 'daily',
+            amount: reward,
+          },
+        },
+        { transaction }
+      );
+
+      await balance.create(
+        {
+          balanceType: 'user:tabcoin',
+          recipientId: request.context.user.id,
+          amount: reward,
+          originatorType: 'event',
+          originatorId: currentEvent.id,
+        },
+        { transaction }
+      );
+    }
+
+    await user.updateRewardedAt(request.context.user.id, { transaction });
+
+    await transaction.query('COMMIT');
+
+    return reward;
+  } catch (error) {
+    await transaction.query('ROLLBACK');
+
+    if (
+      error.databaseErrorCode === database.errorCodes.SERIALIZATION_FAILURE ||
+      error.stack?.startsWith('error: could not serialize access due to concurrent update') ||
+      error.message === 'User already rewarded today'
+    ) {
+      return 0;
+    } else {
+      throw error;
+    }
+  } finally {
+    await transaction.release();
+  }
+}

--- a/models/user.js
+++ b/models/user.js
@@ -403,6 +403,35 @@ async function addFeatures(userId, features, options) {
   return results.rows[0];
 }
 
+async function updateRewardedAt(userId, options) {
+  if (!userId) {
+    throw new ValidationError({
+      message: `É necessário informar o "id" do usuário.`,
+      stack: new Error().stack,
+      errorLocationCode: 'MODEL:USER:UPDATE_REWARDED_AT:USER_ID_REQUIRED',
+      key: 'userId',
+    });
+  }
+
+  const query = {
+    text: `
+      UPDATE
+        users
+      SET
+        rewarded_at = (now() at time zone 'utc')
+      WHERE
+        id = $1
+      RETURNING
+        *
+    ;`,
+    values: [userId],
+  };
+
+  const results = await database.query(query, options);
+
+  return results.rows[0];
+}
+
 export default Object.freeze({
   create,
   findAll,
@@ -413,4 +442,5 @@ export default Object.freeze({
   removeFeatures,
   addFeatures,
   createAnonymous,
+  updateRewardedAt,
 });

--- a/models/validator.js
+++ b/models/validator.js
@@ -649,6 +649,7 @@ const schemas = {
           'firewall:block_users',
           'firewall:block_contents:text_root',
           'firewall:block_contents:text_child',
+          'reward:user:tabcoins',
           'system:update:tabcoins'
         )
         .messages({

--- a/pages/api/v1/user/index.public.js
+++ b/pages/api/v1/user/index.public.js
@@ -4,6 +4,7 @@ import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
 import cacheControl from 'models/cache-control';
 import controller from 'models/controller.js';
+import reward from 'models/reward';
 import session from 'models/session';
 
 export default nextConnect({
@@ -19,6 +20,8 @@ export default nextConnect({
 
 async function getHandler(request, response) {
   const authenticatedUser = request.context.user;
+
+  authenticatedUser.tabcoins += await reward(request);
 
   const secureOutputValues = authorization.filterOutput(authenticatedUser, 'read:user:self', authenticatedUser);
 

--- a/queries/prestigeQueries.js
+++ b/queries/prestigeQueries.js
@@ -30,14 +30,10 @@ WITH content_window AS ((
   WHERE
     owner_id = $1
     AND status = 'published'
-    AND (CASE
-      WHEN $3 IS TRUE THEN parent_id IS NULL
-      WHEN $3 IS FALSE THEN parent_id IS NOT NULL
-      ELSE TRUE
-      END)
+    AND ($3 != TRUE OR parent_id IS NULL)
   ORDER BY
     published_at DESC
-  LIMIT $4 OFFSET $4
+  LIMIT $4 OFFSET $5
 )
 UNION
   SELECT
@@ -49,11 +45,7 @@ UNION
     owner_id = $1
     AND status = 'published'
     AND published_at < $2
-    AND (CASE
-      WHEN $3 IS TRUE THEN parent_id IS NULL
-      WHEN $3 IS FALSE THEN parent_id IS NOT NULL
-      ELSE TRUE
-      END)
+    AND ($3 != TRUE OR parent_id IS NULL)
   ORDER BY
     published_at DESC
   LIMIT $4
@@ -63,7 +55,7 @@ SELECT
 FROM
   content_window
 ORDER BY
-  published_at DESC
+  published_at ASC
 LIMIT $4
 ;
 `;

--- a/tests/integration/api/v1/contents/[username]/[slug]/children/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/children/get.test.js
@@ -88,7 +88,7 @@ describe('GET /api/v1/contents/[username]/[slug]/children', () => {
 
       const childBranchALevel1 = await orchestrator.createContent({
         parent_id: rootBranchLevel0.id,
-        owner_id: firstUser.id,
+        owner_id: secondUser.id,
         title: 'Child branch A [Level 1]',
         status: 'published',
       });
@@ -102,14 +102,14 @@ describe('GET /api/v1/contents/[username]/[slug]/children', () => {
 
       const childBranchALevel3 = await orchestrator.createContent({
         parent_id: childBranchALevel2.id,
-        owner_id: firstUser.id,
+        owner_id: secondUser.id,
         title: 'Child branch A [Level 3]',
         status: 'published',
       });
 
       const childBranchBLevel1 = await orchestrator.createContent({
         parent_id: rootBranchLevel0.id,
-        owner_id: firstUser.id,
+        owner_id: secondUser.id,
         title: 'Child branch B [Level 1]',
         status: 'published',
       });
@@ -146,12 +146,12 @@ describe('GET /api/v1/contents/[username]/[slug]/children', () => {
       expect(responseBody).toStrictEqual([
         {
           id: childBranchBLevel1.id,
-          owner_id: firstUser.id,
+          owner_id: secondUser.id,
           parent_id: rootBranchLevel0.id,
           slug: childBranchBLevel1.slug,
           title: childBranchBLevel1.title,
           body: childBranchBLevel1.body,
-          tabcoins: 0,
+          tabcoins: 1,
           status: childBranchBLevel1.status,
           source_url: childBranchBLevel1.source_url,
           source_url: childBranchBLevel1.source_url,
@@ -159,27 +159,8 @@ describe('GET /api/v1/contents/[username]/[slug]/children', () => {
           updated_at: childBranchBLevel1.updated_at.toISOString(),
           published_at: childBranchBLevel1.published_at.toISOString(),
           deleted_at: null,
-          owner_username: firstUser.username,
+          owner_username: secondUser.username,
           children: [
-            {
-              id: childBranchBLevel2Content2.id,
-              owner_id: secondUser.id,
-              parent_id: childBranchBLevel1.id,
-              slug: childBranchBLevel2Content2.slug,
-              title: childBranchBLevel2Content2.title,
-              body: childBranchBLevel2Content2.body,
-              tabcoins: 1,
-              status: childBranchBLevel2Content2.status,
-              source_url: childBranchBLevel2Content2.source_url,
-              source_url: childBranchBLevel2Content2.source_url,
-              created_at: childBranchBLevel2Content2.created_at.toISOString(),
-              updated_at: childBranchBLevel2Content2.updated_at.toISOString(),
-              published_at: childBranchBLevel2Content2.published_at.toISOString(),
-              deleted_at: null,
-              owner_username: secondUser.username,
-              children: [],
-              children_deep_count: 0,
-            },
             {
               id: childBranchBLevel2Content1.id,
               owner_id: firstUser.id,
@@ -187,7 +168,7 @@ describe('GET /api/v1/contents/[username]/[slug]/children', () => {
               slug: childBranchBLevel2Content1.slug,
               title: childBranchBLevel2Content1.title,
               body: childBranchBLevel2Content1.body,
-              tabcoins: 0,
+              tabcoins: 1,
               status: childBranchBLevel2Content1.status,
               source_url: childBranchBLevel2Content1.source_url,
               source_url: childBranchBLevel2Content1.source_url,
@@ -199,24 +180,43 @@ describe('GET /api/v1/contents/[username]/[slug]/children', () => {
               children: [],
               children_deep_count: 0,
             },
+            {
+              id: childBranchBLevel2Content2.id,
+              owner_id: secondUser.id,
+              parent_id: childBranchBLevel1.id,
+              slug: childBranchBLevel2Content2.slug,
+              title: childBranchBLevel2Content2.title,
+              body: childBranchBLevel2Content2.body,
+              tabcoins: 0,
+              status: childBranchBLevel2Content2.status,
+              source_url: childBranchBLevel2Content2.source_url,
+              source_url: childBranchBLevel2Content2.source_url,
+              created_at: childBranchBLevel2Content2.created_at.toISOString(),
+              updated_at: childBranchBLevel2Content2.updated_at.toISOString(),
+              published_at: childBranchBLevel2Content2.published_at.toISOString(),
+              deleted_at: null,
+              owner_username: secondUser.username,
+              children: [],
+              children_deep_count: 0,
+            },
           ],
           children_deep_count: 2,
         },
         {
           id: childBranchALevel1.id,
-          owner_id: firstUser.id,
+          owner_id: secondUser.id,
           parent_id: rootBranchLevel0.id,
           slug: childBranchALevel1.slug,
           title: childBranchALevel1.title,
           body: childBranchALevel1.body,
           status: childBranchALevel1.status,
-          tabcoins: 0,
+          tabcoins: 1,
           source_url: childBranchALevel1.source_url,
           created_at: childBranchALevel1.created_at.toISOString(),
           updated_at: childBranchALevel1.updated_at.toISOString(),
           published_at: childBranchALevel1.published_at.toISOString(),
           deleted_at: null,
-          owner_username: firstUser.username,
+          owner_username: secondUser.username,
           children: [
             {
               id: childBranchALevel2.id,
@@ -226,7 +226,7 @@ describe('GET /api/v1/contents/[username]/[slug]/children', () => {
               title: childBranchALevel2.title,
               body: childBranchALevel2.body,
               status: childBranchALevel2.status,
-              tabcoins: 0,
+              tabcoins: 1,
               source_url: childBranchALevel2.source_url,
               created_at: childBranchALevel2.created_at.toISOString(),
               updated_at: childBranchALevel2.updated_at.toISOString(),
@@ -236,19 +236,19 @@ describe('GET /api/v1/contents/[username]/[slug]/children', () => {
               children: [
                 {
                   id: childBranchALevel3.id,
-                  owner_id: firstUser.id,
+                  owner_id: secondUser.id,
                   parent_id: childBranchALevel2.id,
                   slug: childBranchALevel3.slug,
                   title: childBranchALevel3.title,
                   body: childBranchALevel3.body,
-                  tabcoins: 0,
+                  tabcoins: 1,
                   status: childBranchALevel3.status,
                   source_url: childBranchALevel3.source_url,
                   created_at: childBranchALevel3.created_at.toISOString(),
                   updated_at: childBranchALevel3.updated_at.toISOString(),
                   published_at: childBranchALevel3.published_at.toISOString(),
                   deleted_at: null,
-                  owner_username: firstUser.username,
+                  owner_username: secondUser.username,
                   children: [],
                   children_deep_count: 0,
                 },
@@ -266,7 +266,7 @@ describe('GET /api/v1/contents/[username]/[slug]/children', () => {
       const secondUser = await orchestrator.createUser();
 
       const rootBranchLevel0 = await orchestrator.createContent({
-        owner_id: firstUser.id,
+        owner_id: secondUser.id,
         title: 'root',
         status: 'published',
       });

--- a/tests/integration/api/v1/contents/[username]/[slug]/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/get.test.js
@@ -293,12 +293,13 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
       });
     });
 
-    test('Content "child" with with "children"', async () => {
+    test('Content "child" with "children"', async () => {
       const defaultUser = await orchestrator.createUser();
+      const secondUser = await orchestrator.createUser();
       await orchestrator.activateUser(defaultUser);
 
       const rootContent = await orchestrator.createContent({
-        owner_id: defaultUser.id,
+        owner_id: secondUser.id,
         title: 'Conteúdo root',
         body: 'Conteúdo root',
         status: 'published',
@@ -313,7 +314,7 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
 
       const childContentLevel1 = await orchestrator.createContent({
         parent_id: childContent.id,
-        owner_id: defaultUser.id,
+        owner_id: secondUser.id,
         body: 'Conteúdo child nível 1',
         status: 'published',
       });

--- a/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
@@ -2816,7 +2816,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const defaultUser = await orchestrator.createUser();
         await orchestrator.activateUser(defaultUser);
         const sessionObject = await orchestrator.createSession(defaultUser);
-        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: 8 });
+        const prestigeContents = await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: 8 });
 
         const defaultUserContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
@@ -2837,7 +2837,13 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         expect(userResponseBodyBefore.tabcoins).toEqual(8);
         expect(userResponseBodyBefore.tabcash).toEqual(0);
 
-        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: 1 });
+        await orchestrator.createBalance({
+          balanceType: 'content:tabcoin',
+          recipientId: prestigeContents[0].id,
+          amount: 1,
+          originatorType: 'orchestrator',
+          originatorId: prestigeContents[0].id,
+        });
 
         const contentResponse = await fetch(
           `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
@@ -2952,8 +2958,6 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         expect(userResponseBodyBefore.tabcoins).toEqual(0);
         expect(userResponseBodyBefore.tabcash).toEqual(0);
 
-        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: 1 });
-
         const contentResponse = await fetch(
           `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
           {
@@ -2989,7 +2993,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const defaultUser = await orchestrator.createUser();
         await orchestrator.activateUser(defaultUser);
         const defaultUserSession = await orchestrator.createSession(defaultUser);
-        await orchestrator.createPrestige(defaultUser.id);
+        const prestigeContents = await orchestrator.createPrestige(defaultUser.id);
 
         const defaultUserContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
@@ -2998,7 +3002,13 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
           status: 'published',
         });
 
-        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: 8 });
+        await orchestrator.createBalance({
+          balanceType: 'content:tabcoin',
+          recipientId: prestigeContents[0].id,
+          amount: 8,
+          originatorType: 'orchestrator',
+          originatorId: prestigeContents[0].id,
+        });
 
         await orchestrator.createRate(defaultUserContent, 10);
 
@@ -3104,7 +3114,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const defaultUser = await orchestrator.createUser();
         await orchestrator.activateUser(defaultUser);
         const defaultUserSession = await orchestrator.createSession(defaultUser);
-        await orchestrator.createPrestige(defaultUser.id);
+        const prestigeContents = await orchestrator.createPrestige(defaultUser.id);
 
         const defaultUserContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
@@ -3113,7 +3123,13 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
           status: 'published',
         });
 
-        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: 10 });
+        await orchestrator.createBalance({
+          balanceType: 'content:tabcoin',
+          recipientId: prestigeContents[0].id,
+          amount: 10,
+          originatorType: 'orchestrator',
+          originatorId: prestigeContents[0].id,
+        });
 
         await orchestrator.createRate(defaultUserContent, -10);
 
@@ -3862,8 +3878,6 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
           status: 'published',
         });
 
-        await orchestrator.createPrestige(secondUser.id, { rootPrestigeNumerator: 10 });
-
         await orchestrator.createRate(childContent, 10);
 
         const userResponse1 = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${secondUser.username}`, {
@@ -3930,8 +3944,6 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
           body: 'Body with no minimum amount of relevant words',
           status: 'published',
         });
-
-        await orchestrator.createPrestige(secondUser.id, { rootPrestigeNumerator: 10 });
 
         await orchestrator.createRate(childContent, -10);
 

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -2902,7 +2902,7 @@ describe('POST /api/v1/contents', () => {
         const defaultUser = await orchestrator.createUser();
         await orchestrator.activateUser(defaultUser);
         const sessionObject = await orchestrator.createSession(defaultUser);
-        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: -6, rootPrestigeDenominator: 10 });
+        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: -1, rootPrestigeDenominator: 2 });
 
         const contentResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
           method: 'post',
@@ -2941,7 +2941,7 @@ describe('POST /api/v1/contents', () => {
         const secondUser = await orchestrator.createUser();
         await orchestrator.activateUser(secondUser);
         const sessionObject = await orchestrator.createSession(defaultUser);
-        await orchestrator.createPrestige(defaultUser.id, { childPrestigeNumerator: -4, childPrestigeDenominator: 5 });
+        await orchestrator.createPrestige(defaultUser.id, { childPrestigeNumerator: -5, childPrestigeDenominator: 1 });
 
         const rootContent = await orchestrator.createContent({
           owner_id: secondUser.id,
@@ -2984,7 +2984,7 @@ describe('POST /api/v1/contents', () => {
         const defaultUser = await orchestrator.createUser();
         await orchestrator.activateUser(defaultUser);
         const sessionObject = await orchestrator.createSession(defaultUser);
-        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: -1, rootPrestigeDenominator: 2 });
+        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: -9, rootPrestigeDenominator: 20 });
 
         const contentResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
           method: 'post',
@@ -3043,7 +3043,7 @@ describe('POST /api/v1/contents', () => {
         const secondUser = await orchestrator.createUser();
         await orchestrator.activateUser(secondUser);
         const sessionObject = await orchestrator.createSession(defaultUser);
-        await orchestrator.createPrestige(defaultUser.id, { childPrestigeNumerator: -7, childPrestigeDenominator: 10 });
+        await orchestrator.createPrestige(defaultUser.id, { childPrestigeNumerator: -6, childPrestigeDenominator: 6 });
 
         const rootContent = await orchestrator.createContent({
           owner_id: secondUser.id,
@@ -3165,7 +3165,7 @@ describe('POST /api/v1/contents', () => {
         const secondUser = await orchestrator.createUser();
         await orchestrator.activateUser(secondUser);
         const sessionObject = await orchestrator.createSession(defaultUser);
-        await orchestrator.createPrestige(defaultUser.id, { childPrestigeNumerator: 0 });
+        await orchestrator.createPrestige(defaultUser.id, { childPrestigeNumerator: -1 });
 
         const rootContent = await orchestrator.createContent({
           owner_id: secondUser.id,
@@ -3287,7 +3287,7 @@ describe('POST /api/v1/contents', () => {
         const secondUser = await orchestrator.createUser();
         await orchestrator.activateUser(secondUser);
         const sessionObject = await orchestrator.createSession(defaultUser);
-        await orchestrator.createPrestige(defaultUser.id, { childPrestigeNumerator: 1, childPrestigeDenominator: 10 });
+        await orchestrator.createPrestige(defaultUser.id, { childPrestigeNumerator: 0, childPrestigeDenominator: 6 });
 
         const rootContent = await orchestrator.createContent({
           owner_id: secondUser.id,
@@ -3572,7 +3572,7 @@ describe('POST /api/v1/contents', () => {
         const secondUser = await orchestrator.createUser();
         await orchestrator.activateUser(secondUser);
         const sessionObject = await orchestrator.createSession(defaultUser);
-        await orchestrator.createPrestige(defaultUser.id, { childPrestigeNumerator: 1, childPrestigeDenominator: 10 });
+        await orchestrator.createPrestige(defaultUser.id, { childPrestigeNumerator: 0, childPrestigeDenominator: 6 });
 
         const rootContent = await orchestrator.createContent({
           owner_id: secondUser.id,

--- a/tests/integration/api/v1/user/get.test.js
+++ b/tests/integration/api/v1/user/get.test.js
@@ -519,7 +519,7 @@ describe('GET /api/v1/user', () => {
         let defaultUser = await orchestrator.createUser();
         defaultUser = await orchestrator.activateUser(defaultUser);
         const defaultUserSession = await orchestrator.createSession(defaultUser);
-        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: -1, childPrestigeNumerator: -1 });
+        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: -1 });
 
         const fetchUser = async () =>
           await fetch(`${orchestrator.webserverUrl}/api/v1/user`, {

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -14,6 +14,12 @@ import recovery from 'models/recovery.js';
 import session from 'models/session.js';
 import user from 'models/user.js';
 
+if (process.env.NODE_ENV !== 'test') {
+  throw new Error({
+    message: 'Orchestrator should only be used in tests',
+  });
+}
+
 const webserverUrl = webserver.host;
 const emailServiceUrl = `http://${process.env.EMAIL_HTTP_HOST}:${process.env.EMAIL_HTTP_PORT}`;
 
@@ -321,6 +327,24 @@ async function createPrestige(
   return [...rootContents, ...childContents];
 }
 
+async function updateRewardedAt(userId, rewardedAt) {
+  const query = {
+    text: `
+      UPDATE
+        users
+      SET
+        rewarded_at = $1
+      WHERE
+        id = $2
+      RETURNING
+        *
+    ;`,
+    values: [rewardedAt, userId],
+  };
+
+  return await database.query(query);
+}
+
 const orchestrator = {
   waitForAllServices,
   dropAllTables,
@@ -341,6 +365,7 @@ const orchestrator = {
   createBalance,
   createPrestige,
   createRate,
+  updateRewardedAt,
 };
 
 export default orchestrator;

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -239,24 +239,24 @@ async function createFirewallTestFunctions() {
   }
 }
 
-// Prestige does not have to be an integer, so it can be given rationally.
+// Prestige does not have to be an integer, so it can be given as a fraction.
 // If the denominator is 0, the respective prestige will not be created.
 async function createPrestige(
   userId,
   {
     rootPrestigeNumerator = 1,
     rootPrestigeDenominator = 4,
-    childPrestigeNumerator = 1,
-    childPrestigeDenominator = 5,
+    childPrestigeNumerator = 0,
+    childPrestigeDenominator = 1,
   } = {}
 ) {
   if (
     rootPrestigeDenominator < 0 ||
     childPrestigeDenominator < 0 ||
-    rootPrestigeDenominator > 10 ||
-    childPrestigeDenominator > 10
+    rootPrestigeDenominator > 20 ||
+    childPrestigeDenominator > 20
   ) {
-    throw new Error('rootPrestigeDenominator and childPrestigeDenominator must be between 0 and 10');
+    throw new Error('rootPrestigeDenominator and childPrestigeDenominator must be between 0 and 20');
   }
 
   const rootContents = [];

--- a/tests/unit/models/prestige.test.js
+++ b/tests/unit/models/prestige.test.js
@@ -94,6 +94,7 @@ describe('prestige model', () => {
       const timeOffset = new Date(Date.now() - 1000 * 60 * 60 * 24 * 2);
       const isRoot = true;
       const limit = 10;
+      const offset = 3;
       const transaction = null;
       const database = {
         query: jest.fn().mockResolvedValue({ rows: [] }),
@@ -104,7 +105,7 @@ describe('prestige model', () => {
       expect(database.query).toHaveBeenCalledWith(
         {
           text: expect.any(String),
-          values: [userId, timeOffset, isRoot, limit],
+          values: [userId, timeOffset, isRoot, limit, offset],
         },
         { transaction }
       );
@@ -203,8 +204,8 @@ describe('prestige model', () => {
     const cases = [
       // isRoot, tabcoinsMean, prestigeLevel
       [true, -1, -1],
-      [true, 0.4, -1],
-      [true, 0.41, 0],
+      [true, 0.5, -1],
+      [true, 0.51, 0],
       [true, 1.1, 0],
       [true, 1.11, 1],
       [true, 1.2, 1],
@@ -227,8 +228,8 @@ describe('prestige model', () => {
       [true, 4.1, 10],
 
       [false, -1, -1],
-      [false, 0.2, -1],
-      [false, 0.21, 0],
+      [false, 0.4, -1],
+      [false, 0.41, 0],
       [false, 1.0, 0],
       [false, 1.01, 1],
       [false, 1.1, 1],
@@ -245,9 +246,9 @@ describe('prestige model', () => {
       [false, 1.71, 7],
       [false, 2.0, 7],
       [false, 2.01, 8],
-      [false, 3, 8],
-      [false, 3.1, 9],
-      [false, 4, 9],
+      [0, 3, 8],
+      [null, 3.1, 9],
+      [undefined, 4, 9],
       [false, 4.1, 10],
     ];
 

--- a/tests/unit/models/reward.test.js
+++ b/tests/unit/models/reward.test.js
@@ -1,0 +1,310 @@
+import { v4 as uuidV4 } from 'uuid';
+
+import database, { mockQuery, mockRelease } from 'infra/database';
+import balance from 'models/balance';
+import content from 'models/content';
+import event from 'models/event';
+import prestige from 'models/prestige';
+import reward from 'models/reward';
+import user from 'models/user';
+
+const tabcoinsBase = 20;
+const contentAgeBase = 1000 * 60 * 60 * 24 * 7; // one week in milliseconds
+
+jest.mock('infra/database', () => {
+  const mockQuery = jest.fn();
+  const mockRelease = jest.fn();
+  return {
+    transaction: jest.fn().mockResolvedValue({
+      query: mockQuery,
+      release: mockRelease,
+    }),
+    errorCodes: {
+      SERIALIZATION_FAILURE: '40001',
+    },
+    mockQuery,
+    mockRelease,
+  };
+});
+
+jest.mock('models/balance');
+
+jest.mock('models/content.js', () => ({
+  findWithStrategy: jest.fn().mockResolvedValue({
+    rows: [{ created_at: new Date() }],
+  }),
+}));
+
+jest.mock('models/event', () => ({
+  create: jest.fn().mockResolvedValue({ id: uuidV4() }),
+}));
+
+jest.mock('models/prestige', () => ({
+  getByUserId: jest.fn().mockResolvedValue(2),
+}));
+
+jest.mock('models/user', () => ({
+  findOneById: jest.fn().mockResolvedValue({
+    rewarded_at: new Date('2021-01-01'),
+  }),
+  updateRewardedAt: jest.fn(),
+}));
+
+function createRequestObj(props = {}) {
+  return {
+    context: {
+      user: {
+        id: props.id ?? uuidV4(),
+        username: props.username ?? 'testuser',
+        tabcoins: props.tabcoins ?? 0,
+        rewarded_at: props.rewarded_at ?? new Date('2021-01-01'),
+      },
+      clientIp: props.clientIp ?? '127.0.0.1',
+    },
+  };
+}
+
+describe('reward model', () => {
+  it('Should not reward if "request" is undefined', async () => {
+    let request;
+
+    const result = await reward(request);
+
+    expect(result).toBe(0);
+    expect(balance.create).not.toHaveBeenCalled();
+    expect(user.updateRewardedAt).not.toHaveBeenCalled();
+  });
+
+  it('Should not reward if "context" is undefined', async () => {
+    const request = {};
+
+    const result = await reward(request);
+
+    expect(result).toBe(0);
+    expect(balance.create).not.toHaveBeenCalled();
+    expect(user.updateRewardedAt).not.toHaveBeenCalled();
+  });
+
+  it('Should not reward if "user" is undefined', async () => {
+    const request = createRequestObj();
+    request.context.user = undefined;
+
+    const result = await reward(request);
+
+    expect(result).toBe(0);
+    expect(balance.create).not.toHaveBeenCalled();
+    expect(user.updateRewardedAt).not.toHaveBeenCalled();
+  });
+
+  it('Should not reward if "tabcoins" is undefined', async () => {
+    const request = createRequestObj();
+    request.context.user.tabcoins = undefined;
+
+    const result = await reward(request);
+
+    expect(result).toBe(0);
+    expect(balance.create).not.toHaveBeenCalled();
+    expect(user.updateRewardedAt).not.toHaveBeenCalled();
+  });
+
+  it('Should not reward if "userId" is undefined', async () => {
+    const request = createRequestObj();
+    request.context.user.id = undefined;
+
+    const result = await reward(request);
+
+    expect(result).toBe(0);
+    expect(balance.create).not.toHaveBeenCalled();
+    expect(user.updateRewardedAt).not.toHaveBeenCalled();
+  });
+
+  it('Should not reward if "username" is undefined', async () => {
+    const request = createRequestObj();
+    request.context.user.username = undefined;
+
+    const result = await reward(request);
+
+    expect(result).toBe(0);
+    expect(balance.create).not.toHaveBeenCalled();
+    expect(user.updateRewardedAt).not.toHaveBeenCalled();
+  });
+
+  it('Should not reward if "rewarded_at" is undefined', async () => {
+    const request = createRequestObj();
+    request.context.user.rewarded_at = undefined;
+
+    const result = await reward(request);
+
+    expect(result).toBe(0);
+    expect(balance.create).not.toHaveBeenCalled();
+    expect(user.updateRewardedAt).not.toHaveBeenCalled();
+  });
+
+  it('Should not reward if user has already been rewarded today', async () => {
+    const request = createRequestObj({
+      rewarded_at: new Date().setUTCHours(0, 0, 0, 0),
+    });
+
+    const result = await reward(request);
+
+    expect(result).toBe(0);
+    expect(balance.create).not.toHaveBeenCalled();
+    expect(user.updateRewardedAt).not.toHaveBeenCalled();
+  });
+
+  it('Should not reward if user has already been rewarded now', async () => {
+    const request = createRequestObj({
+      rewarded_at: new Date(),
+    });
+
+    const result = await reward(request);
+
+    expect(result).toBe(0);
+    expect(balance.create).not.toHaveBeenCalled();
+    expect(user.updateRewardedAt).not.toHaveBeenCalled();
+  });
+
+  it('Should not simultaneously reward', async () => {
+    // First "rewarded_at" is in the past (2021-01-01).
+    const request = createRequestObj();
+    // Then "rewarded_at" is set to "now" to simulate a concurrent reward.
+    user.findOneById.mockResolvedValueOnce({ rewarded_at: new Date() });
+
+    const result = await reward(request);
+
+    expect(mockQuery).toHaveBeenCalledWith('ROLLBACK');
+    expect(mockRelease).toHaveBeenCalled();
+    expect(result).toBe(0);
+  });
+
+  it('Should not reward if tabcoinsFactor is greater than prestigeFactor', async () => {
+    const request = createRequestObj({
+      tabcoins: tabcoinsBase + 1,
+    });
+    prestige.getByUserId.mockResolvedValueOnce(1);
+
+    const result = await reward(request);
+
+    expect(result).toBe(0);
+    expect(balance.create).not.toHaveBeenCalled();
+    expect(user.updateRewardedAt).toHaveBeenCalledWith(request.context.user.id, { transaction: expect.any(Object) });
+  });
+
+  it('Should not reward if tabcoinsFactor is equal to prestigeFactor', async () => {
+    const request = createRequestObj({
+      tabcoins: tabcoinsBase,
+    });
+    prestige.getByUserId.mockResolvedValueOnce(1);
+
+    const result = await reward(request);
+
+    expect(result).toBe(0);
+    expect(balance.create).not.toHaveBeenCalled();
+    expect(user.updateRewardedAt).toHaveBeenCalledWith(request.context.user.id, { transaction: expect.any(Object) });
+  });
+
+  it('Should reward if tabcoinsFactor is less than prestigeFactor', async () => {
+    const request = createRequestObj({
+      tabcoins: tabcoinsBase - 1,
+    });
+    prestige.getByUserId.mockResolvedValueOnce(1);
+
+    const result = await reward(request);
+
+    expect(result).toBeGreaterThan(0);
+
+    expect(database.transaction).toHaveBeenCalled();
+    expect(mockQuery).toHaveBeenCalledWith('BEGIN');
+    expect(mockQuery).toHaveBeenCalledWith('COMMIT');
+    expect(mockRelease).toHaveBeenCalled();
+    expect(user.updateRewardedAt).toHaveBeenCalledWith(request.context.user.id, { transaction: expect.any(Object) });
+
+    expect(balance.create).toHaveBeenCalledWith(
+      {
+        amount: result,
+        balanceType: 'user:tabcoin',
+        originatorId: expect.any(String),
+        originatorType: 'event',
+        recipientId: request.context.user.id,
+      },
+      { transaction: expect.any(Object) }
+    );
+    expect(event.create).toHaveBeenCalledWith(
+      {
+        metadata: {
+          amount: result,
+          reward_type: 'daily',
+        },
+        originatorIp: request.context.clientIp,
+        originatorUserId: request.context.user.id,
+        type: 'reward:user:tabcoins',
+      },
+      { transaction: expect.any(Object) }
+    );
+  });
+
+  describe('Reward correct values', () => {
+    const cases = [
+      // [ contentAge, tabcoins, prestige, reward ]
+      [0, 0, 0, 0],
+      [0, 0, 1, 1],
+      [0, 0, 2, 2],
+      [0, 0, 3, 3],
+      [0, 0, tabcoinsBase, tabcoinsBase],
+      [0, 0, tabcoinsBase * 2, tabcoinsBase * 2],
+      [0, tabcoinsBase - 1, 0, 0],
+      [0, tabcoinsBase - 1, 1, 1],
+      [0, tabcoinsBase - 1, 2, 2],
+      [0, tabcoinsBase, 1, 0],
+      [0, tabcoinsBase, 2, 1],
+      [0, tabcoinsBase, 3, 2],
+      [0, tabcoinsBase * 2 - 1, 3, 0],
+      [0, tabcoinsBase * 2 - 1, 4, 1],
+      [0, tabcoinsBase * 2, 4, 0],
+      [0, tabcoinsBase * 2, 5, 1],
+      [0, tabcoinsBase * 3, 9, 0],
+      [0, tabcoinsBase * 3, 10, 1],
+
+      [1, 0, 0, 0],
+      [1, 0, 1, 1],
+      [1, 0, 2, 1],
+      [1, 0, 3, 2],
+      [1, 0, 4, 2],
+      [1, 0, 5, 3],
+
+      [1, tabcoinsBase - 1, 0, 0],
+      [1, tabcoinsBase - 1, 1, 1],
+      [1, tabcoinsBase - 1, 2, 1],
+      [1, tabcoinsBase - 1, 3, 2],
+      [1, tabcoinsBase, 1, 0],
+      [1, tabcoinsBase, 2, 1],
+      [1, tabcoinsBase, 3, 1],
+      [1, tabcoinsBase, 4, 2],
+
+      [2, 0, 0, 0],
+      [2, 0, 1, 1],
+      [2, 0, 3, 1],
+      [2, 0, 4, 2],
+      [2, 0, 6, 2],
+      [2, 0, 7, 3],
+
+      [365, 0, 1, 1],
+      [365, tabcoinsBase, 2, 1],
+    ];
+
+    test.each(cases)(
+      'With content age %d, user tabcoins %d and prestige %d, should return %d',
+      async (contentAge, tabcoins, userPrestige, expected) => {
+        const request = createRequestObj({ tabcoins });
+        prestige.getByUserId.mockResolvedValueOnce(userPrestige);
+        content.findWithStrategy.mockResolvedValueOnce({
+          rows: [{ created_at: new Date(new Date().getTime() - contentAge * contentAgeBase - 1) }],
+        });
+
+        const result = await reward(request);
+
+        expect(result).toBe(expected);
+      }
+    );
+  });
+});


### PR DESCRIPTION
Usuários que participam do fluxo completo de colaboração no TabNews irão receber TabCoins extras diariamente.

### Objetivos

O foco principal é aumentar o volume de qualificações, mas essa funcionalidade também atende de maneira simples boa parte das sugestões da issue ["Brainstorming de TabCoins"](https://github.com/filipedeschamps/tabnews.com.br/issues/1438), além de criar uma nova motivação para os usuários que gostam da gamificação.

### Como ser Recompensado?

Para ganhar os TabCoins, os usuários precisam ter recebido mais qualificações positivas do que negativas em suas publicações, e usar boa parte dos TabCoins ganhos para qualificar os conteúdos (não acumular TabCoins).

A recompensa irá ocorrer no primeiro acesso do usuário a cada 24 horas. O horário de corte é 21:00 (de Brasília), então após esse horário já é possível resgatar a recompensa até às 21hrs do dia seguinte.

### Quanto irei Receber?

O valor ganho irá depender das qualificações recebidas em seus conteúdos, da idade do seu conteúdo mais recente e do seu saldo de TabCoins.

A parte que depende das qualificações usa a mesma [função que computa os ganhos ao publicar comentários](https://github.com/filipedeschamps/tabnews.com.br/blob/0c50cd743c924ee1e49e53f32b47e7d67e4afceb/models/prestige.js#L28). Para a equação da recompensa (R), vamos chamar esse dado de P (pois aquela função calcula o prestígio).

A idade do conteúdo mais recente irá considerar qualquer publicação, seja root ou comentário. Essa idade é dividida por um tempo de base, que podemos ajustar futuramente, mas nesse primeiro experimento estamos usando 1 semana como base. Com essa fração obtemos o fator idade, que vamos chamar de I.

Já o saldo de TabCoins será dividido por uma quantidade de base também, que começamos com 20, e então é elevado ao quadrado. Esse dado nos dá uma noção se o usuário costuma qualificar os conteúdos, então vamos chamar de Q.

Então a recompensa diária será calculada como:

R = ( P - Q ) / ( I + 1 )

O que no código é:

```js
const reward = Math.ceil((prestige - tabcoinsFactor) / contentAgeFactor)
```

onde `contentAgeFactor` é no mínimo 1.

O resultado sempre é arredondado para cima, então se o usuário tiver boas qualificações, e não estiver acumulando muitos TabCoins, ele vai receber no mínimo 1 TabCoin por dia que acessar ao TabNews, mesmo que o tempo da última publicação seja grande.

Mas para quem publica com frequência (intervalo menor que 1 semana), e usa os TabCoins para qualificar (acumula no máximo 20), conseguirá manter tanto o fator Q como o fator I em 0 (zero), então os ganhos só irão depender de P, que depende da qualidade dos seus conteúdos, e que deve ficar mais realista com o maior volume de qualificações.

### Implementação

Agora temos o evento `reward:user:tabcoins`, então ele foi adicionado ao validador.

Foi adicionada a coluna `rewarded_at` na tabela `users` para sabermos se o usuário precisa ser recompensado ou se já foi. Como essa coluna armazena a data e horário, não precisamos mexer nela se futuramente quisermos modificar a frequência das recompensas.

Para atualizar esse novo campo, foi criada a função `updateRewardedAt` no `models/user.js`.

Foi criado o `models/reward.js` que aproveita facilmente diversos outros `models` e o `database` para computar e armazenar tudo relacionado:

Então foi só usar o `reward` no `getHandler` da `api/user`:

```js
authenticatedUser.tabcoins += await reward(request)
```

O restante das modificações são só para os testes, então separei no commit dab9a3cb6cdccc69a813da448be54e459888fbd8.