### PR TITLE
[Responsividade e Acessibilidade] Truncar `username` longo na lista de conteúdos e mais

### DIFF
--- a/pages/interface/components/ContentList/index.js
+++ b/pages/interface/components/ContentList/index.js
@@ -1,4 +1,4 @@
-import { Box, EmptyState, Link, PastTime, Text } from '@/TabNewsUI';
+import { Box, EmptyState, Link, PastTime, Text, Tooltip } from '@/TabNewsUI';
 import { ChevronLeftIcon, ChevronRightIcon, CommentIcon } from '@/TabNewsUI/icons';
 
 export default function ContentList({ contentList: list, pagination, paginationBasePath, emptyStateProps }) {
@@ -14,7 +14,7 @@ export default function ContentList({ contentList: list, pagination, paginationB
           sx={{
             display: 'grid',
             gap: '0.5rem',
-            gridTemplateColumns: 'auto 1fr',
+            gridTemplateColumns: 'auto minmax(0, 1fr)',
           }}>
           <RenderItems />
           <EndOfRelevant />
@@ -29,6 +29,7 @@ export default function ContentList({ contentList: list, pagination, paginationB
             display: 'flex',
             width: '100%',
             justifyContent: 'center',
+            whiteSpace: 'nowrap',
             gap: 4,
             m: 4,
             mb: 2,
@@ -78,7 +79,7 @@ export default function ContentList({ contentList: list, pagination, paginationB
             {itemCount}.
           </Text>
         </Box>,
-        <Box as="article" key={contentObject.id} sx={{ overflow: 'auto' }}>
+        <Box as="article" key={contentObject.id}>
           <Box
             sx={{
               overflow: 'auto',
@@ -106,7 +107,16 @@ export default function ContentList({ contentList: list, pagination, paginationB
               </Link>
             )}
           </Box>
-          <Box sx={{ width: 'fit-content', fontSize: 0, color: 'neutral.emphasis' }}>
+          <Box
+            sx={{
+              display: 'grid',
+              gap: 1,
+              gridTemplateColumns:
+                'max-content max-content max-content max-content minmax(20px, max-content) max-content max-content',
+              fontSize: 0,
+              whiteSpace: 'nowrap',
+              color: 'neutral.emphasis',
+            }}>
             <Text>
               <TabCoinsText count={contentObject.tabcoins} />
             </Text>
@@ -115,12 +125,16 @@ export default function ContentList({ contentList: list, pagination, paginationB
               <ChildrenDeepCountText count={contentObject.children_deep_count} />
             </Text>
             {' · '}
-            <Link sx={{ color: 'neutral.emphasis' }} href={`/${contentObject.owner_username}`}>
-              {contentObject.owner_username}
-            </Link>
+            <Tooltip aria-label={`Autor: ${contentObject.owner_username}`}>
+              <Box sx={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                <Link sx={{ color: 'neutral.emphasis' }} href={`/${contentObject.owner_username}`}>
+                  {contentObject.owner_username}
+                </Link>
+              </Box>
+            </Tooltip>
             {' · '}
-            <Text sx={{ width: '100px', height: '16px', float: 'inline-end' }}>
-              <PastTime direction="nw" date={contentObject.published_at} sx={{ position: 'absolute', ml: 1 }} />
+            <Text>
+              <PastTime direction="nw" date={contentObject.published_at} />
             </Text>
           </Box>
         </Box>,

--- a/pages/interface/components/Header/index.js
+++ b/pages/interface/components/Header/index.js
@@ -67,7 +67,7 @@ export default function HeaderComponent() {
         </HeaderLink>
       </PrimerHeader.Item>
 
-      <PrimerHeader.Item full>
+      <PrimerHeader.Item full sx={{ mr: 0 }}>
         <HeaderLink href="/recentes" sx={asPath.startsWith('/recentes') ? activeLinkStyle : undefined}>
           Recentes
         </HeaderLink>
@@ -77,7 +77,8 @@ export default function HeaderComponent() {
         <PrimerHeader.Item
           sx={{
             display: user ? ['none', 'flex'] : 'flex',
-            mr: 1,
+            ml: 3,
+            mr: [1, , 3],
           }}>
           <SearchBarButton />
           <SearchIconButton />
@@ -86,16 +87,16 @@ export default function HeaderComponent() {
 
       {!isLoading && !user && (
         <>
-          <PrimerHeader.Item sx={{ mr: 2 }}>
+          <PrimerHeader.Item sx={{ mr: 1 }}>
             <ThemeSwitcher />
           </PrimerHeader.Item>
-          <PrimerHeader.Item sx={{ display: ['none', 'flex'] }}>
+          <PrimerHeader.Item sx={{ display: ['none', 'flex'], ml: 2 }}>
             <HeaderLink href={loginUrl}>Login</HeaderLink>
           </PrimerHeader.Item>
           <PrimerHeader.Item sx={{ display: ['none', 'flex'], mr: 1 }}>
             <HeaderLink href="/cadastro">Cadastrar</HeaderLink>
           </PrimerHeader.Item>
-          <PrimerHeader.Item sx={{ display: ['flex', 'none'], mr: 1 }}>
+          <PrimerHeader.Item sx={{ display: ['flex', 'none'], ml: 2, mr: 1 }}>
             <HeaderLink href={loginUrl}>Entrar</HeaderLink>
           </PrimerHeader.Item>
         </>
@@ -117,7 +118,7 @@ export default function HeaderComponent() {
 
           <PrimerHeader.Item
             sx={{
-              mr: 2,
+              mr: [0, 2],
               fontSize: 0,
               fontWeight: 'bold',
             }}>

--- a/pages/interface/components/PastTime/index.js
+++ b/pages/interface/components/PastTime/index.js
@@ -35,9 +35,9 @@ export default function PastTime({ date, formatText, ...props }) {
 
   return (
     <Tooltip aria-label={tooltipLabel} suppressHydrationWarning {...props}>
-      <span style={{ whiteSpace: 'nowrap' }} suppressHydrationWarning>
+      <time dateTime={date} style={{ whiteSpace: 'nowrap' }} suppressHydrationWarning>
         {getText(date)}
-      </span>
+      </time>
     </Tooltip>
   );
 }

--- a/pages/interface/components/TabCashCount/index.js
+++ b/pages/interface/components/TabCashCount/index.js
@@ -4,7 +4,7 @@ import { SquareFillIcon } from '@/TabNewsUI/icons';
 export default function TabCashCount({ amount, direction, sx }) {
   return (
     <Tooltip aria-label="TabCash" direction={direction ?? 's'} noDelay={true} wrap={true}>
-      <Box sx={{ display: 'flex', alignItems: 'center', ...sx }}>
+      <Box sx={{ display: 'flex', textWrap: 'nowrap', alignItems: 'center', ...sx }}>
         <SquareFillIcon fill="#2da44e" size={16} />
         <Text>{amount?.toLocaleString('pt-BR')}</Text>
       </Box>

--- a/pages/interface/components/TabCoinCount/index.js
+++ b/pages/interface/components/TabCoinCount/index.js
@@ -4,7 +4,7 @@ import { SquareFillIcon } from '@/TabNewsUI/icons';
 export default function TabCoinCount({ amount, direction, sx }) {
   return (
     <Tooltip aria-label="TabCoins" direction={direction ?? 's'} noDelay={true} wrap={true}>
-      <Box sx={{ display: 'flex', alignItems: 'center', ...sx }}>
+      <Box sx={{ display: 'flex', textWrap: 'nowrap', alignItems: 'center', ...sx }}>
         <SquareFillIcon fill="#0969da" size={16} />
         <Text>{amount?.toLocaleString('pt-BR')}</Text>
       </Box>

--- a/pages/interface/components/ThemeSelector/index.js
+++ b/pages/interface/components/ThemeSelector/index.js
@@ -62,6 +62,7 @@ export function ThemeSwitcher({ ...props }) {
           outline: '2px solid #FFF',
         },
         px: '7px',
+        pb: '3px',
       }}
       {...props}>
       {mode === 'day' ? <MoonIcon size={16} /> : <SunIcon size={16} />}


### PR DESCRIPTION
Aplica algumas melhorias de responsividade e acessibilidade.

## Lista de conteúdos

Agora será truncado o `username` sempre que faltar espaço.

Usando `display: grid`, consegui eliminar a necessidade dos diversos `overflow: hidden` e do `position: absolute` no `Tooltip`, então acredito que chegamos em um resultado melhor, pois a solução anterior (#1562) parecia mais um bug do que o bug que ela corrigiu: 😅

Antes | Depois
--- | ---
![image](https://github.com/filipedeschamps/tabnews.com.br/assets/77860630/b5101502-e947-47c7-9bb2-81331b8683ae) | ![image](https://github.com/filipedeschamps/tabnews.com.br/assets/77860630/dbec6b66-8f00-42bc-a251-bcf07091f603)

Por estarmos truncando o `username`, adicionei um `Tooltip`:

![image](https://github.com/filipedeschamps/tabnews.com.br/assets/77860630/c66feafe-0df9-41c8-98de-c48020cb780d)

Em resoluções com pouca largura (menores de 360px), achei melhor manter o scroll horizontal como ocorria anteriormente, pois ele já vai ser necessário por causa do Header. Exemplo com 160px:

Antes | Depois
--- | ---
![image](https://github.com/filipedeschamps/tabnews.com.br/assets/77860630/1c159a7a-a5b4-49b1-a3da-5a2ec1b559a9) | ![image](https://github.com/filipedeschamps/tabnews.com.br/assets/77860630/bdd3f262-f087-4292-84d1-665d2b492b9a)

Obs. O título continua quebrando a linha para facilitar a leitura sem precisar do scroll horizontal.

## Header

Em telas de 360px de largura, para usuários com grandes saldos de TabCoins e/ou TabCash, ainda podia ser necessário um pequeno scroll horizontal para visualizar todo o Header, então reduzi alguns espaçamentos para telas menores do que o target 544px. O mais perceptível é o espaçamento entre os saldos:

Antes | Depois
--- | ---
![image](https://github.com/filipedeschamps/tabnews.com.br/assets/77860630/404d80b2-4eb3-4b54-8e5c-3e9cde257fca) | ![image](https://github.com/filipedeschamps/tabnews.com.br/assets/77860630/32f329b0-bafb-4bd6-b132-73e5bec70d7e)


## Telas ainda menores

Dois problemas que só ocorriam em telas muito menores do que 360px, mas que achei que valia a pena melhorar:

Antes | Depois
--- | ---
![image](https://github.com/filipedeschamps/tabnews.com.br/assets/77860630/f6b71c2f-8b7b-4fce-ae7c-18690b786199) | ![image](https://github.com/filipedeschamps/tabnews.com.br/assets/77860630/d41cb99f-1bc0-443d-8c9f-e2ef680b4871)
![image](https://github.com/filipedeschamps/tabnews.com.br/assets/77860630/497e1ed0-b2f0-4a0c-bed5-5883086b3214) | ![image](https://github.com/filipedeschamps/tabnews.com.br/assets/77860630/a015e14f-881a-4c87-8011-3f666f4436ad)

## HTML semântico

Como ajustei o `Tooltip` do `PastTime`, já aproveitei para trocar a tag `span` pela `time`.
