### PR TITLE
Usar variáveis de ambiente no docker-compose.development.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Start containers
-        run: docker-compose -f infra/docker-compose.development.yml up -d
+        run: npm run services:up
 
       - uses: actions/cache@v2
         with:
@@ -32,7 +32,7 @@ jobs:
 
       - name: Stop containers
         if: always()
-        run: docker-compose -f infra/docker-compose.development.yml down
+        run: npm run services:down
 
   lint-styles:
     name: Lint Styles

--- a/infra/docker-compose.development.yml
+++ b/infra/docker-compose.development.yml
@@ -2,11 +2,11 @@ version: '2.4'
 services:
   postgres_dev:
     container_name: 'postgres-dev'
-    image: 'postgres:14.1-alpine'
+    image: 'postgres:14.7-alpine'
     env_file:
       - ../.env
     ports:
-      - '54320:5432'
+      - '${POSTGRES_PORT}:5432'
     volumes:
       - postgres_data:/data/postgres
     restart: unless-stopped
@@ -14,10 +14,10 @@ services:
     container_name: mailcatcher
     image: sj26/mailcatcher
     expose:
-      - 1025
-      - 1080
+      - '${EMAIL_SMTP_PORT}'
+      - '${EMAIL_HTTP_PORT}'
     ports:
-      - 1025:1025
-      - 1080:1080
+      - '${EMAIL_SMTP_PORT}:1025'
+      - '${EMAIL_HTTP_PORT}:1080'
 volumes:
   postgres_data:

--- a/package.json
+++ b/package.json
@@ -69,8 +69,9 @@
   "scripts": {
     "dev": "kill-port 3000 && npm run services:up && npm run migration:run && npm run migration:seed && npm run next && npm run services:stop",
     "next": "next dev",
-    "services:up": "docker-compose -f infra/docker-compose.development.yml up -d || docker compose -f infra/docker-compose.development.yml up -d",
-    "services:stop": "docker-compose -f infra/docker-compose.development.yml stop || docker compose -f infra/docker-compose.development.yml stop",
+    "services:up": "docker-compose --env-file .env -f infra/docker-compose.development.yml up -d || docker compose --env-file .env -f infra/docker-compose.development.yml up -d",
+    "services:stop": "docker-compose --env-file .env -f infra/docker-compose.development.yml stop || docker compose --env-file .env -f infra/docker-compose.development.yml stop",
+    "services:down": "docker-compose --env-file .env -f infra/docker-compose.development.yml down || docker compose --env-file .env -f infra/docker-compose.development.yml down",
     "build": "next build",
     "build:local": "kill-port 3000 && npm run services:up && npm run migration:run && npm run migration:seed && next build && npm run services:stop",
     "start": "next start",


### PR DESCRIPTION
## Mudanças realizadas

Tive um problema ao rodar os serviços já tendo a porta do SMTP ocupada, mesmo alterando as variáveis de ambiente. Então percebi que as variáveis de ambientes não estavam sendo usadas no `infra/docker-compose.development.yml`.

* Estou usando strings explícitas como valores para as portas, conforme sugerido na [documentação](https://docs.docker.com/compose/compose-file/compose-file-v3/#ports).
* Estou usando o parâmetro [`--env-file`](https://docs.docker.com/engine/reference/commandline/run/#env) pelo CLI. Tentei usar o [`env_file`](https://docs.docker.com/compose/compose-file/05-services/#env_file) no `.yml`, mas não estava funcionando (_"The \"EMAIL_SMTP_PORT\" variable is not set. Defaulting to a blank string."_). Pelo o que entendi, o `env_file` passa as variáveis de ambiente para o container, e não para ser usada no próprio `yml`.
* Aproveitei para usar o `npm run services:up` no `.github/workflows/ci.yml`, já que era o mesmo comando do `package.json`.

Testei localmente no Linux e Windows, também testei no Codespaces e Gitpod. Não precisei mudar a configuração `.gitpod.yml` para funcionar, mas não sei porquê.

## Tipo de mudança

- [x] Correção de bug
