### PR TITLE
feat: Adicionando rss para as rotas da api

### DIFF
--- a/models/content.js
+++ b/models/content.js
@@ -193,18 +193,19 @@ async function findWithStrategy(options = {}) {
     new: getNew,
     old: getOld,
     relevant: getRelevant,
+    relevant_rss: getRelevantRss,
   };
 
   return await strategies[options.strategy](options);
 
   async function getNew(options = {}) {
     const results = {};
-
+    
     options.order = 'published_at DESC';
     results.rows = await findAll(options);
     options.totalRows = results.rows[0]?.total_rows;
     results.pagination = await getPagination(options);
-
+    
     return results;
   }
 
@@ -235,6 +236,22 @@ async function findWithStrategy(options = {}) {
     } else {
       results.rows = rankContentListByRelevance(contentList);
     }
+
+    values.totalRows = results.rows[0]?.total_rows;
+    results.pagination = await getPagination(values, options);
+
+    return results;
+  }
+
+  async function getRelevantRss(values = {}) {
+    const results = {};
+    const options = {};
+
+    values.order = 'published_at DESC';
+
+    const contentList = await findAll(values, options);
+
+    results.rows = rankContentListByRelevance(contentList);
 
     values.totalRows = results.rows[0]?.total_rows;
     results.pagination = await getPagination(values, options);

--- a/models/rss.js
+++ b/models/rss.js
@@ -5,12 +5,10 @@ import { Viewer } from '@/TabNewsUI';
 import webserver from 'infra/webserver.js';
 import removeMarkdown from 'models/remove-markdown';
 
-function generateRss2(contentList) {
+function generateRss2(contentList, path) {
   const webserverHost = webserver.host;
 
-  // TODO: make this property flexible in the future to
-  // support things like: `/[username]/rss`
-  const feedURL = `${webserverHost}/recentes/rss`;
+  const feedURL = `${webserverHost}/${path}`;
 
   const feed = new Feed({
     title: 'TabNews',

--- a/next.config.js
+++ b/next.config.js
@@ -27,7 +27,15 @@ module.exports = {
     return [
       {
         source: '/recentes/rss',
-        destination: '/api/v1/contents/rss',
+        destination: '/api/v1/contents/rss?strategy=new',
+      },
+      {
+        source: '/rss/recentes',
+        destination: '/api/v1/contents/rss?strategy=new',
+      },
+      {
+        source: '/rss/relevantes',
+        destination: '/api/v1/contents/rss?strategy=relevant_rss',
       },
     ];
   },

--- a/pages/api/v1/contents/rss/index.public.js
+++ b/pages/api/v1/contents/rss/index.public.js
@@ -19,21 +19,21 @@ export default nextConnect({
 
 async function handleRequest(request, response) {
   const userTryingToList = user.createAnonymous();
-
+  
   const results = await content.findWithStrategy({
-    strategy: 'new',
+    strategy: request.query.strategy,
     where: {
       parent_id: null,
       status: 'published',
     },
-    page: 1,
-    per_page: 30,
+    page: request.query.page,
+    per_page: request.query.per_page,
   });
 
   const contentListFound = results.rows;
 
   const secureContentListFound = authorization.filterOutput(userTryingToList, 'read:content:list', contentListFound);
-  const rss2 = rss.generateRss2(secureContentListFound);
+  const rss2 = rss.generateRss2(secureContentListFound, request.params.wild);
 
   response.setHeader('Content-Type', 'text/xml; charset=utf-8');
   response.status(200).send(rss2);


### PR DESCRIPTION
Baseado na discussão do pull [adding rss to relevant route and changing default path to starts with rss](https://github.com/filipedeschamps/tabnews.com.br/pull/1480), foi adicionado de forma **simples** um feed rss para a rota de relevantes.

Os caminhos padrões não foram modificados, para garantir compatibilidade com a api já existente.
As rotas novas são simplificadas:
`/rss/recentes`
`/rss/relevantes`
Além da não modificada:
`/relevantes/rss`

Mais:
essas rotas agora são capazes também de aceitar per_page e page, com padrão definido respectivamente em 30 e 1(default da api)

Como dito na discussão informada anteriormente, foi criada uma consulta única para a página de rss relevantes na forma de uma nova estrategia chamada  'relevantes_rss', podendo ser modificada posteriormente.

Nenhum teste foi escrito para essa implementação, a fim de (se necessário), melhora-lá antes da escrita dos testes.

@aprendendofelipe 