### PR TITLE
Ajustes nas funções do `authorization` para deixá-las mais seguras e fáceis de entender o que fazem

### DIFF
--- a/pages/api/v1/contents/[username]/[slug]/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/index.public.js
@@ -115,31 +115,30 @@ async function patchHandler(request, response) {
     });
   }
 
-  let filteredBodyValues;
-
   if (!unfilteredBodyValues.parent_id) {
-    if (!authorization.can(userTryingToPatch, 'create:content:text_root', unfilteredBodyValues)) {
+    if (!authorization.can(userTryingToPatch, 'create:content:text_root')) {
       throw new ForbiddenError({
         message: 'Você não possui permissão para editar conteúdos na raiz do site.',
         action: 'Verifique se você possui a feature "create:content:text_root".',
         errorLocationCode: 'CONTROLLER:CONTENT:PATCH_HANDLER:CREATE:CONTENT:TEXT_ROOT:FEATURE_NOT_FOUND',
       });
     }
-
-    filteredBodyValues = authorization.filterInput(userTryingToPatch, 'update:content', unfilteredBodyValues);
-  }
-
-  if (unfilteredBodyValues.parent_id) {
-    if (!authorization.can(userTryingToPatch, 'create:content:text_child', unfilteredBodyValues)) {
+  } else {
+    if (!authorization.can(userTryingToPatch, 'create:content:text_child')) {
       throw new ForbiddenError({
         message: 'Você não possui permissão para editar conteúdos dentro de outros conteúdos.',
         action: 'Verifique se você possui a feature "create:content:text_child".',
         errorLocationCode: 'CONTROLLER:CONTENT:PATCH_HANDLER:CREATE:CONTENT:TEXT_CHILD:FEATURE_NOT_FOUND',
       });
     }
-
-    filteredBodyValues = authorization.filterInput(userTryingToPatch, 'update:content', unfilteredBodyValues);
   }
+
+  const filteredBodyValues = authorization.filterInput(
+    userTryingToPatch,
+    'update:content',
+    unfilteredBodyValues,
+    contentToBeUpdated
+  );
 
   const transaction = await database.transaction();
 

--- a/pages/api/v1/contents/index.public.js
+++ b/pages/api/v1/contents/index.public.js
@@ -111,7 +111,7 @@ async function postHandler(request, response) {
   let secureInputValues;
 
   if (!insecureInputValues.parent_id) {
-    if (!authorization.can(userTryingToCreate, 'create:content:text_root', insecureInputValues)) {
+    if (!authorization.can(userTryingToCreate, 'create:content:text_root')) {
       throw new ForbiddenError({
         message: 'Você não possui permissão para criar conteúdos na raiz do site.',
         action: 'Verifique se você possui a feature "create:content:text_root".',
@@ -120,10 +120,8 @@ async function postHandler(request, response) {
     }
 
     secureInputValues = authorization.filterInput(userTryingToCreate, 'create:content:text_root', insecureInputValues);
-  }
-
-  if (insecureInputValues.parent_id) {
-    if (!authorization.can(userTryingToCreate, 'create:content:text_child', insecureInputValues)) {
+  } else {
+    if (!authorization.can(userTryingToCreate, 'create:content:text_child')) {
       throw new ForbiddenError({
         message: 'Você não possui permissão para criar conteúdos dentro de outros conteúdos.',
         action: 'Verifique se você possui a feature "create:content:text_child".',

--- a/pages/api/v1/users/[username]/index.public.js
+++ b/pages/api/v1/users/[username]/index.public.js
@@ -80,7 +80,6 @@ async function patchHandler(request, response) {
   const targetUsername = request.query.username;
   const targetUser = await user.findOneByUsername(targetUsername);
   const insecureInputValues = request.body;
-  const secureInputValues = authorization.filterInput(userTryingToPatch, 'update:user', insecureInputValues);
 
   if (!authorization.can(userTryingToPatch, 'update:user', targetUser)) {
     throw new ForbiddenError({
@@ -89,6 +88,13 @@ async function patchHandler(request, response) {
       errorLocationCode: 'CONTROLLER:USERS:USERNAME:PATCH:USER_CANT_UPDATE_OTHER_USER',
     });
   }
+
+  const secureInputValues = authorization.filterInput(
+    userTryingToPatch,
+    'update:user',
+    insecureInputValues,
+    targetUser
+  );
 
   // TEMPORARY BEHAVIOR
   // TODO: only let user update "password"


### PR DESCRIPTION
Ao revisar o PR #1615 eu notei que a implementação poderia ser mais simples, mas que a complexidade do `authorization` não deixava isso muito visível.

Eu até estava sugerindo as mudanças no próprio PR, mas acabou ficando mais fácil trazer em um PR separado as partes que não mudam nada no comportamento atual (garantido pelos mesmos testes).

## Mudanças realizadas

Agora a função `can` exige que seja passado o `resource` quando ele for importante para a verificação. Antes a função verificava apenas a `feature` caso não fosse passado o `resource`, mesmo para os casos em que a autorização dependia de alguma verificação no `resource`, que é o caso de edição de usuários ou conteúdos.

Pela mudança na `can`, agora `filterInput` também exige o `target` quando isso for importante.

E a `canRequest` abstraia algo que não era necessário, ao utilizar a `can`, quando na verdade ela só está interessada em verificar se o usuário possui a `feature`.

## Tipo de mudança

<!-- Descomente a linha abaixo que corresponde ao tipo de mudança realizada no PR. -->

- [x] Refatoração

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Os antigos testes estão passando localmente.
