### PR TITLE
fix(tabcoin-buttons): fix tabcoin vertical alignment

### DIFF
--- a/pages/interface/components/TabCoinButtons/index.js
+++ b/pages/interface/components/TabCoinButtons/index.js
@@ -102,17 +102,10 @@ export default function TabCoinButtons({ content }) {
           disabled={isInAction}
         />
       </Tooltip>
-      <Box>
-        <div id={`reward-${contentObject.id}`} style={{ marginLeft: '-10px', width: '1px' }}></div>
-        <Text
-          sx={{
-            fontSize: 0,
-            fontWeight: 'bold',
-            color: 'accent.emphasis',
-          }}>
-          {contentObject.tabcoins}
-        </Text>
-      </Box>
+      <Text sx={{ fontSize: 0, fontWeight: 'bold', py: '4px', color: 'accent.emphasis' }}>
+        <div id={`reward-${contentObject.id}`} style={{ marginLeft: '-10px' }} aria-hidden></div>
+        {contentObject.tabcoins}
+      </Text>
       <Tooltip aria-label="Não achei relevante" direction="ne">
         <IconButton
           variant="invisible"


### PR DESCRIPTION
Corrige alinhamento vertical da contagem de tabcoins de um conteúdo

|  Atual |  Correção |
|---|---|
|  <img width="40" alt="Captura de Tela 2023-11-15 às 18 22 04" src="https://github.com/filipedeschamps/tabnews.com.br/assets/30873873/8d1a78c7-66ea-4219-a786-6185a8e4919a"> | <img width="40" alt="Captura de Tela 2023-11-15 às 18 21 04" src="https://github.com/filipedeschamps/tabnews.com.br/assets/30873873/dc11a83e-76a6-45c3-b4a7-f5ddb96c6dd3"> |