### PR TITLE
Torna visível o Tooltip do ícone de exibir/ocultar a senha

### DIFF
--- a/pages/cadastro/index.public.js
+++ b/pages/cadastro/index.public.js
@@ -127,7 +127,7 @@ function SignUpForm() {
             block={true}
             aria-label="Seu nome de usuário"
             contrast
-            sx={{ minHeight: '46px', px: 2, '&:focus-within': { backgroundColor: 'canvas.default' } }}
+            sx={{ px: 2, '&:focus-within': { backgroundColor: 'canvas.default' } }}
           />
           {errorObject?.key === 'username' && (
             <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
@@ -151,7 +151,7 @@ function SignUpForm() {
             block={true}
             aria-label="Seu email"
             contrast
-            sx={{ minHeight: '46px', px: 2, '&:focus-within': { backgroundColor: 'canvas.default' } }}
+            sx={{ px: 2, '&:focus-within': { backgroundColor: 'canvas.default' } }}
           />
           {errorObject?.key === 'email' && errorObject?.message && (
             <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>

--- a/pages/cadastro/recuperar/index.public.js
+++ b/pages/cadastro/recuperar/index.public.js
@@ -140,7 +140,7 @@ function RecoverPasswordForm() {
             <FormControl.Label>Digite seu e-mail</FormControl.Label>
             <TextInput
               contrast
-              sx={{ minHeight: '46px', px: 2, '&:focus-within': { backgroundColor: 'canvas.default' } }}
+              sx={{ px: 2, '&:focus-within': { backgroundColor: 'canvas.default' } }}
               ref={userInputRef}
               onChange={clearErrors}
               name="userInput"

--- a/pages/interface/components/PasswordInput/index.js
+++ b/pages/interface/components/PasswordInput/index.js
@@ -1,18 +1,11 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
-import { FormControl, TextInput } from '@/TabNewsUI';
+import { FormControl, IconButton, TextInput, Tooltip } from '@/TabNewsUI';
 import { AlertFillIcon, EyeClosedIcon, EyeIcon } from '@/TabNewsUI/icons';
 
 export default function PasswordInput({ inputRef, id, name, label, errorObject, setErrorObject, ...props }) {
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
   const [capsLockWarningMessage, setCapsLockWarningMessage] = useState(false);
-
-  useEffect(() => {
-    // change tooltip direction of TextInput.Action
-    const tooltip = inputRef.current.parentElement.getElementsByClassName('tooltipped-n')[0];
-    tooltip?.classList.add('tooltipped-nw');
-    tooltip?.classList.remove('tooltipped-n');
-  }, [inputRef]);
 
   function focusAfterEnd(ref) {
     setTimeout(() => {
@@ -46,15 +39,21 @@ export default function PasswordInput({ inputRef, id, name, label, errorObject, 
       <FormControl.Label>{label}</FormControl.Label>
       <TextInput
         trailingVisual={
-          <TextInput.Action
+          // Using custom Tooltip while waiting for the fix of the `TextInput.Action`
+          // Issue https://github.com/primer/react/issues/4091
+          <Tooltip
             aria-label={isPasswordVisible ? 'Ocultar a senha' : 'Visualizar a senha'}
-            onClick={handlePasswordVisible}
-            icon={isPasswordVisible ? EyeClosedIcon : EyeIcon}
-            sx={{ color: 'fg.subtle' }}
-          />
+            direction="nw"
+            sx={{ position: 'absolute' }}>
+            <IconButton
+              onClick={handlePasswordVisible}
+              icon={isPasswordVisible ? EyeClosedIcon : EyeIcon}
+              variant="invisible"
+            />
+          </Tooltip>
         }
         contrast
-        sx={{ minHeight: '46px', pl: 2, '&:focus-within': { backgroundColor: 'canvas.default' } }}
+        sx={{ pl: 2, '&:focus-within': { backgroundColor: 'canvas.default' } }}
         ref={inputRef}
         onChange={clearErrors}
         onKeyDown={detectCapsLock}

--- a/pages/login/index.public.js
+++ b/pages/login/index.public.js
@@ -106,7 +106,7 @@ function LoginForm() {
               block={true}
               aria-label="Seu email"
               contrast
-              sx={{ minHeight: '46px', px: 2, '&:focus-within': { backgroundColor: 'canvas.default' } }}
+              sx={{ px: 2, '&:focus-within': { backgroundColor: 'canvas.default' } }}
             />
             {errorObject?.key === 'email' && (
               <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>

--- a/pages/perfil/index.public.js
+++ b/pages/perfil/index.public.js
@@ -199,7 +199,7 @@ function EditProfileForm() {
             block={true}
             aria-label="Seu nome de usuário"
             contrast
-            sx={{ minHeight: '46px', px: 2, '&:focus-within': { backgroundColor: 'canvas.default' } }}
+            sx={{ px: 2, '&:focus-within': { backgroundColor: 'canvas.default' } }}
           />
           {errorObject?.key === 'username' && (
             <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
@@ -222,7 +222,7 @@ function EditProfileForm() {
             block={true}
             aria-label="Seu email"
             contrast
-            sx={{ minHeight: '46px', px: 2, '&:focus-within': { backgroundColor: 'canvas.default' } }}
+            sx={{ px: 2, '&:focus-within': { backgroundColor: 'canvas.default' } }}
           />
           {errorObject?.key === 'email' && errorObject.type !== 'typo' && (
             <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>


### PR DESCRIPTION
## O problema

Na tela de login ou cadastro, deixe o cursor sobre o ícone do olho no campo de senha.

O Tooltip deveria estar visível com o texto `Ocultar a senha` ou `Visualizar a senha`.


Antes | Depois
--- | ---
![image](https://github.com/filipedeschamps/tabnews.com.br/assets/77860630/319b87cc-04c7-40bc-94af-9ac1d1f91026) | ![image](https://github.com/filipedeschamps/tabnews.com.br/assets/77860630/8c547a09-be7a-47e8-a050-4fc7d139ab9f)

Não é algo específico do TabNews, mas um [problema conhecido da versão atual do Primer](https://github.com/primer/react/issues/4091). O problema ocorre até no componente de exemplo na página deles.

## Mudanças realizadas

Substituí o `TextInput.Action` pelo nosso `Tooltip` customizado junto de um `IconButton`.

Também aproveitei o PR para remover outros "ajustes" que o `TextInput.Action` exigia no passado, mas que já não eram mais necessários na versão atual do Primer. Um determinava a altura mínima de todos os campos de texto dos formulários para ficar no mesmo padrão do campo de senha, e o outro ajuste era na posição padrão do Tooltip do `TextInput.Action`.

## Tipo de mudança

- [x] Correção de bug

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).