### PR TITLE
[Barra de pesquisa mobile] Mostrar opções de classificação dos resultados

### DIFF
--- a/pages/interface/components/SearchBox/index.js
+++ b/pages/interface/components/SearchBox/index.js
@@ -141,6 +141,7 @@ function GoogleBox({ onInputRender = () => {}, onSuggestionsRender = () => {} } 
 
     const waitInputBox = waitForElm('.gsc-input-box');
     const waitSuggestionBox = waitForElm('.gssb_c');
+    const waitAboveResultsBox = waitForElm('.gsc-above-wrapper-area');
 
     (async () => {
       const inputBox = await waitInputBox.start();
@@ -151,9 +152,15 @@ function GoogleBox({ onInputRender = () => {}, onSuggestionsRender = () => {} } 
       onSuggestionsRender(suggestionBox);
     })();
 
+    (async () => {
+      const aboveResultsBox = await waitAboveResultsBox.start();
+      aboveResultsBox.style.display = 'block';
+    })();
+
     return () => {
       waitInputBox.cancel();
       waitSuggestionBox.cancel();
+      waitAboveResultsBox.cancel();
     };
   }, [onInputRender, onSuggestionsRender]);
 


### PR DESCRIPTION
A barra de pesquisa do Google estava omitindo a opção de classificar os resultados quando a pesquisa era realizada em dispositivos de tela pequena.

Esse PR faz sempre mostrar as opções de classificação dos resultados:

![image](https://github.com/filipedeschamps/tabnews.com.br/assets/77860630/f8d87b3e-c646-43c1-8dc8-176fa1b2e37b) ![image](https://github.com/filipedeschamps/tabnews.com.br/assets/77860630/462ae6fa-c79e-4b70-817a-9f8a8a9b7588)