### PR TITLE
Ajustes nas ferramentas de moderação

### DIFF
--- a/models/analytics.js
+++ b/models/analytics.js
@@ -124,6 +124,14 @@ async function getVotesGraph({ limit = 300, showUsernames = false } = {}) {
   const ipNodesMap = new Map();
   const votesMap = new Map();
 
+  // Since `votesMap` will maintain the insertion order, this allows moderators
+  // to filter by user nodes that participated in the most recent ratings.
+  // For public data, the result must be inverted to make it
+  // difficult to identify the users represented by each node.
+  if (!showUsernames) {
+    results.rows.reverse();
+  }
+
   results.rows.forEach((row) => {
     const from = usersMap.get(row.from)?.id || hash(row.from, row.id);
     const to = usersMap.get(row.to)?.id || hash(row.to, row.id);
@@ -148,6 +156,7 @@ async function getVotesGraph({ limit = 300, showUsernames = false } = {}) {
 
     const fromToKey = `${row.transaction_type}-${from}-${to}`;
     votesMap.set(fromToKey, {
+      id: fromToKey,
       from,
       to,
       type: row.transaction_type,

--- a/models/analytics.js
+++ b/models/analytics.js
@@ -6,8 +6,8 @@ async function getChildContentsPublished() {
   const results = await database.query(`
   WITH range_values AS (
     SELECT date_trunc('day', NOW() - INTERVAL '2 MONTHS') as minval,
-           date_trunc('day', max(published_at)) as maxval
-    FROM contents),
+           date_trunc('day', NOW()) as maxval
+  ),
 
   day_range AS (
     SELECT generate_series(minval, maxval, '1 day'::interval) as date
@@ -24,7 +24,8 @@ async function getChildContentsPublished() {
   SELECT TO_CHAR(day_range.date :: DATE, 'dd/mm') as date,
          daily_counts.ct::INTEGER as respostas
   FROM day_range
-  LEFT OUTER JOIN daily_counts on day_range.date = daily_counts.date;
+  LEFT OUTER JOIN daily_counts on day_range.date = daily_counts.date
+  ORDER BY day_range.date;
   `);
 
   return results.rows.map((row) => {
@@ -39,8 +40,8 @@ async function getRootContentsPublished() {
   const results = await database.query(`
   WITH range_values AS (
     SELECT date_trunc('day', NOW() - INTERVAL '2 MONTHS') as minval,
-           date_trunc('day', max(published_at)) as maxval
-    FROM contents),
+           date_trunc('day', NOW()) as maxval
+  ),
 
   day_range AS (
     SELECT generate_series(minval, maxval, '1 day'::interval) as date
@@ -57,7 +58,8 @@ async function getRootContentsPublished() {
   SELECT TO_CHAR(day_range.date :: DATE, 'dd/mm') as date,
          daily_counts.ct::INTEGER as conteudos
   FROM day_range
-  LEFT OUTER JOIN daily_counts on day_range.date = daily_counts.date;
+  LEFT OUTER JOIN daily_counts on day_range.date = daily_counts.date
+  ORDER BY day_range.date;
   `);
 
   return results.rows.map((row) => {
@@ -72,8 +74,8 @@ async function getUsersCreated() {
   const results = await database.query(`
   WITH range_values AS (
     SELECT date_trunc('day', NOW() - INTERVAL '2 MONTHS') as minval,
-           date_trunc('day', max(created_at)) as maxval
-    FROM users),
+           date_trunc('day', NOW()) as maxval
+  ),
 
   day_range AS (
     SELECT generate_series(minval, maxval, '1 day'::interval) as date
@@ -90,7 +92,8 @@ async function getUsersCreated() {
   SELECT TO_CHAR(day_range.date :: DATE, 'dd/mm') as date,
          daily_counts.ct::INTEGER as cadastros
   FROM day_range
-  LEFT OUTER JOIN daily_counts on day_range.date = daily_counts.date;
+  LEFT OUTER JOIN daily_counts on day_range.date = daily_counts.date
+  ORDER BY day_range.date;
   `);
 
   return results.rows.map((row) => {
@@ -223,8 +226,8 @@ async function getVotesTaken() {
   const results = await database.query(`
   WITH range_values AS (
     SELECT date_trunc('day', NOW() - INTERVAL '2 MONTHS') as minval,
-           date_trunc('day', max(created_at)) as maxval
-    FROM events),
+           date_trunc('day', NOW()) as maxval
+  ),
 
   day_range AS (
     SELECT generate_series(minval, maxval, '1 day'::interval) as date
@@ -242,7 +245,8 @@ async function getVotesTaken() {
   SELECT TO_CHAR(day_range.date :: DATE, 'dd/mm') as date,
          daily_counts.ct::INTEGER as votos
   FROM day_range
-  LEFT OUTER JOIN daily_counts on day_range.date = daily_counts.date;
+  LEFT OUTER JOIN daily_counts on day_range.date = daily_counts.date
+  ORDER BY day_range.date;
   `);
 
   return results.rows.map((row) => {

--- a/models/analytics.js
+++ b/models/analytics.js
@@ -186,7 +186,7 @@ async function getVotesGraph({ limit = 300, showUsernames = false } = {}) {
         votes: usersMap.get(user).votes,
       });
 
-      ipEdges.push({ from, to: ipId, type: 'network' });
+      ipEdges.push({ id: `net-${from}-${ipId}`, from, to: ipId, type: 'network' });
     });
 
     sharedIps.push({ id: ipId, group: 'IPs' });

--- a/models/analytics.js
+++ b/models/analytics.js
@@ -211,7 +211,7 @@ async function getVotesGraph({ limit = 300, showUsernames = false } = {}) {
     usersMap.set(row.key, {
       id: user.id,
       group: row.nuked ? 'nuked' : 'users',
-      username: showUsernames && (user.votes > 2 || user.shared) ? row.username : null,
+      username: showUsernames && row.username,
       votes: user.votes,
     });
   });

--- a/models/ban.js
+++ b/models/ban.js
@@ -49,6 +49,7 @@ async function nuke(userId, options = {}) {
             events
           WHERE
             originator_user_id = $1
+            AND created_at > NOW() - INTERVAL '2 weeks'
             AND type = 'update:content:tabcoins'
           ORDER BY
             created_at ASC

--- a/models/content.js
+++ b/models/content.js
@@ -574,7 +574,7 @@ async function creditOrDebitTabCoins(oldContent, newContent, options = {}) {
 
     // We should not credit if the content has little or no value.
     // Expected 5 or more words with 5 or more characters.
-    if (newContent.body.split(/[a-z]{5,}/i).length < 6) return;
+    if (newContent.body.split(/[a-z]{5,}/i, 6).length < 6) return;
   }
 
   if (userEarnings > 0) {

--- a/models/user.js
+++ b/models/user.js
@@ -34,6 +34,7 @@ async function findOneByUsername(username, options = {}) {
           users
         WHERE
           LOWER(username) = LOWER($1)
+          AND NOT 'nuked' = ANY(features)
         LIMIT
           1
       )`;

--- a/pages/interface/components/TabNewsUI/icons/index.js
+++ b/pages/interface/components/TabNewsUI/icons/index.js
@@ -1,5 +1,5 @@
 export { CgTab } from 'react-icons/cg';
-export { FaUser, FaTree } from 'react-icons/fa';
+export { FaPause, FaPlay, FaTree, FaUser } from 'react-icons/fa';
 export {
   ChevronDownIcon,
   ChevronLeftIcon,

--- a/pages/interface/components/TabNewsUI/index.js
+++ b/pages/interface/components/TabNewsUI/index.js
@@ -21,6 +21,7 @@ export { default as ThemeSelector, ThemeSwitcher } from '@/ThemeSelector';
 export {
   ActionList,
   ActionMenu,
+  AnchoredOverlay,
   BaseStyles,
   Box,
   BranchName,

--- a/tests/integration/api/v1/status/votes/get.test.js
+++ b/tests/integration/api/v1/status/votes/get.test.js
@@ -105,6 +105,7 @@ describe('GET /api/v1/status/votes', () => {
       expect(votesData.nodes[1].votes).toEqual(1);
       expect(votesData.edges[0].from).toEqual(votesData.nodes[0].id);
       expect(votesData.edges[0].to).toEqual(votesData.nodes[1].id);
+      expect(votesData.edges[0].id).toEqual(`credit-${votesData.nodes[0].id}-${votesData.nodes[1].id}`);
     });
 
     describe('Same user after losing "read:votes:others" feature', () => {

--- a/tests/integration/api/v1/users/[username]/delete.test.js
+++ b/tests/integration/api/v1/users/[username]/delete.test.js
@@ -454,9 +454,16 @@ describe('DELETE /api/v1/users/[username]', () => {
 
       const secondUserCheck2Body = await secondUserCheck2.json();
 
-      expect(secondUserCheck2Body.tabcoins).toStrictEqual(0);
-      expect(secondUserCheck2Body.tabcash).toStrictEqual(0);
-      expect(secondUserCheck2Body.features).toStrictEqual(['nuked']);
+      expect(secondUserCheck2.status).toEqual(404);
+      expect(secondUserCheck2Body.status_code).toEqual(404);
+      expect(secondUserCheck2Body.name).toEqual('NotFoundError');
+      expect(secondUserCheck2Body.message).toEqual('O "username" informado não foi encontrado no sistema.');
+      expect(secondUserCheck2Body.action).toEqual('Verifique se o "username" está digitado corretamente.');
+      expect(secondUserCheck2Body.status_code).toEqual(404);
+      expect(secondUserCheck2Body.error_location_code).toEqual('MODEL:USER:FIND_ONE_BY_USERNAME:NOT_FOUND');
+      expect(uuidVersion(secondUserCheck2Body.error_id)).toEqual(4);
+      expect(uuidVersion(secondUserCheck2Body.request_id)).toEqual(4);
+      expect(secondUserCheck2Body.key).toEqual('username');
 
       // 14) CHECK FIRST USER ROOT CONTENT (POST-BAN)
       const firstUserRootContentCheck2 = await fetch(
@@ -523,6 +530,38 @@ describe('DELETE /api/v1/users/[username]', () => {
       });
     });
 
+    test('With "ban_type" on a non-existing user', async () => {
+      const firstUser = await orchestrator.createUser();
+      await orchestrator.activateUser(firstUser);
+      const firstUserSession = await orchestrator.createSession(firstUser);
+      await orchestrator.addFeaturesToUser(firstUser, ['ban:user']);
+
+      const nukeResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/users/donotexist`, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+          cookie: `session_id=${firstUserSession.token}`,
+        },
+
+        body: JSON.stringify({
+          ban_type: 'nuke',
+        }),
+      });
+
+      const nukeResponseBody = await nukeResponse.json();
+
+      expect(nukeResponse.status).toEqual(404);
+      expect(nukeResponseBody.status_code).toEqual(404);
+      expect(nukeResponseBody.name).toEqual('NotFoundError');
+      expect(nukeResponseBody.message).toEqual('O "username" informado não foi encontrado no sistema.');
+      expect(nukeResponseBody.action).toEqual('Verifique se o "username" está digitado corretamente.');
+      expect(nukeResponseBody.status_code).toEqual(404);
+      expect(nukeResponseBody.error_location_code).toEqual('MODEL:USER:FIND_ONE_BY_USERNAME:NOT_FOUND');
+      expect(uuidVersion(nukeResponseBody.error_id)).toEqual(4);
+      expect(uuidVersion(nukeResponseBody.request_id)).toEqual(4);
+      expect(nukeResponseBody.key).toEqual('username');
+    });
+
     test('With "ban_type" on an user with "nuked" feature', async () => {
       const firstUser = await orchestrator.createUser();
       await orchestrator.activateUser(firstUser);
@@ -574,17 +613,16 @@ describe('DELETE /api/v1/users/[username]', () => {
 
       const nuke2ResponseBody = await nuke2Response.json();
 
-      expect(nuke2Response.status).toStrictEqual(422);
-
-      expect(nuke2ResponseBody).toStrictEqual({
-        name: 'UnprocessableEntityError',
-        message: 'Este usuário já está banido permanentemente.',
-        action: 'Verifique se você está tentando banir permanentemente o usuário correto.',
-        status_code: 422,
-        error_id: nuke2ResponseBody.error_id,
-        request_id: nuke2ResponseBody.request_id,
-        error_location_code: 'CONTROLLER:USERS:USERNAME:DELETE:USER_ALREADY_NUKED',
-      });
+      expect(nuke2Response.status).toEqual(404);
+      expect(nuke2ResponseBody.status_code).toEqual(404);
+      expect(nuke2ResponseBody.name).toEqual('NotFoundError');
+      expect(nuke2ResponseBody.message).toEqual('O "username" informado não foi encontrado no sistema.');
+      expect(nuke2ResponseBody.action).toEqual('Verifique se o "username" está digitado corretamente.');
+      expect(nuke2ResponseBody.status_code).toEqual(404);
+      expect(nuke2ResponseBody.error_location_code).toEqual('MODEL:USER:FIND_ONE_BY_USERNAME:NOT_FOUND');
+      expect(uuidVersion(nuke2ResponseBody.error_id)).toEqual(4);
+      expect(uuidVersion(nuke2ResponseBody.request_id)).toEqual(4);
+      expect(nuke2ResponseBody.key).toEqual('username');
     });
   });
 });

--- a/tests/integration/api/v1/users/[username]/delete.test.js
+++ b/tests/integration/api/v1/users/[username]/delete.test.js
@@ -426,8 +426,6 @@ describe('DELETE /api/v1/users/[username]', () => {
         username: secondUser.username,
         description: secondUser.description,
         features: ['nuked'],
-        tabcoins: 0,
-        tabcash: 0,
         created_at: secondUser.created_at.toISOString(),
         updated_at: nukeResponseBody.updated_at,
       });
@@ -593,8 +591,6 @@ describe('DELETE /api/v1/users/[username]', () => {
         username: secondUser.username,
         description: secondUser.description,
         features: ['nuked'],
-        tabcoins: 0,
-        tabcash: 0,
         created_at: secondUser.created_at.toISOString(),
         updated_at: nuke1ResponseBody.updated_at,
       });

--- a/tests/integration/api/v1/users/[username]/get.test.js
+++ b/tests/integration/api/v1/users/[username]/get.test.js
@@ -133,5 +133,26 @@ describe('GET /api/v1/users/[username]', () => {
       expect(responseBody).not.toHaveProperty('password');
       expect(responseBody).not.toHaveProperty('email');
     });
+
+    test('Retrieving nuked user', async () => {
+      const userCreated = await orchestrator.createUser({ username: 'nukedUser' });
+
+      await orchestrator.addFeaturesToUser(userCreated, ['nuked']);
+
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/nukedUser`);
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(404);
+      expect(responseBody.status_code).toEqual(404);
+      expect(responseBody.name).toEqual('NotFoundError');
+      expect(responseBody.message).toEqual('O "username" informado não foi encontrado no sistema.');
+      expect(responseBody.action).toEqual('Verifique se o "username" está digitado corretamente.');
+      expect(responseBody.status_code).toEqual(404);
+      expect(responseBody.error_location_code).toEqual('MODEL:USER:FIND_ONE_BY_USERNAME:NOT_FOUND');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.key).toEqual('username');
+    });
   });
 });


### PR DESCRIPTION
### Banimento de usuários

90040db847e9b6c96c9fb2408939580a838c4055 Não diferenciar os usuários banidos de usuários inexistentes

Antes | Depois
--- | ---
![image](https://github.com/filipedeschamps/tabnews.com.br/assets/77860630/5182c5cb-103a-45c0-8912-25fb26be3336) | ![image](https://github.com/filipedeschamps/tabnews.com.br/assets/77860630/a1e7d2c0-c713-4e87-91ff-6898679c321e)
![image](https://github.com/filipedeschamps/tabnews.com.br/assets/77860630/313e6639-8546-4b63-8aee-47c3f4e3f8d9) | ![image](https://github.com/filipedeschamps/tabnews.com.br/assets/77860630/e79adcd2-fa54-4d60-bb3c-d7d0c4645f4c)

327a1b754a8a7eb047df3f2dc2f2f98fbad81df9 Exclui todos conteúdos publicados com uma única ida ao banco de dados.

620233c69a3dfdad57d1c439c29b81e343641329 Como o saldo final do usuário banido não fica mais disponível, não há necessidade de desfazer todos as transações, então com esse commit só são desfeitas as qualificações.

0f59053e6b5d88307093db86dd60abbb272f1b17 Para reduzir impactos nos saldos de usuários sem envolvimento com o usuário banido, agora só são desfeitas as qualificações que o usuário realizou nas últimas duas semanas.

--- 

### Grafo de qualificações

cda3a10f583ce8221cd4f66445b1f28ff5766bcb, d390a3ff99556d6306d06c2db11286c2729f798c e 248ad6cdc9dc440c6c7726c64a77eab2d81a0d83:


- Agora é possível parar e reiniciar a simulação física. 
![image](https://github.com/filipedeschamps/tabnews.com.br/assets/77860630/519d6d87-3763-45ba-bde7-e5cbe2a2866e) ![image](https://github.com/filipedeschamps/tabnews.com.br/assets/77860630/d64f8407-ce3b-4a32-92fc-69e0b5de5bd7)
- A simulação não inicia mais automaticamente com o hover, mas apenas ao mover os nós ou redimensionar. Nesses casos, a simulação para novamente se o usuário já tiver pausado manualmente antes.
- Criado o menu de filtros do grafo, que irá aparecer apenas para moderadores, onde é possível selecionar os tipos e quantidades de nós e arestas que serão mostrados:

![image](https://github.com/filipedeschamps/tabnews.com.br/assets/77860630/3341c96a-b342-45aa-999c-780dddd12ee2)

- Foram melhoradas as mensagens de status que aparecem ao selecionar ou passar o mouse sobre os nós e arestas.

---

### Outros gráficos da página de status

14f0c674c8b81467e1e299c53db1f51a7f5b8350 Corrige os gráficos para mostrar os dados sempre em ordem crescente de data.

Os gráficos nem sempre mostravam os dados em ordem correta, pois não havia nenhuma classificação dos dados por data. Exemplo fora de ordem:

![image](https://github.com/filipedeschamps/tabnews.com.br/assets/77860630/bbef93a7-720e-4560-92b9-7f0ec8fa7a30)

---

### Apenas aproveitando o PR

- 06473dd5f3ec2cf753a33f204cfc8c69da11344a faz um ajuste de performance adicionando um limite no `split` que estima a quantidade de palavras na publicação, pois não é necessário dividir o texto mais do que 5 vezes.