### PR TITLE
Salvar Email no autocomplete ao invés do Nome de Usuário no Cadastro

### DIFF
--- a/pages/cadastro/index.public.js
+++ b/pages/cadastro/index.public.js
@@ -114,12 +114,12 @@ function SignUpForm() {
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
         {globalErrorMessage && <Flash variant="danger">{globalErrorMessage}</Flash>}
 
-        <FormControl id="username">
+        <FormControl id="name">
           <FormControl.Label>Nome de usuário</FormControl.Label>
           <TextInput
             ref={usernameRef}
             onChange={clearErrors}
-            name="username"
+            name="name"
             size="large"
             autoCorrect="off"
             autoCapitalize="off"
@@ -144,6 +144,7 @@ function SignUpForm() {
             onChange={clearErrors}
             name="email"
             size="large"
+            autoComplete="username"
             autoCorrect="off"
             autoCapitalize="off"
             spellCheck={false}


### PR DESCRIPTION
## Mudanças realizadas

Ao realizar o cadastro, os gerenciadores de senha dos navegadores sugeriam salvar a combinação Nome de Usuário + Senha. Pesquisando, encontrei uma [solução](https://stackoverflow.com/a/57902690/8839059) para salvar Email + Senha sem precisar alterar a ordem dos campos.

O PR contém duas alterações:

- Novo atributo `autocomplete="username"` no campo de email para orientar o gerenciador de senha dos navegadores.
- Mudança do `id` do campo de Nome de Usuário para não confundir o gerenciador de senhas do Bitwarden. O `name` foi modificado apenas para ficar igual ao `id`. Nos testes que realizei, o gerenciador de senha dos navegadores não precisavam dessa alteração.

Nenhuma mudança foi necessária na tela de Login.

### Teste com o gerenciador do Firefox e Bitwarden:

[Screencast](https://github.com/filipedeschamps/tabnews.com.br/assets/26308880/5536f95f-fa4c-43bb-87af-59f32a3be7ed)

### Teste com o gerenciador do Chromium:

[Screencast](https://github.com/filipedeschamps/tabnews.com.br/assets/26308880/f37d13b7-7c60-48f9-b0b7-8317cb278a04)

Resolve #943

## Tipo de mudança

<!-- Descomente a linha abaixo que corresponde ao tipo de mudança realizada no PR.

- [x] Correção de bug
<!-- - [x] Nova funcionalidade -->
<!-- - [x] _**Breaking change**_ (a alteração causa uma quebra de compatibilidade na API ou em links públicos do site) -->
<!-- - [x] Atualização de documentação -->

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [ ] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
