### PR TITLE
feat(captcha): Implement captcha on frontend and on api

### DIFF
--- a/infra/migrations/1698968536361_create-captcha-table.js
+++ b/infra/migrations/1698968536361_create-captcha-table.js
@@ -1,42 +1,42 @@
 /* eslint-disable camelcase */
 
 exports.up = (pgm) => {
-    pgm.createTable('captchas', {
-        id: {
-          type: 'uuid',
-          default: pgm.func('gen_random_uuid()'),
-          notNull: true,
-          primaryKey: true,
-        },
-        
-        token: {
-          type: 'varchar(60)',
-          notNull: true,
-        },
-    
-        expires_at: {
-          type: 'timestamp with time zone',
-          notNull: true,
-        },
+  pgm.createTable('captchas', {
+    id: {
+      type: 'uuid',
+      default: pgm.func('gen_random_uuid()'),
+      notNull: true,
+      primaryKey: true,
+    },
 
-        used: {
-          type: 'boolean',
-          notNull: true,
-          default: false,
-        },
-    
-        created_at: {
-          type: 'timestamp with time zone',
-          notNull: true,
-          default: pgm.func("(now() at time zone 'utc')"),
-        },
-    
-        updated_at: {
-          type: 'timestamp with time zone',
-          notNull: true,
-          default: pgm.func("(now() at time zone 'utc')"),
-        },
-      });
+    token: {
+      type: 'varchar(60)',
+      notNull: true,
+    },
+
+    expires_at: {
+      type: 'timestamp with time zone',
+      notNull: true,
+    },
+
+    used: {
+      type: 'boolean',
+      notNull: true,
+      default: false,
+    },
+
+    created_at: {
+      type: 'timestamp with time zone',
+      notNull: true,
+      default: pgm.func("(now() at time zone 'utc')"),
+    },
+
+    updated_at: {
+      type: 'timestamp with time zone',
+      notNull: true,
+      default: pgm.func("(now() at time zone 'utc')"),
+    },
+  });
 };
 
 exports.down = (pgm) => {

--- a/infra/migrations/1698968536361_create-captcha-table.js
+++ b/infra/migrations/1698968536361_create-captcha-table.js
@@ -1,0 +1,44 @@
+/* eslint-disable camelcase */
+
+exports.up = (pgm) => {
+    pgm.createTable('captchas', {
+        id: {
+          type: 'uuid',
+          default: pgm.func('gen_random_uuid()'),
+          notNull: true,
+          primaryKey: true,
+        },
+        
+        token: {
+          type: 'varchar(60)',
+          notNull: true,
+        },
+    
+        expires_at: {
+          type: 'timestamp with time zone',
+          notNull: true,
+        },
+
+        used: {
+          type: 'boolean',
+          notNull: true,
+          default: false,
+        },
+    
+        created_at: {
+          type: 'timestamp with time zone',
+          notNull: true,
+          default: pgm.func("(now() at time zone 'utc')"),
+        },
+    
+        updated_at: {
+          type: 'timestamp with time zone',
+          notNull: true,
+          default: pgm.func("(now() at time zone 'utc')"),
+        },
+      });
+};
+
+exports.down = (pgm) => {
+  pgm.dropTable('captchas');
+};

--- a/infra/rate-limit.js
+++ b/infra/rate-limit.js
@@ -92,6 +92,10 @@ function getLimit(method, path, ip) {
       requests: 50,
       window: '30 m',
     },
+    'POST /api/v1/sessions/captcha': {
+      requests: 50,
+      window: '30 m',
+    },
     'POST /api/v1/users': {
       requests: 50,
       window: '30 m',

--- a/models/authorization.js
+++ b/models/authorization.js
@@ -76,6 +76,8 @@ function filterInput(user, feature, input) {
     filteredInputValues = {
       email: input.email,
       password: input.password,
+      captcha_id: input.captcha_id,
+      captcha: input.captcha,
     };
   }
 

--- a/models/captcha.js
+++ b/models/captcha.js
@@ -100,16 +100,12 @@ async function validate(captchaToken, captchaId, options = {}) {
             id = $1
             AND token = $2
             AND used = false
-            AND expires_at <= now()
-          RETURNING
-            *
           ;`,
     values: [captchaId, captchaToken],
   };
 
   const results = await database.query(query, options);
-  const isAnValidCaptcha = Boolean(results.rows.length);
-
+  const isAnValidCaptcha = Boolean(results.rows.length && new Date(results.rows[0].expiresAt < new Date()));
   if (!isAnValidCaptcha) return false;
 
   const updateCaptchaQuery = {

--- a/models/captcha.js
+++ b/models/captcha.js
@@ -1,0 +1,132 @@
+//import { UnauthorizedError } from 'errors';
+import database from 'infra/database.js';
+//import cacheControl from 'models/cache-control';
+//import validator from 'models/validator.js';
+
+const TOKEN_EXPIRATION_IN_SECONDS = 60 * 10; // 10 minutes
+
+const unmountedTokenSet = new Set([
+  'programacao',
+  'desenvolvimento',
+  'linguagens',
+  'inteligencia',
+  'artificial',
+  'codigo',
+  'computacao',
+  'ciber',
+  'seguranca',
+  'iot',
+  'cloud',
+  'computing',
+  'bigdata',
+  'redes',
+  'web',
+  'aplicativos',
+  'blockchain',
+  'machine',
+  'learning',
+  'data',
+  'science',
+  'frontend',
+  'backend',
+  'seguranca',
+  'api',
+  'framework',
+  'algoritmo',
+  'java',
+  'javascript',
+  'python',
+  'cpp',
+  'html',
+  'css',
+  'php',
+  'ruby',
+  'swift',
+  'go',
+  'rust',
+  'sql',
+  'nodejs',
+  'react',
+  'vuejs',
+  'angular',
+  'git',
+  'devops',
+  'open',
+  'source',
+  'maquina',
+  'virtual',
+  'compilacao',
+  'depuracao',
+  'hacker',
+  'ciclodevida',
+  'repositorio',
+  'ide',
+  'api',
+  'rest',
+]);
+
+function createRandomToken() {
+  const randomSortedUnmountedTokens = unmountedTokenSet.sort(() => Math.random() - 0.5);
+  const mountedToken = randomSortedUnmountedTokens.slice(0, 2).join(' ');
+
+  return mountedToken;
+}
+
+async function create() {
+  const captchaToken = createRandomToken();
+  const expiresAt = new Date(Date.now() + 1000 * TOKEN_EXPIRATION_IN_SECONDS);
+
+  const query = {
+    text: `INSERT INTO captchas (token, expires_at)
+               VALUES($1, $2) RETURNING *;`,
+    values: [captchaToken, expiresAt],
+  };
+
+  const results = await database.query(query);
+  return results.rows[0];
+}
+
+async function validate(captchaToken, captchaId, options = {}) {
+  const query = {
+    text: `
+          SELECT
+            *
+          FROM
+            captchas
+          WHERE
+            id = $1
+            AND token = $2
+            AND used = false
+            AND expires_at <= now()
+          RETURNING
+            *
+          ;`,
+    values: [captchaId, captchaToken],
+  };
+
+  const results = await database.query(query, options);
+  const isAnValidCaptcha = Boolean(results.rows.length);
+
+  if(!isAnValidCaptcha) return false;
+
+  const updateCaptchaQuery = {
+    text: `
+          UPDATE 
+            captchas
+          SET 
+            used = true
+          WHERE 
+            id = $1
+          ;`,
+    values: [captchaId],
+  };
+
+  await database.query(updateCaptchaQuery, options);
+
+  return true;
+}
+
+export default Object.freeze({
+  create,
+  validate,
+});

--- a/models/validator.js
+++ b/models/validator.js
@@ -800,6 +800,40 @@ const schemas = {
         }),
     });
   },
+
+  captcha_id: function () {
+    return Joi.object({
+      captcha_id: Joi.string()
+        .trim()
+        .guid({ version: 'uuidv4' })
+        .when('$required.captcha_id', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
+        .messages({
+          'any.required': `"captcha_id" é um campo obrigatório.`,
+          'string.empty': `"captcha_id" não pode estar em branco.`,
+          'string.base': `"captcha_id" deve ser do tipo String.`,
+          'string.guid': `"captcha_id" deve possuir um token UUID na versão 4.`,
+        }),
+    });
+  },
+
+  captcha: function () {
+    return Joi.object({
+      captcha: Joi.string()
+        .min(0)
+        .max(60)
+        .trim()
+        .invalid(null)
+        .when('$required.captcha', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
+        .messages({
+          'any.required': `"captcha" é um campo obrigatório.`,
+          'string.empty': `"captcha" não pode estar em branco.`,
+          'string.base': `"captcha" deve ser do tipo String.`,
+          'string.min': `"captcha" deve conter no mínimo {#limit} caracteres.`,
+          'string.max': `"captcha" deve conter no máximo {#limit} caracteres.`,
+          'any.invalid': `"captcha" possui o valor inválido "null".`,
+        }),
+    });
+  },
 };
 
 const withoutMarkdown = (value, helpers) => {

--- a/pages/api/v1/sessions/captcha/index.public.js
+++ b/pages/api/v1/sessions/captcha/index.public.js
@@ -20,6 +20,6 @@ async function postHandler(request, response) {
 
   return response.status(200).json({
     id: captchaData.id,
-    image: captchaPng.toString('base64'),
+    image: `data:image/png;base64,${captchaPng.toString('base64')}`,
   });
 }

--- a/pages/api/v1/sessions/captcha/index.public.js
+++ b/pages/api/v1/sessions/captcha/index.public.js
@@ -1,0 +1,25 @@
+import nextConnect from 'next-connect';
+
+import cacheControl from 'models/cache-control';
+import captcha from 'models/captcha';
+import controller from 'models/controller.js';
+
+export default nextConnect({
+  attachParams: true,
+  onNoMatch: controller.onNoMatchHandler,
+  onError: controller.onErrorHandler,
+})
+  .use(controller.injectRequestMetadata)
+  .use(controller.logRequest)
+  .use(cacheControl.noCache)
+  .post(postHandler);
+
+async function postHandler(request, response) {
+  const captchaData = await captcha.create();
+  const captchaPng = await captcha.asPng(captchaData.token);
+
+  return response.status(200).json({
+    id: captchaData.id,
+    image: captchaPng.toString('base64'),
+  });
+}

--- a/tests/integration/api/v1/_use-cases/registration-flow.test.js
+++ b/tests/integration/api/v1/_use-cases/registration-flow.test.js
@@ -103,6 +103,8 @@ describe('Use case: Registration Flow (all successfully)', () => {
   });
 
   test('Login (successfully)', async () => {
+    const validCaptcha = await orchestrator.createCaptcha();
+
     const postSessionResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/sessions`, {
       method: 'post',
       headers: {
@@ -111,6 +113,8 @@ describe('Use case: Registration Flow (all successfully)', () => {
       body: JSON.stringify({
         email: 'RegularRegistrationFlow@gmail.com',
         password: 'RegularRegistrationFlowPassword',
+        captcha_id: validCaptcha.id,
+        captcha: validCaptcha.token,
       }),
     });
 

--- a/tests/integration/api/v1/sessions/captcha/post.test.js
+++ b/tests/integration/api/v1/sessions/captcha/post.test.js
@@ -1,0 +1,32 @@
+import fetch from 'cross-fetch';
+import { version as uuidVersion } from 'uuid';
+
+import orchestrator from 'tests/orchestrator.js';
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.dropAllTables();
+  await orchestrator.runPendingMigrations();
+});
+
+describe('POST /api/v1/sessions/captcha', () => {
+  describe('Anonymous User', () => {
+    test('Request a captcha', async () => {
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/sessions/captcha`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({}),
+      });
+
+      const responseBody = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(uuidVersion(responseBody.id)).toEqual(4);
+      expect(responseBody).toHaveProperty('image');
+      expect(responseBody.image).toMatch(/^data:image\//);
+      expect(typeof responseBody.image).toBe('string');
+    });
+  });
+});

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -8,6 +8,7 @@ import migrator from 'infra/migrator.js';
 import webserver from 'infra/webserver.js';
 import activation from 'models/activation.js';
 import balance from 'models/balance.js';
+import captcha from 'models/captcha.js';
 import content from 'models/content.js';
 import event from 'models/event.js';
 import recovery from 'models/recovery.js';
@@ -345,6 +346,11 @@ async function updateRewardedAt(userId, rewardedAt) {
   return await database.query(query);
 }
 
+async function createCaptcha() {
+  const captchaData = await captcha.create();
+  return captchaData;
+}
+
 const orchestrator = {
   waitForAllServices,
   dropAllTables,
@@ -366,6 +372,7 @@ const orchestrator = {
   createPrestige,
   createRate,
   updateRewardedAt,
+  createCaptcha,
 };
 
 export default orchestrator;


### PR DESCRIPTION
Conforme descrito na [Issue 1170](https://github.com/filipedeschamps/tabnews.com.br/issues/1170) e na [Milestone 7](https://github.com/filipedeschamps/tabnews.com.br/issues/1490), este pull traz a implementação de um captcha tanto para o frontend, quanto para a API seguindo o principio de implementação de @rodrigoKulb .

Foi criado um novo endpoint na api em /sessions/captcha, que retorna um json contendo id e image, que contém uma imagem em base64.

O endpoint sessions foi alterado e agora recebe mais argumentos além de senha e email, sendo eles captcha_id(o id vindo do captcha no endpoint), e captcha, sendo o token contido na imagem base64.

Os captchas podem ser usados apenas uma vez, e tem uma expiração de 10 minutos, com um rate-limit de 50 a cada 30 minutos.

Testes foram atualizados, e alguns novos adicionados, mas acredito que alguns novos precisam ser escritos para aumentar a cobertura da feature.

para quem usa a api, para criar a sessão agora precisará pedir um captcha ao sessions/captcha, e informar os dados na hora de criar a sessão. Para a aplicação web, isso é feito de modo 'automatico' usando getServerSideProps.

**ESTE PULL TRAZ BREAKING FEATURES.**