### PR TITLE
Considerar acentos ao contar quantidade mínima de caracteres por palavra do conteúdo

### DIFF
--- a/models/content.js
+++ b/models/content.js
@@ -8,6 +8,7 @@ import prestige from 'models/prestige';
 import user from 'models/user.js';
 import validator from 'models/validator.js';
 import queries from 'queries/rankingQueries';
+import { isContentTooShort } from 'utils/content';
 
 async function findAll(values = {}, options = {}) {
   values = validateValues(values);
@@ -589,8 +590,7 @@ async function creditOrDebitTabCoins(oldContent, newContent, options = {}) {
     }
 
     // We should not credit if the content has little or no value.
-    // Expected 5 or more words with 5 or more characters.
-    if (newContent.body.split(/[a-z]{5,}/i, 6).length < 6) return;
+    if (isContentTooShort(newContent.body)) return;
   }
 
   if (userEarnings > 0) {

--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -26,6 +26,7 @@ import {
 } from '@/TabNewsUI';
 import { KebabHorizontalIcon, LinkIcon, PencilIcon, TrashIcon } from '@/TabNewsUI/icons';
 import { isTrustedDomain, isValidJsonString, processNdJsonStream, useUser } from 'pages/interface';
+import { isContentTooShort } from 'utils/content';
 
 const CONTENT_TITLE_PLACEHOLDER_EXAMPLES = [
   'e.g. Nova versão do Python é anunciada com melhorias de desempenho',
@@ -312,24 +313,23 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
         return;
       }
 
-      const confirmBodyValue =
-        newData.body.split(/[a-z]{5,}/i, 6).length < 6
-          ? await confirm({
-              title: 'Tem certeza que deseja publicar essa mensagem curta?',
-              content: (
-                <Flash variant="warning">
-                  ⚠ Atenção: Pedimos encarecidamente que{' '}
-                  <Link href="https://www.tabnews.com.br/filipedeschamps/tentando-construir-um-pedaco-de-internet-mais-massa">
-                    leia isso antes
-                  </Link>{' '}
-                  de fazer essa publicação.
-                </Flash>
-              ),
-              cancelButtonContent: 'Cancelar',
-              confirmButtonContent: 'Publicar',
-              confirmButtonType: 'danger',
-            })
-          : true;
+      const confirmBodyValue = isContentTooShort(newData.body)
+        ? await confirm({
+            title: 'Tem certeza que deseja publicar essa mensagem curta?',
+            content: (
+              <Flash variant="warning">
+                ⚠ Atenção: Pedimos encarecidamente que{' '}
+                <Link href="https://www.tabnews.com.br/filipedeschamps/tentando-construir-um-pedaco-de-internet-mais-massa">
+                  leia isso antes
+                </Link>{' '}
+                de fazer essa publicação.
+              </Flash>
+            ),
+            cancelButtonContent: 'Cancelar',
+            confirmButtonContent: 'Publicar',
+            confirmButtonType: 'danger',
+          })
+        : true;
 
       if (!confirmBodyValue) return;
 

--- a/tests/unit/utils/content.test.js
+++ b/tests/unit/utils/content.test.js
@@ -1,0 +1,23 @@
+import { isContentTooShort } from 'utils/content';
+
+describe('isContentTooShort', () => {
+  it('Should return true when content is shorter than the minimum number of words', async () => {
+    const content = 'já concordei ctg.';
+    expect(isContentTooShort(content)).toBe(true);
+  });
+
+  it('Should return false when content is exactly the minimum number of letters and words', async () => {
+    const content = 'teste curto antes áéíóú çãâôz';
+    expect(isContentTooShort(content)).toBe(false);
+  });
+
+  it('Should return false when content is beyond the the minimum number of letters and words', async () => {
+    const content = 'testando palavras compridas também acentuadas';
+    expect(isContentTooShort(content)).toBe(false);
+  });
+
+  it('Should return true when content is empty', async () => {
+    const content = '';
+    expect(isContentTooShort(content)).toBe(true);
+  });
+});

--- a/utils/content.js
+++ b/utils/content.js
@@ -1,0 +1,9 @@
+export function isContentTooShort(content) {
+  const minimumNumLettersPerWord = 5;
+  const minimumNumWords = 5;
+
+  const regexPattern = new RegExp(`[a-záéíóúâôãõç]{${minimumNumLettersPerWord},}`, 'gi');
+  const matches = content.normalize('NFC').match(regexPattern);
+
+  return !matches || matches.length < minimumNumWords;
+}


### PR DESCRIPTION
Implementei a alteração na contagem de palavras.

## Mudanças realizadas

Implementada função recomendada no issue: https://github.com/filipedeschamps/tabnews.com.br/issues/1487

Resolve #1487

## Tipo de mudança

<!-- Descomente a linha abaixo que corresponde ao tipo de mudança realizada no PR. -->

[x] Correção de bug 

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
