### PR TITLE
Muda tipo de segurança da conexão `SMTP` de `SMTPS` para `STARTTLS`

### DIFF
--- a/infra/email.js
+++ b/infra/email.js
@@ -7,7 +7,7 @@ import webserver from 'infra/webserver.js';
 const transporterConfiguration = {
   host: process.env.EMAIL_SMTP_HOST,
   port: process.env.EMAIL_SMTP_PORT,
-  secure: true,
+  requireTLS: true,
   auth: {
     user: process.env.EMAIL_USER,
     pass: process.env.EMAIL_PASSWORD,
@@ -15,7 +15,7 @@ const transporterConfiguration = {
 };
 
 if (!webserver.isServerlessRuntime) {
-  transporterConfiguration.secure = false;
+  transporterConfiguration.requireTLS = false;
 }
 
 const transporter = nodemailer.createTransport(transporterConfiguration);


### PR DESCRIPTION
Conforme a conversa em #1614, estamos testando o serviço [Resend](https://resend.com/) para envio de emails.

Mas estamos encontrando esporadicamente o erro:

- `Client network socket disconnected before secure TLS connection was established`.

## Mudanças realizadas

A ideia é testar a mudança da porta `465` para a `587` e ver se isso faz cessar os erros.

Usar a porta `587` exige mudarmos a configuração do [Nodemailer](https://nodemailer.com/) deixando o `secure: falso` (default), mas isso é compensado ao habilitar `requireTLS`, que garante a transição de uma conexão não segura para uma conexão segura durante a comunicação, e não envia o email se a transição não for possível.

## Tipo de mudança

- [x] Correção de bug

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Os antigos testes estão passando localmente.
- [ ] Alterar a variável `EMAIL_HTTP_PORT` na Vercel.
