### PR TITLE
fix(modifies interface component 'tabcoinsbuttons'): disables voting buttons for content owner

### DIFF
--- a/pages/interface/components/TabCoinButtons/index.js
+++ b/pages/interface/components/TabCoinButtons/index.js
@@ -81,7 +81,8 @@ export default function TabCoinButtons({ content }) {
     }
   }
 
-  const isInAction = isPosting || isAnimatingCredit || isAnimatingDebit;
+  const isOwnerOfPost = user?.id === contentObject?.owner_id;
+  const isInAction = isPosting || isAnimatingCredit || isAnimatingDebit || isOwnerOfPost;
 
   return (
     <Box


### PR DESCRIPTION
Re-escrita do PR #1105 

"The change will disable the Like and Dislike buttons on Posts and Comments authored by the Current User (logged in).

Well, I believe it doesn't make sense for the owner of the post/comment to have the option to click to vote for himself, as the API itself does not allow this behavior. Hence, I wrote a check, which for each post/comment, compares the ID of the Owner of the Content, with the ID of the Current User, thus being able to disable the buttons."