### PR TITLE
Continuando #1542 - Adiciona o recurso de copiar código para a área de transferência

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@bytemd/plugin-math": "1.21.0",
         "@bytemd/plugin-mermaid": "1.21.0",
         "@bytemd/react": "1.21.0",
+        "@primer/octicons": "19.8.0",
         "@primer/octicons-react": "18.3.0",
         "@primer/react": "35.25.1",
         "@resvg/resvg-js": "2.4.1",
@@ -1952,6 +1953,14 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@primer/behaviors/-/behaviors-1.3.3.tgz",
       "integrity": "sha512-iHMRuu8YWDJIdqCi1krx0cyFNeqszNKTOb0dXFu2wQ5BeIqxqPJLD7rjZ2Vjf/+YaPSbWuIQE1H6TaGMMsDfdA=="
+    },
+    "node_modules/@primer/octicons": {
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@primer/octicons/-/octicons-19.8.0.tgz",
+      "integrity": "sha512-Imze/fyW41Io5fN+27T5EAeXJrgBjMbz6nzU+wYbRylXvIAjLPUvaJPVoStiFlgSU+TjTUJqg5A9rgMDzTyMCg==",
+      "dependencies": {
+        "object-assign": "^4.1.1"
+      }
     },
     "node_modules/@primer/octicons-react": {
       "version": "18.3.0",
@@ -15226,6 +15235,14 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@primer/behaviors/-/behaviors-1.3.3.tgz",
       "integrity": "sha512-iHMRuu8YWDJIdqCi1krx0cyFNeqszNKTOb0dXFu2wQ5BeIqxqPJLD7rjZ2Vjf/+YaPSbWuIQE1H6TaGMMsDfdA=="
+    },
+    "@primer/octicons": {
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/@primer/octicons/-/octicons-19.8.0.tgz",
+      "integrity": "sha512-Imze/fyW41Io5fN+27T5EAeXJrgBjMbz6nzU+wYbRylXvIAjLPUvaJPVoStiFlgSU+TjTUJqg5A9rgMDzTyMCg==",
+      "requires": {
+        "object-assign": "^4.1.1"
+      }
     },
     "@primer/octicons-react": {
       "version": "18.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@bytemd/plugin-math": "1.21.0",
         "@bytemd/plugin-mermaid": "1.21.0",
         "@bytemd/react": "1.21.0",
-        "@primer/octicons": "19.8.0",
         "@primer/octicons-react": "18.3.0",
         "@primer/react": "35.25.1",
         "@resvg/resvg-js": "2.4.1",
@@ -1954,14 +1953,6 @@
       "resolved": "https://registry.npmjs.org/@primer/behaviors/-/behaviors-1.3.3.tgz",
       "integrity": "sha512-iHMRuu8YWDJIdqCi1krx0cyFNeqszNKTOb0dXFu2wQ5BeIqxqPJLD7rjZ2Vjf/+YaPSbWuIQE1H6TaGMMsDfdA=="
     },
-    "node_modules/@primer/octicons": {
-      "version": "19.8.0",
-      "resolved": "https://registry.npmjs.org/@primer/octicons/-/octicons-19.8.0.tgz",
-      "integrity": "sha512-Imze/fyW41Io5fN+27T5EAeXJrgBjMbz6nzU+wYbRylXvIAjLPUvaJPVoStiFlgSU+TjTUJqg5A9rgMDzTyMCg==",
-      "dependencies": {
-        "object-assign": "^4.1.1"
-      }
-    },
     "node_modules/@primer/octicons-react": {
       "version": "18.3.0",
       "resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-18.3.0.tgz",
@@ -1974,14 +1965,11 @@
       }
     },
     "node_modules/@primer/primitives": {
-      "version": "7.11.7",
-      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-7.11.7.tgz",
-      "integrity": "sha512-8PDEn3yj8oE/9B7o5hwjD0LSy7xz9xZ3gGTPWi/u0MxHZJ/fxERgxnBG21eCLKZ19KjhIb5AsmSQyFbGR5urYQ==",
+      "version": "7.15.3",
+      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-7.15.3.tgz",
+      "integrity": "sha512-BFxFKwa0Bkr+esqbXU5Yt91z/58J2MPoW1cYtp0j2rUYus4lIZnczX7+ZYb7j4BqpfY/88q9Vn+BRwW/Sx4eIA==",
       "dev": true,
-      "peer": true,
-      "dependencies": {
-        "markdown-table-ts": "^1.0.3"
-      }
+      "peer": true
     },
     "node_modules/@primer/react": {
       "version": "35.25.1",
@@ -15236,14 +15224,6 @@
       "resolved": "https://registry.npmjs.org/@primer/behaviors/-/behaviors-1.3.3.tgz",
       "integrity": "sha512-iHMRuu8YWDJIdqCi1krx0cyFNeqszNKTOb0dXFu2wQ5BeIqxqPJLD7rjZ2Vjf/+YaPSbWuIQE1H6TaGMMsDfdA=="
     },
-    "@primer/octicons": {
-      "version": "19.8.0",
-      "resolved": "https://registry.npmjs.org/@primer/octicons/-/octicons-19.8.0.tgz",
-      "integrity": "sha512-Imze/fyW41Io5fN+27T5EAeXJrgBjMbz6nzU+wYbRylXvIAjLPUvaJPVoStiFlgSU+TjTUJqg5A9rgMDzTyMCg==",
-      "requires": {
-        "object-assign": "^4.1.1"
-      }
-    },
     "@primer/octicons-react": {
       "version": "18.3.0",
       "resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-18.3.0.tgz",
@@ -15251,14 +15231,11 @@
       "requires": {}
     },
     "@primer/primitives": {
-      "version": "7.11.7",
-      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-7.11.7.tgz",
-      "integrity": "sha512-8PDEn3yj8oE/9B7o5hwjD0LSy7xz9xZ3gGTPWi/u0MxHZJ/fxERgxnBG21eCLKZ19KjhIb5AsmSQyFbGR5urYQ==",
+      "version": "7.15.3",
+      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-7.15.3.tgz",
+      "integrity": "sha512-BFxFKwa0Bkr+esqbXU5Yt91z/58J2MPoW1cYtp0j2rUYus4lIZnczX7+ZYb7j4BqpfY/88q9Vn+BRwW/Sx4eIA==",
       "dev": true,
-      "peer": true,
-      "requires": {
-        "markdown-table-ts": "^1.0.3"
-      }
+      "peer": true
     },
     "@primer/react": {
       "version": "35.25.1",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@bytemd/plugin-math": "1.21.0",
     "@bytemd/plugin-mermaid": "1.21.0",
     "@bytemd/react": "1.21.0",
+    "@primer/octicons": "19.8.0",
     "@primer/octicons-react": "18.3.0",
     "@primer/react": "35.25.1",
     "@resvg/resvg-js": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "@bytemd/plugin-math": "1.21.0",
     "@bytemd/plugin-mermaid": "1.21.0",
     "@bytemd/react": "1.21.0",
-    "@primer/octicons": "19.8.0",
     "@primer/octicons-react": "18.3.0",
     "@primer/react": "35.25.1",
     "@resvg/resvg-js": "2.4.1",

--- a/pages/interface/components/Markdown/index.js
+++ b/pages/interface/components/Markdown/index.js
@@ -14,6 +14,8 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { Box, EditorColors, EditorStyles, useTheme } from '@/TabNewsUI';
 
+import { copyCodeToClipboardPlugin } from './plugins/copy-code-to-clipboard';
+
 const bytemdPluginBaseList = [
   gfmPlugin({ locale: gfmLocale }),
   highlightSsrPlugin(),
@@ -23,6 +25,7 @@ const bytemdPluginBaseList = [
   }),
   breaksPlugin(),
   gemojiPlugin(),
+  copyCodeToClipboardPlugin(),
 ];
 
 function usePlugins() {

--- a/pages/interface/components/Markdown/plugins/copy-code-to-clipboard.js
+++ b/pages/interface/components/Markdown/plugins/copy-code-to-clipboard.js
@@ -1,0 +1,108 @@
+import { check, copy } from '@primer/octicons';
+
+/**
+ * @returns {import('@bytemd/react').ViewerProps['plugins'][0]}
+ */
+
+export function copyCodeToClipboardPlugin() {
+  function createCopyButton(parentElement, contentToCopy) {
+    const buttonElement = createButtonElement();
+
+    buttonElement.onclick = async () => {
+      await navigator.clipboard.writeText(contentToCopy);
+      setStateAfterCopy(buttonElement);
+      setTimeout(() => setStateBeforeCopy(buttonElement), 2000);
+    };
+
+    return parentElement.appendChild(buttonElement);
+
+    function createButtonElement() {
+      const buttonElement = document.createElement('button');
+
+      buttonElement.setAttribute('type', 'button');
+      setStyleProperties(buttonElement, {
+        width: '32px',
+        height: '32px',
+        display: 'grid',
+        'place-content': 'center',
+        'background-color': 'transparent',
+        cursor: 'pointer',
+        'border-radius': '6px',
+        transition: '0.2s ease-in-out',
+        'transition-property': 'color, background-color, border-color',
+      });
+      setStateBeforeCopy(buttonElement);
+      buttonElement.classList.add('copy-button');
+
+      return buttonElement;
+    }
+
+    function setStateBeforeCopy(buttonElement) {
+      setAttributes(buttonElement, {
+        title: 'Copiar',
+        'aria-label': 'Copiar',
+      });
+      setStyleProperties(buttonElement, {
+        'pointer-events': 'auto',
+      });
+      buttonElement.innerHTML = copy.toSVG();
+      buttonElement.classList.remove('copied');
+    }
+
+    function setStateAfterCopy(buttonElement) {
+      setAttributes(buttonElement, {
+        title: 'Copiado',
+        'aria-label': 'Copiado',
+      });
+      setStyleProperties(buttonElement, {
+        'pointer-events': 'none',
+      });
+      buttonElement.innerHTML = check.toSVG();
+      buttonElement.classList.add('copied');
+    }
+
+    function setAttributes(buttonElement, attributes) {
+      for (const attribute in attributes) {
+        buttonElement.setAttribute(attribute, attributes[attribute]);
+      }
+    }
+  }
+
+  function setStyleProperties(element, styleProperties) {
+    for (const styleProperty in styleProperties) {
+      element.style.setProperty(styleProperty, styleProperties[styleProperty]);
+    }
+  }
+
+  return {
+    viewerEffect({ markdownBody }) {
+      if (!navigator.clipboard) return;
+
+      const codeElements = markdownBody.querySelectorAll('pre > code');
+
+      if (codeElements.length === 0) return;
+
+      codeElements.forEach((codeElement) => {
+        if (!codeElement.innerHTML) return;
+
+        const pre = codeElement.parentElement;
+        const codeToCopy = codeElement.innerText;
+
+        const externalDivElement = document.createElement('div');
+        setStyleProperties(externalDivElement, {
+          position: 'relative',
+          top: '-6px',
+          right: '-6px',
+          'min-width': '32px',
+        });
+        pre.appendChild(externalDivElement);
+
+        const internalDivElement = document.createElement('div');
+        internalDivElement.style.position = 'absolute';
+        externalDivElement.appendChild(internalDivElement);
+
+        createCopyButton(internalDivElement, codeToCopy);
+      });
+    },
+  };
+}

--- a/pages/interface/components/Markdown/plugins/copy-code-to-clipboard.js
+++ b/pages/interface/components/Markdown/plugins/copy-code-to-clipboard.js
@@ -1,4 +1,7 @@
-import { check, copy } from '@primer/octicons';
+const checkIcon =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z"/></svg>';
+const copyIcon =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z"/><path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"/></svg>';
 
 /**
  * @returns {import('@bytemd/react').ViewerProps['plugins'][0]}
@@ -25,8 +28,9 @@ export function copyCodeToClipboardPlugin() {
         height: '32px',
         display: 'grid',
         'place-content': 'center',
-        'background-color': 'transparent',
         cursor: 'pointer',
+        'border-style': 'solid',
+        'border-width': '1px',
         'border-radius': '6px',
         transition: '0.2s ease-in-out',
         'transition-property': 'color, background-color, border-color',
@@ -45,7 +49,7 @@ export function copyCodeToClipboardPlugin() {
       setStyleProperties(buttonElement, {
         'pointer-events': 'auto',
       });
-      buttonElement.innerHTML = copy.toSVG();
+      buttonElement.innerHTML = copyIcon;
       buttonElement.classList.remove('copied');
     }
 
@@ -57,7 +61,7 @@ export function copyCodeToClipboardPlugin() {
       setStyleProperties(buttonElement, {
         'pointer-events': 'none',
       });
-      buttonElement.innerHTML = check.toSVG();
+      buttonElement.innerHTML = checkIcon;
       buttonElement.classList.add('copied');
     }
 
@@ -86,6 +90,8 @@ export function copyCodeToClipboardPlugin() {
         if (!codeElement.innerHTML) return;
 
         const pre = codeElement.parentElement;
+        if (pre.childElementCount > 1) return;
+
         const codeToCopy = codeElement.innerText;
 
         const externalDivElement = document.createElement('div');
@@ -95,6 +101,12 @@ export function copyCodeToClipboardPlugin() {
           right: '-6px',
           'min-width': '32px',
         });
+        setStyleProperties(pre, {
+          display: 'flex',
+          'justify-content': 'space-between',
+          gap: '4px',
+        });
+
         pre.appendChild(externalDivElement);
 
         const internalDivElement = document.createElement('div');

--- a/pages/interface/components/Markdown/styles/index.js
+++ b/pages/interface/components/Markdown/styles/index.js
@@ -1803,9 +1803,6 @@ export function ViewerStyles() {
           line-height: 1.45;
           background-color: ${colors.canvas.subtle};
           border-radius: 6px;
-          display: flex;
-          justify-content: space-between;
-          gap: 4px;
         }
         .markdown-body .math {
           overflow: auto;
@@ -1918,19 +1915,20 @@ export function ViewerStyles() {
         }
 
         .copy-button {
-          border: 1px solid ${colors.btn.border} !important;
-          color: ${colors.fg.muted} !important;
+          border-color: ${colors.btn.border};
+          color: ${colors.fg.muted};
+          background-color: ${colors.btn.bg};
         }
 
         .copy-button:hover {
-          border-color: ${colors.btn.fg} !important;
-          background-color: ${colors.btn.hoverBg} !important;
+          border-color: ${colors.btn.hoverBorder};
+          background-color: ${colors.btn.hoverBg};
         }
 
         .copy-button.copied {
-          border-color: ${colors.success.fg} !important;
-          background-color: ${colors.btn.hoverBg} !important;
-          color: ${colors.success.fg} !important;
+          border-color: ${colors.success.fg};
+          background-color: ${colors.btn.hoverBg};
+          color: ${colors.success.fg};
         }
       `}
     </style>

--- a/pages/interface/components/Markdown/styles/index.js
+++ b/pages/interface/components/Markdown/styles/index.js
@@ -1803,6 +1803,9 @@ export function ViewerStyles() {
           line-height: 1.45;
           background-color: ${colors.canvas.subtle};
           border-radius: 6px;
+          display: flex;
+          justify-content: space-between;
+          gap: 4px;
         }
         .markdown-body .math {
           overflow: auto;
@@ -1912,6 +1915,22 @@ export function ViewerStyles() {
 
         .markdown-body ::-webkit-calendar-picker-indicator {
           filter: invert(50%);
+        }
+
+        .copy-button {
+          border: 1px solid ${colors.btn.border} !important;
+          color: ${colors.fg.muted} !important;
+        }
+
+        .copy-button:hover {
+          border-color: ${colors.btn.fg} !important;
+          background-color: ${colors.btn.hoverBg} !important;
+        }
+
+        .copy-button.copied {
+          border-color: ${colors.success.fg} !important;
+          background-color: ${colors.btn.hoverBg} !important;
+          color: ${colors.success.fg} !important;
         }
       `}
     </style>


### PR DESCRIPTION
Dando continuidade ao trabalho do @kaique-soares no #1542, eu removi a biblioteca `@primer/octicons`, pois estava adicionando mais de 100kB ao load inicial do TabNews.

Deixando fixos no código os dois elementos `svg` necessários (`check` e `copy`), o aumento passou a ser de apenas 3kB.

Essa melhoria do @kaique-soares tem grande potencial de virar um plugin do ByteMD, então movi o restante da estilização que estava no arquivo `/Markdown/styles/index.js` para dentro do `/Markdown/plugins/copy-code-to-clipboard.js`, restando apenas a definição de cores de acordo com o tema.

**[Edit]** A melhoria já é um plogin do ByteMD, mas quero dizer que tem potencial de virar um PR na biblioteca oficial 😅