### PR TITLE
Adiciona o recurso de copiar código para a área de transferência

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@bytemd/plugin-math": "1.21.0",
         "@bytemd/plugin-mermaid": "1.21.0",
         "@bytemd/react": "1.21.0",
+        "@primer/octicons": "19.8.0",
         "@primer/octicons-react": "18.3.0",
         "@primer/react": "35.25.1",
         "@resvg/resvg-js": "2.4.1",
@@ -1952,6 +1953,14 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@primer/behaviors/-/behaviors-1.3.3.tgz",
       "integrity": "sha512-iHMRuu8YWDJIdqCi1krx0cyFNeqszNKTOb0dXFu2wQ5BeIqxqPJLD7rjZ2Vjf/+YaPSbWuIQE1H6TaGMMsDfdA=="
+    },
+    "node_modules/@primer/octicons": {
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@primer/octicons/-/octicons-19.8.0.tgz",
+      "integrity": "sha512-Imze/fyW41Io5fN+27T5EAeXJrgBjMbz6nzU+wYbRylXvIAjLPUvaJPVoStiFlgSU+TjTUJqg5A9rgMDzTyMCg==",
+      "dependencies": {
+        "object-assign": "^4.1.1"
+      }
     },
     "node_modules/@primer/octicons-react": {
       "version": "18.3.0",
@@ -15226,6 +15235,14 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@primer/behaviors/-/behaviors-1.3.3.tgz",
       "integrity": "sha512-iHMRuu8YWDJIdqCi1krx0cyFNeqszNKTOb0dXFu2wQ5BeIqxqPJLD7rjZ2Vjf/+YaPSbWuIQE1H6TaGMMsDfdA=="
+    },
+    "@primer/octicons": {
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@primer/octicons/-/octicons-19.8.0.tgz",
+      "integrity": "sha512-Imze/fyW41Io5fN+27T5EAeXJrgBjMbz6nzU+wYbRylXvIAjLPUvaJPVoStiFlgSU+TjTUJqg5A9rgMDzTyMCg==",
+      "requires": {
+        "object-assign": "^4.1.1"
+      }
     },
     "@primer/octicons-react": {
       "version": "18.3.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@bytemd/plugin-math": "1.21.0",
     "@bytemd/plugin-mermaid": "1.21.0",
     "@bytemd/react": "1.21.0",
+    "@primer/octicons": "19.8.0",
     "@primer/octicons-react": "18.3.0",
     "@primer/react": "35.25.1",
     "@resvg/resvg-js": "2.4.1",

--- a/pages/interface/components/Markdown/index.js
+++ b/pages/interface/components/Markdown/index.js
@@ -14,6 +14,8 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { Box, EditorColors, EditorStyles, useTheme } from '@/TabNewsUI';
 
+import { copyCodeToClipboardPlugin } from './plugins/copy-code-to-clipboard';
+
 const bytemdPluginBaseList = [
   gfmPlugin({ locale: gfmLocale }),
   highlightSsrPlugin(),
@@ -23,6 +25,7 @@ const bytemdPluginBaseList = [
   }),
   breaksPlugin(),
   gemojiPlugin(),
+  copyCodeToClipboardPlugin(),
 ];
 
 function usePlugins() {

--- a/pages/interface/components/Markdown/plugins/copy-code-to-clipboard.js
+++ b/pages/interface/components/Markdown/plugins/copy-code-to-clipboard.js
@@ -1,0 +1,108 @@
+import { check, copy } from '@primer/octicons';
+
+/**
+ * @returns {import('@bytemd/react').ViewerProps['plugins'][0]}
+ */
+
+export function copyCodeToClipboardPlugin() {
+  function createCopyButton(parentElement, contentToCopy) {
+    const buttonElement = createButtonElement();
+
+    buttonElement.onclick = async () => {
+      await navigator.clipboard.writeText(contentToCopy);
+      setStateAfterCopy(buttonElement);
+      setTimeout(() => setStateBeforeCopy(buttonElement), 2000);
+    };
+
+    return parentElement.appendChild(buttonElement);
+
+    function createButtonElement() {
+      const buttonElement = document.createElement('button');
+
+      buttonElement.setAttribute('type', 'button');
+      setStyleProperties(buttonElement, {
+        width: '32px',
+        height: '32px',
+        display: 'grid',
+        'place-content': 'center',
+        'background-color': 'transparent',
+        cursor: 'pointer',
+        'border-radius': '6px',
+        transition: '0.2s ease-in-out',
+        'transition-property': 'color, background-color, border-color',
+      });
+      setStateBeforeCopy(buttonElement);
+      buttonElement.classList.add('copy-button');
+
+      return buttonElement;
+    }
+
+    function setStateBeforeCopy(buttonElement) {
+      setAttributes(buttonElement, {
+        title: 'Copiar',
+        'aria-label': 'Copiar',
+      });
+      setStyleProperties(buttonElement, {
+        'pointer-events': 'auto',
+      });
+      buttonElement.innerHTML = copy.toSVG();
+      buttonElement.classList.remove('copied');
+    }
+
+    function setStateAfterCopy(buttonElement) {
+      setAttributes(buttonElement, {
+        title: 'Copiado',
+        'aria-label': 'Copiado',
+      });
+      setStyleProperties(buttonElement, {
+        'pointer-events': 'none',
+      });
+      buttonElement.innerHTML = check.toSVG();
+      buttonElement.classList.add('copied');
+    }
+
+    function setAttributes(buttonElement, attributes) {
+      for (const attribute in attributes) {
+        buttonElement.setAttribute(attribute, attributes[attribute]);
+      }
+    }
+  }
+
+  function setStyleProperties(element, styleProperties) {
+    for (const styleProperty in styleProperties) {
+      element.style.setProperty(styleProperty, styleProperties[styleProperty]);
+    }
+  }
+
+  return {
+    viewerEffect({ markdownBody }) {
+      if (!navigator.clipboard) return;
+
+      const codeElements = markdownBody.querySelectorAll('pre > code');
+
+      if (codeElements.length === 0) return;
+
+      codeElements.forEach((codeElement) => {
+        if (!codeElement.innerHTML) return;
+
+        const pre = codeElement.parentElement;
+        const codeToCopy = codeElement.innerText;
+
+        const externalDivElement = document.createElement('div');
+        setStyleProperties(externalDivElement, {
+          position: 'relative',
+          top: '-6px',
+          right: '-6px',
+          'min-width': '32px',
+        });
+        pre.appendChild(externalDivElement);
+
+        const internalDivElement = document.createElement('div');
+        internalDivElement.style.position = 'absolute';
+        externalDivElement.appendChild(internalDivElement);
+
+        createCopyButton(internalDivElement, codeToCopy);
+      });
+    },
+  };
+}

--- a/pages/interface/components/Markdown/styles/index.js
+++ b/pages/interface/components/Markdown/styles/index.js
@@ -1803,6 +1803,9 @@ export function ViewerStyles() {
           line-height: 1.45;
           background-color: ${colors.canvas.subtle};
           border-radius: 6px;
+          display: flex;
+          justify-content: space-between;
+          gap: 4px;
         }
         .markdown-body .math {
           overflow: auto;
@@ -1912,6 +1915,22 @@ export function ViewerStyles() {
 
         .markdown-body ::-webkit-calendar-picker-indicator {
           filter: invert(50%);
+        }
+
+        .copy-button {
+          border: 1px solid ${colors.btn.border} !important;
+          color: ${colors.fg.muted} !important;
+        }
+
+        .copy-button:hover {
+          border-color: ${colors.btn.fg} !important;
+          background-color: ${colors.btn.hoverBg} !important;
+        }
+
+        .copy-button.copied {
+          border-color: ${colors.success.fg} !important;
+          background-color: ${colors.btn.hoverBg} !important;
+          color: ${colors.success.fg} !important;
         }
       `}
     </style>


### PR DESCRIPTION
Esta PR adiciona o recurso de copiar código para a área de transferência, `copy code to clipboard`. Em resumo, foi criado um plugin para o `bytemd`, chamado `copyCodeToClipboardPlugin` e ele foi adicionado no fim da lista de plugins, aqui:

https://github.com/filipedeschamps/tabnews.com.br/blob/ad30e20a3bffc84aadc15c3b3bcecd753627acb3/pages/interface/components/Markdown/index.js#L17

## Issue relacionada
- Segue a issue relacionada que esta PR resolve #1422

## Preview
![preview-light-mode](https://github.com/filipedeschamps/tabnews.com.br/assets/57193392/413d8841-6432-4f7f-b1c4-19ec195fa5e5)

![preview-dark-mode](https://github.com/filipedeschamps/tabnews.com.br/assets/57193392/115973dd-c1a1-4197-9f7e-52ecbddbb1e1)

