### PR TITLE
Adiciona `key` para o React mostrar numeração correta nas listas de conteúdos.

### DIFF
--- a/pages/interface/components/ContentList/index.js
+++ b/pages/interface/components/ContentList/index.js
@@ -19,6 +19,7 @@ export default function ContentList({ contentList: list, pagination, paginationB
             padding: 0,
             margin: 0,
           }}
+          key={listNumberStart}
           start={listNumberStart}>
           <RenderItems />
           <EndOfRelevant />


### PR DESCRIPTION
## Mudanças realizadas

Com o PR #1580 as listas de conteúdos passaram a usar as tags `ol` e `li`, e o parâmetro `start` define o número do primeiro item. Por exemplo, iniciando em 31 na página 2.

Acontece que o React nem sempre está atualizando os números ao mudarmos de página, mesmo com a mudança do valor em `start`. No Safari eu não vi o bug, mas no Chrome acontece sempre.

Para forçar a renderização com os números corretos, `listNumberStart` também foi passado como `key` para a tag `ol`.

Para testar, navegue entre diferentes páginas que tenham o mesmo `pathname` usando os botões `Anterior` e/ou `Próximo` no final da lista. Por exemplo, à partir da `/pagina/3`. Compare as duas versões:

- Com bug: https://tabnews-git-accessibility-fixes-tabnews.vercel.app/recentes/pagina/3
- Corrigido: https://tabnews-git-content-list-numbering-tabnews.vercel.app/recentes/pagina/3

## Tipo de mudança

- [x] Correção de bug

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).