### PR TITLE
Melhorias envolvendo envio de emails

### DIFF
--- a/infra/email.js
+++ b/infra/email.js
@@ -1,24 +1,32 @@
+import retry from 'async-retry';
 import nodemailer from 'nodemailer';
 
 import { ServiceError } from 'errors';
 import logger from 'infra/logger.js';
 import webserver from 'infra/webserver.js';
 
-const transporterConfiguration = {
-  host: process.env.EMAIL_SMTP_HOST,
-  port: process.env.EMAIL_SMTP_PORT,
-  secure: true,
-  auth: {
-    user: process.env.EMAIL_USER,
-    pass: process.env.EMAIL_PASSWORD,
-  },
-};
+const RETRIES_PER_EMAIL_SERVICE = 1;
 
-if (!webserver.isServerlessRuntime) {
-  transporterConfiguration.secure = false;
+const transporterConfigs = [];
+let configNumber = '';
+
+while (process.env['EMAIL_SMTP_HOST' + configNumber]) {
+  transporterConfigs.push({
+    host: process.env['EMAIL_SMTP_HOST' + configNumber],
+    port: process.env['EMAIL_SMTP_PORT' + configNumber],
+    secure: webserver.isServerlessRuntime,
+    auth: {
+      user: process.env['EMAIL_USER' + configNumber],
+      pass: process.env['EMAIL_PASSWORD' + configNumber],
+    },
+  });
+
+  configNumber = transporterConfigs.length + 1;
 }
 
-const transporter = nodemailer.createTransport(transporterConfiguration);
+const transporters = transporterConfigs.map((config) => nodemailer.createTransport(config));
+
+const retries = (RETRIES_PER_EMAIL_SERVICE + 1) * transporters.length - 1;
 
 async function send({ from, to, subject, html, text }) {
   const mailOptions = {
@@ -30,17 +38,43 @@ async function send({ from, to, subject, html, text }) {
   };
 
   try {
-    await transporter.sendMail(mailOptions);
+    await retry(tryToSendEmail, {
+      retries,
+      minTimeout: 0,
+      maxTimeout: 0,
+      factor: 0,
+      randomize: false,
+      onRetry: logError,
+    });
   } catch (error) {
+    logError(error, retries + 1);
+    throw error;
+  }
+
+  async function tryToSendEmail(bail, attempt) {
+    const configIndex = (attempt - 1) % transporters.length;
+    const transporter = transporters[configIndex];
+
+    await transporter.sendMail(mailOptions);
+  }
+
+  function logError(error, attempt) {
+    const configIndex = (attempt - 1) % transporters.length;
+
     const errorObject = new ServiceError({
       message: error.message,
       action: 'Verifique se o serviço de emails está disponível.',
       stack: error.stack,
-      context: mailOptions,
+      context: {
+        attempt,
+        emailSmtpHost: transporterConfigs[configIndex].host,
+        from: mailOptions.from,
+        to: mailOptions.to,
+        subject: mailOptions.subject,
+      },
       errorLocationCode: 'INFRA:EMAIl:SEND',
     });
     logger.error(errorObject);
-    throw errorObject;
   }
 }
 

--- a/pages/interface/index.js
+++ b/pages/interface/index.js
@@ -3,4 +3,6 @@ export { default as useCollapse } from './hooks/useCollapse';
 export { default as useMediaQuery } from './hooks/useMediaQuery';
 export { UserProvider, default as useUser } from './hooks/useUser';
 export { default as suggestEmail } from './utils/email-suggestion';
+export { default as isValidJsonString } from './utils/is-valid-json-string';
+export { default as processNdJsonStream } from './utils/nd-json-stream';
 export { default as isTrustedDomain } from './utils/trusted-domain';

--- a/pages/interface/utils/is-valid-json-string.js
+++ b/pages/interface/utils/is-valid-json-string.js
@@ -1,0 +1,12 @@
+export default function isValidJsonString(jsonString) {
+  if (!(jsonString && typeof jsonString === 'string')) {
+    return false;
+  }
+
+  try {
+    JSON.parse(jsonString);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}

--- a/pages/interface/utils/nd-json-stream.js
+++ b/pages/interface/utils/nd-json-stream.js
@@ -1,0 +1,42 @@
+import { isValidJsonString } from 'pages/interface';
+
+export default function processNdJsonStream(stream, cb) {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let partialData = '';
+
+  const readChunk = () => {
+    reader.read().then(({ done, value }) => {
+      if (done) return;
+      partialData += decoder.decode(value, { stream: true });
+
+      partialData = processChunk(partialData, cb);
+
+      readChunk();
+    });
+  };
+
+  readChunk();
+}
+
+function processChunk(chunk, cb) {
+  let partialData = chunk;
+  let delimiterIndex = -1;
+
+  if (isValidJsonString(partialData)) {
+    cb(JSON.parse(partialData));
+    return '';
+  }
+
+  while ((delimiterIndex = partialData.lastIndexOf('\n')) !== -1) {
+    partialData = partialData.slice(0, delimiterIndex);
+
+    if (isValidJsonString(partialData)) {
+      cb(JSON.parse(partialData));
+
+      return processChunk(chunk.slice(delimiterIndex + 1), cb);
+    }
+  }
+
+  return chunk;
+}

--- a/tests/unit/infra/email.test.js
+++ b/tests/unit/infra/email.test.js
@@ -1,0 +1,173 @@
+import nodemailer from 'nodemailer';
+
+import { ServiceError } from 'errors';
+import logger from 'infra/logger';
+import webserver from 'infra/webserver';
+
+jest.mock('nodemailer', () => ({
+  createTransport: jest.fn(),
+}));
+
+jest.mock('infra/logger', () => ({
+  error: jest.fn(),
+}));
+
+jest.mock('infra/webserver', () => ({
+  isServerlessRuntime: false,
+}));
+
+describe('infra/email > send', () => {
+  let send;
+  let originalEnv;
+  const sendMail = jest.fn();
+
+  const defaultTestEnv = {
+    EMAIL_SMTP_HOST: 'host.test',
+    EMAIL_SMTP_PORT: 1025,
+    EMAIL_USER: 'email_user_test',
+    EMAIL_PASSWORD: 'email_password_test',
+  };
+
+  const defaultMailOptions = {
+    auth: {
+      user: defaultTestEnv.EMAIL_USER,
+      pass: defaultTestEnv.EMAIL_PASSWORD,
+    },
+    secure: false,
+    host: defaultTestEnv.EMAIL_SMTP_HOST,
+    port: defaultTestEnv.EMAIL_SMTP_PORT,
+  };
+
+  const defaultEmailData = {
+    from: 'test@example.com',
+    to: 'recipient@example.com',
+    subject: 'Test Email',
+    html: '<p>Test HTML</p>',
+    text: 'Test Text',
+  };
+
+  beforeAll(() => {
+    originalEnv = process.env;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sendMail.mockResolvedValue();
+    nodemailer.createTransport.mockReturnValue({ sendMail });
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  describe('With single email service', () => {
+    beforeEach(() => {
+      process.env = {
+        ...originalEnv,
+        ...defaultTestEnv,
+      };
+
+      jest.isolateModules(() => {
+        delete require.cache[require.resolve('infra/email')];
+        const { default: email } = require('infra/email');
+        send = email.send;
+      });
+    });
+
+    it('should send an email with the provided options', async () => {
+      await expect(send(defaultEmailData)).resolves.not.toThrow();
+
+      expect(nodemailer.createTransport).toHaveBeenCalledTimes(1);
+      expect(nodemailer.createTransport).toHaveBeenCalledWith(defaultMailOptions);
+      expect(sendMail).toHaveBeenCalledWith(defaultEmailData);
+    });
+
+    it('should throw an error if sending the email fails all attempts', async () => {
+      sendMail.mockRejectedValue(new Error('Failed to send email'));
+
+      await expect(send(defaultEmailData)).rejects.toThrow('Failed to send email');
+
+      expect(sendMail).toHaveBeenCalledTimes(2);
+      expect(logger.error).toHaveBeenCalledTimes(2);
+      expect(logger.error).toHaveBeenCalledWith(new ServiceError({ message: 'Failed to send email' }));
+    });
+
+    it('should retry if sending the email fails once', async () => {
+      sendMail.mockRejectedValueOnce(new Error('Failed to send email'));
+
+      await expect(send(defaultEmailData)).resolves.not.toThrow();
+
+      expect(sendMail).toHaveBeenCalledTimes(2);
+      expect(logger.error).toHaveBeenCalledTimes(1);
+      expect(logger.error).toHaveBeenCalledWith(new ServiceError({ message: 'Failed to send email' }));
+    });
+  });
+
+  describe('With two email services', () => {
+    const secondEmailServiceEnv = {
+      EMAIL_SMTP_HOST2: 'host.test2',
+      EMAIL_SMTP_PORT2: 1026,
+      EMAIL_USER2: 'email_user_test2',
+      EMAIL_PASSWORD2: 'email_password_test2',
+    };
+
+    const secondMailOptions = {
+      auth: {
+        user: secondEmailServiceEnv.EMAIL_USER2,
+        pass: secondEmailServiceEnv.EMAIL_PASSWORD2,
+      },
+      secure: true,
+      host: secondEmailServiceEnv.EMAIL_SMTP_HOST2,
+      port: secondEmailServiceEnv.EMAIL_SMTP_PORT2,
+    };
+
+    beforeAll(() => {
+      webserver.isServerlessRuntime = true;
+    });
+
+    beforeEach(() => {
+      process.env = {
+        ...originalEnv,
+        ...defaultTestEnv,
+        ...secondEmailServiceEnv,
+      };
+
+      jest.isolateModules(() => {
+        delete require.cache[require.resolve('infra/email')];
+        const { default: email } = require('infra/email');
+        send = email.send;
+      });
+    });
+
+    it('should send an email with the provided options', async () => {
+      await expect(send(defaultEmailData)).resolves.not.toThrow();
+
+      expect(nodemailer.createTransport).toHaveBeenCalledTimes(2);
+      expect(nodemailer.createTransport).toHaveBeenCalledWith({ ...defaultMailOptions, secure: true });
+      expect(nodemailer.createTransport).toHaveBeenCalledWith(secondMailOptions);
+      expect(sendMail).toHaveBeenCalledWith(defaultEmailData);
+    });
+
+    it('should throw an error if sending the email fails all attempts', async () => {
+      sendMail.mockRejectedValue(new Error('Failed to send email'));
+
+      await expect(send(defaultEmailData)).rejects.toThrow('Failed to send email');
+      expect(sendMail).toHaveBeenCalledTimes(4);
+      expect(logger.error).toHaveBeenCalledTimes(4);
+      expect(logger.error).toHaveBeenCalledWith(new ServiceError({ message: 'Failed to send email' }));
+    });
+
+    it('should retry with alternative email service', async () => {
+      sendMail.mockRejectedValueOnce(new Error('Failed to send email'));
+      await expect(send(defaultEmailData)).resolves.not.toThrow();
+
+      expect(nodemailer.createTransport).toHaveBeenCalledTimes(2);
+      expect(nodemailer.createTransport).toHaveBeenCalledWith({ ...defaultMailOptions, secure: true });
+      expect(nodemailer.createTransport).toHaveBeenCalledWith(secondMailOptions);
+
+      expect(sendMail).toHaveBeenCalledTimes(2);
+      expect(logger.error).toHaveBeenCalledTimes(1);
+      expect(logger.error).toHaveBeenCalledWith(new ServiceError({ message: 'Failed to send email' }));
+    });
+  });
+});


### PR DESCRIPTION
## Mudanças realizadas

Baseado na conversa em #1630...


### Contingência de serviço de envio de email

- Permite adicionar mais de um serviço de email para utilização automática em caso de erro no principal.
- Para adicionar mais serviços, basta adicionar 2, 3, 4... ao final das variáveis de ambiente de email.
- Adiciona uma retentativa de envio de email para cada diferente serviço configurado. Em caso de erro, serão efetuadas duas tentativas para cada serviço.
- Registra logs internos de `ServiceError` se houver problema em qualquer tentativa de envio de email, mesmo que alguma das tentativas tenha sucesso.
- Com isso podemos testar mais uma vez o Resend sem os riscos dos problemas que enfrentamos em #1614 e #1616.

### Respostas via *stream*

- Adiciona a possibilidade de respostas via stream na API.
- Adequa também as respostas de erro via stream.
- Implementa respostas via stream para as requisições de criação de comentários, o que permite devolver a informação de que a publicação foi realizada com sucesso enquanto o processamento do envio de email de notificação ainda está ocorrendo.
- Para não haver *breaking change* , a resposta continua sendo enviada como JSON único por padrão, mas para publicações de comentários em que for enviado o *header* `Accept: 'application/x-ndjson'`, a resposta poderá vir como um conjunto de JSON separados por quebras de linhas.
- Adapta o front-end para enviar o cabeçalho e processar a resposta via stream. Em caso de sucesso na criação da publicação, mas em que ocorrer qualquer outro erro interno, o erro só será impresso no console do navegador.
- Não podemos devolver muitas informações em caso de erros de serviços internos, então deixar o erro apenas no console parece suficiente para usuários que estiverem ativamente realizando testes.
- Para quem utilizar a API sem enviar o cabeçalho `application/x-ndjson`, em caso de sucesso na publicação do comentário, mas com erro no envio da notificação, a requisição retornará com sucesso e o erro só estará presente nos logs internos.

As melhorias para contingência do serviço de email se aplicam a todos os emails, mas a resposta via *stream*, por enquanto, foi implementada apenas para a criação de comentários.

Resolve:
- #1451 
- #1630 

### Possíveis melhorias relacionadas (para outro momento)

- Processar em paralelo tudo que for possível dentro de cada requisição.
- Estudar as possibilidades de utilizar um serviço externo de filas.

## Tipo de mudança

- [x] Correção de bug
- [x] Nova funcionalidade

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.