### PR TITLE
Conserta o plural na contagem de comentários

### DIFF
--- a/pages/interface/components/ContentList/index.js
+++ b/pages/interface/components/ContentList/index.js
@@ -69,7 +69,7 @@ export default function ContentList({ contentList: list, pagination, paginationB
 
   function RenderItems() {
     function ChildrenDeepCountText({ count }) {
-      return count > 1 ? `${count} comentários` : `${count} comentário`;
+      return count === 1 ? `${count} comentários` : `${count} comentário`;
     }
 
     function TabCoinsText({ count }) {


### PR DESCRIPTION
## Mudanças realizadas

Conserta o texto da contagem de comentários, assim quando uma publicação tem 0 comentários, aparece `0 comentários` ao invés de `0 comentário`

## Tipo de mudança

[x] Correção de bug
