### PR TITLE
Reverte o commit comemorativo ao aniversário de 1 ano do lançamento do TabNews

### DIFF
--- a/pages/interface/components/Header/index.js
+++ b/pages/interface/components/Header/index.js
@@ -4,7 +4,6 @@ import {
   ActionList,
   ActionMenu,
   Box,
-  Confetti,
   HeaderLink,
   IconButton,
   Link,
@@ -41,9 +40,6 @@ export default function HeaderComponent() {
       sx={{
         px: [2, null, null, 3],
       }}>
-      {Date.now() < 1700708400000 && (asPath === '/' || asPath.includes('parabens-tabnews')) && (
-        <Confetti tweenDuration={45000} />
-      )}
       <PrimerHeader.Item>
         <HeaderLink href="/" aria-label="Voltar para a página inicial">
           <CgTab size={32} />


### PR DESCRIPTION
Reverte o commit 7c1e03513448eedc86cf0bd203c03651399b26de desativando os confetes que eram jogados apenas no dia de aniversário do TabNews.