### PR TITLE
Commits mais rápidos ao rodar o lint apenas nos arquivos preparados

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,8 +90,12 @@
     "pre-commit": "lint-staged"
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx,json,css,scss,md}": [
-      "npm run lint:fix"
+    "*.{js,jsx,ts,tsx}": [
+      "eslint --fix",
+      "prettier --write"
+    ],
+    "*.{json,css,scss,md}": [
+      "prettier --write"
     ]
   },
   "engines": {


### PR DESCRIPTION
Com a configuração anterior, o script `npm run lint:fix` era chamado uma vez para cada arquivo preparado, mas esse script roda o lint em todos os arquivos. Como resultado, um commit com **5 arquivos** preparados estava rodando o lint em **todos os arquivos do projeto**, mas não só isso, fazia esse processo **5 vezes** em sequência.

Com a mudança proposta, o `eslint` e o `prettier` rodarão apenas nos arquivos preparados, e, como esperado, apenas uma vez em cada. E para as extensões `json`, `css`, `scss` e `md` só será executado o `prettier`.