### PR TITLE
feat: adicionar retorno de resultados para comentários

### DIFF
--- a/models/content.js
+++ b/models/content.js
@@ -236,7 +236,7 @@ async function findWithStrategy(options = {}) {
     const results = {};
     const options = {};
 
-    if (!values?.where?.owner_username) {
+    if (!values?.where?.owner_username && values?.where?.parent_id === null) {
       options.strategy = 'relevant_global';
     }
     values.order = 'published_at DESC';


### PR DESCRIPTION
Adicionar uma query com nome type na API para retornar os comentários de uma postagem, listar todos os comentários por paginação e estratégia.

## Mudanças realizadas

<!-- Por favor, inclua uma descrição sobre o que foi modificado nesse PR. Inclua também qualquer motivação ou contexto relevante.  -->
Adicionar retorno de resultados para comentários, como recentemente foi adicionado na aba recentes tabs com "todos", "comentários", além das "publicações"., não encontrei alguma alteração na API em relação ao retorno dos comentários.

<!-- Se o PR contém uma modificação da interface gráfica (UI), adicione fotos ou vídeos comparando o antes e depois. -->

<!-- Se o PR contém modificações de API, mencione os endpoints afetados. -->
Endpoints afetados:
```
GET {{BaseUrl}}/contents?page={pagina}&per_page={porPagina}&strategy={estrategia}
```

Novo endpoint adicionado:
```
GET {{BaseUrl}}/contents?page={pagina}&per_page={porPagina}&strategy={estrategia}&type={Tipo}
```

O "type" deve possuir um dos seguintes valores: "comments"

<!-- Caso esse PR resolva algum issue, você pode descomentar a linha abaixo e substituir (issue) pelo número dele. -->
<!-- Resolve #(issue) -->

## Tipo de mudança

<!-- Descomente a linha abaixo que corresponde ao tipo de mudança realizada no PR. -->

<!-- - [x] Correção de bug -->
- [x] Nova funcionalidade
<!-- - [x] _**Breaking change**_ (a alteração causa uma quebra de compatibilidade na API ou em links públicos do site) -->
<!-- - [x] Atualização de documentação -->

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [ ] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
