### PR TITLE
Criar endpoint e componente de atividades do usuário por data

### DIFF
--- a/models/authorization.js
+++ b/models/authorization.js
@@ -176,16 +176,22 @@ function filterOutput(user, feature, output) {
   }
 
   if (feature === 'read:user') {
-    filteredOutputValues = {
-      id: output.id,
-      username: output.username,
-      description: output.description,
-      features: output.features,
-      tabcoins: output.tabcoins,
-      tabcash: output.tabcash,
-      created_at: output.created_at,
-      updated_at: output.updated_at,
-    };
+    if (output.activity)
+      filteredOutputValues = {
+        id: output.userId,
+        activity: output.activity,
+      };
+    else
+      filteredOutputValues = {
+        id: output.id,
+        username: output.username,
+        description: output.description,
+        features: output.features,
+        tabcoins: output.tabcoins,
+        tabcash: output.tabcash,
+        created_at: output.created_at,
+        updated_at: output.updated_at,
+      };
   }
 
   if (feature === 'read:user:self') {

--- a/pages/api/v1/users/[username]/activity/index.public.js
+++ b/pages/api/v1/users/[username]/activity/index.public.js
@@ -1,0 +1,50 @@
+import nextConnect from 'next-connect';
+
+import authorization from 'models/authorization';
+import cacheControl from 'models/cache-control';
+import controller from 'models/controller.js';
+import user from 'models/user.js';
+import validator from 'models/validator.js';
+
+export default nextConnect({
+  attachParams: true,
+  onNoMatch: controller.onNoMatchHandler,
+  onError: controller.onErrorHandler,
+})
+  .use(controller.injectRequestMetadata)
+  .use(controller.logRequest)
+  .use(cacheControl.swrMaxAge(10))
+  .get(getValidationHandler, getHandler);
+
+function getValidationHandler(request, response, next) {
+  const cleanValues = validator(request.query, {
+    username: 'required',
+  });
+
+  request.query = cleanValues;
+
+  next();
+}
+
+async function getHandler(request, response) {
+  const userTryingToGet = user.createAnonymous();
+  const userDataFromDatabase = await user.findOneByUsername(request.query.username, {
+    withBalance: false,
+  });
+
+  if (!userDataFromDatabase) {
+    return response.status(404).json({
+      message: `O usuário informado não foi encontrado no sistema.`,
+      action: 'Verifique se o "username" está digitado corretamente.',
+      stack: new Error().stack,
+      errorLocationCode: 'CONTROLLER:USER:GET_HANDLER:USERNAME_NOT_FOUND',
+      key: 'username',
+    });
+  }
+
+  const userActivityFromDatabase = await user.getUserActivity(userDataFromDatabase.id);
+
+  const secureOutputValues = authorization.filterOutput(userTryingToGet, 'read:user', userActivityFromDatabase);
+
+  return response.status(200).json(secureOutputValues);
+}

--- a/tests/integration/api/v1/users/[username]/activity/get.test.js
+++ b/tests/integration/api/v1/users/[username]/activity/get.test.js
@@ -1,0 +1,96 @@
+import fetch from 'cross-fetch';
+import { version as uuidVersion } from 'uuid';
+
+import orchestrator from 'tests/orchestrator.js';
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.dropAllTables();
+  await orchestrator.runPendingMigrations();
+});
+
+describe('GET /api/v1/users/[username]/activity', () => {
+  describe('Anonymous user', () => {
+    test('Retrieving non-existing user', async () => {
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/donotexist/activity`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(404);
+      expect(responseBody.status_code).toEqual(404);
+      expect(responseBody.name).toEqual('NotFoundError');
+      expect(responseBody.message).toEqual('O "username" informado não foi encontrado no sistema.');
+      expect(responseBody.action).toEqual('Verifique se o "username" está digitado corretamente.');
+      expect(responseBody.status_code).toEqual(404);
+      expect(responseBody.error_location_code).toEqual('MODEL:USER:FIND_ONE_BY_USERNAME:NOT_FOUND');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.key).toEqual('username');
+    });
+
+    test('Retrieving nuked user', async () => {
+      const userCreated = await orchestrator.createUser({ username: 'nukedUser' });
+
+      await orchestrator.addFeaturesToUser(userCreated, ['nuked']);
+
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/nukedUser/activity`);
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(404);
+      expect(responseBody.status_code).toEqual(404);
+      expect(responseBody.name).toEqual('NotFoundError');
+      expect(responseBody.message).toEqual('O "username" informado não foi encontrado no sistema.');
+      expect(responseBody.action).toEqual('Verifique se o "username" está digitado corretamente.');
+      expect(responseBody.status_code).toEqual(404);
+      expect(responseBody.error_location_code).toEqual('MODEL:USER:FIND_ONE_BY_USERNAME:NOT_FOUND');
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(responseBody.key).toEqual('username');
+    });
+
+    test('Retrieving user with no activity', async () => {
+      const userCreated = await orchestrator.createUser({ username: 'userWithNoActivity' });
+
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/userWithNoActivity/activity`);
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(200);
+      expect(responseBody).toEqual({
+        id: userCreated.id,
+        activity: [],
+      });
+    });
+
+    test('Retrieving user with activity', async () => {
+      const userCreated = await orchestrator.createUser({ username: 'userWithActivity' });
+
+      await orchestrator.createContent({
+        owner_id: userCreated.id,
+        title: 'contentCreated',
+        status: 'published',
+      });
+
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/userWithActivity/activity`);
+
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(200);
+      expect(responseBody).toEqual({
+        id: userCreated.id,
+        activity: [
+          {
+            count: 1,
+            date: new Date().toISOString().split('T')[0],
+          },
+        ],
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Mudanças realizadas

Adiciona um endpoint que busca as atividades do usuário por dia, sendo uma soma de posts e comentários criados, queria saber a opinião de vocês sobre contabilizar os TabCoins e TabCash.

Endpoint adicionado:
`GET /api/v1/users/[username]/activity`

Exemplo de resposta:
```json
{
    "id": "56c8cbcc-a678-41c4-a0c3-6e280570f163",
    "activity": [
        {
            "count": 1,
            "date": "2024-01-24"
        }
    ]
}
```

<!-- Se o PR contém modificações de API, mencione os endpoints afetados. -->

Resolve #1599 

## Tipo de mudança

- [x] Nova funcionalidade

## Checklist:

- [ ] Testar query com conteúdos mais antigos (anos)
- [ ] Adicionar mais testes
- [ ] Criar componente para interface
- [ ] Melhorar abordagem em `filterOutput`
