### PR TITLE
Editar o perfil de outro usuário

### DIFF
--- a/infra/scripts/seed-database.js
+++ b/infra/scripts/seed-database.js
@@ -31,6 +31,7 @@ async function seedDevelopmentUsers() {
     'create:content:text_child',
     'update:content',
     'update:user',
+    'update:user:others',
     'ban:user',
     'read:migration',
     'create:migration',

--- a/models/authorization.js
+++ b/models/authorization.js
@@ -38,6 +38,7 @@ const availableFeatures = new Set([
   'read:user:list',
   'read:votes:others',
   'update:content:others',
+  'update:user:others',
   'ban:user',
   'create:recovery_token:username',
 ]);
@@ -90,6 +91,12 @@ function filterInput(user, feature, input, target) {
       password: input.password,
       description: input.description,
       notifications: input.notifications,
+    };
+  }
+
+  if (feature === 'update:user:others' && can(user, feature)) {
+    filteredInputValues = {
+      description: input.description,
     };
   }
 

--- a/models/email-confirmation.js
+++ b/models/email-confirmation.js
@@ -4,15 +4,15 @@ import email from 'infra/email.js';
 import webserver from 'infra/webserver.js';
 import user from 'models/user.js';
 
-async function createAndSendEmail(userId, newEmail) {
-  const userFound = await user.findOneById(userId);
-  const tokenObject = await create(userFound.id, newEmail);
+async function createAndSendEmail(userId, newEmail, options) {
+  const userFound = await user.findOneById(userId, options);
+  const tokenObject = await create(userFound.id, newEmail, options);
   await sendEmailToUser(userFound, newEmail, tokenObject.id);
 
   return tokenObject;
 }
 
-async function create(userId, newEmail) {
+async function create(userId, newEmail, options) {
   const query = {
     text: `
       INSERT INTO
@@ -25,7 +25,7 @@ async function create(userId, newEmail) {
     values: [userId, newEmail],
   };
 
-  const results = await database.query(query);
+  const results = await database.query(query, options);
   return results.rows[0];
 }
 

--- a/models/validator.js
+++ b/models/validator.js
@@ -676,6 +676,7 @@ const schemas = {
       type: Joi.string()
         .valid(
           'create:user',
+          'update:user',
           'ban:user',
           'create:content:text_root',
           'create:content:text_child',

--- a/pages/perfil/index.public.js
+++ b/pages/perfil/index.public.js
@@ -35,31 +35,28 @@ function EditProfileForm() {
 
   const { user, fetchUser, isLoading: userIsLoading } = useUser();
 
-  const usernameRef = useRef('');
-  const emailRef = useRef('');
-  const notificationsRef = useRef('');
-
-  useEffect(() => {
-    if (router && !user && !userIsLoading) {
-      router.push(`/login?redirect=${router.asPath}`);
-    }
-
-    if (user && !userIsLoading) {
-      usernameRef.current.value = user.username;
-      emailRef.current.value = user.email;
-      notificationsRef.current.checked = user.notifications;
-    }
-  }, [user, router, userIsLoading]);
-
-  useEffect(() => {
-    fetchUser();
-  }, [fetchUser]);
+  const usernameRef = useRef();
+  const emailRef = useRef();
+  const notificationsRef = useRef();
 
   const [globalMessageObject, setGlobalMessageObject] = useState(undefined);
   const [isLoading, setIsLoading] = useState(false);
   const [errorObject, setErrorObject] = useState(undefined);
   const [emailDisabled, setEmailDisabled] = useState(false);
   const [description, setDescription] = useState(user?.description || '');
+
+  useEffect(() => {
+    if (router && !user && !userIsLoading) {
+      router.push(`/login?redirect=${router.asPath}`);
+    }
+
+    if (user && !userIsLoading && !usernameRef.current.value) {
+      setDescription(user.description);
+      usernameRef.current.value = user.username;
+      emailRef.current.value = user.email;
+      notificationsRef.current.checked = user.notifications;
+    }
+  }, [user, router, userIsLoading]);
 
   function clearMessages() {
     setErrorObject(undefined);


### PR DESCRIPTION
## Mudanças realizadas

1. Uso da permissão `update:user:others` para editar o nome de usuário e descrição de outro usuário.
2. Criação de evento ao editar o perfil, similar ao que ocorre na edição de um conteúdo.
3. Correção de bug na edição de perfil onde, ao realizar um `blur` e `focus` na página `/perfil`, o nome de usuário e e-mail voltavam aos valores iniciais. Isso ocorre devido ao código do `onFocus` no hook `useUser` e foi evitado pela condição `!usernameRef.current.value` no `useEffect` em `EditProfileForm`.
4. Correção de bug de descrição vazia ao recarregar a página (F5). Isso foi corrigido com o `setDescription` no `useEffect` em `EditProfileForm`.

Endpoint afetado: `PATCH /api/v1/users/[username]`

UI:

[Vídeo editando o perfil de outro usuário, mostrando o resultado e depois atualizando para mostrar que irá editar o próprio perfil](https://github.com/filipedeschamps/tabnews.com.br/assets/26308880/9557918b-cc08-4cc2-8a1f-5db92ee4cca9)

### Permissão (_feature_)

Apesar de eu ter dito (https://github.com/filipedeschamps/tabnews.com.br/issues/1466#issuecomment-1891147726) que poderíamos usar a permissão `update:content:others`, vi que precisaria modificar a validação em `can` para comparar não só o `resource.owner_id`, como também `resource.id`, e isso só seria validado se estivesse atualizando a descrição. Se outros campos estivessem sendo atualizados, precisaria validar `update:user:others` (mencionado em `ForbiddenError.action`). Então deixei a validação com a permissão que já estava no código (mas que ninguém possui hoje, e nem era validada em `can`).

Se acharem que ainda faz sentido ter toda a modificação mencionada acima para granular as permissões em dois tipos diferentes (modificar qualquer valor do outro usuário e modificar apenas a descrição), posso implementar.

### Evento

O evento é para ficar assim mesmo, por enquanto? Só coloquei o básico, como é hoje ao atualizar um conteúdo.

### Campos editáveis de outro usuário (UI e API)

Tirei a opção de recuperar a senha da UI (já que esse é outro fluxo), a opção de receber notificações por e-mail e o e-mail em si. Faz sentido?

Não vejo o motivo para um moderador precisar editar as notificações de outro usuário, e o e-mail foi removido porque não é possível ver o e-mail de outro usuário. Não sei se deveria adicionar o `password` nessa lista de validação no backend também.

Resolve #1466

## Tipo de mudança

- [x] Correção de bug
- [x] Nova funcionalidade

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
