### PR TITLE
feat(error message text): add `createErrorMessage` function

### DIFF
--- a/pages/[username]/index.public.js
+++ b/pages/[username]/index.public.js
@@ -31,7 +31,7 @@ import authorization from 'models/authorization.js';
 import content from 'models/content.js';
 import user from 'models/user.js';
 import validator from 'models/validator.js';
-import { useUser } from 'pages/interface';
+import { createErrorMessage, useUser } from 'pages/interface';
 
 export default function Page({ userFound: userFoundFallback }) {
   const { data: userFound, mutate: userFoundMutate } = useSWR(`/api/v1/users/${userFoundFallback.username}`, {
@@ -92,9 +92,8 @@ export default function Page({ userFound: userFoundFallback }) {
     setGlobalMessageObject({
       type: 'danger',
       position: 'main',
-      text: `${responseBody.message} ${responseBody.action}`,
+      text: createErrorMessage(responseBody),
     });
-    return;
   }
 
   function handleEditDescription() {
@@ -328,7 +327,7 @@ function DescriptionForm({
         setGlobalMessageObject({
           type: 'danger',
           position: 'description',
-          text: `${responseBody.message} Informe ao suporte este valor: ${responseBody.error_id}`,
+          text: createErrorMessage(responseBody),
         });
       }
     } catch (error) {

--- a/pages/cadastro/ativar/[token].public.js
+++ b/pages/cadastro/ativar/[token].public.js
@@ -2,6 +2,7 @@ import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
 import { Box, Confetti, DefaultLayout, Flash } from '@/TabNewsUI';
+import { createErrorMessage } from 'pages/interface';
 
 export default function ActiveUser() {
   const router = useRouter();
@@ -34,7 +35,7 @@ export default function ActiveUser() {
 
       if (response.status >= 400 && response.status <= 503) {
         const responseBody = await response.json();
-        setGlobalMessage(`${responseBody.message} ${responseBody.action}`);
+        setGlobalMessage(createErrorMessage(responseBody));
         setIsSuccess(false);
         return;
       }

--- a/pages/cadastro/index.public.js
+++ b/pages/cadastro/index.public.js
@@ -15,7 +15,7 @@ import {
   Text,
   TextInput,
 } from '@/TabNewsUI';
-import { suggestEmail } from 'pages/interface';
+import { createErrorMessage, suggestEmail } from 'pages/interface';
 
 export default function Register() {
   return (
@@ -99,7 +99,7 @@ function SignUpForm() {
       }
 
       if (response.status >= 403) {
-        setGlobalErrorMessage(`${responseBody.message} Informe ao suporte este valor: ${responseBody.error_id}`);
+        setGlobalErrorMessage(createErrorMessage(responseBody));
         setIsLoading(false);
         return;
       }

--- a/pages/cadastro/recuperar/[token].public.js
+++ b/pages/cadastro/recuperar/[token].public.js
@@ -2,6 +2,7 @@ import { useRouter } from 'next/router';
 import { useRef, useState } from 'react';
 
 import { Box, ButtonWithLoader, DefaultLayout, Flash, FormControl, Heading, PasswordInput } from '@/TabNewsUI';
+import { createErrorMessage } from 'pages/interface';
 
 export default function RecoverPassword() {
   return (
@@ -77,7 +78,7 @@ function RecoverPasswordForm() {
       }
 
       if (response.status >= 401) {
-        setGlobalErrorMessage(`${responseBody.message} ${responseBody.action} (${responseBody.error_id})`);
+        setGlobalErrorMessage(createErrorMessage(responseBody));
         setIsLoading(false);
         return;
       }

--- a/pages/cadastro/recuperar/index.public.js
+++ b/pages/cadastro/recuperar/index.public.js
@@ -2,7 +2,7 @@ import { useRouter } from 'next/router';
 import { useEffect, useRef, useState } from 'react';
 
 import { Box, ButtonWithLoader, DefaultLayout, Flash, FormControl, Heading, TextInput } from '@/TabNewsUI';
-import { useUser } from 'pages/interface';
+import { createErrorMessage, useUser } from 'pages/interface';
 
 export default function RecoverPassword() {
   return (
@@ -86,7 +86,7 @@ function RecoverPasswordForm() {
       }
 
       if (response.status >= 401) {
-        setGlobalErrorMessage(`${responseBody.message} ${responseBody.action} (${responseBody.error_id})`);
+        setGlobalErrorMessage(createErrorMessage(responseBody));
         setIsLoading(false);
         return;
       }

--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -25,7 +25,7 @@ import {
   Viewer,
 } from '@/TabNewsUI';
 import { KebabHorizontalIcon, LinkIcon, PencilIcon, TrashIcon } from '@/TabNewsUI/icons';
-import { isTrustedDomain, isValidJsonString, processNdJsonStream, useUser } from 'pages/interface';
+import { createErrorMessage, isTrustedDomain, isValidJsonString, processNdJsonStream, useUser } from 'pages/interface';
 
 const CONTENT_TITLE_PLACEHOLDER_EXAMPLES = [
   'e.g. Nova versão do Python é anunciada com melhorias de desempenho',
@@ -162,17 +162,8 @@ function ViewMode({ setComponentMode, contentObject, isPageRootOwner, viewFrame 
 
     if (response.status === 200) {
       setComponentMode('deleted');
-      return;
-    }
-
-    if ([400, 401, 403].includes(response.status)) {
-      setGlobalErrorMessage(`${responseBody.message} ${responseBody.action}`);
-      return;
-    }
-
-    if (response.status >= 500) {
-      setGlobalErrorMessage(`${responseBody.message} Informe ao suporte este valor: ${responseBody.error_id}`);
-      return;
+    } else {
+      setGlobalErrorMessage(createErrorMessage(responseBody));
     }
   };
 
@@ -403,7 +394,7 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
         if (response.status === 201) {
           return (responseBody) => {
             if (responseBody.message) {
-              setGlobalErrorMessage(`${responseBody.message} ${responseBody.action} ${responseBody.error_id}`);
+              setGlobalErrorMessage(createErrorMessage(responseBody));
               console.error(responseBody);
               return;
             }
@@ -424,14 +415,14 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
             setErrorObject(responseBody);
 
             if (responseBody.key === 'slug') {
-              setGlobalErrorMessage(`${responseBody.message} ${responseBody.action}`);
+              setGlobalErrorMessage(createErrorMessage(responseBody, { omitErrorId: true }));
             }
           };
         }
 
         if (response.status >= 401) {
           return (responseBody) => {
-            setGlobalErrorMessage(`${responseBody.message} ${responseBody.action} ${responseBody.error_id}`);
+            setGlobalErrorMessage(createErrorMessage(responseBody));
           };
         }
       }

--- a/pages/interface/components/TabCoinButtons/index.js
+++ b/pages/interface/components/TabCoinButtons/index.js
@@ -5,7 +5,7 @@ import { useReward } from 'react-rewards';
 
 import { Box, IconButton, TabCoinBalanceTooltip, Tooltip } from '@/TabNewsUI';
 import { ChevronDownIcon, ChevronUpIcon } from '@/TabNewsUI/icons';
-import { useUser } from 'pages/interface';
+import { createErrorMessage, useUser } from 'pages/interface';
 
 export default function TabCoinButtons({ content }) {
   const router = useRouter();
@@ -74,7 +74,12 @@ export default function TabCoinButtons({ content }) {
         return;
       }
 
-      alert(`${responseBody.message} ${responseBody.action}`);
+      alert(
+        createErrorMessage(responseBody, {
+          omitErrorId: response.status == 422,
+        }),
+      );
+
       setIsPosting(false);
     } catch (error) {
       setIsPosting(false);

--- a/pages/interface/index.js
+++ b/pages/interface/index.js
@@ -3,6 +3,7 @@ export { default as useCollapse } from './hooks/useCollapse';
 export { default as useMediaQuery } from './hooks/useMediaQuery';
 export { UserProvider, default as useUser } from './hooks/useUser';
 export { default as suggestEmail } from './utils/email-suggestion';
+export { default as createErrorMessage } from './utils/error-message';
 export { default as isValidJsonString } from './utils/is-valid-json-string';
 export { default as processNdJsonStream } from './utils/nd-json-stream';
 export { default as isTrustedDomain } from './utils/trusted-domain';

--- a/pages/interface/utils/error-message.js
+++ b/pages/interface/utils/error-message.js
@@ -1,0 +1,18 @@
+export default function createErrorMessage(responseBody, { omitErrorId = false } = {}) {
+  const { message, action, error_id } = responseBody || {};
+  const errorMessages = [];
+
+  if (message) {
+    errorMessages.push(message);
+  }
+
+  if (action && action !== "Informe ao suporte o valor encontrado no campo 'error_id'.") {
+    errorMessages.push(action);
+  }
+
+  if (error_id && !omitErrorId) {
+    errorMessages.push(`Informe ao suporte o valor (${error_id})`);
+  }
+
+  return errorMessages.join(' ') || 'Erro desconhecido. Tente novamente mais tarde.';
+}

--- a/pages/login/index.public.js
+++ b/pages/login/index.public.js
@@ -12,7 +12,7 @@ import {
   Text,
   TextInput,
 } from '@/TabNewsUI';
-import { useUser } from 'pages/interface';
+import { createErrorMessage, useUser } from 'pages/interface';
 
 export default function Login() {
   return (
@@ -74,7 +74,7 @@ function LoginForm() {
       }
 
       if (response.status >= 401) {
-        setGlobalErrorMessage(`${responseBody.message} ${responseBody.action}`);
+        setGlobalErrorMessage(createErrorMessage(responseBody));
         setIsLoading(false);
         return;
       }

--- a/pages/perfil/confirmar-email/[token].public.js
+++ b/pages/perfil/confirmar-email/[token].public.js
@@ -2,6 +2,7 @@ import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
 import { Box, Confetti, DefaultLayout, Flash } from '@/TabNewsUI';
+import { createErrorMessage } from 'pages/interface';
 
 export default function ActiveUser() {
   const router = useRouter();
@@ -34,7 +35,11 @@ export default function ActiveUser() {
 
       if (response.status >= 400 && response.status <= 503) {
         const responseBody = await response.json();
-        setGlobalMessage(`${responseBody.message} ${responseBody.action}`);
+        setGlobalMessage(
+          createErrorMessage(responseBody, {
+            omitErrorId: [400, 404].includes(response.status),
+          }),
+        );
         setIsSuccess(false);
         return;
       }

--- a/pages/perfil/index.public.js
+++ b/pages/perfil/index.public.js
@@ -16,7 +16,7 @@ import {
   TextInput,
   useConfirm,
 } from '@/TabNewsUI';
-import { suggestEmail, useUser } from 'pages/interface';
+import { createErrorMessage, suggestEmail, useUser } from 'pages/interface';
 
 export default function EditProfile() {
   return (
@@ -167,7 +167,7 @@ function EditProfileForm() {
       if (response.status >= 403) {
         setGlobalMessageObject({
           type: 'danger',
-          text: `${responseBody.message} Informe ao suporte este valor: ${responseBody.error_id}`,
+          text: createErrorMessage(responseBody),
         });
         setIsLoading(false);
         return;

--- a/tests/unit/interface/utils/error-message.test.js
+++ b/tests/unit/interface/utils/error-message.test.js
@@ -1,0 +1,78 @@
+import { createErrorMessage } from 'pages/interface';
+
+describe('createErrorMessage', () => {
+  it('should return default error message when responseBody is null', () => {
+    const responseBody = null;
+    const errorMessage = createErrorMessage(responseBody);
+    expect(errorMessage).toEqual('Erro desconhecido. Tente novamente mais tarde.');
+  });
+
+  it('should return default error message when responseBody is undefined', () => {
+    const responseBody = undefined;
+    const errorMessage = createErrorMessage(responseBody);
+    expect(errorMessage).toEqual('Erro desconhecido. Tente novamente mais tarde.');
+  });
+
+  it('should return error message', () => {
+    const responseBody = {
+      message: 'Entrada inválida.',
+    };
+    const errorMessage = createErrorMessage(responseBody);
+    expect(errorMessage).toEqual('Entrada inválida.');
+  });
+
+  it('should return error message with action', () => {
+    const responseBody = {
+      action: 'Tente novamente.',
+    };
+    const errorMessage = createErrorMessage(responseBody);
+    expect(errorMessage).toEqual('Tente novamente.');
+  });
+
+  it('should return error message with error_id', () => {
+    const responseBody = {
+      error_id: '123456789',
+    };
+    const errorMessage = createErrorMessage(responseBody);
+    expect(errorMessage).toEqual('Informe ao suporte o valor (123456789)');
+  });
+
+  it('should return error message with message and action', () => {
+    const responseBody = {
+      message: 'Entrada inválida.',
+      action: 'Tente novamente.',
+    };
+    const errorMessage = createErrorMessage(responseBody);
+    expect(errorMessage).toEqual('Entrada inválida. Tente novamente.');
+  });
+
+  it('should return error message without error_id when omitErrorId is true', () => {
+    const responseBody = {
+      message: 'Entrada inválida.',
+      action: 'Tente novamente.',
+      error_id: '123456789',
+    };
+    const errorMessage = createErrorMessage(responseBody, { omitErrorId: true });
+    expect(errorMessage).toEqual('Entrada inválida. Tente novamente.');
+  });
+
+  it('should return error message with message, action, and error_id', () => {
+    const responseBody = {
+      message: 'Entrada inválida.',
+      action: 'Tente novamente.',
+      error_id: '123456789',
+    };
+    const errorMessage = createErrorMessage(responseBody);
+    expect(errorMessage).toEqual('Entrada inválida. Tente novamente. Informe ao suporte o valor (123456789)');
+  });
+
+  it('should return error message without action when action is a specific string', () => {
+    const responseBody = {
+      message: 'Um erro interno não esperado aconteceu.',
+      action: "Informe ao suporte o valor encontrado no campo 'error_id'.",
+      error_id: '123456789',
+    };
+    const errorMessage = createErrorMessage(responseBody);
+    expect(errorMessage).toEqual('Um erro interno não esperado aconteceu. Informe ao suporte o valor (123456789)');
+  });
+});


### PR DESCRIPTION
## Mudanças realizadas

Conforme [conversa no PR #1662](https://github.com/filipedeschamps/tabnews.com.br/pull/1662#discussion_r1548758497), padroniza a criação do texto das mensagens de erro no *client* de forma a lidar com os casos de ausência (ou omissão proposital) do `error_id`.

[Edit]  ~Também adiciona a palavra "Erro" no início das mensagens~ Desfiz isso, pois algumas mensagens não ficaram boas começando com "Erro".

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.