### PR TITLE
style: replace `*` in required fields with `(optional)` on non-required

### DIFF
--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -496,7 +496,7 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
           {globalErrorMessage && <Flash variant="danger">{globalErrorMessage}</Flash>}
 
           {!contentObject?.parent_id && (
-            <FormControl id="title" required>
+            <FormControl id="title">
               <FormControl.Label>Título</FormControl.Label>
               <TextInput
                 contrast
@@ -521,7 +521,7 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
             </FormControl>
           )}
 
-          <FormControl id="body" required={!contentObject?.parent_id}>
+          <FormControl id="body">
             <FormControl.Label>{contentObject?.parent_id ? 'Seu comentário' : 'Corpo da publicação'}</FormControl.Label>
             <Editor
               isValid={errorObject?.key === 'body'}
@@ -539,7 +539,10 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
 
           {!contentObject?.parent_id && (
             <FormControl id="source_url">
-              <FormControl.Label>Fonte</FormControl.Label>
+              <FormControl.Label>
+                Fonte
+                <Text sx={{ fontSize: 'small', color: 'fg.muted', ml: '4px' }}>(Opcional)</Text>
+              </FormControl.Label>
               <TextInput
                 contrast
                 sx={{ px: 2, '&:focus-within': { backgroundColor: 'canvas.default' } }}
@@ -559,10 +562,6 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
                 <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
               )}
             </FormControl>
-          )}
-
-          {!contentObject?.parent_id && (
-            <Text sx={{ fontSize: 1 }}>Os campos marcados com um asterisco (*) são obrigatórios.</Text>
           )}
 
           <Box sx={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center' }}>


### PR DESCRIPTION
## Mudanças realizadas

### Resumo:

Neste pull request, realizei uma alteração na forma como os campos obrigatórios são indicados nos formulários, com base em princípios de design e psicologia do usuário.

### Motivação/contexto:

As pesquisas indicam que indicar os campos obrigatórios com asteriscos pode causar desconforto nos usuários. Portanto, optei por marcar os campos opcionais em vez dos obrigatórios para proporcionar uma experiência mais positiva ao usuário.

Referência: [Form fields — Required vs Optional](https://uxdesign.cc/form-field-required-vs-optional-9b4d7cdbf400)

### Alterações:
Removi a propriedade `required` do componente `FormControl`, que levava o primer a inserir automaticamente o asterisco na label. No entanto, a propriedade não afeta a lógica do formulário.

Em seguida, no campo opcional `source`, fiz a adição de um texto `(opcional)`, logo após a label.

### Antes / Depois
<div style="display: flex; justify-content: center;">
    <img src="https://i.imgur.com/aYW08iq.png" alt="Antes" style="width: 45%;">
    <img src="https://i.imgur.com/682uCI6.png" alt="Depois" style="width: 45%;">
</div>

## Tipo de mudança

<!-- Descomente a linha abaixo que corresponde ao tipo de mudança realizada no PR. -->
-  [x] Nova funcionalidade


## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [ ] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
