### PR TITLE
refactor: improve confirmation message when username is changed

### DIFF
--- a/pages/perfil/index.public.js
+++ b/pages/perfil/index.public.js
@@ -81,7 +81,7 @@ function EditProfileForm() {
     if (user.username !== username) {
       const confirmChangeUsername = await confirm({
         title: `Você realmente deseja alterar seu nome de usuário?`,
-        content: `Isto irá quebrar todas as URLs das suas publicações.`,
+        content: `Isso irá quebrar todas as URLs das suas publicações e comentários.`,
         cancelButtonContent: 'Cancelar',
         confirmButtonContent: 'Sim',
       });


### PR DESCRIPTION
## Mudanças realizadas

Nesse PR realizei a troca da mensagem "**Isto irá quebrar todas as URLs das suas publicações.**" por "**Isso irá quebrar todas as URLs das suas publicações e comentários.**" afim de deixar claro ao usuário que caso ele faça a mudança do seu _username_ tanto as URLs de suas publicações como as de comentários também serão quebradas.

<!-- Por favor, inclua uma descrição sobre o que foi modificado nesse PR. Inclua também qualquer motivação ou contexto relevante.  -->

<!-- Se o PR contém uma modificação da interface gráfica (UI), adicione fotos ou vídeos comparando o antes e depois. -->
Antes
![895_antes](https://github.com/filipedeschamps/tabnews.com.br/assets/54281405/f0bf5bb5-a8a0-493d-a5f8-63a8c7e9084d)

Depois
![895_depois](https://github.com/filipedeschamps/tabnews.com.br/assets/54281405/dd95ebbc-bbe3-47db-9e43-4f64c0d4fd98)

<!-- Se o PR contém modificações de API, mencione os endpoints afetados. -->

<!-- Caso esse PR resolva algum issue, você pode descomentar a linha abaixo e substituir (issue) pelo número dele. -->

Resolve #895 

## Tipo de mudança

<!-- Descomente a linha abaixo que corresponde ao tipo de mudança realizada no PR. -->

- [x] Refactor
<!-- - [x] Correção de bug -->
<!-- - [x] Nova funcionalidade -->
<!-- - [x] _**Breaking change**_ (a alteração causa uma quebra de compatibilidade na API ou em links públicos do site) -->
<!-- - [x] Atualização de documentação -->

## Checklist:

- [X] As modificações não geram novos logs de erro ou aviso (_warning_).
- [ ] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [X] Tanto os novos testes quanto os antigos estão passando localmente.
