### PR TITLE
Mostra mais informações do usuário no perfil

### DIFF
--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -14,7 +14,7 @@ import {
   Heading,
   IconButton,
   Link,
-  PublishedSince,
+  PastTime,
   ReadTime,
   Text,
   TextInput,
@@ -201,7 +201,7 @@ function ViewMode({ setComponentMode, contentObject, viewFrame }) {
               href={`/${contentObject.owner_username}/${contentObject.slug}`}
               prefetch={false}
               sx={{ fontSize: 0, color: 'fg.muted', mr: '100px', py: '2px', height: '22px' }}>
-              <PublishedSince direction="n" date={contentObject.published_at} />
+              <PastTime direction="n" date={contentObject.published_at} sx={{ position: 'absolute' }} />
             </Link>
           </Box>
           {(user?.id === contentObject.owner_id || user?.features?.includes('update:content:others')) && (

--- a/pages/interface/components/ContentList/index.js
+++ b/pages/interface/components/ContentList/index.js
@@ -1,4 +1,4 @@
-import { Box, EmptyState, Link, PublishedSince, Text } from '@/TabNewsUI';
+import { Box, EmptyState, Link, PastTime, Text } from '@/TabNewsUI';
 import { ChevronLeftIcon, ChevronRightIcon, CommentIcon } from '@/TabNewsUI/icons';
 
 export default function ContentList({ contentList: list, pagination, paginationBasePath, emptyStateProps }) {
@@ -120,7 +120,7 @@ export default function ContentList({ contentList: list, pagination, paginationB
             </Link>
             {' · '}
             <Text>
-              <PublishedSince direction="nw" date={contentObject.published_at} sx={{ position: 'absolute', ml: 1 }} />
+              <PastTime direction="nw" date={contentObject.published_at} sx={{ position: 'absolute', ml: 1 }} />
             </Text>
           </Box>
         </Box>,

--- a/pages/interface/components/Header/index.js
+++ b/pages/interface/components/Header/index.js
@@ -9,13 +9,14 @@ import {
   Link,
   PrimerHeader,
   SearchBox,
-  Text,
+  TabCashCount,
+  TabCoinCount,
   ThemeSelector,
   ThemeSwitcher,
   Tooltip,
   Truncate,
 } from '@/TabNewsUI';
-import { CgTab, HomeIcon, PersonFillIcon, PlusIcon, SquareFillIcon } from '@/TabNewsUI/icons';
+import { CgTab, HomeIcon, PersonFillIcon, PlusIcon } from '@/TabNewsUI/icons';
 import { useUser } from 'pages/interface';
 
 export default function HeaderComponent() {
@@ -100,12 +101,7 @@ export default function HeaderComponent() {
               fontSize: 0,
               fontWeight: 'bold',
             }}>
-            <Tooltip aria-label="TabCoins" direction="s" noDelay={true} wrap={true}>
-              <Box sx={{ display: 'flex', alignItems: 'center', pr: 1, color: '#0969da' }}>
-                <SquareFillIcon size={16} />
-                <Text sx={{ color: 'fg.onEmphasis' }}>{user.tabcoins?.toLocaleString('pt-BR')}</Text>
-              </Box>
-            </Tooltip>
+            <TabCoinCount amount={user.tabcoins} sx={{ color: 'fg.onEmphasis', pl: 2, pr: 1 }} />
           </PrimerHeader.Item>
 
           <PrimerHeader.Item
@@ -114,12 +110,7 @@ export default function HeaderComponent() {
               fontSize: 0,
               fontWeight: 'bold',
             }}>
-            <Tooltip aria-label="TabCash" direction="s" noDelay={true} wrap={true}>
-              <Box sx={{ display: 'flex', alignItems: 'center', pr: 1, color: '#2da44e' }}>
-                <SquareFillIcon size={16} />
-                <Text sx={{ color: 'fg.onEmphasis' }}>{user.tabcash?.toLocaleString('pt-BR')}</Text>
-              </Box>
-            </Tooltip>
+            <TabCashCount amount={user.tabcash} sx={{ color: 'fg.onEmphasis', pr: 1 }} />
           </PrimerHeader.Item>
 
           <PrimerHeader.Item sx={{ mr: 0 }}>

--- a/pages/interface/components/PastTime/index.js
+++ b/pages/interface/components/PastTime/index.js
@@ -4,18 +4,6 @@ import { useEffect, useState } from 'react';
 
 import { Tooltip } from '@/TabNewsUI';
 
-function formatPublishedSince(date) {
-  try {
-    const publishedSince = formatDistanceToNowStrict(new Date(date), {
-      locale: ptBR,
-    });
-
-    return `${publishedSince} atrás`;
-  } catch (e) {
-    return '';
-  }
-}
-
 function formatTooltipLabel(date, gmt = false) {
   const displayFormat = gmt ? "EEEE, d 'de' MMMM 'de' yyyy 'às' HH:mm z" : "EEEE, d 'de' MMMM 'de' yyyy 'às' HH:mm";
 
@@ -26,17 +14,29 @@ function formatTooltipLabel(date, gmt = false) {
   }
 }
 
-export default function PublishedSince({ date, ...props }) {
+export default function PastTime({ date, formatText, ...props }) {
   const [tooltipLabel, setTooltipLabel] = useState(formatTooltipLabel(date, true));
 
   useEffect(() => {
     setTooltipLabel(formatTooltipLabel(date));
   }, [date]);
 
+  function getText(date) {
+    try {
+      const formattedDate = formatDistanceToNowStrict(new Date(date), {
+        locale: ptBR,
+      });
+
+      return formatText ? formatText(formattedDate) : `${formattedDate} atrás`;
+    } catch (e) {
+      return '';
+    }
+  }
+
   return (
-    <Tooltip sx={{ position: 'absolute' }} aria-label={tooltipLabel} suppressHydrationWarning {...props}>
+    <Tooltip aria-label={tooltipLabel} suppressHydrationWarning {...props}>
       <span style={{ whiteSpace: 'nowrap' }} suppressHydrationWarning>
-        {formatPublishedSince(date)}
+        {getText(date)}
       </span>
     </Tooltip>
   );

--- a/pages/interface/components/TabCashCount/index.js
+++ b/pages/interface/components/TabCashCount/index.js
@@ -1,0 +1,13 @@
+import { Box, Text, Tooltip } from '@/TabNewsUI';
+import { SquareFillIcon } from '@/TabNewsUI/icons';
+
+export default function TabCashCount({ amount, direction, sx }) {
+  return (
+    <Tooltip aria-label="TabCash" direction={direction ?? 's'} noDelay={true} wrap={true}>
+      <Box sx={{ display: 'flex', alignItems: 'center', ...sx }}>
+        <SquareFillIcon fill="#2da44e" size={16} />
+        <Text>{amount?.toLocaleString('pt-BR')}</Text>
+      </Box>
+    </Tooltip>
+  );
+}

--- a/pages/interface/components/TabCoinCount/index.js
+++ b/pages/interface/components/TabCoinCount/index.js
@@ -1,0 +1,13 @@
+import { Box, Text, Tooltip } from '@/TabNewsUI';
+import { SquareFillIcon } from '@/TabNewsUI/icons';
+
+export default function TabCoinCount({ amount, direction, sx }) {
+  return (
+    <Tooltip aria-label="TabCoins" direction={direction ?? 's'} noDelay={true} wrap={true}>
+      <Box sx={{ display: 'flex', alignItems: 'center', ...sx }}>
+        <SquareFillIcon fill="#0969da" size={16} />
+        <Text>{amount?.toLocaleString('pt-BR')}</Text>
+      </Box>
+    </Tooltip>
+  );
+}

--- a/pages/interface/components/TabNewsUI/index.js
+++ b/pages/interface/components/TabNewsUI/index.js
@@ -12,10 +12,12 @@ export { Editor, default as Viewer } from '@/Markdown';
 export { EditorColors, EditorStyles, ViewerStyles } from '@/Markdown/styles';
 export { default as PasswordInput } from '@/PasswordInput';
 export { default as NextNProgress } from '@/Progressbar';
-export { default as PublishedSince } from '@/PublishedSince';
+export { default as PastTime } from '@/PastTime';
 export { default as ReadTime } from '@/ReadTime';
 export { default as SearchBox } from '@/SearchBox';
+export { default as TabCashCount } from '@/TabCashCount';
 export { default as TabCoinButtons } from '@/TabCoinButtons';
+export { default as TabCoinCount } from '@/TabCoinCount';
 export { default as ThemeProvider } from '@/ThemeProvider';
 export { default as ThemeSelector, ThemeSwitcher } from '@/ThemeSelector';
 export {


### PR DESCRIPTION
Implementando o que foi dito no issue https://github.com/filipedeschamps/tabnews.com.br/issues/1557:
- [x] Mostrar TabCoins e TabCash.
- [x] Mostrar data de cadastro.
- [x] Opção de Editar Perfil.

Aproveitei também para remover a opção de Nuke no próprio perfil.

O que fica para outro PR:
- [ ] Opção de moderar a descrição do perfil (essa e outras coisas sobre a descrição estão no issue https://github.com/filipedeschamps/tabnews.com.br/issues/1466)
- [ ] Destacar usuários novos, similar o Hacker News (sugestão do Filipe https://github.com/filipedeschamps/tabnews.com.br/issues/1557#issuecomment-1828100857, acho que não tem issue para isso)

---

### Detalhes

1. Apesar de muito parecidos, não criei um único componente para `TabCoinCount` e `TabCashCount` por não conseguir pensar num bom nome.
2. A opção de `Editar Perfil` ficou sem ícone porque no menu da conta (topo superior direito) está sem ícone. Como contraponto, o Nuke (no perfil do usuário) e todas as opções em um conteúdo tem ícone. Apesar disso, não acho que tenha ficado ruim/feio ou inconsistente.
3. Cogitei criar testes para o `PastTime` em `tests/unit/components`, mas não o fiz porque não tem nenhum teste de UI nem biblioteca nas dependência (exemplo: [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro/)), mas se for desejável, eu crio.
4. Não vi o que precisa editar no banco para ter TabCoins e TabCash e fazer um GIF melhor 😅.

### Resultado

[Usuário "admin" no próprio perfil](https://github.com/filipedeschamps/tabnews.com.br/assets/26308880/bc71b064-a02b-4c61-8a43-381cba6ac8d3)