### PR TITLE
Adiciona o grafo dos votos por usuários e por ips na página de status (tudo anonimizado)

### DIFF
--- a/models/analytics.js
+++ b/models/analytics.js
@@ -1,3 +1,5 @@
+import crypto from 'node:crypto';
+
 import database from 'infra/database.js';
 
 async function getChildContentsPublished() {
@@ -99,8 +101,118 @@ async function getUsersCreated() {
   });
 }
 
+async function getVotesGraph({ limit = 300 } = {}) {
+  const results = await database.query({
+    text: `
+      SELECT
+        events.originator_user_id as from,
+        events.metadata->>'content_owner_id' as to,
+        events.metadata->>'transaction_type' as transaction_type,
+        events.originator_ip as ip,
+        events.created_at
+      FROM events
+      WHERE
+        events.type = 'update:content:tabcoins'
+      ORDER BY events.created_at DESC
+      LIMIT $1;
+    `,
+    values: [limit],
+  });
+
+  const usersMap = new Map();
+  const ipNodesMap = new Map();
+  const votesMap = new Map();
+  const ipEdgesMap = new Map();
+
+  results.rows.forEach((row) => {
+    const from = hashWithCache(row.from);
+    const to = hashWithCache(row.to);
+    const ip = hashWithCache(row.ip);
+
+    usersMap.set(from, { id: from, group: 'users' });
+    usersMap.set(to, { id: to, group: 'users' });
+
+    if (ipNodesMap.has(ip)) {
+      ipNodesMap.get(ip).add(from);
+    } else {
+      ipNodesMap.set(ip, new Set([from]));
+    }
+
+    const fromToKey = `${row.transaction_type}-${from}-${to}`;
+    votesMap.set(fromToKey, {
+      from,
+      to,
+      arrows: 'to',
+      color: row.transaction_type === 'credit' ? 'green' : 'red',
+      value: votesMap.has(fromToKey) ? votesMap.get(fromToKey).value + 1 : 1,
+    });
+
+    ipEdgesMap.set(`${from}-${ip}`, { from, to: ip, color: 'cyan' });
+  });
+
+  const sharedIps = [...ipNodesMap]
+    .map((ip) => ({ id: ip[0], group: ip[1].size > 1 ? 'IPs' : undefined }))
+    .filter((ip) => ip.group);
+
+  const ipEdges = [...ipEdgesMap.values()].filter((edge) => sharedIps.some((ip) => ip.id === edge.to));
+
+  return {
+    nodes: [...usersMap.values(), ...sharedIps],
+    edges: [...votesMap.values(), ...ipEdges],
+  };
+}
+
+async function getVotesTaken() {
+  const results = await database.query(`
+  WITH range_values AS (
+    SELECT date_trunc('day', NOW() - INTERVAL '2 MONTHS') as minval,
+           date_trunc('day', NOW()) as maxval
+  ),
+
+  day_range AS (
+    SELECT generate_series(minval, maxval, '1 day'::interval) as date
+    FROM range_values
+  ),
+
+  daily_counts AS (
+    SELECT date_trunc('day', created_at) as date,
+           count(*) as ct
+    FROM events
+    WHERE type = 'update:content:tabcoins'
+    GROUP BY 1
+  )
+
+  SELECT TO_CHAR(day_range.date :: DATE, 'dd/mm') as date,
+         daily_counts.ct::INTEGER as votos
+  FROM day_range
+  LEFT OUTER JOIN daily_counts on day_range.date = daily_counts.date;
+  `);
+
+  return results.rows.map((row) => {
+    return {
+      date: row.date,
+      votos: row.votos || 0,
+    };
+  });
+}
+
 export default Object.freeze({
   getChildContentsPublished,
   getRootContentsPublished,
   getUsersCreated,
+  getVotesGraph,
+  getVotesTaken,
 });
+
+const hashCache = {};
+
+function hashWithCache(input) {
+  if (hashCache[input]) return hashCache[input];
+
+  const hash = crypto.createHash('md5');
+  const salt = crypto.randomBytes(16).toString('base64');
+  hash.update(salt + input);
+  const token = hash.digest('base64').slice(0, 7);
+  hashCache[input] = token;
+  return token;
+}

--- a/models/session.js
+++ b/models/session.js
@@ -1,5 +1,5 @@
 import cookie from 'cookie';
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 
 import { UnauthorizedError } from 'errors';
 import database from 'infra/database.js';

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,8 @@
         "snakeize": "0.1.0",
         "styled-components": "5.3.10",
         "swr": "2.1.4",
-        "uuid": "9.0.0"
+        "uuid": "9.0.0",
+        "vis-network": "9.1.7"
       },
       "devDependencies": {
         "@commitlint/cli": "17.6.1",
@@ -1027,6 +1028,18 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@egjs/hammerjs": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+      "peer": true,
+      "dependencies": {
+        "@types/hammerjs": "^2.0.36"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/@emotion/is-prop-valid": {
@@ -2559,6 +2572,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/hammerjs": {
+      "version": "2.0.42",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.42.tgz",
+      "integrity": "sha512-Xxk14BrwHnGi0xlURPRb+Y0UNn2w3cTkeFm7pKMsYOaNgH/kabbJLhcBoNIodwsbTz7Z8KcWjtDvlGH0nc0U9w==",
+      "peer": true
     },
     "node_modules/@types/hast": {
       "version": "2.3.4",
@@ -4104,6 +4123,12 @@
         "array-ify": "^1.0.0",
         "dot-prop": "^5.1.0"
       }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "peer": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -8527,6 +8552,12 @@
       "bin": {
         "katex": "cli.js"
       }
+    },
+    "node_modules/keycharm": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/keycharm/-/keycharm-0.4.0.tgz",
+      "integrity": "sha512-TyQTtsabOVv3MeOpR92sIKk/br9wxS+zGj4BG7CR8YbK4jM3tyIBaF0zhzeBUMx36/Q/iQLOKKOT+3jOQtemRQ==",
+      "peer": true
     },
     "node_modules/khroma": {
       "version": "2.0.0",
@@ -13485,6 +13516,54 @@
         "d3-timer": "^3.0.1"
       }
     },
+    "node_modules/vis-data": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/vis-data/-/vis-data-7.1.7.tgz",
+      "integrity": "sha512-Jfrb6Ixyr3jdqFgpCBWnzb4w7PdD3UjOY6vea9yXixoKSLveUj+rAuxByoRKRvdjhsRtsYCEXG6MXjjx+uvGvQ==",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/visjs"
+      },
+      "peerDependencies": {
+        "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
+        "vis-util": "^5.0.1"
+      }
+    },
+    "node_modules/vis-network": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/vis-network/-/vis-network-9.1.7.tgz",
+      "integrity": "sha512-ET1P5j9g5+HUwJpMMuDT5+bnuofXvqFwH7fllQ9RWcOJwKxR3gnNOW2qwDKvv243WACyf7Kbmih2UkmiQ/4HdA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/visjs"
+      },
+      "peerDependencies": {
+        "@egjs/hammerjs": "^2.0.0",
+        "component-emitter": "^1.3.0",
+        "keycharm": "^0.2.0 || ^0.3.0 || ^0.4.0",
+        "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
+        "vis-data": "^6.3.0 || ^7.0.0",
+        "vis-util": "^5.0.1"
+      }
+    },
+    "node_modules/vis-util": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/vis-util/-/vis-util-5.0.5.tgz",
+      "integrity": "sha512-NQHl/gkJYW7+MEJ0Ed4oo5nsvtUl95rfruZQj69T2oSLBrnDfxUJzBZ00rA5fNuSLW9DL+FemdMOVGvMu6kIrQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/visjs"
+      },
+      "peerDependencies": {
+        "@egjs/hammerjs": "^2.0.0",
+        "component-emitter": "^1.3.0"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -14487,6 +14566,15 @@
             "@jridgewell/sourcemap-codec": "^1.4.10"
           }
         }
+      }
+    },
+    "@egjs/hammerjs": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+      "peer": true,
+      "requires": {
+        "@types/hammerjs": "^2.0.36"
       }
     },
     "@emotion/is-prop-valid": {
@@ -15627,6 +15715,12 @@
         "@types/node": "*"
       }
     },
+    "@types/hammerjs": {
+      "version": "2.0.42",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.42.tgz",
+      "integrity": "sha512-Xxk14BrwHnGi0xlURPRb+Y0UNn2w3cTkeFm7pKMsYOaNgH/kabbJLhcBoNIodwsbTz7Z8KcWjtDvlGH0nc0U9w==",
+      "peer": true
+    },
     "@types/hast": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.4.tgz",
@@ -16745,6 +16839,12 @@
         "array-ify": "^1.0.0",
         "dot-prop": "^5.1.0"
       }
+    },
+    "component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "peer": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -20018,6 +20118,12 @@
       "requires": {
         "commander": "^8.3.0"
       }
+    },
+    "keycharm": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/keycharm/-/keycharm-0.4.0.tgz",
+      "integrity": "sha512-TyQTtsabOVv3MeOpR92sIKk/br9wxS+zGj4BG7CR8YbK4jM3tyIBaF0zhzeBUMx36/Q/iQLOKKOT+3jOQtemRQ==",
+      "peer": true
     },
     "khroma": {
       "version": "2.0.0",
@@ -23541,6 +23647,26 @@
         "d3-time": "^3.0.0",
         "d3-timer": "^3.0.1"
       }
+    },
+    "vis-data": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/vis-data/-/vis-data-7.1.7.tgz",
+      "integrity": "sha512-Jfrb6Ixyr3jdqFgpCBWnzb4w7PdD3UjOY6vea9yXixoKSLveUj+rAuxByoRKRvdjhsRtsYCEXG6MXjjx+uvGvQ==",
+      "peer": true,
+      "requires": {}
+    },
+    "vis-network": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/vis-network/-/vis-network-9.1.7.tgz",
+      "integrity": "sha512-ET1P5j9g5+HUwJpMMuDT5+bnuofXvqFwH7fllQ9RWcOJwKxR3gnNOW2qwDKvv243WACyf7Kbmih2UkmiQ/4HdA==",
+      "requires": {}
+    },
+    "vis-util": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/vis-util/-/vis-util-5.0.5.tgz",
+      "integrity": "sha512-NQHl/gkJYW7+MEJ0Ed4oo5nsvtUl95rfruZQj69T2oSLBrnDfxUJzBZ00rA5fNuSLW9DL+FemdMOVGvMu6kIrQ==",
+      "peer": true,
+      "requires": {}
     },
     "walker": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "snakeize": "0.1.0",
     "styled-components": "5.3.10",
     "swr": "2.1.4",
-    "uuid": "9.0.0"
+    "uuid": "9.0.0",
+    "vis-network": "9.1.7"
   },
   "devDependencies": {
     "@commitlint/cli": "17.6.1",

--- a/pages/interface/components/Graph/index.js
+++ b/pages/interface/components/Graph/index.js
@@ -1,0 +1,59 @@
+import { useEffect, useRef } from 'react';
+import { Network } from 'vis-network';
+
+import { Box, Spinner } from '@/TabNewsUI';
+
+function Graph({ title, data, options: { locale = 'pt-br', groups, ...options } = {}, ...props }) {
+  const containerRef = useRef(null);
+  const networkRef = useRef(null);
+
+  useEffect(() => {
+    if (networkRef.current || !containerRef.current) return;
+
+    networkRef.current = new Network(
+      containerRef.current,
+      { edges: [], nodes: [] },
+      {
+        locale,
+        groups: {
+          users: { shape: 'icon', icon: { code: '👤' } },
+          IPs: { shape: 'icon', icon: { code: '🌐' } },
+          ...groups,
+        },
+        ...options,
+      }
+    );
+  }, [containerRef, locale, options, groups]);
+
+  useEffect(() => {
+    if (!networkRef.current) return;
+    networkRef.current.setData(data);
+  }, [data]);
+
+  useEffect(() => {
+    if (!networkRef.current) return;
+    networkRef.current.on('startStabilizing', () => setTimeout(() => networkRef.current.stopSimulation(), 3000));
+    return () => networkRef.current.destroy();
+  }, []);
+
+  return (
+    <Box>
+      <h2>{title}</h2>
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        width="100%"
+        height="70vh"
+        border="2px solid rgba(102, 102, 102, .5)"
+        borderRadius={6}
+        overflow="hidden"
+        {...props}
+        ref={containerRef}>
+        <Spinner size="large" />
+      </Box>
+    </Box>
+  );
+}
+
+export default Graph;

--- a/pages/status/index.public.js
+++ b/pages/status/index.public.js
@@ -2,10 +2,11 @@ import { getStaticPropsRevalidate } from 'next-swr';
 import useSWR from 'swr';
 
 import { BarChart } from '@/Charts';
+import Graph from '@/Graph';
 import { Box, DefaultLayout, Heading, Label, LabelGroup, Truncate } from '@/TabNewsUI';
 import analytics from 'models/analytics.js';
 
-export default function Page({ usersCreated, rootContentPublished, childContentPublished }) {
+export default function Page({ usersCreated, rootContentPublished, childContentPublished, votesGraph, votesTaken }) {
   const { data: statusObject, isLoading: statusObjectIsLoading } = useSWR('/api/v1/status', {
     refreshInterval: 1000 * 10,
   });
@@ -20,6 +21,10 @@ export default function Page({ usersCreated, rootContentPublished, childContentP
         <BarChart title="Novas publicações" data={rootContentPublished} yDataKey="conteudos" name="conteúdos" />
 
         <BarChart title="Novas respostas" data={childContentPublished} yDataKey="respostas" />
+
+        <BarChart title="Novas qualificações" data={votesTaken} yDataKey="votos" />
+
+        <Graph title="Qualificações × Usuários × Origens" data={votesGraph} />
 
         <Box>
           <h2>Banco de Dados</h2>
@@ -164,12 +169,16 @@ export const getStaticProps = getStaticPropsRevalidate(async () => {
   const childContentPublished = await analytics.getChildContentsPublished();
   const rootContentPublished = await analytics.getRootContentsPublished();
   const usersCreated = await analytics.getUsersCreated();
+  const votesGraph = await analytics.getVotesGraph();
+  const votesTaken = await analytics.getVotesTaken();
 
   return {
     props: {
       usersCreated,
       rootContentPublished,
       childContentPublished,
+      votesGraph,
+      votesTaken,
     },
     revalidate: 30,
     swr: { refreshInterval: 1000 * 60 * 5 },


### PR DESCRIPTION
PR para facilitar a identificação de abusos envolvendo qualificações de conteúdos.

Adiciona o grafo dos votos por usuários e por IPs na página de status (tudo anonimizado), e também adiciona o gráfico da quantidade de qualificações diárias nos últimos 60 dias.

Para a primeira versão estão sendo mostradas as últimas 300 qualificações no grafo. Vejam que em homologação, pela quantidade reduzida de usuários, os votos são bem concentrados:

![image](https://github.com/filipedeschamps/tabnews.com.br/assets/77860630/1e21e4c6-8771-4544-9604-550daa992b6b)