### PR TITLE
Salvar operações de saldo em `balance_operations` e nas novas tabelas e reabilitar endpoints

### DIFF
--- a/infra/migrations/1712454019816_alter-function-content-credit-debit.js
+++ b/infra/migrations/1712454019816_alter-function-content-credit-debit.js
@@ -30,8 +30,6 @@ exports.up = (pgm) => {
 };
 
 exports.down = (pgm) => {
-  // Do not drop the created tables to avoid accidentally losing data.
-
   pgm.createFunction(
     'get_content_balance_credit_debit',
     [

--- a/infra/migrations/1712454019816_alter-function-content-credit-debit.js
+++ b/infra/migrations/1712454019816_alter-function-content-credit-debit.js
@@ -1,0 +1,63 @@
+exports.up = (pgm) => {
+  pgm.createFunction(
+    'get_content_balance_credit_debit',
+    [
+      {
+        name: 'content_id_input',
+        mode: 'IN',
+        type: 'uuid',
+      },
+    ],
+    {
+      returns: 'TABLE (total_balance BIGINT, total_credit BIGINT, total_debit BIGINT) ROWS 1',
+      language: 'plpgsql',
+      replace: true,
+    },
+    `
+    BEGIN
+      RETURN QUERY
+        SELECT
+          COALESCE(SUM(amount), 0) AS total_balance,
+          COALESCE(SUM(CASE WHEN balance_type = 'credit' THEN amount END), 0) AS total_credit,
+          COALESCE(SUM(CASE WHEN balance_type = 'debit' THEN amount END), 0) AS total_debit
+        FROM
+          content_tabcoin_operations
+        WHERE
+          recipient_id = content_id_input;
+    END;
+  `,
+  );
+};
+
+exports.down = (pgm) => {
+  // Do not drop the created tables to avoid accidentally losing data.
+
+  pgm.createFunction(
+    'get_content_balance_credit_debit',
+    [
+      {
+        name: 'content_id_input',
+        mode: 'IN',
+        type: 'uuid',
+      },
+    ],
+    {
+      returns: 'TABLE (total_balance BIGINT, total_credit BIGINT, total_debit BIGINT) ROWS 1',
+      language: 'plpgsql',
+      replace: true,
+    },
+    `
+    BEGIN
+      RETURN QUERY
+        SELECT
+          COALESCE(SUM(amount), 0) AS total_balance,
+          COALESCE(SUM(CASE WHEN balance_type = 'content:tabcoin:credit' THEN amount END), 0) AS total_credit,
+          COALESCE(SUM(CASE WHEN balance_type = 'content:tabcoin:debit' THEN amount END), 0) AS total_debit
+        FROM
+          balance_operations
+        WHERE
+          recipient_id = content_id_input;
+    END;
+  `,
+  );
+};

--- a/models/balance.js
+++ b/models/balance.js
@@ -1,49 +1,86 @@
 import { UnprocessableEntityError } from 'errors';
 import database from 'infra/database.js';
 
-async function findOne(operationId, options = {}) {
+const tableNameMap = {
+  'user:tabcoin': 'user_tabcoin_operations',
+  'user:tabcash': 'user_tabcash_operations',
+  default: 'content_tabcoin_operations',
+};
+
+const balanceTypeMap = {
+  'content:tabcoin:credit': 'credit',
+  'content:tabcoin:debit': 'debit',
+  default: 'initial',
+};
+
+const sqlFunctionMap = {
+  'user:tabcoin': 'get_user_current_tabcoins',
+  'user:tabcash': 'get_user_current_tabcash',
+  default: 'get_content_current_tabcoins',
+};
+
+async function findAllByOriginatorId(originatorId, options) {
   const query = {
     text: `
-      SELECT
-        *
-      FROM
-        balance_operations
-      WHERE
-        id = $1
-      LIMIT
-        1
-    ;`,
-    values: [operationId],
+      SELECT * FROM (
+        SELECT id, recipient_id, amount, originator_type, originator_id,
+          'user:tabcoin' AS balance_type
+        FROM user_tabcoin_operations
+        WHERE originator_id = $1
+      UNION ALL
+        SELECT id, recipient_id, amount, originator_type, originator_id,
+          'user:tabcash' AS balance_type
+        FROM user_tabcash_operations
+        WHERE originator_id = $1
+      UNION ALL
+        SELECT id, recipient_id, amount, originator_type, originator_id,
+          CONCAT('content:tabcoin:', balance_type) AS balance_type
+        FROM content_tabcoin_operations
+        WHERE originator_id = $1
+      ) AS all_operations;
+    `,
+    values: [originatorId],
   };
 
   const results = await database.query(query, options);
-  return results.rows[0];
+  return results.rows;
 }
 
 async function create({ balanceType, recipientId, amount, originatorType, originatorId }, options = {}) {
+  const tableName = tableNameMap[balanceType] || tableNameMap.default;
+  const hasBalanceTypeColum = balanceType.startsWith('content:tabcoin');
+
   const query = {
     text: `
-      INSERT INTO balance_operations
-        (balance_type, recipient_id, amount, originator_type, originator_id)
+      INSERT INTO ${tableName}
+        (recipient_id, amount, originator_type, originator_id${hasBalanceTypeColum ? ', balance_type' : ''})
       VALUES
-        ($1, $2, $3, $4, $5)
+        ($1, $2, $3, $4${hasBalanceTypeColum ? ', $5' : ''})
       RETURNING * ;
       `,
-    values: [balanceType, recipientId, amount, originatorType, originatorId],
+    values: [recipientId, amount, originatorType, originatorId],
   };
+
+  if (hasBalanceTypeColum) {
+    const parsedBalanceType = balanceTypeMap[balanceType] || balanceTypeMap.default;
+
+    query.values.push(parsedBalanceType);
+  }
 
   const results = await database.query(query, options);
   return results.rows[0];
 }
 
-async function getTotal({ balanceType, recipientId }, options = {}) {
+async function getTotal({ balanceType, recipientId }, options) {
+  const sqlFunction = sqlFunctionMap[balanceType] || sqlFunctionMap.default;
+
   const query = {
-    text: 'SELECT get_current_balance($1, $2);',
-    values: [balanceType, recipientId],
+    text: `SELECT ${sqlFunction}($1) AS total;`,
+    values: [recipientId],
   };
 
   const results = await database.query(query, options);
-  return results.rows[0].get_current_balance;
+  return results.rows[0].total;
 }
 
 async function getContentTabcoinsCreditDebit({ recipientId }, options = {}) {
@@ -67,22 +104,26 @@ async function rateContent({ contentId, contentOwnerId, fromUserId, transactionT
   const tabCoinsToTransactToContent = transactionType === 'credit' ? 1 : -1;
   const originatorType = 'event';
   const originatorId = options.eventId;
-  const contentBalanceType = transactionType === 'credit' ? 'content:tabcoin:credit' : 'content:tabcoin:debit';
 
   const query = {
     text: `
-      WITH users_inserts AS (
-        INSERT INTO balance_operations
-          (balance_type, recipient_id, amount, originator_type, originator_id)
+      WITH users_tabcoin_inserts AS (
+        INSERT INTO user_tabcoin_operations
+          (recipient_id, amount, originator_type, originator_id)
         VALUES
-          ('user:tabcoin', $1, $2, $8, $9),
-          ('user:tabcash', $1, $3, $8, $9),
-          ('user:tabcoin', $6, $7, $8, $9)
+          ($1, $2, $8, $9),
+          ($6, $7, $8, $9)
         RETURNING
           *
       ),
+      users_tabcash_insert AS (
+        INSERT INTO user_tabcash_operations
+          (recipient_id, amount, originator_type, originator_id)
+        VALUES
+          ($1, $3, $8, $9)
+      ),
       content_insert AS (
-        INSERT INTO balance_operations
+        INSERT INTO content_tabcoin_operations
           (balance_type, recipient_id, amount, originator_type, originator_id)
         VALUES
           ($10, $4, $5, $8, $9)
@@ -90,12 +131,12 @@ async function rateContent({ contentId, contentOwnerId, fromUserId, transactionT
           *
       )
       SELECT
-        get_current_balance('user:tabcoin', $1) AS user_current_tabcoin_balance,
+        get_user_current_tabcoins($1) AS user_current_tabcoin_balance,
         tabcoins_count.total_balance as content_current_tabcoin_balance,
         tabcoins_count.total_credit as content_current_tabcoin_credit,
         tabcoins_count.total_debit as content_current_tabcoin_debit 
       FROM
-        users_inserts,
+        users_tabcoin_inserts,
         content_insert,
         get_content_balance_credit_debit(content_insert.recipient_id) tabcoins_count
       LIMIT
@@ -115,7 +156,7 @@ async function rateContent({ contentId, contentOwnerId, fromUserId, transactionT
       originatorType, // $8
       originatorId, // $9
 
-      contentBalanceType, // $10
+      transactionType, // $10
     ],
   };
 
@@ -137,9 +178,7 @@ async function rateContent({ contentId, contentOwnerId, fromUserId, transactionT
   };
 }
 
-async function undo(operationId, options = {}) {
-  const balanceOperation = await findOne(operationId, options);
-
+async function undo(balanceOperation, options) {
   const invertedBalanceOperation = {
     balanceType: balanceOperation.balance_type,
     recipientId: balanceOperation.recipient_id,
@@ -153,7 +192,7 @@ async function undo(operationId, options = {}) {
 }
 
 export default Object.freeze({
-  findOne,
+  findAllByOriginatorId,
   create,
   getTotal,
   getContentTabcoinsCreditDebit,

--- a/models/ban.js
+++ b/models/ban.js
@@ -33,10 +33,10 @@ async function nuke(userId, options = {}) {
     const userEvents = await getAllRatingEventsFromUser(userId, options);
 
     for (const userEvent of userEvents) {
-      const eventBalanceOperations = await getRatingBalanceOperationsFromEvent(userEvent.id, options);
+      const eventBalanceOperations = await balance.findAllByOriginatorId(userEvent.id, options);
 
       for (const eventBalanceOperation of eventBalanceOperations) {
-        await balance.undo(eventBalanceOperation.id, options);
+        await balance.undo(eventBalanceOperation, options);
       }
     }
 
@@ -55,26 +55,6 @@ async function nuke(userId, options = {}) {
             created_at ASC
         ;`,
         values: [userId],
-      };
-
-      const results = await database.query(query, options);
-
-      return results.rows;
-    }
-
-    async function getRatingBalanceOperationsFromEvent(eventId, options = {}) {
-      const query = {
-        text: `
-          SELECT
-            *
-          FROM
-            balance_operations
-          WHERE
-            originator_id = $1
-          ORDER BY
-            created_at ASC
-        ;`,
-        values: [eventId],
       };
 
       const results = await database.query(query, options);

--- a/models/user.js
+++ b/models/user.js
@@ -14,8 +14,8 @@ async function findAll() {
         users
       CROSS JOIN LATERAL (
         SELECT
-          get_current_balance('user:tabcoin', users.id) as tabcoins,
-          get_current_balance('user:tabcash', users.id) as tabcash
+          get_user_current_tabcoins(users.id) as tabcoins,
+          get_user_current_tabcash(users.id) as tabcash
       ) as balance
       ORDER BY
         created_at ASC
@@ -42,8 +42,8 @@ async function findOneByUsername(username, options = {}) {
   const balanceQuery = `
       SELECT
         user_found.*,
-        get_current_balance('user:tabcoin', user_found.id) as tabcoins,
-        get_current_balance('user:tabcash', user_found.id) as tabcash
+        get_user_current_tabcoins(user_found.id) as tabcoins,
+        get_user_current_tabcash(user_found.id) as tabcash
       FROM
         user_found
       `;
@@ -86,8 +86,8 @@ async function findOneByEmail(email, options = {}) {
   const balanceQuery = `
       SELECT
         user_found.*,
-        get_current_balance('user:tabcoin', user_found.id) as tabcoins,
-        get_current_balance('user:tabcash', user_found.id) as tabcash
+        get_user_current_tabcoins(user_found.id) as tabcoins,
+        get_user_current_tabcash(user_found.id) as tabcash
       FROM
         user_found
       `;
@@ -131,8 +131,8 @@ async function findOneById(userId, options = {}) {
   const balanceQuery = `
       SELECT
         user_found.*,
-        get_current_balance('user:tabcoin', user_found.id) as tabcoins,
-        get_current_balance('user:tabcash', user_found.id) as tabcash
+        get_user_current_tabcoins(user_found.id) as tabcoins,
+        get_user_current_tabcash(user_found.id) as tabcash
       FROM
         user_found
       `;

--- a/queries/prestigeQueries.js
+++ b/queries/prestigeQueries.js
@@ -14,14 +14,13 @@ SELECT
   amount,
   content_events.type
 FROM
-  balance_operations
+  user_tabcoin_operations
 INNER JOIN
   content_events
-ON balance_operations.originator_id = content_events.id
-  AND (balance_operations.recipient_id != content_events.originator_user_id
+ON user_tabcoin_operations.originator_id = content_events.id
+  AND (user_tabcoin_operations.recipient_id != content_events.originator_user_id
     OR content_events.type = 'create:content:text_root'
     OR content_events.type = 'create:content:text_child')
-WHERE balance_type = 'user:tabcoin'
 ;
 `;
 
@@ -55,7 +54,7 @@ UNION
   LIMIT $4
 )
 SELECT
-  get_current_balance('content:tabcoin', content_window.id) as tabcoins
+  get_content_current_tabcoins(content_window.id) as tabcoins
 FROM
   content_window
 ORDER BY


### PR DESCRIPTION
## Mudanças realizadas

Criei esta branch a partir da `refactor-table-balance-operations` (PR #1656).

* Salva as operações de saldo em `balance_operations` e também nas novas tabelas.
* Habilita novamente os endpoints que modificam `balance_operations`, removendo a resposta de manutenção. Ainda deixei o arquivo `pages/api/v1/_responses/maintenance.public.js` porque imagino que possa ser útil em outras ocasiões.

Este PR faz parte do processo de migração do registro de saldos da tabela `balance_operations` para três tabelas específicas: `content_tabcoin_operations`, `user_tabcoin_operations` e `user_tabcash_operations`. O PR #1656 deve ser mesclado primeiro, seguido da migração dos dados existentes durante o período de manutenção (sem novas escritas de saldo pela API), e então o merge deste PR, voltando ao modo de operação normal.

## Tipo de mudança

- [x] Refatoração.
- [x] Retorna a API ao estado normal.

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
