### PR TITLE
Downgrade do Node.js para `lts/hydrogen` (`v18`)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: '20'
+          node-version: '18'
           cache: 'npm'
       - run: npm ci
       - run: npm run dev & npx jest --runInBand
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '20'
+          node-version: '18'
           cache: 'npm'
       - run: npm ci
       - run: npm run lint

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/iron
+lts/hydrogen

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Rodar o TabNews em sua máquina local é uma tarefa extremamente simples.
 
 Você precisa ter duas principais dependências instaladas:
 
-- Node.js LTS v20 (ou qualquer versão superior)
+- Node.js LTS v18 (ou qualquer versão superior)
 - Docker Engine v17.12.0 com Docker Compose v1.24.1 (ou qualquer versão superior)
 
 Utiliza `nvm`? Então pode executar `nvm install` na pasta do projeto para instalar e utilizar a versão mais apropriada do Node.js.

--- a/infra/database.js
+++ b/infra/database.js
@@ -50,16 +50,7 @@ async function query(query, options = {}) {
     if (client && !options.transaction) {
       const tooManyConnections = await checkForTooManyConnections(client);
 
-      try {
-        client.release(tooManyConnections && webserver.isServerlessRuntime);
-      } catch (error) {
-        console.log({
-          location: 'database_query_finally',
-          cache: { ...cache, pool: !!cache.pool },
-          error,
-        });
-        throw error;
-      }
+      client.release(tooManyConnections && webserver.isServerlessRuntime);
     }
   }
 }
@@ -103,11 +94,6 @@ async function checkForTooManyConnections(client) {
       cache.openedConnectionsLastUpdate = currentTime;
     }
   } catch (error) {
-    console.log({
-      location: 'checkForTooManyConnections',
-      cache: { ...cache, pool: !!cache.pool },
-      error,
-    });
     if (error.code === 'ECONNRESET') {
       return true;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "retry-cli": "0.7.0"
       },
       "engines": {
-        "node": "20"
+        "node": "18"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     ]
   },
   "engines": {
-    "node": "20"
+    "node": "18"
   },
   "name": "tabnews.com.br",
   "description": "Conteúdos para quem vive de programação e tecnologia.",


### PR DESCRIPTION
Altera a versão do Node para `v18`, já que no PR #1565 atualizamos o Node da `v16` diretamente para a `v20` e passamos a receber erros esporádicos:

`Invoke Error 	{"errorType":"Error","errorMessage":"read ECONNRESET","code":"ECONNRESET","errno":-104,"syscall":"read","stack":["Error: read ECONNRESET","    at TCP.onStreamRead (node:internal/stream_base_commons:217:20)","    at TCP.callbackTrampoline (node:internal/async_hooks:130:17)"]}`

Estou removendo os logs adicionados no PR #1571 para debug, pois nenhum deles foi acionado nos momentos em que os erros acima ocorreram.

Porém mantive o `databaseCache` no contexto dos erros gerados dentro do módulo `database` para melhorar a observabilidade:

https://github.com/filipedeschamps/tabnews.com.br/blob/60b2f300d3d653b9446f1921f7254a52e465e0b4/infra/database.js#L187-L193