### PR TITLE
Usando tags mais adequadas para acessibilidade e SEO

### DIFF
--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -158,6 +158,7 @@ function ViewMode({ setComponentMode, contentObject, viewFrame }) {
 
   return (
     <Box
+      as="article"
       sx={{
         display: 'flex',
         flexDirection: 'column',
@@ -188,8 +189,8 @@ function ViewMode({ setComponentMode, contentObject, viewFrame }) {
               mt: '2px',
               color: 'fg.muted',
             }}>
-            <BranchName as={Link} href={`/${contentObject.owner_username}`}>
-              {contentObject.owner_username}
+            <BranchName as="address" sx={{ fontStyle: 'normal' }}>
+              <Link href={`/${contentObject.owner_username}`}>{contentObject.owner_username}</Link>
             </BranchName>
             {!contentObject.parent_id && (
               <>
@@ -200,7 +201,7 @@ function ViewMode({ setComponentMode, contentObject, viewFrame }) {
             <Link
               href={`/${contentObject.owner_username}/${contentObject.slug}`}
               prefetch={false}
-              sx={{ fontSize: 0, color: 'fg.muted', mr: '100px', py: '2px', height: '22px' }}>
+              sx={{ fontSize: 0, color: 'fg.muted', mr: '100px', py: '1px', height: '22px' }}>
               <PastTime direction="n" date={contentObject.published_at} sx={{ position: 'absolute' }} />
             </Link>
           </Box>
@@ -436,13 +437,13 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
 
   return (
     <Box sx={{ mb: 4, width: '100%' }}>
-      <form onSubmit={handleSubmit} style={{ width: '100%' }}>
+      <form onSubmit={handleSubmit} style={{ width: '100%' }} noValidate>
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
           {globalErrorMessage && <Flash variant="danger">{globalErrorMessage}</Flash>}
 
           {!contentObject?.parent_id && (
-            <FormControl id="title">
-              <FormControl.Label visuallyHidden>Título</FormControl.Label>
+            <FormControl id="title" required>
+              <FormControl.Label>Título</FormControl.Label>
               <TextInput
                 contrast
                 sx={{ px: 2, '&:focus-within': { backgroundColor: 'canvas.default' } }}
@@ -453,8 +454,7 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
                 autoCorrect="off"
                 autoCapitalize="off"
                 spellCheck={false}
-                placeholder="Título"
-                aria-label="Título"
+                placeholder="e.g. Desafios que tive no meu primeiro ano empreendendo com software"
                 // eslint-disable-next-line jsx-a11y/no-autofocus
                 autoFocus={true}
                 block={true}
@@ -467,8 +467,8 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
             </FormControl>
           )}
 
-          <FormControl id="body">
-            <FormControl.Label visuallyHidden>Corpo</FormControl.Label>
+          <FormControl id="body" required={!contentObject?.parent_id}>
+            <FormControl.Label>{contentObject?.parent_id ? 'Seu comentário' : 'Corpo da publicação'}</FormControl.Label>
             <Editor
               isValid={errorObject?.key === 'body'}
               value={newData.body}
@@ -484,7 +484,7 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
 
           {!contentObject?.parent_id && (
             <FormControl id="source_url">
-              <FormControl.Label visuallyHidden>Fonte (opcional)</FormControl.Label>
+              <FormControl.Label>Fonte</FormControl.Label>
               <TextInput
                 contrast
                 sx={{ px: 2, '&:focus-within': { backgroundColor: 'canvas.default' } }}
@@ -495,8 +495,7 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
                 autoCorrect="off"
                 autoCapitalize="off"
                 spellCheck={false}
-                placeholder="Fonte (opcional)"
-                aria-label="Fonte (opcional)"
+                placeholder="https://origem.site/noticia"
                 block={true}
                 value={newData.source_url}
               />
@@ -505,6 +504,10 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
                 <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
               )}
             </FormControl>
+          )}
+
+          {!contentObject?.parent_id && (
+            <Text sx={{ fontSize: 1 }}>Os campos marcados com um asterisco (*) são obrigatórios.</Text>
           )}
 
           <Box sx={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center' }}>

--- a/pages/interface/components/ContentList/index.js
+++ b/pages/interface/components/ContentList/index.js
@@ -2,7 +2,7 @@ import { Box, EmptyState, Link, PastTime, Text, Tooltip } from '@/TabNewsUI';
 import { ChevronLeftIcon, ChevronRightIcon, CommentIcon } from '@/TabNewsUI/icons';
 
 export default function ContentList({ contentList: list, pagination, paginationBasePath, emptyStateProps }) {
-  const listNumberOffset = pagination.perPage * (pagination.currentPage - 1);
+  const listNumberStart = pagination.perPage * (pagination.currentPage - 1) + 1;
 
   const previousPageUrl = `${paginationBasePath}/${pagination?.previousPage}`;
   const nextPageUrl = `${paginationBasePath}/${pagination?.nextPage}`;
@@ -11,11 +11,15 @@ export default function ContentList({ contentList: list, pagination, paginationB
     <>
       {list.length > 0 ? (
         <Box
+          as="ol"
           sx={{
             display: 'grid',
             gap: '0.5rem',
-            gridTemplateColumns: 'auto minmax(0, 1fr)',
-          }}>
+            gridTemplateColumns: 'min-content minmax(0, 1fr)',
+            padding: 0,
+            margin: 0,
+          }}
+          start={listNumberStart}>
           <RenderItems />
           <EndOfRelevant />
         </Box>
@@ -71,87 +75,91 @@ export default function ContentList({ contentList: list, pagination, paginationB
       return count > 1 || count < -1 ? `${count} tabcoins` : `${count} tabcoin`;
     }
 
-    return list.map((contentObject, index) => {
-      const itemCount = index + 1 + listNumberOffset;
-      return [
-        <Box key={itemCount} sx={{ textAlign: 'right' }}>
-          <Text sx={{ fontSize: 2, color: 'fg.default', fontWeight: 'semibold', textAlign: 'right' }}>
-            {itemCount}.
-          </Text>
-        </Box>,
-        <Box as="article" key={contentObject.id}>
-          <Box
-            sx={{
-              overflow: 'auto',
+    return list.map((contentObject) => {
+      return (
+        <Box
+          key={contentObject.id}
+          as="li"
+          sx={{
+            display: 'contents',
+            ':before': {
+              content: 'counter(list-item) "."',
+              counterIncrement: 'list-item',
               fontWeight: 'semibold',
-              fontSize: 2,
-              '> a': {
-                ':link': {
-                  color: 'fg.default',
+              width: 'min-content',
+              marginLeft: 'auto',
+            },
+          }}>
+          <Box as="article">
+            <Box
+              sx={{
+                overflow: 'auto',
+                fontWeight: 'semibold',
+                fontSize: 2,
+                '> a': {
+                  ':link': {
+                    color: 'fg.default',
+                  },
+                  ':visited': {
+                    color: 'fg.subtle',
+                  },
                 },
-                ':visited': {
-                  color: 'fg.subtle',
-                },
-              },
-            }}>
-            {contentObject.parent_id ? (
-              <Link
-                sx={{ wordWrap: 'break-word', fontStyle: 'italic', fontWeight: 'normal' }}
-                href={`/${contentObject.owner_username}/${contentObject.slug}`}>
-                <CommentIcon verticalAlign="middle" size="small" />
-                {` "${contentObject.body}"`}
-              </Link>
-            ) : (
-              <Link sx={{ wordWrap: 'break-word' }} href={`/${contentObject.owner_username}/${contentObject.slug}`}>
-                {contentObject.title}
-              </Link>
-            )}
-          </Box>
-          <Box
-            sx={{
-              display: 'grid',
-              gap: 1,
-              gridTemplateColumns:
-                'max-content max-content max-content max-content minmax(20px, max-content) max-content max-content',
-              fontSize: 0,
-              whiteSpace: 'nowrap',
-              color: 'neutral.emphasis',
-            }}>
-            <Text>
-              <TabCoinsText count={contentObject.tabcoins} />
-            </Text>
-            {' · '}
-            <Text>
-              <ChildrenDeepCountText count={contentObject.children_deep_count} />
-            </Text>
-            {' · '}
-            <Tooltip aria-label={`Autor: ${contentObject.owner_username}`}>
-              <Box sx={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
-                <Link sx={{ color: 'neutral.emphasis' }} href={`/${contentObject.owner_username}`}>
-                  {contentObject.owner_username}
+              }}>
+              {contentObject.parent_id ? (
+                <Link
+                  sx={{ wordWrap: 'break-word', fontStyle: 'italic', fontWeight: 'normal' }}
+                  href={`/${contentObject.owner_username}/${contentObject.slug}`}>
+                  <CommentIcon verticalAlign="middle" size="small" />
+                  {` "${contentObject.body}"`}
                 </Link>
-              </Box>
-            </Tooltip>
-            {' · '}
-            <Text>
-              <PastTime direction="nw" date={contentObject.published_at} />
-            </Text>
+              ) : (
+                <Link sx={{ wordWrap: 'break-word' }} href={`/${contentObject.owner_username}/${contentObject.slug}`}>
+                  {contentObject.title}
+                </Link>
+              )}
+            </Box>
+            <Box
+              sx={{
+                display: 'grid',
+                gap: 1,
+                gridTemplateColumns:
+                  'max-content max-content max-content max-content minmax(20px, max-content) max-content max-content',
+                fontSize: 0,
+                whiteSpace: 'nowrap',
+                color: 'neutral.emphasis',
+              }}>
+              <Text>
+                <TabCoinsText count={contentObject.tabcoins} />
+              </Text>
+              {' · '}
+              <Text>
+                <ChildrenDeepCountText count={contentObject.children_deep_count} />
+              </Text>
+              {' · '}
+              <Tooltip aria-label={`Autor: ${contentObject.owner_username}`}>
+                <Box sx={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                  <Text as="address" sx={{ fontStyle: 'normal' }}>
+                    <Link sx={{ color: 'neutral.emphasis' }} href={`/${contentObject.owner_username}`}>
+                      {contentObject.owner_username}
+                    </Link>
+                  </Text>
+                </Box>
+              </Tooltip>
+              {' · '}
+              <Text>
+                <PastTime direction="nw" date={contentObject.published_at} />
+              </Text>
+            </Box>
           </Box>
-        </Box>,
-      ];
+        </Box>
+      );
     });
   }
 
   function EndOfRelevant() {
-    if (paginationBasePath == '/pagina' && !pagination.nextPage)
-      return [
-        <Box key={0} sx={{ textAlign: 'right' }}>
-          <Text
-            sx={{ fontSize: 2, color: 'fg.default', fontWeight: 'semibold', textAlign: 'right', visibility: 'hidden' }}>
-            0.
-          </Text>
-        </Box>,
-        <Box key={-1}>
+    if (paginationBasePath == '/pagina' && !pagination.nextPage) {
+      return (
+        <Box key="end-of-relevant" sx={{ gridColumnStart: 2 }}>
           <Link sx={{ wordWrap: 'break-word' }} href={'/recentes'}>
             <Box
               sx={{
@@ -163,8 +171,9 @@ export default function ContentList({ contentList: list, pagination, paginationB
             </Box>
             <Box sx={{ fontSize: 0 }}>Veja todos os conteúdos que já foram publicados na seção Recentes.</Box>
           </Link>
-        </Box>,
-      ];
+        </Box>
+      );
+    }
     return null;
   }
 

--- a/pages/interface/components/DefaultLayout/index.js
+++ b/pages/interface/components/DefaultLayout/index.js
@@ -7,6 +7,7 @@ export default function DefaultLayout({ children, containerWidth = 'large', meta
       {metadata && <Head metadata={metadata} />}
       <Header />
       <Box
+        as="main"
         maxWidth={containerWidth}
         sx={{
           marginX: 'auto',

--- a/pages/interface/components/Header/index.js
+++ b/pages/interface/components/Header/index.js
@@ -44,34 +44,32 @@ export default function HeaderComponent() {
   const activeLinkStyle = {
     textDecoration: 'underline',
     textUnderlineOffset: 6,
+    ml: 3,
   };
 
   return (
-    <PrimerHeader
-      id="header"
-      sx={{
-        minWidth: 'max-content',
-        px: [2, null, null, 3],
-      }}>
+    <PrimerHeader as="header" id="header" sx={{ minWidth: 'max-content', px: [2, null, null, 3] }}>
       <SearchBoxOverlay />
-      <PrimerHeader.Item>
-        <HeaderLink href="/" aria-label="Voltar para a página inicial">
-          <CgTab size={32} />
-          <Box sx={{ ml: 2, display: ['none', 'block'] }}>TabNews</Box>
-        </HeaderLink>
-      </PrimerHeader.Item>
+      <Box as="nav" sx={{ display: 'flex', flex: 1, margin: 0, padding: 0 }}>
+        <PrimerHeader.Item sx={{ mr: 0 }}>
+          <HeaderLink href="/" aria-label="Página inicial Relevantes" aria-current={asPath === '/' ? 'page' : false}>
+            <CgTab size={32} />
 
-      <PrimerHeader.Item>
-        <HeaderLink href="/" sx={asPath === '/' || asPath.startsWith('/pagina') ? activeLinkStyle : undefined}>
-          Relevantes
-        </HeaderLink>
-      </PrimerHeader.Item>
+            <Box sx={{ ml: 2, display: ['none', 'block'] }}>TabNews</Box>
 
-      <PrimerHeader.Item full sx={{ mr: 0 }}>
-        <HeaderLink href="/recentes" sx={asPath.startsWith('/recentes') ? activeLinkStyle : undefined}>
-          Recentes
-        </HeaderLink>
-      </PrimerHeader.Item>
+            <Box sx={asPath === '/' || asPath.startsWith('/pagina') ? activeLinkStyle : { ml: 3 }}>Relevantes</Box>
+          </HeaderLink>
+        </PrimerHeader.Item>
+
+        <PrimerHeader.Item full sx={{ mr: 0 }}>
+          <HeaderLink
+            href="/recentes"
+            aria-current={asPath === '/recentes' ? 'page' : false}
+            sx={asPath.startsWith('/recentes') ? activeLinkStyle : { ml: 3 }}>
+            Recentes
+          </HeaderLink>
+        </PrimerHeader.Item>
+      </Box>
 
       {!isLoading && (
         <PrimerHeader.Item

--- a/pages/interface/components/ReadTime/index.js
+++ b/pages/interface/components/ReadTime/index.js
@@ -10,7 +10,7 @@ export default function ReadTime({ text, ...props }) {
   }, [text]);
 
   return (
-    <Text sx={{ fontSize: 0, color: 'fg.muted', py: '2px', height: '22px' }} {...props}>
+    <Text sx={{ fontSize: 0, color: 'fg.muted', py: '1px', height: '22px' }} {...props}>
       {readTimeInMinutes}
     </Text>
   );

--- a/pages/interface/components/TabCashCount/index.js
+++ b/pages/interface/components/TabCashCount/index.js
@@ -4,6 +4,7 @@ import { SquareFillIcon } from '@/TabNewsUI/icons';
 export default function TabCashCount({ amount, direction, mode = 'tooltip', sx }) {
   const modes = {
     tooltip: {
+      iconLabel: 'TabCash',
       iconSize: 16,
       text: amount?.toLocaleString('pt-BR'),
     },
@@ -13,11 +14,11 @@ export default function TabCashCount({ amount, direction, mode = 'tooltip', sx }
     },
   };
 
-  const { iconSize, text } = modes[mode];
+  const { iconLabel, iconSize, text } = modes[mode];
 
   const content = (
     <Box sx={{ display: 'flex', textWrap: 'nowrap', alignItems: 'center', ...sx }}>
-      <SquareFillIcon fill="#2da44e" size={iconSize} />
+      <SquareFillIcon aria-label={iconLabel} fill="#2da44e" size={iconSize} />
       <Text>{text}</Text>
     </Box>
   );

--- a/pages/interface/components/TabCoinCount/index.js
+++ b/pages/interface/components/TabCoinCount/index.js
@@ -4,6 +4,7 @@ import { SquareFillIcon } from '@/TabNewsUI/icons';
 export default function TabCoinCount({ amount, direction, mode = 'tooltip', sx }) {
   const modes = {
     tooltip: {
+      iconLabel: 'TabCoins',
       iconSize: 16,
       text: amount?.toLocaleString('pt-BR'),
     },
@@ -13,11 +14,11 @@ export default function TabCoinCount({ amount, direction, mode = 'tooltip', sx }
     },
   };
 
-  const { iconSize, text } = modes[mode];
+  const { iconLabel, iconSize, text } = modes[mode];
 
   const content = (
     <Box sx={{ display: 'flex', textWrap: 'nowrap', alignItems: 'center', ...sx }}>
-      <SquareFillIcon fill="#0969da" size={iconSize} />
+      <SquareFillIcon aria-label={iconLabel} fill="#0969da" size={iconSize} />
       <Text>{text}</Text>
     </Box>
   );

--- a/pages/pagina/[page]/index.public.js
+++ b/pages/pagina/[page]/index.public.js
@@ -9,7 +9,7 @@ import validator from 'models/validator.js';
 export default function Home({ contentListFound, pagination }) {
   return (
     <>
-      <DefaultLayout metadata={{ title: `Página ${pagination.currentPage} · Melhores` }}>
+      <DefaultLayout metadata={{ title: `Página ${pagination.currentPage} · Relevantes` }}>
         <ContentList contentList={contentListFound} pagination={pagination} paginationBasePath="/pagina" />
       </DefaultLayout>
     </>

--- a/pages/perfil/index.public.js
+++ b/pages/perfil/index.public.js
@@ -12,6 +12,7 @@ import {
   FormControl,
   Heading,
   Link,
+  Text,
   TextInput,
   useConfirm,
 } from '@/TabNewsUI';
@@ -186,7 +187,7 @@ function EditProfileForm() {
   return (
     <form style={{ width: '100%' }} onSubmit={handleSubmit} onChange={clearMessages}>
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
-        <FormControl id="username">
+        <FormControl id="username" required>
           <FormControl.Label>Nome de usuário</FormControl.Label>
           <TextInput
             ref={usernameRef}
@@ -209,7 +210,7 @@ function EditProfileForm() {
           )}
         </FormControl>
 
-        <FormControl id="email" disabled={emailDisabled}>
+        <FormControl id="email" disabled={emailDisabled} required>
           <FormControl.Label>Email</FormControl.Label>
           <TextInput
             ref={emailRef}
@@ -223,10 +224,10 @@ function EditProfileForm() {
             contrast
             sx={{ minHeight: '46px', px: 2, '&:focus-within': { backgroundColor: 'canvas.default' } }}
           />
-          {errorObject?.key === 'email' && !errorObject?.type && (
+          {errorObject?.key === 'email' && errorObject.type !== 'typo' && (
             <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
           )}
-          {errorObject?.key === 'email' && errorObject?.type === 'typo' && (
+          {errorObject?.key === 'email' && errorObject.type === 'typo' && (
             <FormControl.Validation variant="error">
               <Box sx={{ display: 'flex', alignItems: 'center' }}>
                 <Box>Você quis dizer:</Box>
@@ -261,7 +262,7 @@ function EditProfileForm() {
             compact={true}
           />
 
-          {errorObject?.key === 'description' && errorObject?.type === 'string.max' && (
+          {errorObject?.key === 'description' && errorObject.type === 'string.max' && (
             <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
           )}
         </FormControl>
@@ -287,6 +288,8 @@ function EditProfileForm() {
             Utilize o fluxo de recuperação de senha →
           </Link>
         </FormControl>
+
+        <Text sx={{ fontSize: 1 }}>Os campos marcados com um asterisco (*) são obrigatórios.</Text>
 
         {globalMessageObject && <Flash variant={globalMessageObject.type}>{globalMessageObject.text}</Flash>}
 


### PR DESCRIPTION
## Mudanças realizadas

Esse PR é um "sucessor espiritual" do https://github.com/filipedeschamps/tabnews.com.br/pull/992, implementando os comentários que não foram resolvidos. Acabei realizando alguns estudos para usar as tags de forma mais adequada e vou compartilhar aqui o que descobri.

O objetivo do PR é não ter nenhuma alteração visual, mas usar tags semanticamente corretas, o que deve ter um impacto positivo tanto na acessibilidade quanto no SEO.

1. No outro PR havia modificações para associar a `label` ao `input` nos formulários, mas vi na documentação do [FormControl](https://primer.style/components/form-control/react) que ele já cuida disso.
2. Agora os campos na criação de conteúdo tem o `label` visível e o marcador de `required`, respeitando a documentação do [Text Input](https://primer.style/components/text-input) e [Forms](https://primer.style/ui-patterns/forms/overview) do Primer. Deixei o `form` da criação de conteúdo como `noValidate` porque o navegador conseguia realizar a validação do `title` (com estilização do próprio navegador), mas não do `body`, então ficava sem padrão.
3. Conforme a documentação de formulários do Primer, o Login e o Comentário não precisam de marcação `required` porque já é algo bem esperado. Eu também não coloquei no Cadastro, mas talvez faça sentido por existir um campo “email”, que a pessoa pode pensar que é opcional.
4. De acordo com as [especificações](https://html.spec.whatwg.org/multipage/sections.html#the-nav-element), não há necessidade em usar `nav` no `footer`.
5. Na [especificação](https://html.spec.whatwg.org/multipage/sections.html#the-article-element) diz que o uso de `article`s aninhados é para designar conteúdos relacionados, e inclusive é exemplificado que isso serve para comentários num blog.
6. O `address` deve ser usado uma única vez por `article`. Ou seja, em caso de ter `article`s aninhados, apenas o raiz deve ter `address`. [Referência](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/article#usage_notes).
7. Coloquei no código `as={viewFrame ? 'article' : undefined}` para que uma nova resposta seja um `article` também.
8. Coloquei `list-style` nos itens do header por precaução. Testando localmente no Firefox não precisava.

### Correção extra

1. Antes a mensagem de erro “_"email" deve conter um email válido._” não aparecia por causa da condição `!errorObject?.type`.
2. Resolve #941: Como eu estava mexendo no formulário, acabei adicionando o placeholder de exemplo na Fonte. No título eu coloquei com `e.g.` porque acho que ficou meio estranho sem ele, e na fonte achei o contrário hehe.
3. Acho que isso melhora, mas não resolve o problema de https://github.com/filipedeschamps/tabnews.com.br/issues/1397. Como mencionei lá, parece que existe um cálculo do navegador para dar pontuação e identificar o conteúdo para leitura. Apesar de ter feito as melhorias das tags conforme especificações, no ambiente local o resultado do modo leitura não ficou tão bom quanto eu esperava.

### Ponto em dúvida para melhoria

1. Faz sentido mostrar o label “Corpo” no caso de resposta? Fiquei em dúvida se `Corpo` fica estranho e deveria ser `Resposta` ou `Comentário`. Discutimos no PR https://github.com/filipedeschamps/tabnews.com.br/pull/1577 de usar `Comentário` para o substantivo e `Responder` para a ação, mas clicar em `Responder` e ver um campo escrito `Comentário` pode causar confusão.


## Tipo de mudança

<!-- Descomente a linha abaixo que corresponde ao tipo de mudança realizada no PR. -->

- [x] Correção de bug

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [ ] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
