### PR TITLE
docs(readme): change from "install" to "ci"

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Você precisa ter duas principais dependências instaladas:
 Com o repositório clonado e as dependências globais instaladas, você pode instalar as dependências locais do projeto:
 
 ```bash
-npm install
+npm ci
 ```
 
 ### Rodar o projeto


### PR DESCRIPTION
> Primeiramente, obrigado por esse projeto maravilhoso 💙

## Tipo de mudança

- [x] Atualização de documentação

---

## Mudanças realizadas

Para uma primeira contribuição, gostaria de trazer algo super simples (_até demais_) e que não agrega um valor direto ao projeto, mas sim para os **contribuidores**.

Mudança no **README.md**:

```diff
- npm install
+ npm ci
```

---

### Motivação

Apesar do **package.json** possuir as dependências diretas de forma estática, isso não vale para as dependências indiretas.

#### ℹ️ Isso traz algum problema hoje? Não. Então qual a vantagem?

- Garantir que mesmo as dependências indiretas sejam as mesmas que foram testadas e validadas no repositório
  - Isso também se aplica caso um dia o **package.json** possuir dependências dinâmicas
- Evitar surpresas e comportamentos inesperados, sejam em testes, no desenvolvimento e até na produção localmente
- Apesar de não possuir a mesma relevância das anteriores, é mais rápido e eficaz, visto que ele não vai processar cada sub-dependência em profundidade, mas instalar exatamente o que está no **package-lock.json**

#### 🧑🏻‍🔬 Testando na prática

Forçando a atualização do **package-lock.json** para mostrar visualmente o nível de diferença do que foi instalado no `node_modules` e o que está no **package-lock.json**:

```bash
git diff --numstat
```

```
3065    15689   package-lock.json
```

São **18.754** linhas de diferença, quando somadas as adições e exclusões.

---

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
  - [x] Não diretamente, como mostrado acima
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
