### PR TITLE
Definir a metatag `theme-color`

### DIFF
--- a/pages/interface/components/Head/index.js
+++ b/pages/interface/components/Head/index.js
@@ -1,6 +1,7 @@
 import NextHead from 'next/head';
 import { useRouter } from 'next/router';
 
+import { useTheme } from '@/TabNewsUI';
 import webserver from 'infra/webserver.js';
 import { useMediaQuery } from 'pages/interface';
 
@@ -8,6 +9,8 @@ const webserverHost = webserver.host;
 
 export function DefaultHead() {
   const router = useRouter();
+
+  const { theme } = useTheme();
 
   const systemTheme = useMediaQuery('(prefers-color-scheme: dark)');
   const favicon = systemTheme ? '/favicon-dark.png' : '/favicon-light.png';
@@ -46,6 +49,7 @@ export function DefaultHead() {
       <meta property="twitter:description" content={description} key="twitter:description" />
       <meta property="twitter:image" content={image} key="twitter:image" />
 
+      <meta name="theme-color" content={theme.colors.header.bg} />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
       <link rel="icon" href={favicon} type="image/png" />
       <link rel="manifest" href="/manifest.json" crossOrigin="use-credentials" />


### PR DESCRIPTION
## Mudanças realizadas

Eu não tinha percebido esse problema quando usava o Brave no celular, mas ao acessar o TabNews pelo Firefox e pelo Chrome eu percebi que não era uma experiência legal no modo escuro. Fiz um teste no Safari, no iPhone, e ele já considerava o `theme-color` como sendo a cor de fundo do `Header`, mas o Safari respeita a presença dessa metatag.

Fiz alguns testes e usar a mesma cor do `Header` foi a solução mais simples. As orientações do [Android](https://developer.android.com/design/ui/mobile/guides/foundations/system-bars#takeaways) e [iOS](https://developer.apple.com/design/human-interface-guidelines/status-bars) para aplicativos são de usar a mesma cor do conteúdo próximo também (o iOS me deixou um pouco na dúvida, mas no exemplo com barra de navegação está com a mesma cor).

| Atual (Claro) | Atual (Escuro) |
| --- | --- |
| ![Modo claro atualmente](https://github.com/filipedeschamps/tabnews.com.br/assets/26308880/9d7e02e8-448f-4550-a497-a591f1e1b8fc) | ![Modo escuro atualmente](https://github.com/filipedeschamps/tabnews.com.br/assets/26308880/db4c60b2-9562-425a-805a-ec60c526fd54) |

| Mesma cor do `Header` (Claro) | Mesma cor do `Header` (Escuro) |
| --- | --- |
| ![Header claro](https://github.com/filipedeschamps/tabnews.com.br/assets/26308880/c5257304-1f2f-4d58-b6d0-f3be3c2d57c6) | ![Header escuro](https://github.com/filipedeschamps/tabnews.com.br/assets/26308880/a53e107e-9600-448f-8a11-63ba5fd0c251) |

## Tipo de mudança

- [x] Nova funcionalidade