### PR TITLE
Adicionar rel="nofollow" nos links de conteúdos gerados por usuário

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "react-icons": "4.8.0",
         "react-rewards": "2.0.4",
         "recharts": "2.5.0",
+        "rehype-external-links": "3.0.0",
         "satori": "0.9.1",
         "set-cookie-parser": "2.6.0",
         "slug": "8.2.2",
@@ -3089,6 +3090,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
     },
     "node_modules/@upstash/core-analytics": {
       "version": "0.0.6",
@@ -7399,6 +7405,17 @@
       "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/is-absolute-url": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-4.0.1.tgz",
+      "integrity": "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-arguments": {
@@ -11876,6 +11893,87 @@
         "node": ">=6"
       }
     },
+    "node_modules/rehype-external-links": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-external-links/-/rehype-external-links-3.0.0.tgz",
+      "integrity": "sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "is-absolute-url": "^4.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-external-links/node_modules/@types/hast": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.3.tgz",
+      "integrity": "sha512-2fYGlaDy/qyLlhidX42wAH0KBi2TCjKMH8CHmBXgRlJ3Y+OXTiqsPQ6IWarZKwF1JoUcAJdPogv1d4b0COTpmQ==",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/rehype-external-links/node_modules/@types/unist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+      "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+    },
+    "node_modules/rehype-external-links/node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-external-links/node_modules/unist-util-is": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-external-links/node_modules/unist-util-visit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-external-links/node_modules/unist-util-visit-parents": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-highlight": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/rehype-highlight/-/rehype-highlight-6.0.0.tgz",
@@ -16254,6 +16352,11 @@
         "eslint-visitor-keys": "^3.3.0"
       }
     },
+    "@ungap/structured-clone": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
+    },
     "@upstash/core-analytics": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@upstash/core-analytics/-/core-analytics-0.0.6.tgz",
@@ -19431,6 +19534,11 @@
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
       "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="
     },
+    "is-absolute-url": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-4.0.1.tgz",
+      "integrity": "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A=="
+    },
     "is-arguments": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
@@ -22572,6 +22680,69 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-1.3.0.tgz",
       "integrity": "sha512-6IQpFBv6e5vz1QAqI+V4k8P2e/3gRrqfCJ9FI+O1FLQTO+Uz6RXZEZOPmTJ6hlGj7gkERzY5BRCv09whKP96/g=="
+    },
+    "rehype-external-links": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-external-links/-/rehype-external-links-3.0.0.tgz",
+      "integrity": "sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==",
+      "requires": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "is-absolute-url": "^4.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "dependencies": {
+        "@types/hast": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.3.tgz",
+          "integrity": "sha512-2fYGlaDy/qyLlhidX42wAH0KBi2TCjKMH8CHmBXgRlJ3Y+OXTiqsPQ6IWarZKwF1JoUcAJdPogv1d4b0COTpmQ==",
+          "requires": {
+            "@types/unist": "*"
+          }
+        },
+        "@types/unist": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+          "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
+        },
+        "hast-util-is-element": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+          "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+          "requires": {
+            "@types/hast": "^3.0.0"
+          }
+        },
+        "unist-util-is": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+          "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+          "requires": {
+            "@types/unist": "^3.0.0"
+          }
+        },
+        "unist-util-visit": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+          "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+          "requires": {
+            "@types/unist": "^3.0.0",
+            "unist-util-is": "^6.0.0",
+            "unist-util-visit-parents": "^6.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+          "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+          "requires": {
+            "@types/unist": "^3.0.0",
+            "unist-util-is": "^6.0.0"
+          }
+        }
+      }
     },
     "rehype-highlight": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-icons": "4.8.0",
     "react-rewards": "2.0.4",
     "recharts": "2.5.0",
+    "rehype-external-links": "3.0.0",
     "satori": "0.9.1",
     "set-cookie-parser": "2.6.0",
     "slug": "8.2.2",

--- a/pages/faq/index.public.js
+++ b/pages/faq/index.public.js
@@ -140,7 +140,7 @@ ${tableOfContents}\n`;
               </Text>
             </Link>
           </Heading>,
-          <Viewer key={`a-${faq.id}`} value={faq.answer} />,
+          <Viewer key={`a-${faq.id}`} areLinksTrusted value={faq.answer} />,
         ])}
       </Box>
     </DefaultLayout>

--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -26,6 +26,7 @@ import {
 } from '@/TabNewsUI';
 import { KebabHorizontalIcon, LinkIcon, PencilIcon, TrashIcon } from '@/TabNewsUI/icons';
 import { useUser } from 'pages/interface';
+import isTrustedDomain from 'pages/interface/utils/trusted-domain';
 
 export default function Content({ content, isPageRootOwner, mode = 'view', viewFrame = false }) {
   const [componentMode, setComponentMode] = useState(mode);
@@ -240,7 +241,12 @@ function ViewMode({ setComponentMode, contentObject, isPageRootOwner, viewFrame 
       {contentObject.source_url && (
         <Box>
           <Text as="p" fontWeight="bold" sx={{ wordBreak: 'break-all' }}>
-            <LinkIcon size={16} /> Fonte: <Link href={contentObject.source_url}>{contentObject.source_url}</Link>
+            <LinkIcon size={16} /> Fonte:{' '}
+            <Link
+              href={contentObject.source_url}
+              rel={isTrustedDomain(contentObject.source_url) ? undefined : 'nofollow'}>
+              {contentObject.source_url}
+            </Link>
           </Text>
         </Box>
       )}

--- a/pages/interface/components/Markdown/plugins/external-links.js
+++ b/pages/interface/components/Markdown/plugins/external-links.js
@@ -1,0 +1,31 @@
+import rehypeExternalLinks from 'rehype-external-links';
+
+import { isTrustedDomain } from 'pages/interface';
+
+/**
+ * @param {(import('rehype-external-links').Options | null | undefined)} options
+ * @returns {import('bytemd').BytemdPlugin}
+ */
+export function externalLinksPlugin(options) {
+  /**
+   * @param {(import('hast').Element)} element
+   * @returns {Array<string> | string | null | undefined}
+   */
+  function createRel(element) {
+    const rel = [];
+    const url = element.properties.href;
+    if (url) {
+      if (!isTrustedDomain(url)) {
+        rel.push('nofollow');
+      }
+      if (element.properties.target === '_blank') {
+        rel.push('noopener');
+      }
+    }
+    return rel;
+  }
+
+  return {
+    rehype: (processor) => processor.use(() => rehypeExternalLinks({ rel: createRel, ...options })),
+  };
+}

--- a/pages/interface/index.js
+++ b/pages/interface/index.js
@@ -3,3 +3,4 @@ export { default as useCollapse } from './hooks/useCollapse';
 export { default as useMediaQuery } from './hooks/useMediaQuery';
 export { UserProvider, default as useUser } from './hooks/useUser';
 export { default as suggestEmail } from './utils/email-suggestion';
+export { default as isTrustedDomain } from './utils/trusted-domain';

--- a/pages/interface/utils/trusted-domain.js
+++ b/pages/interface/utils/trusted-domain.js
@@ -1,0 +1,13 @@
+import webserver from 'infra/webserver';
+
+const DEFAULT_TRUSTED_HOSTS = ['tabnews.com.br', 'github.com', 'curso.dev'];
+
+const webserverHostname = new URL(webserver.host).hostname;
+const trustedHosts = [...new Set([webserverHostname, ...DEFAULT_TRUSTED_HOSTS])];
+
+export default function isTrustedDomain(url) {
+  const { hostname } = new URL(url, webserver.host);
+  return trustedHosts.some(
+    (trustedHostname) => hostname === trustedHostname || hostname.endsWith(`.${trustedHostname}`)
+  );
+}

--- a/pages/museu/evolucao-do-tabnews/index.public.js
+++ b/pages/museu/evolucao-do-tabnews/index.public.js
@@ -245,7 +245,7 @@ export default function Page() {
             <Link href="https://github.com/rafatcb">Rafael Tavares</Link>
           </Box>
         </Box>
-        <Viewer value={body} />
+        <Viewer areLinksTrusted value={body} />
       </Box>
     </DefaultLayout>
   );

--- a/pages/termos-de-uso/index.public.js
+++ b/pages/termos-de-uso/index.public.js
@@ -45,12 +45,12 @@ export default function Page() {
     <DefaultLayout metadata={{ title: 'Termos de Uso' }}>
       <Box>
         <Heading as="h1">Termos de Uso</Heading>
-        <Viewer value={body} />
+        <Viewer areLinksTrusted value={body} />
       </Box>
 
       <Box sx={{ mt: 5 }}>
         <Heading as="h2">Histórico de alterações</Heading>
-        <Viewer value={changelog} />
+        <Viewer areLinksTrusted value={changelog} />
       </Box>
     </DefaultLayout>
   );

--- a/tests/unit/interface/utils/trusted-domain.test.js
+++ b/tests/unit/interface/utils/trusted-domain.test.js
@@ -1,0 +1,30 @@
+import { isTrustedDomain } from 'pages/interface';
+
+describe('isTrustedDomain', () => {
+  it('should trust only specific domains and their subdomains', () => {
+    expect(isTrustedDomain('http://www.github.com')).toBe(true);
+    expect(isTrustedDomain('https://tabnews.com.br')).toBe(true);
+    expect(isTrustedDomain('//curso.dev')).toBe(true);
+    expect(isTrustedDomain('http://sub.tabnews.com.br')).toBe(true);
+    expect(isTrustedDomain('https://www.example.com')).toBe(false);
+  });
+
+  it('should trust relative paths', () => {
+    expect(isTrustedDomain('/recentes')).toBe(true);
+    expect(isTrustedDomain('/relevantes')).toBe(true);
+    expect(isTrustedDomain('/faq')).toBe(true);
+  });
+
+  it('should handle domains without specifying the protocol as relative paths', () => {
+    expect(isTrustedDomain('sub.tabnews.com.br')).toBe(true);
+    expect(isTrustedDomain('example.com')).toBe(true);
+    expect(isTrustedDomain('www.example.com')).toBe(true);
+  });
+
+  it('should check the whole domain', () => {
+    expect(isTrustedDomain('https://tabnews.com.br')).toBe(true);
+    expect(isTrustedDomain('https://tabnews.com')).toBe(false);
+    expect(isTrustedDomain('https://faketabnews.com.br')).toBe(false);
+    expect(isTrustedDomain('https://ttabnews.com.br')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Mudanças realizadas

Adicionei o plugin [`rehype-external-links`](https://github.com/rehypejs/rehype-external-links) que serve exatamente para adicionar o `rel="nofollow"` em links externos. Essa bibliioteca recomenda usar `rehype-sanitize` para conteúdos gerados por usuários, mas o [`bytemd` já faz isso](https://github.com/bytedance/bytemd/blob/9f2212203c780f2d9775e3c2243171cdeea2e81d/packages/bytemd/src/utils.ts#L38) antes de adicionar os plugins do rehype.

Coloquei `areLinksTrusted` nas páginas que nós controlamos o conteúdo. Os links de Fonte continuam sem o `rel="nofollow"` (acho que faz sentido, considerando que a Fonte seja usada da forma adequada, como "origem" do conteúdo).

Futuramente podemos criar alguma heurística para não adicionar o plugin em conteúdos de usuários confiáveis, ou usar a propriedade `test` para permitir domínios confiáveis (GitHub, por exemplo). Um exemplo de `test` que não colocará `rel="nofollow"` no link `https://www.github.com`:

```js
pluginList.push(
  externalLinksPlugin({ test: (node) => node.properties?.href !== 'https://www.github.com' })
);
```

Do jeito que está no PR, o HTML gerado pelos links em publicações ficaram assim (em `localhost`):

![Testes em publicação](https://github.com/filipedeschamps/tabnews.com.br/assets/26308880/c1025f85-72b1-4e1d-b45c-e7bc1de57c35)

![Testes em comentário](https://github.com/filipedeschamps/tabnews.com.br/assets/26308880/4d51812b-cf2a-4130-89e9-4668e2597c06)

Resolve #1236

## Tipo de mudança

- [x] Nova funcionalidade

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [ ] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
