### PR TITLE
Responder "O que é o TabNews" no FAQ (e outras melhorias)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [tabnews.com.br](https://www.tabnews.com.br/)
 
-O [TabNews](https://www.tabnews.com.br/) nasceu com o objetivo de ser um local com **conteúdos de valor concreto para quem trabalha com tecnologia**.
+O [TabNews](https://www.tabnews.com.br/) é um site focado na comunidade da área de tecnologia, destinado a debates e troca de conhecimentos por meio de publicações e comentários criados pelos próprios usuários.
 
 Esse repositório contém o código-fonte do site e da API do TabNews.
 

--- a/pages/faq/index.public.js
+++ b/pages/faq/index.public.js
@@ -4,8 +4,13 @@ import { LinkIcon } from '@/TabNewsUI/icons';
 export default function Page() {
   const faqContent = [
     {
+      id: 'tabnews',
+      question: 'O que é o TabNews?',
+      answer: `O TabNews é um site focado na comunidade da área de tecnologia, destinado a debates e troca de conhecimentos por meio de publicações e comentários criados pelos próprios usuários.`,
+    },
+    {
       id: 'proposito-tabnews',
-      question: 'Por que o TabNews foi criado?',
+      question: 'Qual é o propósito do TabNews?',
       answer: `O TabNews nasceu com o objetivo de ser um local com **conteúdos de valor concreto para quem trabalha com tecnologia**.
 
 Queremos ter conteúdo de qualidade tanto na publicação principal quanto nos comentários, e algo que contribui para isso acontecer é a plataforma dar o mesmo espaço de criação para quem está publicando ambos os tipos de conteúdo. Tudo no TabNews é considerado um **conteúdo**, tanto que um comentário possui a sua própria página (basta clicar na data de publicação do comentário).`,
@@ -13,7 +18,7 @@ Queremos ter conteúdo de qualidade tanto na publicação principal quanto nos c
     {
       id: 'conteudo-tabnews',
       question: 'Que tipo de conteúdo eu posso publicar no TabNews?',
-      answer: `Você pode publicar notícias, artigos, tutoriais, indicações, curiosidades, sugestões de software e ferramentas, perguntas bem formuladas ou qualquer outro tipo de conteúdo que poderá fazer alguma diferença na vida de quem trabalha em áreas diretamente ou indiretamente relacionadas à área de tecnologia.`,
+      answer: `Você pode publicar notícias, artigos, tutoriais, indicações, curiosidades, sugestões de software e ferramentas, perguntas bem formuladas ou outros tipos de conteúdo, desde que o assunto da publicação seja [aceito no TabNews](#assunto-tabnews).`,
     },
     {
       id: 'assunto-tabnews',


### PR DESCRIPTION
## Mudanças realizadas

Realizei algumas alterações comentadas em https://github.com/filipedeschamps/tabnews.com.br/issues/1380#issuecomment-1888853812 e https://github.com/filipedeschamps/tabnews.com.br/issues/1380#issuecomment-1893716522.

A resposta para a pergunta "O que é o TabNews" veio com base no que consegui juntar das [respostas no TabNews](https://www.tabnews.com.br/rafael/o-que-e-o-tabnews). Devido às respostas, decidi ler as definições de Fórum ([en](https://en.wikipedia.org/wiki/Internet_forum), [pt](https://pt.wikipedia.org/wiki/F%C3%B3rum_de_discuss%C3%A3o)) e do Reddit ([en](https://en.wikipedia.org/wiki/Reddit), [pt](https://pt.wikipedia.org/wiki/Reddit)) para procurar uma intersecção com o TabNews. Já deixei essa resposta também no `README.md`, conforme discutido [aqui](https://github.com/filipedeschamps/tabnews.com.br/pull/1583#discussion_r1449797274).

Acredito que as respostas tendem a melhorar conforme há interações de outras pessoas para a construção delas, então interpretem isso como uma "sugestão inicial". A revisão desse PR é importante e qualquer membro do TabNews pode colaborar.