### PR TITLE
Considerar acentos ao contar quantidade mínima de palavras do conteúdo

### DIFF
--- a/models/content.js
+++ b/models/content.js
@@ -585,7 +585,9 @@ async function creditOrDebitTabCoins(oldContent, newContent, options = {}) {
 
     // We should not credit if the content has little or no value.
     // Expected 5 or more words with 5 or more characters.
-    if (newContent.body.split(/[a-z]{5,}/i, 6).length < 6) return;
+    const numCharacters = 5;
+
+    if (newContent.body.normalize('NFC').match(/[a-záéíóúâôãõç]{5,}/gi).length < numCharacters) return;
   }
 
   if (userEarnings > 0) {

--- a/models/content.js
+++ b/models/content.js
@@ -8,6 +8,7 @@ import prestige from 'models/prestige';
 import user from 'models/user.js';
 import validator from 'models/validator.js';
 import queries from 'queries/rankingQueries';
+import { isContentTooShort } from 'utils/content';
 
 async function findAll(values = {}, options = {}) {
   values = validateValues(values);
@@ -587,7 +588,7 @@ async function creditOrDebitTabCoins(oldContent, newContent, options = {}) {
     // Expected 5 or more words with 5 or more characters.
     const numCharacters = 5;
 
-    if (newContent.body.normalize('NFC').match(/[a-záéíóúâôãõç]{5,}/gi).length < numCharacters) return;
+    if (isContentTooShort(newContent.body, numCharacters)) return;
   }
 
   if (userEarnings > 0) {

--- a/models/content.js
+++ b/models/content.js
@@ -586,9 +586,9 @@ async function creditOrDebitTabCoins(oldContent, newContent, options = {}) {
 
     // We should not credit if the content has little or no value.
     // Expected 5 or more words with 5 or more characters.
-    const numCharacters = 5;
+    const minimumNumWords = 5;
 
-    if (isContentTooShort(newContent.body, numCharacters)) return;
+    if (isContentTooShort(newContent.body, minimumNumWords)) return;
   }
 
   if (userEarnings > 0) {

--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -27,6 +27,7 @@ import {
 import { KebabHorizontalIcon, LinkIcon, PencilIcon, TrashIcon } from '@/TabNewsUI/icons';
 import { useUser } from 'pages/interface';
 import isTrustedDomain from 'pages/interface/utils/trusted-domain';
+import { isContentTooShort } from 'utils/content';
 
 const CONTENT_TITLE_PLACEHOLDER_EXAMPLES = [
   'e.g. Nova versão do Python é anunciada com melhorias de desempenho',
@@ -313,24 +314,24 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
         return;
       }
 
-      const confirmBodyValue =
-        newData.body.split(/[a-z]{5,}/i, 6).length < 6
-          ? await confirm({
-              title: 'Tem certeza que deseja publicar essa mensagem curta?',
-              content: (
-                <Flash variant="warning">
-                  ⚠ Atenção: Pedimos encarecidamente que{' '}
-                  <Link href="https://www.tabnews.com.br/filipedeschamps/tentando-construir-um-pedaco-de-internet-mais-massa">
-                    leia isso antes
-                  </Link>{' '}
-                  de fazer essa publicação.
-                </Flash>
-              ),
-              cancelButtonContent: 'Cancelar',
-              confirmButtonContent: 'Publicar',
-              confirmButtonType: 'danger',
-            })
-          : true;
+      const numCharacters = 5;
+      const confirmBodyValue = isContentTooShort(newData.body, numCharacters)
+        ? await confirm({
+            title: 'Tem certeza que deseja publicar essa mensagem curta?',
+            content: (
+              <Flash variant="warning">
+                ⚠ Atenção: Pedimos encarecidamente que{' '}
+                <Link href="https://www.tabnews.com.br/filipedeschamps/tentando-construir-um-pedaco-de-internet-mais-massa">
+                  leia isso antes
+                </Link>{' '}
+                de fazer essa publicação.
+              </Flash>
+            ),
+            cancelButtonContent: 'Cancelar',
+            confirmButtonContent: 'Publicar',
+            confirmButtonType: 'danger',
+          })
+        : true;
 
       if (!confirmBodyValue) return;
 

--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -314,8 +314,8 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
         return;
       }
 
-      const numCharacters = 5;
-      const confirmBodyValue = isContentTooShort(newData.body, numCharacters)
+      const minimumNumWords = 5;
+      const confirmBodyValue = isContentTooShort(newData.body, minimumNumWords)
         ? await confirm({
             title: 'Tem certeza que deseja publicar essa mensagem curta?',
             content: (

--- a/tests/unit/utils/content.test.js
+++ b/tests/unit/utils/content.test.js
@@ -1,15 +1,15 @@
 import { isContentTooShort } from 'utils/content';
 
 describe('.isContentTooShort', () => {
-  it('Should return true when content is shorter than numCharacters', async () => {
-    const numCharacters = 5;
+  it('Should return true when content is shorter than minimumNumWords', async () => {
+    const minimumNumWords = 5;
     const content = 'já concordei ctg.';
-    expect(isContentTooShort(content, numCharacters)).toBe(true);
+    expect(isContentTooShort(content, minimumNumWords)).toBe(true);
   });
 
-  it('Should return false when content is NOT shorter than numCharacters', async () => {
-    const numCharacters = 5;
+  it('Should return false when content is NOT shorter than minimumNumWords', async () => {
+    const minimumNumWords = 5;
     const content = 'palhaçada que você disse para flávia beber cachaça!';
-    expect(isContentTooShort(content, numCharacters)).toBe(false);
+    expect(isContentTooShort(content, minimumNumWords)).toBe(false);
   });
 });

--- a/tests/unit/utils/content.test.js
+++ b/tests/unit/utils/content.test.js
@@ -1,0 +1,15 @@
+import { isContentTooShort } from 'utils/content';
+
+describe('.isContentTooShort', () => {
+  it('Should return true when content is shorter than numCharacters', async () => {
+    const numCharacters = 5;
+    const content = 'já concordei ctg.';
+    expect(isContentTooShort(content, numCharacters)).toBe(true);
+  });
+
+  it('Should return false when content is NOT shorter than numCharacters', async () => {
+    const numCharacters = 5;
+    const content = 'palhaçada que você disse para flávia beber cachaça!';
+    expect(isContentTooShort(content, numCharacters)).toBe(false);
+  });
+});

--- a/tests/unit/utils/content.test.js
+++ b/tests/unit/utils/content.test.js
@@ -12,4 +12,10 @@ describe('.isContentTooShort', () => {
     const content = 'palhaçada que você disse para flávia beber cachaça!';
     expect(isContentTooShort(content, minimumNumWords)).toBe(false);
   });
+
+  it('Should return true when content is empty', async () => {
+    const minimumNumWords = 5;
+    const content = '';
+    expect(isContentTooShort(content, minimumNumWords)).toBe(true);
+  });
 });

--- a/utils/content.js
+++ b/utils/content.js
@@ -1,0 +1,5 @@
+export function isContentTooShort(content, numCharacters) {
+  const regexPattern = new RegExp(`[a-záéíóúâôãõç]{${numCharacters},}`, 'gi');
+  const matches = content.normalize('NFC').match(regexPattern);
+  return matches && matches.length < numCharacters;
+}

--- a/utils/content.js
+++ b/utils/content.js
@@ -1,5 +1,5 @@
-export function isContentTooShort(content, numCharacters) {
-  const regexPattern = new RegExp(`[a-záéíóúâôãõç]{${numCharacters},}`, 'gi');
+export function isContentTooShort(content, minimumNumWords) {
+  const regexPattern = new RegExp(`[a-záéíóúâôãõç]{${minimumNumWords},}`, 'gi');
   const matches = content.normalize('NFC').match(regexPattern);
-  return matches && matches.length < numCharacters;
+  return matches && matches.length < minimumNumWords;
 }

--- a/utils/content.js
+++ b/utils/content.js
@@ -1,5 +1,8 @@
 export function isContentTooShort(content, minimumNumWords) {
   const regexPattern = new RegExp(`[a-záéíóúâôãõç]{${minimumNumWords},}`, 'gi');
   const matches = content.normalize('NFC').match(regexPattern);
-  return matches && matches.length < minimumNumWords;
+
+  if (!matches) return true;
+
+  return matches.length < minimumNumWords;
 }


### PR DESCRIPTION
Implementei a alteração na contagem de palavras.

## Mudanças realizadas

Implementada função recomendada no issue: https://github.com/filipedeschamps/tabnews.com.br/issues/1487

Resolve #1487

## Tipo de mudança

<!-- Descomente a linha abaixo que corresponde ao tipo de mudança realizada no PR. -->

[x] Correção de bug 

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
