### PR TITLE
Corrige o débito de TabCoins ao excluir conteúdo positivado

### DIFF
--- a/queries/prestigeQueries.js
+++ b/queries/prestigeQueries.js
@@ -2,6 +2,7 @@ const byContentId = `
 WITH content_events AS (
   SELECT
     id,
+    originator_user_id,
     type
   FROM
     events
@@ -17,6 +18,9 @@ FROM
 INNER JOIN
   content_events
 ON balance_operations.originator_id = content_events.id
+  AND (balance_operations.recipient_id != content_events.originator_user_id
+    OR content_events.type = 'create:content:text_root'
+    OR content_events.type = 'create:content:text_child')
 WHERE balance_type = 'user:tabcoin'
 ;
 `;

--- a/tests/integration/api/v1/status/votes/get.test.js
+++ b/tests/integration/api/v1/status/votes/get.test.js
@@ -81,7 +81,7 @@ describe('GET /api/v1/status/votes', () => {
     });
 
     test('Should retrieve voting data', async () => {
-      orchestrator.createRate({ owner_id: privilegedUser.id, id: uuidV4() }, 2);
+      orchestrator.createRate({ owner_id: privilegedUser.id, id: uuidV4() }, 1);
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/status/votes`, {
         method: 'GET',


### PR DESCRIPTION
A função `createRate()` do orquestrador não reproduzia fielmente o comportamento de qualificações realizadas por um usuários reais, e isso impedia a detecção de um bug no momento de debitar as TabCoins pela exclusão de um conteúdo.

Esse PR corrige o orquestrador e o bug, evitando inconsistência no saldo de TabCoins ao excluir conteúdos.

O bug era causado por um erro na query que busca os ganhos dos conteúdos.

A consulta olha para os eventos e busca os balanços correspondentes, e o erro ocorria por estarem sendo retornados indevidamente o balanço do usuário que realizou a qualificação junto ao balanço do usuário qualificado. Como isso o saldo do conteúdo ficava menor do que o real, gerando um ganho indevido de TabCoins ao excluir conteúdos positivados.

Agora a consulta retorna apenas o balanço do usuário que recebeu os votos, e com isso ocorre o débito correto no momento de exclusão do conteúdo.

O bug não causava prejuízos para os usuários, apenas ganhos indevidos.