### PR TITLE
Corrige a consulta para considerar também os comentários no cálculo da recompensa

### DIFF
--- a/models/prestige.js
+++ b/models/prestige.js
@@ -30,7 +30,7 @@ async function getByUserId(
   {
     timeOffset = new Date(Date.now() - 1000 * 60 * 60 * 24 * 2), // 2 days ago
     offset = 3,
-    isRoot,
+    isRoot = false,
     limit = 20,
     transaction,
     database = db,

--- a/queries/prestigeQueries.js
+++ b/queries/prestigeQueries.js
@@ -30,7 +30,7 @@ WITH content_window AS ((
   WHERE
     owner_id = $1
     AND status = 'published'
-    AND ($3 != TRUE OR parent_id IS NULL)
+    AND ($3 = FALSE OR parent_id IS NULL)
   ORDER BY
     published_at DESC
   LIMIT $4 OFFSET $5
@@ -45,7 +45,7 @@ UNION
     owner_id = $1
     AND status = 'published'
     AND published_at < $2
-    AND ($3 != TRUE OR parent_id IS NULL)
+    AND ($3 = FALSE OR parent_id IS NULL)
   ORDER BY
     published_at DESC
   LIMIT $4

--- a/tests/integration/api/v1/user/get.test.js
+++ b/tests/integration/api/v1/user/get.test.js
@@ -366,7 +366,7 @@ describe('GET /api/v1/user', () => {
     });
 
     describe('Reward', () => {
-      const defaultTestRewardValue = 3;
+      const defaultTestRewardValue = 2;
 
       test('Should be able to reward the user once a day', async () => {
         let defaultUser = await orchestrator.createUser();

--- a/tests/unit/models/prestige.test.js
+++ b/tests/unit/models/prestige.test.js
@@ -246,9 +246,9 @@ describe('prestige model', () => {
       [false, 1.71, 7],
       [false, 2.0, 7],
       [false, 2.01, 8],
-      [0, 3, 8],
-      [null, 3.1, 9],
-      [undefined, 4, 9],
+      [false, 3, 8],
+      [false, 3.1, 9],
+      [false, 4, 9],
       [false, 4.1, 10],
     ];
 


### PR DESCRIPTION
Na busca dos conteúdos para o cálculo da média de TabCoins, `$3 != TRUE` era avaliado como `TRUE` quando `isRoot` não era fornecido. Com isso a recompensa estava sendo computada usando apenas conteúdos "root".

O teste só não apontou o erro porque durante a criação eu calculei errado o `defaultTestRewardValue` como sendo `3`, o que coincidentemente bateu com o retornado para `isRoot = true`. Mas o valor correto de `defaultTestRewardValue` é `2`, e ao corrigir isso, acusou o erro na consulta.

O efeito prático é que as recompensas ganhas nos últimos minutos foram calculadas apenas com base na média de TabCoins dos conteúdos "root". Isso deve ter beneficiado a maioria dos usuários, pois geralmente os comentários recebem menos votos, mas isso não é necessariamente verdade para todos, então esse PR corrige a recompensa para considerar a média de qualquer tipo de publicação, seja "root" ou "child".