### PR TITLE
Migração para criar novas tabelas de saldo

### DIFF
--- a/infra/migrations/1711833444337_create-separate-balance-operations-tables.js
+++ b/infra/migrations/1711833444337_create-separate-balance-operations-tables.js
@@ -1,0 +1,257 @@
+exports.up = (pgm) => {
+  pgm.createTable('content_tabcoin_operations', {
+    id: {
+      type: 'uuid',
+      default: pgm.func('gen_random_uuid()'),
+      notNull: true,
+      primaryKey: true,
+    },
+
+    sequence: {
+      type: 'serial',
+      notNull: true,
+    },
+
+    balance_type: {
+      type: 'text',
+      notNull: true,
+    },
+
+    recipient_id: {
+      type: 'uuid',
+      notNull: true,
+    },
+
+    amount: {
+      type: 'integer',
+      notNull: true,
+    },
+
+    originator_type: {
+      type: 'text',
+      notNull: true,
+    },
+
+    originator_id: {
+      type: 'uuid',
+      notNull: true,
+    },
+
+    created_at: {
+      type: 'timestamp with time zone',
+      notNull: true,
+      default: pgm.func("(now() at time zone 'utc')"),
+    },
+  });
+
+  pgm.createTable('user_tabcoin_operations', {
+    id: {
+      type: 'uuid',
+      default: pgm.func('gen_random_uuid()'),
+      notNull: true,
+      primaryKey: true,
+    },
+
+    sequence: {
+      type: 'serial',
+      notNull: true,
+    },
+
+    recipient_id: {
+      type: 'uuid',
+      notNull: true,
+    },
+
+    amount: {
+      type: 'integer',
+      notNull: true,
+    },
+
+    originator_type: {
+      type: 'text',
+      notNull: true,
+    },
+
+    originator_id: {
+      type: 'uuid',
+      notNull: true,
+    },
+
+    created_at: {
+      type: 'timestamp with time zone',
+      notNull: true,
+      default: pgm.func("(now() at time zone 'utc')"),
+    },
+  });
+
+  pgm.createTable('user_tabcash_operations', {
+    id: {
+      type: 'uuid',
+      default: pgm.func('gen_random_uuid()'),
+      notNull: true,
+      primaryKey: true,
+    },
+
+    sequence: {
+      type: 'serial',
+      notNull: true,
+    },
+
+    recipient_id: {
+      type: 'uuid',
+      notNull: true,
+    },
+
+    amount: {
+      type: 'integer',
+      notNull: true,
+    },
+
+    originator_type: {
+      type: 'text',
+      notNull: true,
+    },
+
+    originator_id: {
+      type: 'uuid',
+      notNull: true,
+    },
+
+    created_at: {
+      type: 'timestamp with time zone',
+      notNull: true,
+      default: pgm.func("(now() at time zone 'utc')"),
+    },
+  });
+
+  pgm.createFunction(
+    'get_content_current_tabcoins',
+    [
+      {
+        name: 'recipient_id_input',
+        mode: 'IN',
+        type: 'uuid',
+      },
+    ],
+    {
+      returns: 'integer',
+      language: 'plpgsql',
+      replace: true,
+    },
+    `
+    DECLARE
+      total_tabcoins integer;
+    BEGIN
+      SELECT COALESCE(SUM(amount), 0)
+      INTO total_tabcoins
+      FROM content_tabcoin_operations
+      WHERE
+        recipient_id = recipient_id_input;
+
+      RETURN total_tabcoins;
+    END;
+  `,
+  );
+
+  pgm.createFunction(
+    'get_user_current_tabcoins',
+    [
+      {
+        name: 'recipient_id_input',
+        mode: 'IN',
+        type: 'uuid',
+      },
+    ],
+    {
+      returns: 'integer',
+      language: 'plpgsql',
+      replace: true,
+    },
+    `
+    DECLARE
+      total_tabcoins integer;
+    BEGIN
+      SELECT COALESCE(SUM(amount), 0)
+      INTO total_tabcoins
+      FROM user_tabcoin_operations
+      WHERE
+        recipient_id = recipient_id_input;
+
+      RETURN total_tabcoins;
+    END;
+  `,
+  );
+
+  pgm.createFunction(
+    'get_user_current_tabcash',
+    [
+      {
+        name: 'recipient_id_input',
+        mode: 'IN',
+        type: 'uuid',
+      },
+    ],
+    {
+      returns: 'integer',
+      language: 'plpgsql',
+      replace: true,
+    },
+    `
+    DECLARE
+    total_tabcash integer;
+    BEGIN
+      SELECT COALESCE(SUM(amount), 0)
+      INTO total_tabcash
+      FROM user_tabcash_operations
+      WHERE
+        recipient_id = recipient_id_input;
+
+      RETURN total_tabcash;
+    END;
+  `,
+  );
+
+  pgm.createIndex('content_tabcoin_operations', ['recipient_id', 'balance_type']);
+  pgm.createIndex('user_tabcoin_operations', ['recipient_id']);
+  pgm.createIndex('user_tabcash_operations', ['recipient_id']);
+};
+
+exports.down = (pgm) => {
+  // Do not drop the created tables to avoid accidentally losing data.
+
+  pgm.dropFunction(
+    'get_content_current_tabcoins',
+    [
+      {
+        name: 'recipient_id_input',
+        mode: 'IN',
+        type: 'uuid',
+      },
+    ],
+    { ifExists: true },
+  );
+
+  pgm.dropFunction(
+    'get_user_current_tabcoins',
+    [
+      {
+        name: 'recipient_id_input',
+        mode: 'IN',
+        type: 'uuid',
+      },
+    ],
+    { ifExists: true },
+  );
+
+  pgm.dropFunction(
+    'get_user_current_tabcash',
+    [
+      {
+        name: 'recipient_id_input',
+        mode: 'IN',
+        type: 'uuid',
+      },
+    ],
+    { ifExists: true },
+  );
+};


### PR DESCRIPTION
## Mudanças realizadas

Conforme discutido em https://github.com/filipedeschamps/tabnews.com.br/issues/1491#issuecomment-2002538824, separei o `balance_operations` em três tabelas distintas: uma para as operações de TabCoins de conteúdos, outra para as de TabCoins de usuários e outra para as de TabCash.

Não adicionei `balance_type` na tabela `user_tabcoin_operations` e `user_tabcash_operations` porque na `balance_operations` os valores eram `user:tabcoin` e `user:tabcash`, então seria bem redundante.

Esse processo será feito em alguns PRs diferentes:

1. O primeiro PR é este, e contém a criação das tabelas e das funções.
2. O segundo PR permitirá colocar os endpoints em manutenção de forma dinâmica (https://github.com/filipedeschamps/tabnews.com.br/pull/1662), conforme discutido em https://github.com/filipedeschamps/tabnews.com.br/pull/1656#issuecomment-2029682625 e nos comentários seguintes.
3. O terceiro PR (https://github.com/filipedeschamps/tabnews.com.br/pull/1661) fará a leitura e escrita nas tabelas novas.
4. Um quarto PR poderá ser apenas uma migração para remover a tabela `balance_operations` e as funções que não são mais utilizadas.


## Tipo de mudança

- [x] Refatoração
