### PR TITLE
Aumenta o espaçamento entre o saldo e os botões de TabCoins

### DIFF
--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -53,11 +53,12 @@ export default function Post({ contentFound, rootContentFound, parentContentFoun
                 borderStyle: 'dotted',
                 width: '50%',
                 height: '100%',
+                minHeight: '8px',
               }}
             />
           </Box>
 
-          <Box sx={{ width: '100%', pl: '1px', overflow: 'auto' }}>
+          <Box sx={{ width: '100%', mt: contentFound.title ? 0 : '9px', pl: '1px', overflow: 'auto' }}>
             <Content key={contentFound.id} content={contentFound} mode="view" />
           </Box>
         </Box>
@@ -70,7 +71,7 @@ export default function Post({ contentFound, rootContentFound, parentContentFoun
               borderColor: 'border.default',
               borderStyle: 'solid',
               mt: 4,
-              mb: 4,
+              mb: 3,
               p: 4,
               wordWrap: 'break-word',
             }}>
@@ -102,7 +103,7 @@ function InReplyToLinks({ content, parentContent, rootContent }) {
         [root]->[child]->[child]
       */}
       {content.parent_id && parentContent.id === rootContent.id && (
-        <Box sx={{ fontSize: 1, mb: 3, display: 'flex', flexDirection: 'row' }}>
+        <Box sx={{ fontSize: 1, mb: 2, display: 'flex', flexDirection: 'row' }}>
           <Box
             sx={{
               textAlign: 'center',
@@ -134,7 +135,7 @@ function InReplyToLinks({ content, parentContent, rootContent }) {
         [root]->[child]->[child]
       */}
       {content.parent_id && parentContent.id !== rootContent.id && (
-        <Box sx={{ fontSize: 1, mb: 3, display: 'flex', flexDirection: 'row' }}>
+        <Box sx={{ fontSize: 1, mb: 2, display: 'flex', flexDirection: 'row' }}>
           <Box
             sx={{
               textAlign: 'center',
@@ -194,7 +195,7 @@ function RenderChildrenTree({ childrenList, pageRootOwnerId, renderIntent, rende
           width: '100%',
           wordWrap: 'break-word',
           display: 'flex',
-          mt: 4,
+          mt: 3,
         }}
         key={id}>
         {renderIntent ? (
@@ -216,6 +217,7 @@ function RenderChildrenTree({ childrenList, pageRootOwnerId, renderIntent, rende
                   cursor: 'pointer',
                   width: '80%',
                   height: '100%',
+                  minHeight: '24px',
                   display: 'flex',
                   justifyContent: 'center',
                   mt: 1,
@@ -257,10 +259,11 @@ function RenderChildrenTree({ childrenList, pageRootOwnerId, renderIntent, rende
               </Tooltip>
             </Box>
 
-            <Box sx={{ width: '100%', pl: '1px', overflow: 'auto' }}>
+            <Box
+              sx={{ display: 'flex', flexDirection: 'column', width: '100%', mt: '9px', pl: '1px', overflow: 'auto' }}>
               <Content content={child} isPageRootOwner={isPageRootOwner} mode="view" />
 
-              <Box sx={{ mt: 4 }}>
+              <Box sx={{ display: 'flex', flex: 1, mt: 4, alignItems: 'end' }}>
                 <Content content={{ owner_id, parent_id: id }} mode="compact" viewFrame={true} />
               </Box>
 

--- a/pages/interface/components/TabCoinButtons/index.js
+++ b/pages/interface/components/TabCoinButtons/index.js
@@ -89,7 +89,6 @@ export default function TabCoinButtons({ content }) {
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
-        mt: contentObject.title ? '9px' : '0px',
       }}>
       <Tooltip aria-label="Achei relevante" direction="ne">
         <IconButton
@@ -109,6 +108,7 @@ export default function TabCoinButtons({ content }) {
           textAlign: 'center',
           fontSize: 0,
           fontWeight: 'bold',
+          my: 2,
           py: 1,
           color: 'accent.emphasis',
         }}
@@ -123,7 +123,7 @@ export default function TabCoinButtons({ content }) {
           aria-label="Debitar TabCoin"
           icon={ChevronDownIcon}
           size="small"
-          sx={{ color: 'fg.subtle', lineHeight: '18px' }}
+          sx={{ color: 'fg.subtle', lineHeight: '18px', mb: 2 }}
           onClick={() => transactTabCoin('debit')}
           disabled={isInAction}
         />


### PR DESCRIPTION
Como o PR #1607 adicionou um Tooltip para mostrar mais dados sobre os votos, ficaram elementos interativos muito próximos, o que aumenta o risco de votos acidentais, principalmente em interações por toque na tela.

Ontem eu acabei votando negativamente sem querer em um conteúdo do @Rafatcb ao tentar ver mais dados sobre as qualificações.

Isso é um problema maior enquanto não for implementada a possibilidade de desfazer votos acidentais:

- #1183 .

## Mudanças realizadas

Aumenta o espaçamento entre os 4 elementos interativos ali presentes:

- Achei relevante
- Dados sobre qualificações
- Não achei relevante
- Ocultar comentários

Antes | Depois
--- | ---
![image](https://github.com/filipedeschamps/tabnews.com.br/assets/77860630/bbebc760-5477-41ef-ac41-beb29752204a) | ![image](https://github.com/filipedeschamps/tabnews.com.br/assets/77860630/346cd9d2-113f-4247-839f-9b1e8415c9f4)

## Tipo de mudança

- [x] UX

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
