### PR TITLE
Altera os tipos de transações de conteúdos na tabela `balance_operations`

### DIFF
--- a/infra/migrations/1707850173496_create-function-get-content-credit-debit.js
+++ b/infra/migrations/1707850173496_create-function-get-content-credit-debit.js
@@ -1,0 +1,126 @@
+exports.up = async (pgm) => {
+  await pgm.createFunction(
+    'get_content_balance_credit_debit',
+    [
+      {
+        name: 'content_id_input',
+        mode: 'IN',
+        type: 'uuid',
+      },
+    ],
+    {
+      returns: 'TABLE (total_balance BIGINT, total_credit BIGINT, total_debit BIGINT) ROWS 1',
+      language: 'plpgsql',
+      replace: true,
+    },
+    `
+    BEGIN
+      RETURN QUERY
+        SELECT
+          COALESCE(SUM(amount), 0) AS total_balance,
+          COALESCE(SUM(CASE WHEN balance_type = 'content:tabcoin:credit' THEN amount END), 0) AS total_credit,
+          COALESCE(SUM(CASE WHEN balance_type = 'content:tabcoin:debit' THEN amount END), 0) AS total_debit
+        FROM
+          balance_operations
+        WHERE
+          recipient_id = content_id_input;
+    END;
+  `,
+  );
+
+  await pgm.createFunction(
+    'get_current_balance',
+    [
+      {
+        name: 'balance_type_input',
+        mode: 'IN',
+        type: 'text',
+      },
+      {
+        name: 'recipient_id_input',
+        mode: 'IN',
+        type: 'uuid',
+      },
+    ],
+    {
+      returns: 'integer',
+      language: 'plpgsql',
+      replace: true,
+    },
+    `
+    DECLARE
+      total_balance integer;
+    BEGIN
+      SELECT COALESCE(SUM(amount), 0)
+      INTO total_balance
+      FROM balance_operations
+      WHERE
+        (CASE
+            WHEN balance_type_input = 'content:tabcoin' THEN true
+            ELSE balance_type = balance_type_input 
+        END)
+        AND recipient_id = recipient_id_input;
+
+      RETURN total_balance;
+    END;`,
+  );
+
+  await pgm.createIndex('balance_operations', ['recipient_id', 'balance_type'], { ifNotExists: true });
+
+  await pgm.dropIndex('balance_operations', ['balance_type', 'recipient_id'], { ifExists: true });
+};
+
+exports.down = async (pgm) => {
+  await pgm.dropFunction(
+    'get_content_balance_credit_debit',
+    [
+      {
+        name: 'content_id_input',
+        mode: 'IN',
+        type: 'uuid',
+      },
+    ],
+    { ifExists: true },
+  );
+
+  await pgm.createFunction(
+    'get_current_balance',
+    [
+      {
+        name: 'balance_type_input',
+        mode: 'IN',
+        type: 'text',
+      },
+      {
+        name: 'recipient_id_input',
+        mode: 'IN',
+        type: 'uuid',
+      },
+    ],
+    {
+      returns: 'integer',
+      language: 'plpgsql',
+      replace: true,
+    },
+    `
+    DECLARE
+      total_balance integer;
+    BEGIN
+      total_balance := (
+        SELECT
+          COALESCE(sum(amount), 0)
+        FROM
+          balance_operations
+        WHERE
+          balance_type = balance_type_input
+          AND recipient_id = recipient_id_input
+      );
+      RETURN total_balance;
+    END;
+  `,
+  );
+
+  await pgm.dropIndex('balance_operations', ['recipient_id', 'balance_type'], { ifExists: true });
+
+  await pgm.createIndex('balance_operations', ['balance_type', 'recipient_id'], { ifNotExists: true });
+};

--- a/models/balance.js
+++ b/models/balance.js
@@ -53,6 +53,7 @@ async function rateContent({ contentId, contentOwnerId, fromUserId, transactionT
   const tabCoinsToTransactToContent = transactionType === 'credit' ? 1 : -1;
   const originatorType = 'event';
   const originatorId = options.eventId;
+  const contentBalanceType = transactionType === 'credit' ? 'content:tabcoin:credit' : 'content:tabcoin:debit';
 
   const query = {
     text: `
@@ -70,7 +71,7 @@ async function rateContent({ contentId, contentOwnerId, fromUserId, transactionT
         INSERT INTO balance_operations
           (balance_type, recipient_id, amount, originator_type, originator_id)
         VALUES
-          ('content:tabcoin', $4, $5, $8, $9)
+          ($10, $4, $5, $8, $9)
         RETURNING
           *
       )
@@ -96,6 +97,8 @@ async function rateContent({ contentId, contentOwnerId, fromUserId, transactionT
 
       originatorType, // $8
       originatorId, // $9
+
+      contentBalanceType, // $10
     ],
   };
 

--- a/models/content.js
+++ b/models/content.js
@@ -606,7 +606,7 @@ async function creditOrDebitTabCoins(oldContent, newContent, options = {}) {
   if (contentEarnings > 0) {
     await balance.create(
       {
-        balanceType: 'content:tabcoin',
+        balanceType: 'content:tabcoin:initial',
         recipientId: newContent.id,
         amount: contentEarnings,
         originatorType: options.eventId ? 'event' : 'content',

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -325,7 +325,7 @@ async function createPrestige(
 
   if (rootContents.length) {
     await createBalance({
-      balanceType: 'content:tabcoin',
+      balanceType: rootPrestigeNumerator > 0 ? 'content:tabcoin:credit' : 'content:tabcoin:debit',
       recipientId: rootContents[0].id,
       amount: rootPrestigeNumerator,
       originatorType: 'orchestrator',
@@ -335,7 +335,8 @@ async function createPrestige(
 
   if (childContents.length) {
     await createBalance({
-      balanceType: 'content:tabcoin',
+      balanceType:
+        childPrestigeNumerator + childPrestigeDenominator > 0 ? 'content:tabcoin:credit' : 'content:tabcoin:debit',
       recipientId: childContents[0].id,
       amount: childPrestigeNumerator + childPrestigeDenominator,
       originatorType: 'orchestrator',


### PR DESCRIPTION
## Mudanças realizadas

Alterada a modelagem da tabela `balance_operations` para facilitar a consulta dos saldos de TabCoins dos conteúdos pela função `get_content_balance_credit_debit` criada no PR #1607.

Foi removido `content:tabcoin` das opções para `balance_operations.balance_type` e substituído por `content:tabcoin:initial`, `content:tabcoin:credit` e `content:tabcoin:debit`.

Já foi adicionado no PR atual a versão da função `get_content_balance_credit_debit` que aproveita a mudança em `balance_operations`. Agora ela só recebe um parâmetro, que é o ID do conteúdo.

As mudanças que envolvem o banco de dados já foram aplicadas em homologação, o que não afeta o funcionando das versões existentes de antes do PR #1607.

## Tipo de mudança

- [x] Altera modelagem de dados

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Os testes antigos estão passando localmente.
