### PR TITLE
Diminui o tamanho limite do slug dos conteúdos de 255 para 226 bytes

### DIFF
--- a/models/content.js
+++ b/models/content.js
@@ -396,9 +396,7 @@ function getSlug(title) {
     trim: true,
   });
 
-  const truncatedSlug = generatedSlug.substring(0, 255);
-
-  return truncatedSlug;
+  return generatedSlug;
 }
 
 function populateStatus(postedContent) {

--- a/models/validator.js
+++ b/models/validator.js
@@ -237,7 +237,7 @@ const schemas = {
     return Joi.object({
       slug: Joi.string()
         .min(1)
-        .max(255, 'utf8')
+        .max(226, 'utf8')
         .trim()
         .truncate()
         .invalid(null)

--- a/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
@@ -1054,7 +1054,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
-    test('Content with "slug" containing more than 255 bytes', async () => {
+    test('Content with "slug" containing more than 226 bytes', async () => {
       const defaultUser = await orchestrator.createUser();
       await orchestrator.activateUser(defaultUser);
       const sessionObject = await orchestrator.createSession(defaultUser);
@@ -1074,7 +1074,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
             cookie: `session_id=${sessionObject.token}`,
           },
           body: JSON.stringify({
-            slug: 'this-slug-must-be-changed-to-255-bytesssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss',
+            slug: 'this-slug-must-be-changed-to-226-bytesssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss',
           }),
         }
       );
@@ -1087,7 +1087,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         id: responseBody.id,
         owner_id: defaultUser.id,
         parent_id: null,
-        slug: 'this-slug-must-be-changed-to-255-bytessssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss',
+        slug: 'this-slug-must-be-changed-to-226-bytesssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss',
         title: 'Título velho',
         body: 'Body velho',
         status: 'draft',

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -628,7 +628,7 @@ describe('POST /api/v1/contents', () => {
       expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
-    test('Content with "slug" containing more than 255 bytes', async () => {
+    test('Content with "slug" containing more than 226 bytes', async () => {
       const defaultUser = await orchestrator.createUser();
       await orchestrator.activateUser(defaultUser);
       const sessionObject = await orchestrator.createSession(defaultUser);
@@ -642,7 +642,7 @@ describe('POST /api/v1/contents', () => {
         body: JSON.stringify({
           title: 'Mini curso de Node.js',
           body: 'Instale o Node.js',
-          slug: 'this-slug-must-be-changed-to-255-bytesssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss',
+          slug: 'this-slug-must-be-changed-to-226-bytesssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss',
         }),
       });
 
@@ -654,7 +654,7 @@ describe('POST /api/v1/contents', () => {
         id: responseBody.id,
         owner_id: defaultUser.id,
         parent_id: null,
-        slug: 'this-slug-must-be-changed-to-255-bytessssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss',
+        slug: 'this-slug-must-be-changed-to-226-bytesssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss',
         title: 'Mini curso de Node.js',
         body: 'Instale o Node.js',
         status: 'draft',
@@ -964,7 +964,7 @@ describe('POST /api/v1/contents', () => {
         id: responseBody.id,
         owner_id: defaultUser.id,
         parent_id: null,
-        slug: 'este-titulo-possui-255-caracteres-ocupando-256-bytes-e-deve-com-100-por-cento-de-certeza-gerar-um-slug-ocupando-menos-de-256-bytessssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss',
+        slug: 'este-titulo-possui-255-caracteres-ocupando-256-bytes-e-deve-com-100-por-cento-de-certeza-gerar-um-slug-ocupando-menos-de-256-bytesssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss',
         title:
           'Este título possui 255 caracteres ocupando 256 bytes e deve com 100% de certeza gerar um slug ocupando menos de 256 bytesssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss',
         body: 'Instale o Node.js',
@@ -1051,7 +1051,7 @@ describe('POST /api/v1/contents', () => {
         id: responseBody.id,
         owner_id: defaultUser.id,
         parent_id: null,
-        slug: '4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pm',
+        slug: '4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4p',
         title: '♥'.repeat(255),
         body: 'The title is 255 characters but 765 bytes and the slug should only be 255 bytes',
         status: 'draft',


### PR DESCRIPTION
Vamos precisar usar um limite menor para o tamanho do slug, pois senão teremos erros durante o deploy sempre que houver algum conteúdo recente com slug maior do que 226 bytes.

Isso porque descobri que o limite de bytes do último segmento nos caminhos dinâmicos, na prática, são menores do que o limite de 255 bytes do nome dos arquivos. E que, dependendo do caso, são mais limitados na Vercel do que no Next.js.

O problema não foi notado antes, pois até hoje apenas 2 conteúdos publicados possuem slug maior do que 226 bytes, e apenas um deles é recente.

Quando for feito o deploy em produção eu já vou atualizar esses dois conteúdos para o novo limite, mas o melhor de tudo é que qualquer eventual link que existir com o caminho antigo continuará funcionando, pois o validador irá considerar apenas os 226 primeiros bytes.

Vou deixar registrado o histórico da investigação, pois pode ser útil para quem estiver lidando com o erro `ENAMETOOLONG` mesmo com segmentos menores do que 255 bytes.

### Histórico da investigação do problema

Hoje ocorreu um erro de limite de tamanho do nome de arquivo durante um deploy. E ao investigar, vi que o slug que estava dando problema continha apenas 233 bytes, ou seja, tinha folga com relação ao que definimos como limite, que era 255 bytes (devido à limitação de nome de arquivo).

Então fiz alguns testes e descobri que o limite para o next é de 250 bytes (não 255). Imagino que seja por adicionar a extensão `.html` aos arquivos estáticos, o que usa os 5 bytes adicionais.

Mas isso não explicava o erro durante o deploy, já que o slug tinha 233 bytes, então tive que fazer alguns deploys até entender o que estava ocorrendo. O erro original era:

`Error: ENAMETOOLONG: name too long, open '/vercel/output/functions/[username]/[...slug de 233 bytes...].prerender-fallback.html'`

O erro ocorria em um arquivo de nome `[slug].prerender-fallback.html`, ou seja, tinha 24 bytes adicionados pela Vercel aqui nessa linha:

https://github.com/vercel/vercel/blob/f124779b35bce740e61a8797e4a547d4b9ba068b/packages/cli/src/util/build/write-build-result.ts#L158

Então testei com um slug de 231 bytes e passei a obter erros com arquivos de nome `[slug].json.prerender-fallback.json` (agora 29 bytes adicionais).

Com isso cheguei no limite real de 226 bytes, que somados aos 29 bytes adicionados em uma das etapas do deploy, atinge o limite de 255 bytes.

E tudo indica que esse problema só ocorre durante o deploy na Vercel. Não é uma limitação do Next.js (nele podemos usar 250 bytes). E só temos o limite de 226 bytes para conteúdos que estiverem sendo retornados por `getStaticPaths()` (páginas estáticas geradas em momento de build). Mas não só isso, o problema só ocorre se `fallback` for definido como `"blocking"` ou `true` em conjunto com `revalidate`.