### PR TITLE
[Moderação] Possibilidade de ver `usernames` no grafo de qualificações

### DIFF
--- a/infra/scripts/seed-database.js
+++ b/infra/scripts/seed-database.js
@@ -36,6 +36,8 @@ async function seedDevelopmentUsers() {
     'create:migration',
     'update:content:others',
     'create:recovery_token:username',
+    'read:votes:others',
+    'read:user:list',
   ]);
   await insertUser('user', 'user@user.com', '$2a$04$v0hvAu/y6pJ17LzeCfcKG.rDStO9x5ficm2HTLZIfeDBG8oR/uQXi', [
     'create:session',

--- a/models/authorization.js
+++ b/models/authorization.js
@@ -6,9 +6,7 @@ const availableFeatures = new Set([
   'create:user',
   'read:user',
   'read:user:self',
-  'read:user:list',
   'update:user',
-  'ban:user',
 
   // MIGRATION
   'read:migration',
@@ -19,7 +17,6 @@ const availableFeatures = new Set([
 
   // RECOVERY_TOKEN
   'read:recovery_token',
-  'create:recovery_token:username',
 
   // EMAIL_CONFIRMATION_TOKEN
   'read:email_confirmation_token',
@@ -31,12 +28,18 @@ const availableFeatures = new Set([
   // CONTENT
   'read:content',
   'update:content',
-  'update:content:others',
   'create:content',
   'create:content:text_root',
   'create:content:text_child',
   'read:content:list',
   'read:content:tabcoins',
+
+  // MODERATION
+  'read:user:list',
+  'read:votes:others',
+  'update:content:others',
+  'ban:user',
+  'create:recovery_token:username',
 ]);
 
 function can(user, feature, resource) {

--- a/pages/_app.public.js
+++ b/pages/_app.public.js
@@ -7,6 +7,11 @@ import { DefaultHead, UserProvider } from 'pages/interface';
 
 async function SWRFetcher(resource, init) {
   const response = await fetch(resource, init);
+
+  if (!response.ok) {
+    throw new Error(response.statusText);
+  }
+
   const responseBody = await response.json();
 
   return responseBody;

--- a/pages/api/v1/status/votes/index.public.js
+++ b/pages/api/v1/status/votes/index.public.js
@@ -1,0 +1,31 @@
+import { formatISO } from 'date-fns';
+import nextConnect from 'next-connect';
+
+import analytics from 'models/analytics';
+import authentication from 'models/authentication';
+import authorization from 'models/authorization';
+import cacheControl from 'models/cache-control';
+import controller from 'models/controller.js';
+
+export default nextConnect({
+  attachParams: true,
+  onNoMatch: controller.onNoMatchHandler,
+  onError: controller.onErrorHandler,
+})
+  .use(controller.injectRequestMetadata)
+  .use(authentication.injectAnonymousOrUser)
+  .use(controller.logRequest)
+  .use(cacheControl.noCache)
+  .get(authorization.canRequest('read:votes:others'), getHandler);
+
+async function getHandler(_, response) {
+  const votesGraph = await analytics.getVotesGraph({
+    limit: 1000,
+    showUsernames: true,
+  });
+
+  return response.json({
+    updated_at: formatISO(Date.now()),
+    votesGraph,
+  });
+}

--- a/pages/interface/components/Graph/index.js
+++ b/pages/interface/components/Graph/index.js
@@ -1,59 +1,255 @@
-import { useEffect, useRef } from 'react';
+import { Fragment, useEffect, useRef, useState } from 'react';
 import { Network } from 'vis-network';
 
-import { Box, Spinner } from '@/TabNewsUI';
+import { Box, Link, Spinner, Text, useTheme } from '@/TabNewsUI';
 
-function Graph({ title, data, options: { locale = 'pt-br', groups, ...options } = {}, ...props }) {
+const border = '2px solid rgba(102, 102, 102, .5)'; // To be consistent with Charts style
+
+function Graph({ title, data, simulationTimeout = 3000, options = {}, ...props }) {
   const containerRef = useRef(null);
-  const networkRef = useRef(null);
+  const [network, setNetwork] = useState(null);
+  const [isSelected, setIsSelected] = useState(false);
+  const [status, setStatus] = useState();
+
+  const { theme } = useTheme();
+  const fontColor = theme.colors.fg.default;
 
   useEffect(() => {
-    if (networkRef.current || !containerRef.current) return;
+    if (network || !containerRef.current) return;
 
-    networkRef.current = new Network(
-      containerRef.current,
-      { edges: [], nodes: [] },
-      {
-        locale,
-        groups: {
-          users: { shape: 'icon', icon: { code: '👤' } },
-          IPs: { shape: 'icon', icon: { code: '🌐' } },
-          ...groups,
-        },
-        ...options,
-      }
+    setNetwork(
+      new Network(
+        containerRef.current,
+        {},
+        {
+          locale: 'pt',
+          groups: {
+            users: { shape: 'icon', icon: { code: '👤' } },
+            nuked: { shape: 'icon', icon: { code: '❌' } },
+            IPs: { shape: 'icon', icon: { code: '🌐' } },
+          },
+          interaction: { hover: true },
+        }
+      )
     );
-  }, [containerRef, locale, options, groups]);
+  }, [network]);
 
   useEffect(() => {
-    if (!networkRef.current) return;
-    networkRef.current.setData(data);
-  }, [data]);
+    if (checkIfIsNewData(network, data)) {
+      setStyles(data);
+      network.setData(data);
+    }
+  }, [data, network]);
 
   useEffect(() => {
-    if (!networkRef.current) return;
-    networkRef.current.on('startStabilizing', () => setTimeout(() => networkRef.current.stopSimulation(), 3000));
-    return () => networkRef.current.destroy();
-  }, []);
+    network?.setOptions({ nodes: { font: { color: fontColor } } });
+  }, [fontColor, network]);
+
+  useEffect(() => {
+    network?.setOptions(options);
+  }, [options, network]);
+
+  useEffect(() => {
+    if (!network) return;
+
+    const stopSimulation = () => setTimeout(() => network.stopSimulation(), simulationTimeout);
+
+    const hovered = (event) => {
+      if (!isSelected) setStatus(getStatusProps(event, network));
+    };
+
+    const selectEdge = (event) => {
+      setIsSelected(true);
+      setStatus(getStatusProps(event, network));
+    };
+
+    const deselectEdge = () => {
+      setIsSelected(false);
+      setStatus(null);
+    };
+
+    network.on('startStabilizing', stopSimulation);
+    network.on('hoverEdge', hovered);
+    network.on('hoverNode', hovered);
+    network.on('selectEdge', selectEdge);
+    network.on('deselectEdge', deselectEdge);
+
+    return () => {
+      network.off('startStabilizing', stopSimulation);
+      network.off('hoverEdge', hovered);
+      network.off('hoverNode', hovered);
+      network.off('selectEdge', selectEdge);
+      network.off('deselectEdge', deselectEdge);
+    };
+  }, [isSelected, network, simulationTimeout]);
 
   return (
     <Box>
       <h2>{title}</h2>
-      <Box
-        display="flex"
-        justifyContent="center"
-        alignItems="center"
-        width="100%"
-        height="70vh"
-        border="2px solid rgba(102, 102, 102, .5)"
-        borderRadius={6}
-        overflow="hidden"
-        {...props}
-        ref={containerRef}>
-        <Spinner size="large" />
+      <Box border={border} borderRadius={6} overflow="hidden">
+        <Box
+          ref={containerRef}
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          width="100%"
+          height="70vh"
+          borderBottom={border}
+          {...props}>
+          <Spinner size="large" />
+        </Box>
+        <StatusBar status={status} />
+        <Legend />
       </Box>
     </Box>
   );
 }
 
 export default Graph;
+
+function checkIfIsNewData(network, newData) {
+  if (!network) return false;
+
+  const oldData = network.body.data;
+
+  if (oldData.nodes.length !== newData.nodes.length) return true;
+  if (oldData.edges.length !== newData.edges.length) return true;
+  if (
+    Array.from(oldData.nodes._data.values()).some((node, i) => {
+      if (node.username !== newData.nodes[i].username) return true;
+      if (node.group !== newData.nodes[i].group) return true;
+    })
+  )
+    return true;
+
+  return false;
+}
+
+function setStyles(data) {
+  data.edges.forEach((edge) => {
+    edge.color = edge.type === 'network' ? 'cyan' : edge.type === 'credit' ? 'green' : 'red';
+    if (edge.type !== 'network') edge.arrows = 'to';
+  });
+  data.nodes.forEach((node) => {
+    if (node.group === 'nuked' && node.username) node.label = node.username;
+  });
+}
+
+function getStatusProps(event, network) {
+  const edges =
+    event.edges?.map((edgeId) => network.body.edges[edgeId]) ||
+    (event.edge && [network.body.edges[event.edge]]) ||
+    (event.node && network.body.nodes[event.node]?.edges) ||
+    [];
+
+  const votesMap = new Set();
+  const sharedIpsMap = new Map();
+  let positives = 0;
+  let negatives = 0;
+
+  edges.forEach(({ from, to, options }) => {
+    const isSharedIpNode = to.options.group === 'IPs';
+
+    if (isSharedIpNode) {
+      const ip = options.to;
+
+      if (!sharedIpsMap.has(ip)) {
+        sharedIpsMap.set(ip, new Set());
+
+        to.edges.forEach(({ from }) => {
+          const username = from.options.username;
+          username && sharedIpsMap.get(ip).add(username);
+        });
+      }
+    } else {
+      const fromUsername = from.options.username;
+      fromUsername && votesMap.add(fromUsername);
+
+      const toUsername = to.options.username;
+      toUsername && votesMap.add(toUsername);
+
+      const value = options.value;
+      const isPositive = options.color.color === 'green';
+
+      if (isPositive) {
+        positives += value;
+      } else {
+        negatives += value;
+      }
+    }
+  });
+
+  return { votes: [...votesMap], positives, negatives, shared: [...sharedIpsMap.values()] };
+}
+
+function StatusBar({ status }) {
+  return (
+    <Box display="flex" minHeight={30} justifyContent="center" borderBottom={border} flexWrap="wrap">
+      <DefaultStatusMessage status={status} />
+      <JoinSharedNetworks {...status} />
+      <JoinLinksWithCommaOrAnd paths={status?.votes} />
+      <JoinInteractions {...status} />
+    </Box>
+  );
+}
+
+function DefaultStatusMessage({ status }) {
+  if (status) return null;
+
+  return <Text>Selecione um nó ou aresta</Text>;
+}
+
+function JoinSharedNetworks({ positives, negatives, shared }) {
+  if (!shared) return null;
+
+  return shared.map((sharedFrom, i) => {
+    return (
+      <Fragment key={i}>
+        <JoinLinksWithCommaOrAnd paths={[...sharedFrom]} />
+        {sharedFrom.size === 0 && <Text>Rede compartilhada</Text>}
+        {sharedFrom.size === 1 && <Text>&nbsp;compartilha sua rede&nbsp;</Text>}
+        {sharedFrom.size > 1 && <Text>&nbsp;compartilham a mesma rede&nbsp;</Text>}
+        {i + 2 < shared.length && <Text>,&nbsp;</Text>}
+        {i + 2 === shared.length && <Text>&nbsp;e&nbsp;</Text>}
+        {i + 1 === shared.length && !!(positives || negatives) && <Text>&nbsp;|&nbsp;</Text>}
+      </Fragment>
+    );
+  });
+}
+
+function JoinLinksWithCommaOrAnd({ paths }) {
+  if (!paths?.length) return null;
+
+  return paths.map((path, i) => [
+    <Link key={path + i} href={`/${path}`}>
+      {path}
+    </Link>,
+    i + 2 < paths.length && <Text key={i}>,&nbsp;</Text>,
+    i + 2 == paths.length && <Text key={i}>&nbsp;e&nbsp;</Text>,
+  ]);
+}
+
+function JoinInteractions({ votes, positives, negatives }) {
+  if (!positives && !negatives) return null;
+
+  let content = '';
+
+  if (votes?.length) content += '➔';
+  if (positives) content += ` +${positives} TabCoin${positives > 1 ? 's' : ''}`;
+  if (positives && negatives) content += ' e';
+  if (negatives) content += ` -${negatives} TabCoin${negatives > 1 ? 's' : ''}`;
+
+  if (!content) return null;
+
+  return <Text>&nbsp;{content}</Text>;
+}
+
+function Legend() {
+  return (
+    <Box display="flex" minHeight={30} justifyContent="space-around" alignItems="center" flexWrap="wrap">
+      <Box>👤 Usuários Ativos</Box>
+      <Box>❌ Usuários Banidos</Box>
+      <Box>🌐 Redes Compartilhadas</Box>
+    </Box>
+  );
+}

--- a/tests/integration/api/v1/status/votes/get.test.js
+++ b/tests/integration/api/v1/status/votes/get.test.js
@@ -1,0 +1,135 @@
+import fetch from 'cross-fetch';
+import { v4 as uuidV4, version as uuidVersion } from 'uuid';
+
+import orchestrator from 'tests/orchestrator.js';
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.dropAllTables();
+  await orchestrator.runPendingMigrations();
+});
+
+describe('GET /api/v1/status/votes', () => {
+  describe('Anonymous user', () => {
+    test('Should not retrieve voting data', async () => {
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/status/votes`);
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(403);
+      expect(responseBody.name).toEqual('ForbiddenError');
+      expect(responseBody.message).toEqual('Usuário não pode executar esta operação.');
+      expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "read:votes:others".');
+      expect(responseBody.status_code).toEqual(403);
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_location_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
+    });
+  });
+
+  describe('Default user', () => {
+    test('Should not retrieve voting data', async () => {
+      let defaultUser = await orchestrator.createUser();
+      defaultUser = await orchestrator.activateUser(defaultUser);
+      let defaultUserSession = await orchestrator.createSession(defaultUser);
+
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/status/votes`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          cookie: `session_id=${defaultUserSession.token}`,
+        },
+      });
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(403);
+      expect(responseBody.name).toEqual('ForbiddenError');
+      expect(responseBody.message).toEqual('Usuário não pode executar esta operação.');
+      expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "read:votes:others".');
+      expect(responseBody.status_code).toEqual(403);
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.error_location_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
+    });
+  });
+
+  describe('User with "read:votes:others" feature', () => {
+    let privilegedUser;
+    let privilegedUserSession;
+
+    beforeEach(async () => {
+      privilegedUser = await orchestrator.createUser();
+      privilegedUser = await orchestrator.activateUser(privilegedUser);
+      privilegedUser = await orchestrator.addFeaturesToUser(privilegedUser, ['read:votes:others']);
+      privilegedUserSession = await orchestrator.createSession(privilegedUser);
+    });
+
+    test('Should retrieve empty voting data', async () => {
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/status/votes`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          cookie: `session_id=${privilegedUserSession.token}`,
+        },
+      });
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(200);
+      expect(responseBody).toEqual({ updated_at: expect.any(String), votesGraph: { edges: [], nodes: [] } });
+    });
+
+    test('Should retrieve voting data', async () => {
+      orchestrator.createRate({ owner_id: privilegedUser.id, id: uuidV4() }, 2);
+
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/status/votes`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          cookie: `session_id=${privilegedUserSession.token}`,
+        },
+      });
+
+      const responseBody = await response.json();
+      const votesData = responseBody.votesGraph;
+
+      expect(response.status).toEqual(200);
+      expect(votesData.edges.length).toEqual(1);
+      expect(votesData.edges[0].type).toEqual('credit');
+      expect(votesData.edges[0].value).toEqual(1);
+      expect(votesData.nodes.length).toEqual(2);
+      expect(votesData.nodes[0].group).toEqual('users');
+      expect(votesData.nodes[1].group).toEqual('users');
+      expect(votesData.nodes[0].votes).toEqual(1);
+      expect(votesData.nodes[1].votes).toEqual(1);
+      expect(votesData.edges[0].from).toEqual(votesData.nodes[0].id);
+      expect(votesData.edges[0].to).toEqual(votesData.nodes[1].id);
+    });
+
+    describe('Same user after losing "read:votes:others" feature', () => {
+      test('Should not retrieve voting data', async () => {
+        await orchestrator.removeFeaturesFromUser(privilegedUser, ['read:votes:others']);
+
+        const responseAfter = await fetch(`${orchestrator.webserverUrl}/api/v1/status/votes`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${privilegedUserSession.token}`,
+          },
+        });
+
+        const responseBody = await responseAfter.json();
+
+        expect(responseAfter.status).toEqual(403);
+        expect(responseBody.name).toEqual('ForbiddenError');
+        expect(responseBody.message).toEqual('Usuário não pode executar esta operação.');
+        expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "read:votes:others".');
+        expect(responseBody.status_code).toEqual(403);
+        expect(uuidVersion(responseBody.error_id)).toEqual(4);
+        expect(uuidVersion(responseBody.request_id)).toEqual(4);
+        expect(responseBody.error_location_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
+      });
+    });
+  });
+});


### PR DESCRIPTION
Continuando a funcionalidade de moderação implementada no #1531, agora os moderadores vão conseguir ver o nome dos usuários com maiores movimentações de TabCoins, os usuários banidos recentemente e também os que estão compartilhando conexão de acesso de dados.

Para isso foi criada a feature `read:votes:others`, que já foi adicionada para todos os moderadores, e o endpoint protegido `/status/votes`.

Também foi adicionado o ícone ❌ para usuários banidos (visível para todos), facilitando a identificação de casos já tratados pela moderação.

Além disso, foi adicionada uma legenda para os ícones, e uma barra de status, que mostra dados básicos publicamente, mas dá mais detalhes para os moderadores ao selecionar um nó ou aresta do grafo.

Publicamente estão disponíveis as últimas 300 qualificações no grafo, mas os moderadores podem ver uma quantidade maior.

Está é a versão **pública no ambiente de homologação**:

![image](https://github.com/filipedeschamps/tabnews.com.br/assets/77860630/c3dbb96c-1d6c-421d-beb5-abad5c35f616)

E está é a versão da **moderação**, onde, dado ao menor volume do ambiente de homologação, estão visíveis todas as 734 qualificações desde o início do sistema:

![image](https://github.com/filipedeschamps/tabnews.com.br/assets/77860630/4a6e8014-f1dc-4af2-b1f7-cd935aed4ef3)


E antes de abrir o PR eu já vinha testando em homologação, então mais tarde já vou mesclar em produção 🎉
