### PR TITLE
fix: texto TabCoin no singular concatena com valor booleano

### DIFF
--- a/pages/interface/components/TabCoinCount/index.js
+++ b/pages/interface/components/TabCoinCount/index.js
@@ -9,7 +9,7 @@ export default function TabCoinCount({ amount, direction, mode = 'tooltip', sx }
     },
     full: {
       iconSize: 20,
-      text: `${amount?.toLocaleString('pt-BR')} TabCoin${amount !== 1 && 's'}`,
+      text: `${amount?.toLocaleString('pt-BR')} TabCoin${amount > 1 || amount < -1 ? 's' : ''}`,
     },
   };
 


### PR DESCRIPTION
## Mudanças realizadas
No componente TabCoinCount, existe uma condição para retirar ou adicionar o plural, dependendo se o usuário possui uma única ou mais TabCoins.
O problema ocorre quando o usuário possui apenas uma TabCoin. Nessa condição, a verificação `amount !== 1` faz com que o seu retorno booleano seja concatenado na string "TabCoin", como por exemplo:

![image](https://github.com/filipedeschamps/tabnews.com.br/assets/54487387/ed430f63-c2e4-4b6c-bfa6-3617a764fb82)

Mudei essa condição utilizando o operador ternário para corrigir o problema.

## Tipo de mudança

- [x] Correção de bug