### PR TITLE
Identificar o autor da publicação principal da página nos comentários

### DIFF
--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -85,6 +85,7 @@ export default function Post({ contentFound, rootContentFound, parentContentFoun
             key={contentFound.id}
             childrenDeepCount={contentFound.children_deep_count}
             childrenList={contentFound.children}
+            pageRootOwnerId={contentFound.owner_id}
             renderIntent={childrenToShow}
             renderIncrement={Math.ceil(childrenToShow / 2)}
           />
@@ -178,13 +179,14 @@ function InReplyToLinks({ content, parentContent, rootContent }) {
   );
 }
 
-function RenderChildrenTree({ childrenList, renderIntent, renderIncrement }) {
+function RenderChildrenTree({ childrenList, pageRootOwnerId, renderIntent, renderIncrement }) {
   const { childrenState, handleCollapse, handleExpand } = useCollapse({ childrenList, renderIntent, renderIncrement });
 
   return childrenState.map((child) => {
     const { children, children_deep_count, groupedCount, id, owner_id, renderIntent, renderShowMore } = child;
     const labelShowMore = Math.min(groupedCount, renderIncrement) || '';
     const plural = labelShowMore != 1 ? 's' : '';
+    const isPageRootOwner = pageRootOwnerId === owner_id;
 
     return !renderIntent && !renderShowMore ? null : (
       <Box
@@ -256,7 +258,7 @@ function RenderChildrenTree({ childrenList, renderIntent, renderIncrement }) {
             </Box>
 
             <Box sx={{ width: '100%', pl: '1px', overflow: 'auto' }}>
-              <Content content={child} mode="view" />
+              <Content content={child} isPageRootOwner={isPageRootOwner} mode="view" />
 
               <Box sx={{ mt: 4 }}>
                 <Content content={{ owner_id, parent_id: id }} mode="compact" viewFrame={true} />
@@ -266,6 +268,7 @@ function RenderChildrenTree({ childrenList, renderIntent, renderIncrement }) {
                 <RenderChildrenTree
                   childrenDeepCount={children_deep_count}
                   childrenList={children}
+                  pageRootOwnerId={pageRootOwnerId}
                   renderIntent={renderIntent - 1}
                   renderIncrement={renderIncrement}
                 />

--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -13,18 +13,21 @@ import {
   FormControl,
   Heading,
   IconButton,
+  Label,
+  LabelGroup,
   Link,
   PastTime,
   ReadTime,
   Text,
   TextInput,
+  Tooltip,
   useConfirm,
   Viewer,
 } from '@/TabNewsUI';
 import { KebabHorizontalIcon, LinkIcon, PencilIcon, TrashIcon } from '@/TabNewsUI/icons';
 import { useUser } from 'pages/interface';
 
-export default function Content({ content, mode = 'view', viewFrame = false }) {
+export default function Content({ content, isPageRootOwner, mode = 'view', viewFrame = false }) {
   const [componentMode, setComponentMode] = useState(mode);
   const [contentObject, setContentObject] = useState(content);
   const { user } = useUser();
@@ -59,7 +62,14 @@ export default function Content({ content, mode = 'view', viewFrame = false }) {
   }, [localStorageKey, user, contentObject]);
 
   if (componentMode === 'view') {
-    return <ViewMode setComponentMode={setComponentMode} contentObject={contentObject} viewFrame={viewFrame} />;
+    return (
+      <ViewMode
+        setComponentMode={setComponentMode}
+        contentObject={contentObject}
+        isPageRootOwner={isPageRootOwner}
+        viewFrame={viewFrame}
+      />
+    );
   } else if (componentMode === 'compact') {
     return <CompactMode setComponentMode={setComponentMode} contentObject={contentObject} />;
   } else if (componentMode === 'edit') {
@@ -81,7 +91,7 @@ function ViewModeOptionsMenu({ onDelete, onComponentModeChange }) {
     <Box sx={{ position: 'relative' }}>
       <Box sx={{ position: 'absolute', right: 0 }}>
         {/* I've wrapped ActionMenu with this additional divs, to stop content from vertically
-          flickering after this menu appears */}
+        flickering after this menu appears, because without `position: absolute` it increases the row height */}
         <ActionMenu>
           <ActionMenu.Anchor>
             <IconButton size="small" icon={KebabHorizontalIcon} aria-label="Editar conteúdo" />
@@ -109,7 +119,7 @@ function ViewModeOptionsMenu({ onDelete, onComponentModeChange }) {
   );
 }
 
-function ViewMode({ setComponentMode, contentObject, viewFrame }) {
+function ViewMode({ setComponentMode, contentObject, isPageRootOwner, viewFrame }) {
   const { user, fetchUser } = useUser();
   const [globalErrorMessage, setGlobalErrorMessage] = useState(null);
   const confirm = useConfirm();
@@ -156,6 +166,8 @@ function ViewMode({ setComponentMode, contentObject, viewFrame }) {
     }
   };
 
+  const isOptionsMenuVisible = user?.id === contentObject.owner_id || user?.features?.includes('update:content:others');
+
   return (
     <Box
       as="article"
@@ -187,11 +199,27 @@ function ViewMode({ setComponentMode, contentObject, viewFrame }) {
               whiteSpace: 'nowrap',
               gap: 1,
               mt: '2px',
+              mr: isOptionsMenuVisible ? '28px' : 0,
               color: 'fg.muted',
             }}>
             <BranchName as="address" sx={{ fontStyle: 'normal' }}>
               <Link href={`/${contentObject.owner_username}`}>{contentObject.owner_username}</Link>
             </BranchName>
+            {isPageRootOwner && (
+              <LabelGroup>
+                <Box sx={{ display: 'flex' }}>
+                  <Label aria-hidden sx={{ opacity: 0, userSelect: 'none' }}>
+                    Autor
+                  </Label>
+                  <Tooltip
+                    aria-label="Autor do conteúdo principal da página"
+                    direction="n"
+                    sx={{ position: 'absolute' }}>
+                    <Label>Autor</Label>
+                  </Tooltip>
+                </Box>
+              </LabelGroup>
+            )}
             {!contentObject.parent_id && (
               <>
                 <ReadTime text={contentObject.body} />
@@ -201,11 +229,11 @@ function ViewMode({ setComponentMode, contentObject, viewFrame }) {
             <Link
               href={`/${contentObject.owner_username}/${contentObject.slug}`}
               prefetch={false}
-              sx={{ fontSize: 0, color: 'fg.muted', mr: '100px', py: '1px', height: '22px' }}>
+              sx={{ fontSize: 0, color: 'fg.muted', mr: '80px', py: '1px', height: '22px' }}>
               <PastTime direction="n" date={contentObject.published_at} sx={{ position: 'absolute' }} />
             </Link>
           </Box>
-          {(user?.id === contentObject.owner_id || user?.features?.includes('update:content:others')) && (
+          {isOptionsMenuVisible && (
             <ViewModeOptionsMenu onComponentModeChange={setComponentMode} onDelete={handleClickDelete} />
           )}
         </Box>

--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -88,7 +88,7 @@ export default function Content({ content, isPageRootOwner, mode = 'view', viewF
 
 function ViewModeOptionsMenu({ onDelete, onComponentModeChange }) {
   return (
-    <Box sx={{ position: 'relative' }}>
+    <Box sx={{ position: 'relative', minWidth: '28px' }}>
       <Box sx={{ position: 'absolute', right: 0 }}>
         {/* I've wrapped ActionMenu with this additional divs, to stop content from vertically
         flickering after this menu appears, because without `position: absolute` it increases the row height */}
@@ -198,28 +198,18 @@ function ViewMode({ setComponentMode, contentObject, isPageRootOwner, viewFrame 
               alignItems: 'center',
               whiteSpace: 'nowrap',
               gap: 1,
-              mt: '2px',
-              mr: isOptionsMenuVisible ? '28px' : 0,
               color: 'fg.muted',
             }}>
-            <BranchName as="address" sx={{ fontStyle: 'normal' }}>
+            <BranchName as="address" sx={{ fontStyle: 'normal', pt: 1 }}>
               <Link href={`/${contentObject.owner_username}`}>{contentObject.owner_username}</Link>
             </BranchName>
-            {isPageRootOwner && (
-              <LabelGroup>
-                <Box sx={{ display: 'flex' }}>
-                  <Label aria-hidden sx={{ opacity: 0, userSelect: 'none' }}>
-                    Autor
-                  </Label>
-                  <Tooltip
-                    aria-label="Autor do conteúdo principal da página"
-                    direction="n"
-                    sx={{ position: 'absolute' }}>
-                    <Label>Autor</Label>
-                  </Tooltip>
-                </Box>
-              </LabelGroup>
-            )}
+            <LabelGroup>
+              {isPageRootOwner && (
+                <Tooltip aria-label="Autor do conteúdo principal da página" direction="n" sx={{ position: 'absolute' }}>
+                  <Label>Autor</Label>
+                </Tooltip>
+              )}
+            </LabelGroup>
             {!contentObject.parent_id && (
               <>
                 <ReadTime text={contentObject.body} />
@@ -229,7 +219,7 @@ function ViewMode({ setComponentMode, contentObject, isPageRootOwner, viewFrame 
             <Link
               href={`/${contentObject.owner_username}/${contentObject.slug}`}
               prefetch={false}
-              sx={{ fontSize: 0, color: 'fg.muted', mr: '80px', py: '1px', height: '22px' }}>
+              sx={{ fontSize: 0, color: 'fg.muted' }}>
               <PastTime direction="n" date={contentObject.published_at} sx={{ position: 'absolute' }} />
             </Link>
           </Box>

--- a/pages/interface/components/ReadTime/index.js
+++ b/pages/interface/components/ReadTime/index.js
@@ -10,7 +10,7 @@ export default function ReadTime({ text, ...props }) {
   }, [text]);
 
   return (
-    <Text sx={{ fontSize: 0, color: 'fg.muted', py: '1px', height: '22px' }} {...props}>
+    <Text sx={{ fontSize: 0, color: 'fg.muted' }} {...props}>
       {readTimeInMinutes}
     </Text>
   );

--- a/pages/interface/components/TabNewsUI/index.js
+++ b/pages/interface/components/TabNewsUI/index.js
@@ -21,6 +21,7 @@ export { default as TabCoinButtons } from '@/TabCoinButtons';
 export { default as TabCoinCount } from '@/TabCoinCount';
 export { default as ThemeProvider } from '@/ThemeProvider';
 export { default as ThemeSelector, ThemeSwitcher } from '@/ThemeSelector';
+export { default as Tooltip } from '@/Tooltip';
 export { default as UserHeader } from '@/UserHeader';
 export {
   ActionList,
@@ -45,12 +46,12 @@ export {
   Link as PrimerLink,
   TabNav as PrimerTabNav,
   ThemeProvider as PrimerThemeProvider,
+  Tooltip as PrimerTooltip,
   SSRProvider,
   SegmentedControl,
   Spinner,
   Text,
   TextInput,
-  Tooltip,
   Truncate,
   useConfirm,
   useTheme,

--- a/pages/interface/components/Tooltip/index.js
+++ b/pages/interface/components/Tooltip/index.js
@@ -1,0 +1,15 @@
+import { Box, PrimerTooltip } from '@/TabNewsUI';
+
+export default function Tooltip({ children, ...props }) {
+  const { sx: { position, ...sxRest } = {} } = props;
+
+  if (position === 'absolute')
+    return (
+      <Box sx={{ display: 'inline-flex' }}>
+        <Box sx={{ ...sxRest, visibility: 'hidden' }}>{children}</Box>
+        <PrimerTooltip {...props}>{children}</PrimerTooltip>
+      </Box>
+    );
+
+  return <PrimerTooltip {...props}>{children}</PrimerTooltip>;
+}


### PR DESCRIPTION
## Mudanças realizadas

### Pendente

1. Alguma sugestão de nome melhor do que "Autor" para esse label? Experimentei colocar "Autor(a)", achei um pouco estranho mas talvez seja apenas falta de costume. PS: Hoje "Autor" já é usado no Tooltip da lista de conteúdos, então se for alterado aqui, será alterado lá também.

| Autor | Autor(a) |
|--- | --- |
| ![Nome "Betty3", Label e tooltip "Autor"](https://github.com/filipedeschamps/tabnews.com.br/assets/26308880/7f6b658d-f027-414e-b055-deecd6c6b8be) | ![Nome "Betty3", Label e tooltip "Autor(a)"](https://github.com/filipedeschamps/tabnews.com.br/assets/26308880/fdc1f78c-7bb2-4a42-9c00-914dc779c5bf) |
| ![Nome "rafael", Label e tooltip "Autor"](https://github.com/filipedeschamps/tabnews.com.br/assets/26308880/5e9a7130-831f-4b58-8e2b-604f8aa6394c) | ![Nome "rafael", Label e tooltip "Autor(a)"](https://github.com/filipedeschamps/tabnews.com.br/assets/26308880/97196c8e-e9c4-4f00-9936-85eaefdd68f7)

2. Com o andamento do PR do FAQ para chamar tudo de "conteúdo", talvez faça sentido trocar o texto de `Autor da publicação principal da página` para `Autor do conteúdo principal da página`.


### Detalhes da implementação

- Não consegui pensar num nome melhor para as variáveis, então estou aberto a sugestões.
- Talvez remover o `overflow: "auto"` tenha criado algum bug, mas fiz testes com textos longos e com Zalgo, está funcionando como esperado. Precisei remover por causa do Tooltip (a única outra forma que encontrei seria usar `position: "absolute"`, que traria outros problemas). Isso permitiu remover o `position: "absolute"` do `PastTime` também.
-  O Tooltip não possui detecção automática dos cantos da tela para ter uma exibição melhor, então do jeito que está, o comportamento não fica legal em algumas situações específicas, como um comentário muito aninhado em uma tela pequena.
- Tirei as divs que encapsulavam o `ViewModeOptionsMenu` e não percebi o bug do flicker. Não sei como ele era antes, então seria bom revisarem isso com atenção, porque ou eu reproduzi errado ou a própria biblioteca Primer já corrigiu isso.

Resolve #972 

## Tipo de mudança

 - [x] Nova funcionalidade

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [ ] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
