### PR TITLE
Exibir (e retornar via API) a quantidade de qualificações positivas e negativas do conteúdo

### DIFF
--- a/models/authorization.js
+++ b/models/authorization.js
@@ -249,6 +249,8 @@ function filterOutput(user, feature, output) {
   if (feature === 'read:content:tabcoins') {
     filteredOutputValues = validator(output, {
       tabcoins: 'required',
+      tabcoins_credit: 'required',
+      tabcoins_debit: 'required',
     });
   }
 

--- a/models/balance.js
+++ b/models/balance.js
@@ -46,6 +46,20 @@ async function getTotal({ balanceType, recipientId }, options = {}) {
   return results.rows[0].get_current_balance;
 }
 
+async function getContentTabcoinsCreditDebit({ recipientId }, options = {}) {
+  const query = {
+    text: 'SELECT * FROM get_content_balance_credit_debit($1);',
+    values: [recipientId],
+  };
+
+  const results = await database.query(query, options);
+  return {
+    tabcoins: results.rows[0].total_balance,
+    tabcoins_credit: results.rows[0].total_credit,
+    tabcoins_debit: results.rows[0].total_debit,
+  };
+}
+
 async function rateContent({ contentId, contentOwnerId, fromUserId, transactionType }, options = {}) {
   const tabCoinsToDebitFromUser = -2;
   const tabCashToCreditToUser = 1;
@@ -77,10 +91,13 @@ async function rateContent({ contentId, contentOwnerId, fromUserId, transactionT
       )
       SELECT
         get_current_balance('user:tabcoin', $1) AS user_current_tabcoin_balance,
-        get_current_balance('content:tabcoin', $4) AS content_current_tabcoin_balance
+        tabcoins_count.total_balance as content_current_tabcoin_balance,
+        tabcoins_count.total_credit as content_current_tabcoin_credit,
+        tabcoins_count.total_debit as content_current_tabcoin_debit 
       FROM
         users_inserts,
-        content_insert
+        content_insert,
+        get_content_balance_credit_debit(content_insert.recipient_id) tabcoins_count
       LIMIT
         1
     ;`,
@@ -115,6 +132,8 @@ async function rateContent({ contentId, contentOwnerId, fromUserId, transactionT
 
   return {
     tabcoins: currentBalances.content_current_tabcoin_balance,
+    tabcoins_credit: currentBalances.content_current_tabcoin_credit,
+    tabcoins_debit: currentBalances.content_current_tabcoin_debit,
   };
 }
 
@@ -137,6 +156,7 @@ export default Object.freeze({
   findOne,
   create,
   getTotal,
+  getContentTabcoinsCreditDebit,
   rateContent,
   undo,
 });

--- a/models/validator.js
+++ b/models/validator.js
@@ -4,6 +4,9 @@ import { ValidationError } from 'errors';
 import webserver from 'infra/webserver';
 import removeMarkdown from 'models/remove-markdown';
 
+const MAX_INTEGER = 2147483647;
+const MIN_INTEGER = -2147483648;
+
 export default function validator(object, keys) {
   // Force the clean up of "undefined" values since JSON
   // doesn't support them and Joi doesn't clean
@@ -637,6 +640,8 @@ const schemas = {
       'owner_username',
       'children_deep_count',
       'tabcoins',
+      'tabcoins_credit',
+      'tabcoins_debit',
     ]) {
       const keyValidationFunction = schemas[key];
       contentSchema = contentSchema.concat(keyValidationFunction());
@@ -770,17 +775,55 @@ const schemas = {
     return Joi.object({
       tabcoins: Joi.number()
         .integer()
-        .min(-2147483648)
-        .max(2147483647)
+        .min(MIN_INTEGER)
+        .max(MAX_INTEGER)
         .when('$required.tabcoins', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
           'any.required': `"tabcoins" é um campo obrigatório.`,
           'string.empty': `"tabcoins" não pode estar em branco.`,
           'number.base': `"tabcoins" deve ser do tipo Number.`,
           'number.integer': `"tabcoins" deve ser um Inteiro.`,
-          'number.min': `"tabcoins" deve possuir um valor mínimo de -2147483648.`,
-          'number.max': `"tabcoins" deve possuir um valor máximo de 2147483647.`,
-          'number.unsafe': `"tabcoins" deve possuir um valor máximo de 2147483647.`,
+          'number.min': `"tabcoins" deve possuir um valor mínimo de ${MIN_INTEGER}.`,
+          'number.max': `"tabcoins" deve possuir um valor máximo de ${MAX_INTEGER}.`,
+          'number.unsafe': `"tabcoins" deve possuir um valor máximo de ${MAX_INTEGER}.`,
+        }),
+    });
+  },
+
+  tabcoins_credit: function () {
+    return Joi.object({
+      tabcoins_credit: Joi.number()
+        .integer()
+        .min(0)
+        .max(MAX_INTEGER)
+        .when('$required.tabcoins', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
+        .messages({
+          'any.required': `"tabcoins_credit" é um campo obrigatório.`,
+          'string.empty': `"tabcoins_credit" não pode estar em branco.`,
+          'number.base': `"tabcoins_credit" deve ser do tipo Number.`,
+          'number.integer': `"tabcoins_credit" deve ser um Inteiro.`,
+          'number.min': `"tabcoins_credit" deve possuir um valor mínimo de 0.`,
+          'number.max': `"tabcoins_credit" deve possuir um valor máximo de ${MAX_INTEGER}.`,
+          'number.unsafe': `"tabcoins_credit" deve possuir um valor máximo de ${MAX_INTEGER}.`,
+        }),
+    });
+  },
+
+  tabcoins_debit: function () {
+    return Joi.object({
+      tabcoins_debit: Joi.number()
+        .integer()
+        .min(MIN_INTEGER)
+        .max(0)
+        .when('$required.tabcoins', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
+        .messages({
+          'any.required': `"tabcoins_debit" é um campo obrigatório.`,
+          'string.empty': `"tabcoins_debit" não pode estar em branco.`,
+          'number.base': `"tabcoins_debit" deve ser do tipo Number.`,
+          'number.integer': `"tabcoins_debit" deve ser um Inteiro.`,
+          'number.min': `"tabcoins_debit" deve possuir um valor mínimo de ${MIN_INTEGER}.`,
+          'number.max': `"tabcoins_debit" deve possuir um valor máximo de 0.`,
+          'number.unsafe': `"tabcoins_debit" deve possuir um valor máximo de 0.`,
         }),
     });
   },
@@ -789,17 +832,17 @@ const schemas = {
     return Joi.object({
       tabcash: Joi.number()
         .integer()
-        .min(-2147483648)
-        .max(2147483647)
+        .min(MIN_INTEGER)
+        .max(MAX_INTEGER)
         .when('$required.tabcash', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
           'any.required': `"tabcash" é um campo obrigatório.`,
           'string.empty': `"tabcash" não pode estar em branco.`,
           'number.base': `"tabcash" deve ser do tipo Number.`,
           'number.integer': `"tabcash" deve ser um Inteiro.`,
-          'number.min': `"tabcash" deve possuir um valor mínimo de -2147483648.`,
-          'number.max': `"tabcash" deve possuir um valor máximo de 2147483647.`,
-          'number.unsafe': `"tabcash" deve possuir um valor máximo de 2147483647.`,
+          'number.min': `"tabcash" deve possuir um valor mínimo de ${MIN_INTEGER}.`,
+          'number.max': `"tabcash" deve possuir um valor máximo de ${MAX_INTEGER}.`,
+          'number.unsafe': `"tabcash" deve possuir um valor máximo de ${MAX_INTEGER}.`,
         }),
     });
   },

--- a/pages/interface/components/ContentList/index.js
+++ b/pages/interface/components/ContentList/index.js
@@ -1,4 +1,4 @@
-import { Box, EmptyState, Link, PastTime, Text, Tooltip } from '@/TabNewsUI';
+import { Box, EmptyState, Link, PastTime, TabCoinBalanceTooltip, Text, Tooltip } from '@/TabNewsUI';
 import { ChevronLeftIcon, ChevronRightIcon, CommentIcon } from '@/TabNewsUI/icons';
 
 export default function ContentList({ contentList: list, pagination, paginationBasePath, emptyStateProps }) {
@@ -129,9 +129,12 @@ export default function ContentList({ contentList: list, pagination, paginationB
                 whiteSpace: 'nowrap',
                 color: 'neutral.emphasis',
               }}>
-              <Text>
+              <TabCoinBalanceTooltip
+                direction="ne"
+                credit={contentObject.tabcoins_credit}
+                debit={contentObject.tabcoins_debit}>
                 <TabCoinsText count={contentObject.tabcoins} />
-              </Text>
+              </TabCoinBalanceTooltip>
               {' · '}
               <Text>
                 <ChildrenDeepCountText count={contentObject.children_deep_count} />

--- a/pages/interface/components/TabCoinBalanceTooltip/index.js
+++ b/pages/interface/components/TabCoinBalanceTooltip/index.js
@@ -1,0 +1,21 @@
+import { Tooltip } from '@/TabNewsUI';
+
+export default function TabCoinBalanceTooltip({ children, credit, debit, ...props }) {
+  function getLabel() {
+    const debitCount = Math.abs(debit);
+    const total = credit + debitCount;
+
+    if (total === 0) {
+      return `Nenhum voto`;
+    }
+
+    const creditPercentage = Math.round((credit / total) * 100);
+    return `+${credit} | -${debitCount} (${creditPercentage}% achou relevante)`;
+  }
+
+  return (
+    <Tooltip {...props} aria-label={getLabel()}>
+      {children}
+    </Tooltip>
+  );
+}

--- a/pages/interface/components/TabCoinButtons/index.js
+++ b/pages/interface/components/TabCoinButtons/index.js
@@ -3,7 +3,7 @@ import { useRevalidate } from 'next-swr';
 import { useEffect, useState } from 'react';
 import { useReward } from 'react-rewards';
 
-import { Box, IconButton, Text, Tooltip } from '@/TabNewsUI';
+import { Box, IconButton, TabCoinBalanceTooltip, Tooltip } from '@/TabNewsUI';
 import { ChevronDownIcon, ChevronUpIcon } from '@/TabNewsUI/icons';
 import { useUser } from 'pages/interface';
 
@@ -102,10 +102,21 @@ export default function TabCoinButtons({ content }) {
           disabled={isInAction}
         />
       </Tooltip>
-      <Text sx={{ fontSize: 0, fontWeight: 'bold', py: '4px', color: 'accent.emphasis' }}>
+      <TabCoinBalanceTooltip
+        direction="ne"
+        sx={{
+          width: '100%',
+          textAlign: 'center',
+          fontSize: 0,
+          fontWeight: 'bold',
+          py: 1,
+          color: 'accent.emphasis',
+        }}
+        credit={contentObject.tabcoins_credit}
+        debit={contentObject.tabcoins_debit}>
         <div id={`reward-${contentObject.id}`} style={{ marginLeft: '-10px' }} aria-hidden></div>
         {contentObject.tabcoins}
-      </Text>
+      </TabCoinBalanceTooltip>
       <Tooltip aria-label="Não achei relevante" direction="ne">
         <IconButton
           variant="invisible"

--- a/pages/interface/components/TabNewsUI/index.js
+++ b/pages/interface/components/TabNewsUI/index.js
@@ -17,6 +17,7 @@ export { default as ReadTime } from '@/ReadTime';
 export { default as RecentTabNav } from '@/RecentTabNav';
 export { default as useSearchBox } from '@/SearchBox';
 export { default as TabCashCount } from '@/TabCashCount';
+export { default as TabCoinBalanceTooltip } from '@/TabCoinBalanceTooltip';
 export { default as TabCoinButtons } from '@/TabCoinButtons';
 export { default as TabCoinCount } from '@/TabCoinCount';
 export { default as ThemeProvider } from '@/ThemeProvider';

--- a/queries/rankingQueries.js
+++ b/queries/rankingQueries.js
@@ -15,8 +15,11 @@ const rankedContent = `
             contents.id,
             contents.owner_id,
             contents.published_at,
-            get_current_balance('content:tabcoin', contents.id) as tabcoins
+            tabcoins_count.total_balance as tabcoins,
+            tabcoins_count.total_credit as tabcoins_credit,
+            tabcoins_count.total_debit as tabcoins_debit
         FROM contents
+        LEFT JOIN get_content_balance_credit_debit(contents.id) tabcoins_count ON true
         WHERE
             parent_id IS NULL
             AND status = 'published'
@@ -26,11 +29,14 @@ const rankedContent = `
             contents.id,
             contents.owner_id,
             contents.published_at,
-            get_current_balance('content:tabcoin', contents.id) as tabcoins
+            tabcoins_count.total_balance as tabcoins,
+            tabcoins_count.total_credit as tabcoins_credit,
+            tabcoins_count.total_debit as tabcoins_debit
         FROM contents
         INNER JOIN latest_published_child_contents
             ON latest_published_child_contents.path[1] = contents.id
             AND latest_published_child_contents.owner_id != contents.owner_id
+        LEFT JOIN get_content_balance_credit_debit(contents.id) tabcoins_count ON true
         WHERE
             parent_id IS NULL
             AND status = 'published'
@@ -159,6 +165,8 @@ const rankedContent = `
         contents.published_at,
         contents.deleted_at,
         ranked.tabcoins,
+        ranked.tabcoins_credit,
+        ranked.tabcoins_debit,
         ranked.total_rows,
         users.username as owner_username,
         (

--- a/tests/integration/api/v1/contents/[username]/[slug]/children/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/children/get.test.js
@@ -152,6 +152,8 @@ describe('GET /api/v1/contents/[username]/[slug]/children', () => {
           title: childBranchBLevel1.title,
           body: childBranchBLevel1.body,
           tabcoins: 1,
+          tabcoins_credit: 0,
+          tabcoins_debit: 0,
           status: childBranchBLevel1.status,
           source_url: childBranchBLevel1.source_url,
           source_url: childBranchBLevel1.source_url,
@@ -169,6 +171,8 @@ describe('GET /api/v1/contents/[username]/[slug]/children', () => {
               title: childBranchBLevel2Content1.title,
               body: childBranchBLevel2Content1.body,
               tabcoins: 1,
+              tabcoins_credit: 0,
+              tabcoins_debit: 0,
               status: childBranchBLevel2Content1.status,
               source_url: childBranchBLevel2Content1.source_url,
               source_url: childBranchBLevel2Content1.source_url,
@@ -188,6 +192,8 @@ describe('GET /api/v1/contents/[username]/[slug]/children', () => {
               title: childBranchBLevel2Content2.title,
               body: childBranchBLevel2Content2.body,
               tabcoins: 0,
+              tabcoins_credit: 0,
+              tabcoins_debit: 0,
               status: childBranchBLevel2Content2.status,
               source_url: childBranchBLevel2Content2.source_url,
               source_url: childBranchBLevel2Content2.source_url,
@@ -211,6 +217,8 @@ describe('GET /api/v1/contents/[username]/[slug]/children', () => {
           body: childBranchALevel1.body,
           status: childBranchALevel1.status,
           tabcoins: 1,
+          tabcoins_credit: 0,
+          tabcoins_debit: 0,
           source_url: childBranchALevel1.source_url,
           created_at: childBranchALevel1.created_at.toISOString(),
           updated_at: childBranchALevel1.updated_at.toISOString(),
@@ -227,6 +235,8 @@ describe('GET /api/v1/contents/[username]/[slug]/children', () => {
               body: childBranchALevel2.body,
               status: childBranchALevel2.status,
               tabcoins: 1,
+              tabcoins_credit: 0,
+              tabcoins_debit: 0,
               source_url: childBranchALevel2.source_url,
               created_at: childBranchALevel2.created_at.toISOString(),
               updated_at: childBranchALevel2.updated_at.toISOString(),
@@ -242,6 +252,8 @@ describe('GET /api/v1/contents/[username]/[slug]/children', () => {
                   title: childBranchALevel3.title,
                   body: childBranchALevel3.body,
                   tabcoins: 1,
+                  tabcoins_credit: 0,
+                  tabcoins_debit: 0,
                   status: childBranchALevel3.status,
                   source_url: childBranchALevel3.source_url,
                   created_at: childBranchALevel3.created_at.toISOString(),
@@ -339,6 +351,8 @@ describe('GET /api/v1/contents/[username]/[slug]/children', () => {
           body: childBranchBLevel2Content2.body,
           status: childBranchBLevel2Content2.status,
           tabcoins: 1,
+          tabcoins_credit: 0,
+          tabcoins_debit: 0,
           source_url: childBranchBLevel2Content2.source_url,
           source_url: childBranchBLevel2Content2.source_url,
           created_at: childBranchBLevel2Content2.created_at.toISOString(),
@@ -358,6 +372,8 @@ describe('GET /api/v1/contents/[username]/[slug]/children', () => {
           body: childBranchBLevel2Content1.body,
           status: childBranchBLevel2Content1.status,
           tabcoins: 0,
+          tabcoins_credit: 0,
+          tabcoins_debit: 0,
           source_url: childBranchBLevel2Content1.source_url,
           source_url: childBranchBLevel2Content1.source_url,
           created_at: childBranchBLevel2Content1.created_at.toISOString(),
@@ -367,6 +383,115 @@ describe('GET /api/v1/contents/[username]/[slug]/children', () => {
           owner_username: firstUser.username,
           children: [],
           children_deep_count: 0,
+        },
+      ]);
+    });
+
+    test('Tree with TabCoins credits and debits', async () => {
+      const firstUser = await orchestrator.createUser();
+      const secondUser = await orchestrator.createUser();
+
+      const rootBranchLevel0 = await orchestrator.createContent({
+        owner_id: firstUser.id,
+        title: 'root',
+        status: 'published',
+      });
+
+      const childBranchALevel1 = await orchestrator.createContent({
+        parent_id: rootBranchLevel0.id,
+        owner_id: secondUser.id,
+        title: 'Child branch A [Level 1]',
+        status: 'published',
+      });
+
+      const childBranchALevel2 = await orchestrator.createContent({
+        parent_id: childBranchALevel1.id,
+        owner_id: firstUser.id,
+        title: 'Child branch A [Level 2]',
+        status: 'published',
+      });
+
+      const childBranchBLevel1 = await orchestrator.createContent({
+        parent_id: rootBranchLevel0.id,
+        owner_id: secondUser.id,
+        title: 'Child branch B [Level 1]',
+        status: 'published',
+      });
+
+      await orchestrator.createRate(childBranchALevel2, 4);
+
+      await orchestrator.createRate(childBranchBLevel1, 2);
+      await orchestrator.createRate(childBranchBLevel1, -1);
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${firstUser.username}/${rootBranchLevel0.slug}/children`,
+      );
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(200);
+      expect(responseBody.length).toEqual(2);
+      expect(responseBody).toStrictEqual([
+        {
+          id: childBranchBLevel1.id,
+          owner_id: secondUser.id,
+          parent_id: rootBranchLevel0.id,
+          slug: childBranchBLevel1.slug,
+          title: childBranchBLevel1.title,
+          body: childBranchBLevel1.body,
+          tabcoins: 2,
+          tabcoins_credit: 2,
+          tabcoins_debit: -1,
+          status: childBranchBLevel1.status,
+          source_url: childBranchBLevel1.source_url,
+          source_url: childBranchBLevel1.source_url,
+          created_at: childBranchBLevel1.created_at.toISOString(),
+          updated_at: childBranchBLevel1.updated_at.toISOString(),
+          published_at: childBranchBLevel1.published_at.toISOString(),
+          deleted_at: null,
+          owner_username: secondUser.username,
+          children: [],
+          children_deep_count: 0,
+        },
+        {
+          id: childBranchALevel1.id,
+          owner_id: secondUser.id,
+          parent_id: rootBranchLevel0.id,
+          slug: childBranchALevel1.slug,
+          title: childBranchALevel1.title,
+          body: childBranchALevel1.body,
+          status: childBranchALevel1.status,
+          tabcoins: 1,
+          tabcoins_credit: 0,
+          tabcoins_debit: 0,
+          source_url: childBranchALevel1.source_url,
+          created_at: childBranchALevel1.created_at.toISOString(),
+          updated_at: childBranchALevel1.updated_at.toISOString(),
+          published_at: childBranchALevel1.published_at.toISOString(),
+          deleted_at: null,
+          owner_username: secondUser.username,
+          children: [
+            {
+              id: childBranchALevel2.id,
+              owner_id: firstUser.id,
+              parent_id: childBranchALevel1.id,
+              slug: childBranchALevel2.slug,
+              title: childBranchALevel2.title,
+              body: childBranchALevel2.body,
+              status: childBranchALevel2.status,
+              tabcoins: 5,
+              tabcoins_credit: 4,
+              tabcoins_debit: 0,
+              source_url: childBranchALevel2.source_url,
+              created_at: childBranchALevel2.created_at.toISOString(),
+              updated_at: childBranchALevel2.updated_at.toISOString(),
+              published_at: childBranchALevel2.published_at.toISOString(),
+              deleted_at: null,
+              owner_username: firstUser.username,
+              children: [],
+              children_deep_count: 0,
+            },
+          ],
+          children_deep_count: 1,
         },
       ]);
     });

--- a/tests/integration/api/v1/contents/[username]/[slug]/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/get.test.js
@@ -98,6 +98,8 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
         body: 'Conteúdo relevante deveria estar disponível para todos.',
         status: 'published',
         tabcoins: 1,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         source_url: 'https://www.tabnews.com.br/',
         created_at: defaultUserContent.created_at.toISOString(),
         updated_at: defaultUserContent.updated_at.toISOString(),
@@ -203,6 +205,8 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
         body: 'Body with relevant texts needs to contain a good amount of words',
         status: 'published',
         tabcoins: 1,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         source_url: null,
         created_at: rootContent.created_at.toISOString(),
         updated_at: rootContent.updated_at.toISOString(),
@@ -283,6 +287,8 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
         body: 'Conteúdo child',
         status: 'published',
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         source_url: null,
         created_at: childContent.created_at.toISOString(),
         updated_at: childContent.updated_at.toISOString(),
@@ -351,6 +357,8 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
         body: 'Conteúdo child',
         status: 'published',
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         source_url: null,
         created_at: childContent.created_at.toISOString(),
         updated_at: childContent.updated_at.toISOString(),
@@ -403,6 +411,51 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
 
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
+    });
+
+    test('Content "root" with TabCoins credits and debits', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Conteúdo com TabCoins',
+        body: 'Conteúdo que foi avaliado positiva e negativamente.',
+        status: 'published',
+      });
+
+      await orchestrator.createRate(defaultUserContent, 3);
+      await orchestrator.createRate(defaultUserContent, -1);
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+      );
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(200);
+
+      expect(responseBody).toStrictEqual({
+        id: defaultUserContent.id,
+        owner_id: defaultUser.id,
+        parent_id: null,
+        slug: 'conteudo-com-tabcoins',
+        title: 'Conteúdo com TabCoins',
+        body: 'Conteúdo que foi avaliado positiva e negativamente.',
+        status: 'published',
+        tabcoins: 2,
+        tabcoins_credit: 3,
+        tabcoins_debit: -1,
+        source_url: null,
+        created_at: defaultUserContent.created_at.toISOString(),
+        updated_at: defaultUserContent.updated_at.toISOString(),
+        published_at: defaultUserContent.published_at.toISOString(),
+        deleted_at: null,
+        owner_username: defaultUser.username,
+        children_deep_count: 0,
+      });
+
+      expect(uuidVersion(responseBody.id)).toEqual(4);
+      expect(uuidVersion(responseBody.owner_id)).toEqual(4);
     });
   });
 });

--- a/tests/integration/api/v1/contents/[username]/[slug]/parent/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/parent/get.test.js
@@ -232,6 +232,8 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
         deleted_at: null,
         owner_username: firstUser.username,
         tabcoins: 1,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
       });
     });
 
@@ -293,6 +295,8 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
         deleted_at: null,
         owner_username: firstUser.username,
         tabcoins: 1,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
       });
     });
 
@@ -358,6 +362,8 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
         deleted_at: null,
         owner_username: firstUser.username,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
       });
     });
 
@@ -424,6 +430,58 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
         deleted_at: childContentLevel2Deleted.deleted_at.toISOString(),
         owner_username: firstUser.username,
         tabcoins: 1,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
+      });
+    });
+
+    test('Parent containing TabCoins credits and debits', async () => {
+      const firstUser = await orchestrator.createUser();
+      const secondUser = await orchestrator.createUser();
+
+      const rootContent = await orchestrator.createContent({
+        owner_id: firstUser.id,
+        title: 'Root content title',
+        body: 'Root - Body with relevant texts needs to contain a good amount of words',
+        status: 'published',
+      });
+
+      const childContentLevel1 = await orchestrator.createContent({
+        owner_id: secondUser.id,
+        parent_id: rootContent.id,
+        title: 'Child content title Level 1',
+        body: 'Child content body Level 1',
+        status: 'published',
+      });
+
+      await orchestrator.createRate(rootContent, 10);
+      await orchestrator.createRate(rootContent, -11);
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${secondUser.username}/${childContentLevel1.slug}/parent`,
+      );
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(200);
+
+      expect(responseBody).toStrictEqual({
+        id: rootContent.id,
+        parent_id: null,
+        owner_id: firstUser.id,
+        slug: 'root-content-title',
+        title: 'Root content title',
+        body: 'Root - Body with relevant texts needs to contain a good amount of words',
+        children_deep_count: 1,
+        status: 'published',
+        source_url: null,
+        published_at: rootContent.published_at.toISOString(),
+        created_at: rootContent.created_at.toISOString(),
+        updated_at: rootContent.updated_at.toISOString(),
+        deleted_at: null,
+        owner_username: firstUser.username,
+        tabcoins: 0,
+        tabcoins_credit: 10,
+        tabcoins_debit: -11,
       });
     });
   });

--- a/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
@@ -399,6 +399,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         published_at: responseBody.published_at,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: firstUser.username,
       });
 
@@ -452,6 +454,65 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
+        owner_username: defaultUser.username,
+      });
+
+      expect(uuidVersion(responseBody.id)).toEqual(4);
+      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toEqual(true);
+    });
+
+    test('Content with TabCoins credits and debits', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const sessionObject = await orchestrator.createSession(defaultUser);
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Title',
+        body: 'Body',
+      });
+
+      await orchestrator.createRate(defaultUserContent, 3);
+      await orchestrator.createRate(defaultUserContent, -2);
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${sessionObject.token}`,
+          },
+          body: JSON.stringify({
+            body: 'New body',
+          }),
+        },
+      );
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(200);
+
+      expect(responseBody).toStrictEqual({
+        id: responseBody.id,
+        owner_id: defaultUser.id,
+        parent_id: null,
+        slug: 'title',
+        title: 'Title',
+        body: 'New body',
+        status: 'draft',
+        source_url: null,
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+        published_at: null,
+        deleted_at: null,
+        tabcoins: 1,
+        tabcoins_credit: 3,
+        tabcoins_debit: -2,
         owner_username: defaultUser.username,
       });
 
@@ -582,6 +643,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -745,6 +808,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -835,6 +900,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -1004,6 +1071,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         body: 'Segundo conteúdo',
         status: 'published',
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         source_url: null,
         created_at: responseBody.created_at,
         updated_at: responseBody.updated_at,
@@ -1097,6 +1166,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -1223,6 +1294,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -1441,6 +1514,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -1493,6 +1568,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -1545,6 +1622,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -1597,6 +1676,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -1650,6 +1731,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         published_at: responseBody.published_at,
         deleted_at: null,
         tabcoins: 1,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -1743,6 +1826,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         body: 'Body with relevant texts needs to contain a good amount of words',
         status: 'deleted',
         tabcoins: 1,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         source_url: null,
         created_at: responseBody.created_at,
         updated_at: responseBody.updated_at,
@@ -1975,6 +2060,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -2027,6 +2114,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -2079,6 +2168,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -2131,6 +2222,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -2378,6 +2471,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -2431,6 +2526,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -2520,6 +2617,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -2629,6 +2728,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -4040,6 +4141,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         published_at: responseBody.published_at,
         deleted_at: null,
         tabcoins: 1,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: secondUser.username,
       });
 

--- a/tests/integration/api/v1/contents/[username]/[slug]/root/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/root/get.test.js
@@ -232,6 +232,8 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
         deleted_at: null,
         owner_username: firstUser.username,
         tabcoins: 1,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
       });
     });
 
@@ -293,6 +295,8 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
         deleted_at: null,
         owner_username: firstUser.username,
         tabcoins: 1,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
       });
     });
 
@@ -359,6 +363,8 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
         deleted_at: null,
         owner_username: firstUser.username,
         tabcoins: 1,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
       });
     });
 
@@ -424,6 +430,8 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
         deleted_at: null,
         owner_username: firstUser.username,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         children_deep_count: 0,
       });
     });
@@ -491,7 +499,67 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
         deleted_at: rootContentDeleted.deleted_at.toISOString(),
         owner_username: firstUser.username,
         tabcoins: 1,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         children_deep_count: 0,
+      });
+    });
+
+    test('Root containing TabCoins credits and debits', async () => {
+      const firstUser = await orchestrator.createUser();
+      const secondUser = await orchestrator.createUser();
+
+      const rootContent = await orchestrator.createContent({
+        owner_id: firstUser.id,
+        title: 'Root content title',
+        body: 'Body with relevant texts needs to contain a good amount of words',
+        status: 'published',
+      });
+
+      await orchestrator.createRate(rootContent, 2);
+      await orchestrator.createRate(rootContent, -6);
+
+      const childContentLevel1 = await orchestrator.createContent({
+        owner_id: secondUser.id,
+        parent_id: rootContent.id,
+        title: 'Child content title Level 1',
+        body: 'Child content body Level 1',
+        status: 'published',
+      });
+
+      const childContentLevel2 = await orchestrator.createContent({
+        owner_id: firstUser.id,
+        parent_id: childContentLevel1.id,
+        title: 'Child content title Level 2',
+        body: 'Child content body Level 2',
+        status: 'published',
+      });
+
+      const response = await fetch(
+        `${orchestrator.webserverUrl}/api/v1/contents/${firstUser.username}/${childContentLevel2.slug}/root`,
+      );
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(200);
+
+      expect(responseBody).toStrictEqual({
+        id: rootContent.id,
+        parent_id: null,
+        owner_id: firstUser.id,
+        slug: 'root-content-title',
+        title: 'Root content title',
+        body: 'Body with relevant texts needs to contain a good amount of words',
+        children_deep_count: 2,
+        status: 'published',
+        source_url: null,
+        published_at: rootContent.published_at.toISOString(),
+        created_at: rootContent.created_at.toISOString(),
+        updated_at: rootContent.updated_at.toISOString(),
+        deleted_at: null,
+        owner_username: firstUser.username,
+        tabcoins: -3,
+        tabcoins_credit: 2,
+        tabcoins_debit: -6,
       });
     });
   });

--- a/tests/integration/api/v1/contents/[username]/[slug]/tabcoins/post.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/tabcoins/post.test.js
@@ -174,6 +174,8 @@ describe('POST /api/v1/contents/tabcoins', () => {
 
       expect(postTabCoinsResponseBody).toStrictEqual({
         tabcoins: 2,
+        tabcoins_credit: 1,
+        tabcoins_debit: 0,
       });
 
       const firstUserResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${firstUser.username}`, {
@@ -240,6 +242,8 @@ describe('POST /api/v1/contents/tabcoins', () => {
 
       expect(postTabCoinsResponseBody).toStrictEqual({
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: -1,
       });
 
       const firstUserResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${firstUser.username}`, {
@@ -551,6 +555,8 @@ describe('POST /api/v1/contents/tabcoins', () => {
 
       expect(postTabCoinsResponse1Body).toStrictEqual({
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: -1,
       });
 
       const firstUserResponse1 = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${firstUser.username}`, {
@@ -598,6 +604,8 @@ describe('POST /api/v1/contents/tabcoins', () => {
 
       expect(postTabCoinsResponse2Body).toStrictEqual({
         tabcoins: -1,
+        tabcoins_credit: 0,
+        tabcoins_debit: -2,
       });
 
       const firstUserResponse2 = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${firstUser.username}`, {
@@ -625,11 +633,7 @@ describe('POST /api/v1/contents/tabcoins', () => {
       expect(secondUserResponse2Body.tabcash).toStrictEqual(2);
     });
 
-    // This tests are beign temporarly skipped because of the new feature of not allowing
-    // to credit/debit four times the same content. This feature is just a temporary test
-    // to a more sofisticated feature that will be implemented in the future.
-
-    test.skip('With 20 simultaneous posts, but enough TabCoins for 1', async () => {
+    test('With 20 simultaneous posts, but enough TabCoins for 1', async () => {
       const timesToFetch = 20;
       const firstUser = await orchestrator.createUser();
       const secondUser = await orchestrator.createUser();
@@ -687,7 +691,9 @@ describe('POST /api/v1/contents/tabcoins', () => {
       expect(postTabCoinsResponsesStatus[successPostIndex1]).toEqual(201);
 
       expect(postTabCoinsResponsesBody[successPostIndex1]).toStrictEqual({
-        tabcoins: 2,
+        tabcoins: 1,
+        tabcoins_credit: 1,
+        tabcoins_debit: 0,
       });
 
       postTabCoinsResponsesStatus.splice(successPostIndex1, 1);
@@ -714,7 +720,7 @@ describe('POST /api/v1/contents/tabcoins', () => {
 
       const firstUserResponseBody = await firstUserResponse.json();
 
-      expect(firstUserResponseBody.tabcoins).toStrictEqual(3);
+      expect(firstUserResponseBody.tabcoins).toStrictEqual(1);
       expect(firstUserResponseBody.tabcash).toStrictEqual(0);
 
       const secondUserResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${secondUser.username}`, {
@@ -729,6 +735,10 @@ describe('POST /api/v1/contents/tabcoins', () => {
       expect(secondUserResponseBody.tabcoins).toStrictEqual(0);
       expect(secondUserResponseBody.tabcash).toStrictEqual(1);
     });
+
+    // This tests are being temporarily skipped because of the new feature of not allowing
+    // to credit/debit four times the same content. This feature is just a temporary test
+    // to a more sophisticated feature that will be implemented in the future.
 
     test.skip('With 100 simultaneous posts, but enough TabCoins for 6', async () => {
       const timesToFetch = 100;

--- a/tests/integration/api/v1/contents/[username]/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/get.test.js
@@ -123,6 +123,8 @@ describe('GET /api/v1/contents/[username]', () => {
           deleted_at: null,
           owner_username: firstUser.username,
           tabcoins: 0,
+          tabcoins_credit: 0,
+          tabcoins_debit: 0,
           children_deep_count: 0,
         },
       ]);
@@ -180,6 +182,8 @@ describe('GET /api/v1/contents/[username]', () => {
           deleted_at: null,
           owner_username: firstUser.username,
           tabcoins: 0,
+          tabcoins_credit: 0,
+          tabcoins_debit: 0,
           children_deep_count: 0,
         },
       ]);
@@ -246,6 +250,8 @@ describe('GET /api/v1/contents/[username]', () => {
           deleted_at: null,
           owner_username: firstUser.username,
           tabcoins: 0,
+          tabcoins_credit: 0,
+          tabcoins_debit: 0,
           children_deep_count: 0,
         },
         {
@@ -261,6 +267,8 @@ describe('GET /api/v1/contents/[username]', () => {
           published_at: secondRootContent.published_at.toISOString(),
           deleted_at: null,
           tabcoins: 1,
+          tabcoins_credit: 0,
+          tabcoins_debit: 0,
           owner_username: firstUser.username,
           children_deep_count: 0,
         },
@@ -277,6 +285,8 @@ describe('GET /api/v1/contents/[username]', () => {
           published_at: firstRootContent.published_at.toISOString(),
           deleted_at: null,
           tabcoins: 1,
+          tabcoins_credit: 0,
+          tabcoins_debit: 0,
           owner_username: firstUser.username,
           children_deep_count: 1,
         },
@@ -351,6 +361,8 @@ describe('GET /api/v1/contents/[username]', () => {
           deleted_at: null,
           owner_username: firstUser.username,
           tabcoins: 0,
+          tabcoins_credit: 0,
+          tabcoins_debit: 0,
           children_deep_count: 0,
         },
         {
@@ -366,6 +378,8 @@ describe('GET /api/v1/contents/[username]', () => {
           published_at: secondRootContent.published_at.toISOString(),
           deleted_at: null,
           tabcoins: 1,
+          tabcoins_credit: 0,
+          tabcoins_debit: 0,
           owner_username: firstUser.username,
           children_deep_count: 0,
         },
@@ -382,6 +396,83 @@ describe('GET /api/v1/contents/[username]', () => {
           published_at: firstRootContent.published_at.toISOString(),
           deleted_at: null,
           tabcoins: 1,
+          tabcoins_credit: 0,
+          tabcoins_debit: 0,
+          owner_username: firstUser.username,
+          children_deep_count: 1,
+        },
+      ]);
+
+      expect(uuidVersion(responseBody[0].id)).toEqual(4);
+      expect(uuidVersion(responseBody[1].id)).toEqual(4);
+      expect(uuidVersion(responseBody[0].owner_id)).toEqual(4);
+      expect(uuidVersion(responseBody[1].owner_id)).toEqual(4);
+      expect(responseBody[0].published_at > responseBody[1].published_at).toEqual(true);
+    });
+
+    test('"username" existent with "root" and "child" content with TabCoins credits and debits', async () => {
+      const firstUser = await orchestrator.createUser();
+
+      const rootContent = await orchestrator.createContent({
+        owner_id: firstUser.id,
+        title: 'Conteúdo raiz',
+        status: 'published',
+      });
+
+      await orchestrator.createRate(rootContent, -3);
+      await orchestrator.createRate(rootContent, 1);
+
+      const childContent = await orchestrator.createContent({
+        owner_id: firstUser.id,
+        parent_id: rootContent.id,
+        title: 'Comentário',
+        body: 'Um comentário',
+        status: 'published',
+      });
+
+      await orchestrator.createRate(childContent, 10);
+      await orchestrator.createRate(childContent, -2);
+
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents/${firstUser.username}?strategy=new`);
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(200);
+
+      expect(responseBody).toStrictEqual([
+        {
+          id: childContent.id,
+          owner_id: firstUser.id,
+          parent_id: rootContent.id,
+          slug: 'comentario',
+          title: 'Comentário',
+          body: 'Um comentário',
+          status: 'published',
+          source_url: null,
+          created_at: childContent.created_at.toISOString(),
+          updated_at: childContent.updated_at.toISOString(),
+          published_at: childContent.published_at.toISOString(),
+          deleted_at: null,
+          owner_username: firstUser.username,
+          tabcoins: 8,
+          tabcoins_credit: 10,
+          tabcoins_debit: -2,
+          children_deep_count: 0,
+        },
+        {
+          id: rootContent.id,
+          owner_id: firstUser.id,
+          parent_id: null,
+          slug: 'conteudo-raiz',
+          title: 'Conteúdo raiz',
+          status: 'published',
+          source_url: null,
+          created_at: rootContent.created_at.toISOString(),
+          updated_at: rootContent.updated_at.toISOString(),
+          published_at: rootContent.published_at.toISOString(),
+          deleted_at: null,
+          tabcoins: -1,
+          tabcoins_credit: 1,
+          tabcoins_debit: -3,
           owner_username: firstUser.username,
           children_deep_count: 1,
         },
@@ -739,6 +830,8 @@ describe('GET /api/v1/contents/[username]', () => {
           published_at: secondRootContent.published_at.toISOString(),
           deleted_at: null,
           tabcoins: 1,
+          tabcoins_credit: 0,
+          tabcoins_debit: 0,
           owner_username: firstUser.username,
           children_deep_count: 0,
         },
@@ -755,6 +848,8 @@ describe('GET /api/v1/contents/[username]', () => {
           published_at: firstRootContent.published_at.toISOString(),
           deleted_at: null,
           tabcoins: 1,
+          tabcoins_credit: 0,
+          tabcoins_debit: 0,
           owner_username: firstUser.username,
           children_deep_count: 1,
         },
@@ -841,6 +936,8 @@ describe('GET /api/v1/contents/[username]', () => {
           deleted_at: null,
           owner_username: firstUser.username,
           tabcoins: 0,
+          tabcoins_credit: 0,
+          tabcoins_debit: 0,
           children_deep_count: 0,
         },
         {
@@ -858,6 +955,8 @@ describe('GET /api/v1/contents/[username]', () => {
           deleted_at: null,
           owner_username: firstUser.username,
           tabcoins: 0,
+          tabcoins_credit: 0,
+          tabcoins_debit: 0,
           children_deep_count: 0,
         },
       ]);

--- a/tests/integration/api/v1/contents/get.test.js
+++ b/tests/integration/api/v1/contents/get.test.js
@@ -146,6 +146,8 @@ describe('GET /api/v1/contents', () => {
           published_at: secondRootContent.published_at.toISOString(),
           deleted_at: null,
           tabcoins: 1,
+          tabcoins_credit: 0,
+          tabcoins_debit: 0,
           owner_username: defaultUser.username,
           children_deep_count: 0,
         },
@@ -162,6 +164,8 @@ describe('GET /api/v1/contents', () => {
           published_at: firstRootContent.published_at.toISOString(),
           deleted_at: null,
           tabcoins: 1,
+          tabcoins_credit: 0,
+          tabcoins_debit: 0,
           owner_username: defaultUser.username,
           children_deep_count: 1,
         },
@@ -239,6 +243,8 @@ describe('GET /api/v1/contents', () => {
           published_at: firstRootContent.published_at.toISOString(),
           deleted_at: null,
           tabcoins: 1,
+          tabcoins_credit: 0,
+          tabcoins_debit: 0,
           owner_username: defaultUser.username,
           children_deep_count: 1,
         },
@@ -255,6 +261,8 @@ describe('GET /api/v1/contents', () => {
           published_at: secondRootContent.published_at.toISOString(),
           deleted_at: null,
           tabcoins: 1,
+          tabcoins_credit: 0,
+          tabcoins_debit: 0,
           owner_username: defaultUser.username,
           children_deep_count: 0,
         },
@@ -325,6 +333,8 @@ describe('GET /api/v1/contents', () => {
           published_at: rootContent.published_at.toISOString(),
           deleted_at: null,
           tabcoins: 1,
+          tabcoins_credit: 0,
+          tabcoins_debit: 0,
           owner_username: defaultUser.username,
           children_deep_count: 3,
         },
@@ -1288,6 +1298,8 @@ describe('GET /api/v1/contents', () => {
           deleted_at: null,
           owner_username: secondUser.username,
           tabcoins: 2,
+          tabcoins_credit: 1,
+          tabcoins_debit: 0,
           children_deep_count: 1,
         });
 
@@ -1312,6 +1324,8 @@ describe('GET /api/v1/contents', () => {
           deleted_at: null,
           owner_username: thirdUser.username,
           tabcoins: 1,
+          tabcoins_credit: 0,
+          tabcoins_debit: 0,
           children_deep_count: 1,
         });
 
@@ -1335,6 +1349,8 @@ describe('GET /api/v1/contents', () => {
             deleted_at: null,
             owner_username: owner.username,
             tabcoins,
+            tabcoins_credit: tabcoins,
+            tabcoins_debit: 0,
             children_deep_count: 0,
           };
         }

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -202,6 +202,8 @@ describe('POST /api/v1/contents', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: firstUser.username,
       });
 
@@ -387,6 +389,8 @@ describe('POST /api/v1/contents', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -517,6 +521,8 @@ describe('POST /api/v1/contents', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -590,6 +596,8 @@ describe('POST /api/v1/contents', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -664,6 +672,8 @@ describe('POST /api/v1/contents', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -866,6 +876,8 @@ describe('POST /api/v1/contents', () => {
         body: 'Outro body',
         status: 'published',
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         source_url: null,
         created_at: secondContentBody.created_at,
         updated_at: secondContentBody.updated_at,
@@ -975,6 +987,8 @@ describe('POST /api/v1/contents', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -1018,6 +1032,8 @@ describe('POST /api/v1/contents', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -1061,6 +1077,8 @@ describe('POST /api/v1/contents', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -1104,6 +1122,8 @@ describe('POST /api/v1/contents', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -1147,6 +1167,8 @@ describe('POST /api/v1/contents', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -1191,6 +1213,8 @@ describe('POST /api/v1/contents', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -1235,6 +1259,8 @@ describe('POST /api/v1/contents', () => {
         published_at: responseBody.published_at,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -1410,6 +1436,8 @@ describe('POST /api/v1/contents', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -1454,6 +1482,8 @@ describe('POST /api/v1/contents', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -1498,6 +1528,8 @@ describe('POST /api/v1/contents', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -1542,6 +1574,8 @@ describe('POST /api/v1/contents', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -1746,6 +1780,8 @@ describe('POST /api/v1/contents', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -1790,6 +1826,8 @@ describe('POST /api/v1/contents', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -1864,6 +1902,8 @@ describe('POST /api/v1/contents', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -1909,6 +1949,8 @@ describe('POST /api/v1/contents', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -1959,6 +2001,8 @@ describe('POST /api/v1/contents', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -2065,6 +2109,8 @@ describe('POST /api/v1/contents', () => {
         published_at: null,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -2124,6 +2170,8 @@ describe('POST /api/v1/contents', () => {
         published_at: responseBody.published_at,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -2177,6 +2225,8 @@ describe('POST /api/v1/contents', () => {
         published_at: responseBody.published_at,
         deleted_at: null,
         tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
         owner_username: defaultUser.username,
       });
 
@@ -3039,6 +3089,8 @@ describe('POST /api/v1/contents', () => {
           published_at: responseBody.published_at,
           deleted_at: null,
           tabcoins: 1,
+          tabcoins_credit: 0,
+          tabcoins_debit: 0,
           owner_username: defaultUser.username,
         });
 
@@ -3104,6 +3156,8 @@ describe('POST /api/v1/contents', () => {
           published_at: responseBody.published_at,
           deleted_at: null,
           tabcoins: 1,
+          tabcoins_credit: 0,
+          tabcoins_debit: 0,
           owner_username: defaultUser.username,
         });
 
@@ -3161,6 +3215,8 @@ describe('POST /api/v1/contents', () => {
           published_at: responseBody.published_at,
           deleted_at: null,
           tabcoins: 1,
+          tabcoins_credit: 0,
+          tabcoins_debit: 0,
           owner_username: defaultUser.username,
         });
 
@@ -3226,6 +3282,8 @@ describe('POST /api/v1/contents', () => {
           published_at: responseBody.published_at,
           deleted_at: null,
           tabcoins: 1,
+          tabcoins_credit: 0,
+          tabcoins_debit: 0,
           owner_username: defaultUser.username,
         });
 
@@ -3283,6 +3341,8 @@ describe('POST /api/v1/contents', () => {
           published_at: responseBody.published_at,
           deleted_at: null,
           tabcoins: 1,
+          tabcoins_credit: 0,
+          tabcoins_debit: 0,
           owner_username: defaultUser.username,
         });
 
@@ -3348,6 +3408,8 @@ describe('POST /api/v1/contents', () => {
           published_at: responseBody.published_at,
           deleted_at: null,
           tabcoins: 1,
+          tabcoins_credit: 0,
+          tabcoins_debit: 0,
           owner_username: defaultUser.username,
         });
 
@@ -3444,6 +3506,8 @@ describe('POST /api/v1/contents', () => {
           published_at: responseBody.published_at,
           deleted_at: null,
           tabcoins: 0,
+          tabcoins_credit: 0,
+          tabcoins_debit: 0,
           owner_username: defaultUser.username,
         });
 
@@ -3509,6 +3573,8 @@ describe('POST /api/v1/contents', () => {
           published_at: responseBody.published_at,
           deleted_at: null,
           tabcoins: 0,
+          tabcoins_credit: 0,
+          tabcoins_debit: 0,
           owner_username: defaultUser.username,
         });
 
@@ -3568,6 +3634,8 @@ describe('POST /api/v1/contents', () => {
           published_at: responseBody.published_at,
           deleted_at: null,
           tabcoins: 1,
+          tabcoins_credit: 0,
+          tabcoins_debit: 0,
           owner_username: defaultUser.username,
         });
 
@@ -3633,6 +3701,8 @@ describe('POST /api/v1/contents', () => {
           published_at: responseBody.published_at,
           deleted_at: null,
           tabcoins: 1,
+          tabcoins_credit: 0,
+          tabcoins_debit: 0,
           owner_username: defaultUser.username,
         });
 


### PR DESCRIPTION
## Mudanças realizadas

### Backend

Agora, duas novas propriedades são retornadas junto do conteúdo: `tabcoins_credit` e `tabcoins_debit`. Em consultas que retornavam `tabcoins` de um conteúdo, essas novas propriedades também são retornadas (exemplo: ao qualificar um conteúdo).

Endpoints afetados:

* `GET /api/v1/contents`
* `POST /api/v1/contents`
* `GET /api/v1/contents/[username]`
* `GET /api/v1/contents/[username]/[slug]`
* `PATCH /api/v1/contents/[username]/[slug]`
* `GET /api/v1/contents/[username]/[slug]/children`
* `GET /api/v1/contents/[username]/[slug]/parent`
* `GET /api/v1/contents/[username]/[slug]/root`
* `POST /api/v1/contents/tabcoins`

### Frontend

A apresentação na UI é feita por meio de um Tooltip, tanto na lista de conteúdos quanto na página do conteúdo, para a publicação e para os comentários.

| Lista de conteúdos | Conteúdo |
| --- | --- |
| ![Página da lista de conteúdos](https://github.com/filipedeschamps/tabnews.com.br/assets/26308880/9f31c1a5-182a-438b-a122-dc23f75df43d) | ![Página do conteúdo](https://github.com/filipedeschamps/tabnews.com.br/assets/26308880/62e17714-08a6-4785-83b5-f86fa7de64c3) |

Resolve #1370

## Tipo de mudança

- [x] Nova funcionalidade

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.