### PR TITLE
Permitir desabilitar rotas temporariamente pela variável de ambiente `UNDER_MAINTENANCE`

### DIFF
--- a/.env
+++ b/.env
@@ -15,3 +15,4 @@ EMAIL_HTTP_HOST=localhost
 EMAIL_HTTP_PORT=1080
 EMAIL_USER=
 EMAIL_PASSWORD=
+UNDER_MAINTENANCE={"methodsAndPaths":["POST /api/v1/under-maintenance-test$"]}

--- a/infra/under-maintenance.js
+++ b/infra/under-maintenance.js
@@ -1,0 +1,43 @@
+import webserver from 'infra/webserver';
+
+let underMaintenance;
+
+try {
+  underMaintenance = JSON.parse(process.env.UNDER_MAINTENANCE || '{}');
+} catch (error) {
+  if (webserver.isBuildTime) {
+    console.error('Error parsing UNDER_MAINTENANCE', { error });
+  }
+  underMaintenance = {};
+}
+
+const methodsAndPaths = underMaintenance.methodsAndPaths || [];
+const message = underMaintenance.message || 'Funcionalidade em manutenção.';
+const action = underMaintenance.action || 'Tente novamente mais tarde.';
+const statusCode = underMaintenance.statusCode || 503;
+
+function check(request) {
+  if (methodsAndPaths.length === 0) return;
+
+  const method = request.method;
+  const path = request.nextUrl.pathname;
+
+  const isUnderMaintenance = methodsAndPaths.some((methodAndPath) =>
+    new RegExp(methodAndPath).test(`${method} ${path}`),
+  );
+
+  if (isUnderMaintenance) {
+    return {
+      status: statusCode,
+      body: JSON.stringify({
+        message,
+        action,
+        error_location_code: 'INFRA:UNDER_MAINTENANCE:CHECK:IS_UNDER_MAINTENANCE',
+      }),
+    };
+  }
+}
+
+export default Object.freeze({
+  check,
+});

--- a/middleware.public.js
+++ b/middleware.public.js
@@ -4,6 +4,7 @@ import snakeize from 'snakeize';
 import { UnauthorizedError } from 'errors';
 import logger from 'infra/logger.js';
 import rateLimit from 'infra/rate-limit.js';
+import underMaintenance from 'infra/under-maintenance';
 import webserver from 'infra/webserver.js';
 import ip from 'models/ip.js';
 
@@ -28,6 +29,17 @@ export async function middleware(request) {
 
     return new NextResponse(JSON.stringify(publicErrorObject), {
       status: 401,
+      headers: {
+        'content-type': 'application/json',
+      },
+    });
+  }
+
+  const isUnderMaintenance = underMaintenance.check(request);
+
+  if (isUnderMaintenance) {
+    return new NextResponse(isUnderMaintenance.body, {
+      status: isUnderMaintenance.status,
       headers: {
         'content-type': 'application/json',
       },

--- a/tests/integration/infra/under-maintenance.test.js
+++ b/tests/integration/infra/under-maintenance.test.js
@@ -1,0 +1,43 @@
+import orchestrator from 'tests/orchestrator.js';
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.dropAllTables();
+  await orchestrator.runPendingMigrations();
+});
+
+describe('Under maintenance route', () => {
+  describe('Anonymous user', () => {
+    test('Trying to access "method" and "path" under maintenance', async () => {
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/under-maintenance-test`, {
+        method: 'POST',
+      });
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(503);
+      expect(responseBody.message).toEqual('Funcionalidade em manutenção.');
+      expect(responseBody.action).toEqual('Tente novamente mais tarde.');
+      expect(responseBody.error_location_code).toEqual('INFRA:UNDER_MAINTENANCE:CHECK:IS_UNDER_MAINTENANCE');
+    });
+
+    test('Trying to access "method" under maintenance, but distinct "path"', async () => {
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/inexistent-route`, {
+        method: 'POST',
+      });
+
+      expect(response.status).toEqual(404);
+      expect(response.statusText).toEqual('Not Found');
+      expect(response.ok).toEqual(false);
+    });
+
+    test('Trying to access "path" under maintenance, but distinct "method"', async () => {
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/under-maintenance-test`, {
+        method: 'GET',
+      });
+
+      expect(response.status).toEqual(404);
+      expect(response.statusText).toEqual('Not Found');
+      expect(response.ok).toEqual(false);
+    });
+  });
+});

--- a/tests/unit/infra/under-maintenance.test.js
+++ b/tests/unit/infra/under-maintenance.test.js
@@ -1,0 +1,170 @@
+const defaultMessage = 'Funcionalidade em manutenção.';
+const defaultAction = 'Tente novamente mais tarde.';
+const defaultStatusCode = 503;
+const errorLocationCode = 'INFRA:UNDER_MAINTENANCE:CHECK:IS_UNDER_MAINTENANCE';
+
+let originalUnderMaintenanceProcessEnv;
+
+beforeAll(() => {
+  originalUnderMaintenanceProcessEnv = process.env.UNDER_MAINTENANCE;
+});
+
+beforeEach(async () => {
+  vi.resetModules();
+});
+
+afterAll(() => {
+  process.env.UNDER_MAINTENANCE = originalUnderMaintenanceProcessEnv;
+});
+
+describe('infra/under-maintenance', () => {
+  describe('check', () => {
+    let check;
+
+    beforeEach(async () => {
+      check = await import('infra/under-maintenance').then((module) => module.default.check);
+    });
+
+    describe('when "process.env.UNDER_MAINTENANCE" is falsy', () => {
+      beforeAll(() => {
+        process.env.UNDER_MAINTENANCE = '';
+      });
+
+      it('should return undefined', () => {
+        const request = { method: 'GET', nextUrl: { pathname: '/home' } };
+
+        const result = check(request);
+
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe('when "process.env.UNDER_MAINTENANCE" is invalid', () => {
+      beforeAll(() => {
+        process.env.UNDER_MAINTENANCE = 'Invalid JSON';
+      });
+
+      it('should return undefined', () => {
+        const request = { method: 'GET', nextUrl: { pathname: '/home' } };
+
+        const result = check(request);
+
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe('when "methodsAndPaths" is []', () => {
+      beforeAll(() => {
+        process.env.UNDER_MAINTENANCE = '{"methodsAndPaths":[]}';
+      });
+
+      it('should return undefined', () => {
+        const request = { method: 'POST', nextUrl: { pathname: '/admin' } };
+
+        const result = check(request);
+
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe('when methodsAndPaths is defined', () => {
+      beforeAll(() => {
+        process.env.UNDER_MAINTENANCE = '{"methodsAndPaths":["POST /admin"]}';
+      });
+
+      it('should return the response when the request matches the maintenance conditions', () => {
+        const request = { method: 'POST', nextUrl: { pathname: '/admin/home' } };
+
+        const result = check(request);
+
+        expect(result).toStrictEqual({
+          status: defaultStatusCode,
+          body: JSON.stringify({
+            message: defaultMessage,
+            action: defaultAction,
+            error_location_code: errorLocationCode,
+          }),
+        });
+      });
+
+      it('should return undefined if the "path" does not match the maintenance conditions', () => {
+        const request = { method: 'POST', nextUrl: { pathname: '/home' } };
+
+        const result = check(request);
+
+        expect(result).toBeUndefined();
+      });
+
+      it('should return undefined if the "method" does not match the maintenance conditions', () => {
+        const request = { method: 'GET', nextUrl: { pathname: '/admin' } };
+
+        const result = check(request);
+
+        expect(result).toBeUndefined();
+      });
+
+      describe('when "message" is defined', () => {
+        beforeAll(() => {
+          process.env.UNDER_MAINTENANCE = '{"methodsAndPaths":["GET /home$"],"message":"Custom message"}';
+        });
+
+        it('should return the custom message', () => {
+          const request = { method: 'GET', nextUrl: { pathname: '/home' } };
+
+          const result = check(request);
+
+          expect(result).toStrictEqual({
+            status: defaultStatusCode,
+            body: JSON.stringify({
+              message: 'Custom message',
+              action: defaultAction,
+              error_location_code: errorLocationCode,
+            }),
+          });
+        });
+      });
+
+      describe('when "action" is defined', () => {
+        beforeAll(() => {
+          process.env.UNDER_MAINTENANCE = '{"methodsAndPaths":["GET /home.*"],"action":"Custom action"}';
+        });
+
+        it('should return the custom action', () => {
+          const request = { method: 'GET', nextUrl: { pathname: '/home' } };
+
+          const result = check(request);
+
+          expect(result).toStrictEqual({
+            status: defaultStatusCode,
+            body: JSON.stringify({
+              message: defaultMessage,
+              action: 'Custom action',
+              error_location_code: errorLocationCode,
+            }),
+          });
+        });
+      });
+
+      describe('when "statusCode" is defined', () => {
+        beforeAll(() => {
+          process.env.UNDER_MAINTENANCE = '{"methodsAndPaths":["GET /h.m.$"],"statusCode":200}';
+        });
+
+        it('should return the custom status code', () => {
+          const request = { method: 'GET', nextUrl: { pathname: '/home' } };
+
+          const result = check(request);
+
+          expect(result).toStrictEqual({
+            status: 200,
+            body: JSON.stringify({
+              message: defaultMessage,
+              action: defaultAction,
+              error_location_code: errorLocationCode,
+            }),
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Mudanças realizadas

Permite criar respostas padrão (diretamente pelo middleware) para as requisições com métodos e rotas definidos na variável de ambiente `UNDER_MAINTENANCE`.

O exemplo abaixo envia a resposta padrão para requisições `POST` para o caminho exato `/api/v1/under-maintenance-test`:

`UNDER_MAINTENANCE={"methodsAndPaths":["POST /api/v1/under-maintenance-test$"]}`

A resposta padrão é:

```js
{
  status: 503,
  body: {
    message: 'Funcionalidade em manutenção.',
    action: 'Tente novamente mais tarde.',
    error_location_code: 'INFRA:UNDER_MAINTENANCE:CHECK:IS_UNDER_MAINTENANCE',
  }
}
```

`status`, `message` e `action` podem ser personalizados, caso o tipo de manutenção exigir algo diferente. Por exemplo:

`UNDER_MAINTENANCE={"methodsAndPaths":["GET /api/v1/user$"],"message":"Não é possível obter os dados do usuário no momento","action":"Tente novamente após às 19hrs","statusCode":503}`

Os endoints afetados serão os que retornarem `true` para ```new RegExp(methodAndPath).test(`${method} ${path}`)```.

## Testes

A maioria dos testes criados são de unidade, mas também criei alguns testes de integração.

Adicionei a variável de ambiente no `.env` para poder rodar testes de integração, mas não sei se essa é a melhor alternativa.

Para o teste em homologação, deixei travado o método `POST` para qualquer rota iniciada por `/api/v1/contents`, ou seja, neste deploy não é possível criar ou qualificar conteúdos, mas é possível editar o que foi criado anteriormente:

https://tabnews-git-feature-under-maintenance-tabnews.vercel.app

## Tipo de mudança

- [x] Nova funcionalidade

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
