### PR TITLE
Feedback ao editar perfil

### DIFF
--- a/pages/interface/hooks/useUser/index.js
+++ b/pages/interface/hooks/useUser/index.js
@@ -12,8 +12,8 @@ const UserContext = createContext({
   user: null,
   isLoading: true,
   error: undefined,
-  fetchUser: () => {},
-  logout: () => {},
+  fetchUser: async () => {},
+  logout: async () => {},
 });
 
 export function UserProvider({ children }) {

--- a/pages/perfil/index.public.js
+++ b/pages/perfil/index.public.js
@@ -37,7 +37,6 @@ function EditProfileForm() {
   const usernameRef = useRef('');
   const emailRef = useRef('');
   const notificationsRef = useRef('');
-  const successTimeoutRef = useRef('');
 
   useEffect(() => {
     if (router && !user && !userIsLoading) {
@@ -55,15 +54,15 @@ function EditProfileForm() {
     fetchUser();
   }, [fetchUser]);
 
-  const [globalErrorMessage, setGlobalErrorMessage] = useState(false);
-  const [globalSuccessMessage, setGlobalSuccessMessage] = useState(null);
+  const [globalMessageObject, setGlobalMessageObject] = useState(undefined);
   const [isLoading, setIsLoading] = useState(false);
   const [errorObject, setErrorObject] = useState(undefined);
   const [emailDisabled, setEmailDisabled] = useState(false);
   const [description, setDescription] = useState(user?.description || '');
 
-  function clearErrors() {
+  function clearMessages() {
     setErrorObject(undefined);
+    setGlobalMessageObject(undefined);
   }
 
   async function handleSubmit(event) {
@@ -120,6 +119,10 @@ function EditProfileForm() {
     }
 
     if (Object.keys(payload).length === 0) {
+      setGlobalMessageObject({
+        type: 'warning',
+        text: 'Nenhuma configuração foi alterada',
+      });
       setIsLoading(false);
       return;
     }
@@ -134,8 +137,6 @@ function EditProfileForm() {
         body: JSON.stringify(payload),
       });
 
-      setGlobalErrorMessage(undefined);
-
       const responseBody = await response.json();
 
       if (response.status === 200) {
@@ -149,13 +150,10 @@ function EditProfileForm() {
           });
           setEmailDisabled(true);
         } else {
-          clearTimeout(successTimeoutRef.current);
-
-          setGlobalSuccessMessage('Salvo com sucesso!');
-
-          successTimeoutRef.current = setTimeout(() => {
-            setGlobalSuccessMessage(null);
-          }, 5000);
+          setGlobalMessageObject({
+            type: 'success',
+            text: 'Salvo com sucesso!',
+          });
         }
 
         setIsLoading(false);
@@ -169,28 +167,29 @@ function EditProfileForm() {
       }
 
       if (response.status >= 403) {
-        setGlobalErrorMessage(`${responseBody.message} Informe ao suporte este valor: ${responseBody.error_id}`);
+        setGlobalMessageObject({
+          type: 'danger',
+          text: `${responseBody.message} Informe ao suporte este valor: ${responseBody.error_id}`,
+        });
         setIsLoading(false);
         return;
       }
     } catch (error) {
-      setGlobalErrorMessage('Não foi possível se conectar ao TabNews. Por favor, verifique sua conexão.');
+      setGlobalMessageObject({
+        type: 'danger',
+        text: 'Não foi possível se conectar ao TabNews. Por favor, verifique sua conexão.',
+      });
       setIsLoading(false);
     }
   }
 
   return (
-    <form style={{ width: '100%' }} onSubmit={handleSubmit}>
+    <form style={{ width: '100%' }} onSubmit={handleSubmit} onChange={clearMessages}>
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
-        {globalErrorMessage && <Flash variant="danger">{globalErrorMessage}</Flash>}
-
-        {globalSuccessMessage && <Flash variant="success">{globalSuccessMessage}</Flash>}
-
         <FormControl id="username">
           <FormControl.Label>Nome de usuário</FormControl.Label>
           <TextInput
             ref={usernameRef}
-            onChange={clearErrors}
             name="username"
             size="large"
             autoCorrect="off"
@@ -214,7 +213,6 @@ function EditProfileForm() {
           <FormControl.Label>Email</FormControl.Label>
           <TextInput
             ref={emailRef}
-            onChange={clearErrors}
             name="email"
             size="large"
             autoCorrect="off"
@@ -239,7 +237,7 @@ function EditProfileForm() {
                     sx={{ p: 1 }}
                     onClick={(event) => {
                       event.preventDefault();
-                      clearErrors();
+                      clearMessages();
                       emailRef.current.value = errorObject.suggestion;
                     }}>
                     {errorObject.suggestion.split('@')[0]}@<u>{errorObject.suggestion.split('@')[1]}</u>
@@ -259,7 +257,7 @@ function EditProfileForm() {
 
           <Editor
             onChange={(value) => {
-              clearErrors();
+              clearMessages();
               setDescription(value);
             }}
             value={description}
@@ -278,7 +276,6 @@ function EditProfileForm() {
           <Checkbox
             sx={{ display: 'flex' }}
             ref={notificationsRef}
-            onChange={clearErrors}
             name="notifications"
             aria-label="Você deseja receber notificações?"
           />
@@ -294,6 +291,8 @@ function EditProfileForm() {
             Utilize o fluxo de recuperação de senha →
           </Link>
         </FormControl>
+
+        {globalMessageObject && <Flash variant={globalMessageObject.type}>{globalMessageObject.text}</Flash>}
 
         <FormControl>
           <FormControl.Label visuallyHidden>Salvar</FormControl.Label>

--- a/pages/perfil/index.public.js
+++ b/pages/perfil/index.public.js
@@ -75,19 +75,6 @@ function EditProfileForm() {
     setIsLoading(true);
     setErrorObject(undefined);
 
-    const suggestedEmail = suggestEmail(email);
-
-    if (suggestedEmail) {
-      setErrorObject({
-        suggestion: suggestedEmail,
-        key: 'email',
-        type: 'typo',
-      });
-
-      setIsLoading(false);
-      return;
-    }
-
     const payload = {};
 
     if (user.username !== username) {
@@ -107,6 +94,19 @@ function EditProfileForm() {
     }
 
     if (user.email !== email) {
+      const suggestedEmail = suggestEmail(email);
+
+      if (suggestedEmail) {
+        setErrorObject({
+          suggestion: suggestedEmail,
+          key: 'email',
+          type: 'typo',
+        });
+
+        setIsLoading(false);
+        return;
+      }
+
       payload.email = email;
     }
 

--- a/pages/perfil/index.public.js
+++ b/pages/perfil/index.public.js
@@ -37,6 +37,7 @@ function EditProfileForm() {
   const usernameRef = useRef('');
   const emailRef = useRef('');
   const notificationsRef = useRef('');
+  const successTimeoutRef = useRef('');
 
   useEffect(() => {
     if (router && !user && !userIsLoading) {
@@ -55,6 +56,7 @@ function EditProfileForm() {
   }, [fetchUser]);
 
   const [globalErrorMessage, setGlobalErrorMessage] = useState(false);
+  const [globalSuccessMessage, setGlobalSuccessMessage] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
   const [errorObject, setErrorObject] = useState(undefined);
   const [emailDisabled, setEmailDisabled] = useState(false);
@@ -146,6 +148,14 @@ function EditProfileForm() {
             type: 'confirmation',
           });
           setEmailDisabled(true);
+        } else {
+          clearTimeout(successTimeoutRef.current);
+
+          setGlobalSuccessMessage('Salvo com sucesso!');
+
+          successTimeoutRef.current = setTimeout(() => {
+            setGlobalSuccessMessage(null);
+          }, 5000);
         }
 
         setIsLoading(false);
@@ -173,6 +183,8 @@ function EditProfileForm() {
     <form style={{ width: '100%' }} onSubmit={handleSubmit}>
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
         {globalErrorMessage && <Flash variant="danger">{globalErrorMessage}</Flash>}
+
+        {globalSuccessMessage && <Flash variant="success">{globalSuccessMessage}</Flash>}
 
         <FormControl id="username">
           <FormControl.Label>Nome de usuário</FormControl.Label>


### PR DESCRIPTION
Continuando o trabalho do @viniciusamc nos PRs #1543 e #1545, foi adicionado um feedback também quando o botão de salvar é pressionado sem existir nenhuma alteração de configuração.

![image](https://github.com/filipedeschamps/tabnews.com.br/assets/77860630/64b4ea4c-2c09-4848-a3e4-d02321c39264)

A mensagem global foi reposicionada para logo acima do botão e o timer foi retirado para ela permanecer visível enquanto não forem realizadas novas alterações no formulário.

![image](https://github.com/filipedeschamps/tabnews.com.br/assets/77860630/00d2df85-45c9-4144-9a93-ac60d8c160ab)

Foi refatorada a verificação do domínio do email para ocorrer apenas quando o endereço for alterado.

As funções `fetchUser` e `logout` foram alteradas para `async` no contexto inicial do `useUser`.

