### PR TITLE
Efeito de `hover` separado para os links `TabNews` e `Relevantes`.

### DIFF
--- a/pages/interface/components/Header/index.js
+++ b/pages/interface/components/Header/index.js
@@ -56,9 +56,10 @@ export default function HeaderComponent() {
         <PrimerHeader.Item sx={{ mr: 0 }}>
           <HeaderLink href="/" aria-label="Página inicial Relevantes" aria-current={asPath === '/' ? 'page' : false}>
             <CgTab size={32} />
-
             <Box sx={{ ml: 2, display: ['none', 'block'] }}>TabNews</Box>
+          </HeaderLink>
 
+          <HeaderLink href="/" aria-label="Página inicial Relevantes" aria-current={asPath === '/' ? 'page' : false}>
             <Box sx={asPath === '/' || asPath.startsWith('/pagina') ? activeLinkStyle : { ml: 3 }}>Relevantes</Box>
           </HeaderLink>
         </PrimerHeader.Item>


### PR DESCRIPTION
## Mudanças realizadas


Desculpem, mas o comportamento do Hover nos links do Header estava me fazendo sofrer com TOC rsrsrs 😄

Acredito que o efeito Hover separado para TabNews e Relevantes seja mais adequado, e traga uma sensação melhor na interação do usuário com o menu. 

Anteriormente, o efeito de foco era aplicado aos links `TabNews` e `Relevantes` juntos:

<img width="171" alt="image" src="https://github.com/filipedeschamps/tabnews.com.br/assets/59850744/813a3d90-05d5-40d7-a4e7-a0e87831f030">


Apenas separei os links para o efeito hover individualmente em `TabNews` e `Relevantes`:

<img width="167" alt="image" src="https://github.com/filipedeschamps/tabnews.com.br/assets/59850744/150dddda-ca99-457b-ba0e-5ed7fff980b6">


<!-- Por favor, inclua uma descrição sobre o que foi modificado nesse PR. Inclua também qualquer motivação ou contexto relevante.  -->

<!-- Se o PR contém uma modificação da interface gráfica (UI), adicione fotos ou vídeos comparando o antes e depois. -->

<!-- Se o PR contém modificações de API, mencione os endpoints afetados. -->

<!-- Caso esse PR resolva algum issue, você pode descomentar a linha abaixo e substituir (issue) pelo número dele. -->
<!-- Resolve #(issue) -->

## Tipo de mudança

<!-- Descomente a linha abaixo que corresponde ao tipo de mudança realizada no PR. -->

- [x] Correção de bug 
- [x] Nova funcionalidade
<!-- - [x] _**Breaking change**_ (a alteração causa uma quebra de compatibilidade na API ou em links públicos do site) -->
<!-- - [x] Atualização de documentação -->

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [ ] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
