### PR TITLE
Cria o componente `BarChart` para corrigir o background o Tooltip e a altura dos gráficos no mobile

### DIFF
--- a/pages/interface/components/Charts/index.js
+++ b/pages/interface/components/Charts/index.js
@@ -1,0 +1,23 @@
+import { Bar, BarChart as RechartsBarChart, ResponsiveContainer, Tooltip, XAxis } from 'recharts';
+
+import { Box, useTheme } from '@/TabNewsUI';
+
+export function BarChart({ title, data, yDataKey, name, fill = '#2da44e', xDataKey = 'date' }) {
+  const { theme } = useTheme();
+  const { colors } = theme;
+
+  return (
+    <Box>
+      <h2>{title}</h2>
+      <Box width="100%" height="140px">
+        <ResponsiveContainer>
+          <RechartsBarChart height={400} data={data}>
+            <XAxis dataKey={xDataKey} tick={{ fontSize: 10 }} />
+            <Tooltip contentStyle={{ backgroundColor: colors.canvas.default }} />
+            <Bar type="monotone" dataKey={yDataKey} name={name} fill={fill} />
+          </RechartsBarChart>
+        </ResponsiveContainer>
+      </Box>
+    </Box>
+  );
+}

--- a/pages/status/index.public.js
+++ b/pages/status/index.public.js
@@ -1,7 +1,7 @@
 import { getStaticPropsRevalidate } from 'next-swr';
-import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis } from 'recharts';
 import useSWR from 'swr';
 
+import { BarChart } from '@/Charts';
 import { Box, DefaultLayout, Heading, Label, LabelGroup, Truncate } from '@/TabNewsUI';
 import analytics from 'models/analytics.js';
 
@@ -15,39 +15,11 @@ export default function Page({ usersCreated, rootContentPublished, childContentP
       <Box sx={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
         <Heading as="h1">Estatísticas e Status do Site</Heading>
 
-        <Box>
-          <h2>Novos cadastros</h2>
+        <BarChart title="Novos cadastros" data={usersCreated} yDataKey="cadastros" />
 
-          <ResponsiveContainer width="100%" aspect={7}>
-            <BarChart height={400} data={usersCreated}>
-              <XAxis dataKey="date" tick={{ fontSize: 10 }} />
-              <Tooltip />
-              <Bar type="monotone" dataKey="cadastros" name="cadastros" fill="#2da44e" />
-            </BarChart>
-          </ResponsiveContainer>
-        </Box>
+        <BarChart title="Novas publicações" data={rootContentPublished} yDataKey="conteudos" name="conteúdos" />
 
-        <Box>
-          <h2>Novas publicações</h2>
-          <ResponsiveContainer width="100%" aspect={7}>
-            <BarChart height={400} data={rootContentPublished}>
-              <XAxis dataKey="date" tick={{ fontSize: 10 }} />
-              <Tooltip />
-              <Bar type="monotone" dataKey="conteudos" name="conteúdos" fill="#2da44e" />
-            </BarChart>
-          </ResponsiveContainer>
-        </Box>
-
-        <Box>
-          <h2>Novas respostas</h2>
-          <ResponsiveContainer width="100%" aspect={7}>
-            <BarChart height={400} data={childContentPublished}>
-              <XAxis dataKey="date" tick={{ fontSize: 10 }} />
-              <Tooltip />
-              <Bar type="monotone" dataKey="respostas" name="respostas" fill="#2da44e" />
-            </BarChart>
-          </ResponsiveContainer>
-        </Box>
+        <BarChart title="Novas respostas" data={childContentPublished} yDataKey="respostas" />
 
         <Box>
           <h2>Banco de Dados</h2>


### PR DESCRIPTION
Cria o componente personalizado `BarChart` para facilitar a manutenção e estilização padronizada.

Corrige a altura dos gráficos na versão mobile da página de status, pois ficava difícil distinguir as alturas de cada barra, já que todas ficavam muito baixas.

Também corrige o que o @Poveii relatou na issue #1520, ou seja, adequa o background do Tooltip ao tema de cores.

### Antes

![image](https://github.com/filipedeschamps/tabnews.com.br/assets/77860630/039b1c1e-0c99-416e-9e0a-91b2057afbd7)

### Depois

![image](https://github.com/filipedeschamps/tabnews.com.br/assets/77860630/68583aad-7d6d-492d-ab8c-6460c4406807)

