### PR TITLE
Cria componente de paginação e teste de unidade no frontend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "@commitlint/cli": "18.6.1",
         "@commitlint/config-conventional": "18.6.2",
         "@faker-js/faker": "8.4.1",
+        "@testing-library/react": "15.0.0",
         "@vitejs/plugin-react": "4.2.1",
         "autoprefixer": "10.4.17",
         "concurrently": "8.2.2",
@@ -3711,6 +3712,81 @@
       "integrity": "sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==",
       "dev": true
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.0.0.tgz",
+      "integrity": "sha512-PmJPnogldqoVFf+EwbHvbBJ98MmqASV8kLrBYgsDNxQcFMeIS7JFL48sfyXvuMtgmWO/wMhh25odr+8VhDmn4g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
+    },
+    "node_modules/@testing-library/react": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-15.0.0.tgz",
+      "integrity": "sha512-Nb2Sq8MoSvGVdOGGppRqXeafLtvXCOwiOQtcbqCfkpVNZZNUqIjeSOwrfJ59zBfmZbAn8PitnWEzUKD1YwMrCg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^10.0.0",
+        "@types/react-dom": "^18.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -5330,15 +5406,16 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.6.tgz",
-      "integrity": "sha512-Mj50FLHtlsoVfRfnHaZvyrooHcrlceNZdL/QBvJJVd9Ta55qCQK0gs4ss2oZDeV9zFCs6ewzYgVE5yfVmfFpVg==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
       "dev": true,
       "dependencies": {
+        "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.3",
-        "set-function-length": "^1.2.0"
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6998,6 +7075,12 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true
+    },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
@@ -7307,6 +7390,18 @@
       "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
       "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
       "dev": true
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.2.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
@@ -11320,6 +11415,15 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -20509,6 +20613,64 @@
       "integrity": "sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==",
       "dev": true
     },
+    "@testing-library/dom": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.0.0.tgz",
+      "integrity": "sha512-PmJPnogldqoVFf+EwbHvbBJ98MmqASV8kLrBYgsDNxQcFMeIS7JFL48sfyXvuMtgmWO/wMhh25odr+8VhDmn4g==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "27.5.1",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+          "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
+          }
+        },
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+          "dev": true
+        }
+      }
+    },
+    "@testing-library/react": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-15.0.0.tgz",
+      "integrity": "sha512-Nb2Sq8MoSvGVdOGGppRqXeafLtvXCOwiOQtcbqCfkpVNZZNUqIjeSOwrfJ59zBfmZbAn8PitnWEzUKD1YwMrCg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^10.0.0",
+        "@types/react-dom": "^18.0.0"
+      }
+    },
+    "@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true
+    },
     "@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -21782,15 +21944,16 @@
       "dev": true
     },
     "call-bind": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.6.tgz",
-      "integrity": "sha512-Mj50FLHtlsoVfRfnHaZvyrooHcrlceNZdL/QBvJJVd9Ta55qCQK0gs4ss2oZDeV9zFCs6ewzYgVE5yfVmfFpVg==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
       "dev": true,
       "requires": {
+        "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.3",
-        "set-function-length": "^1.2.0"
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.1"
       }
     },
     "callsites": {
@@ -23000,6 +23163,12 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true
+    },
     "dom-helpers": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
@@ -23244,6 +23413,15 @@
       "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
       "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
       "dev": true
+    },
+    "es-define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.2.4"
+      }
     },
     "es-errors": {
       "version": "1.3.0",
@@ -26145,6 +26323,12 @@
       "requires": {
         "yallist": "^3.0.2"
       }
+    },
+    "lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true
     },
     "magic-string": {
       "version": "0.30.8",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@commitlint/cli": "18.6.1",
     "@commitlint/config-conventional": "18.6.2",
     "@faker-js/faker": "8.4.1",
+    "@testing-library/react": "15.0.0",
     "@vitejs/plugin-react": "4.2.1",
     "autoprefixer": "10.4.17",
     "concurrently": "8.2.2",

--- a/pages/interface/components/ContentList/index.js
+++ b/pages/interface/components/ContentList/index.js
@@ -1,11 +1,8 @@
-import { Box, EmptyState, Link, PastTime, TabCoinBalanceTooltip, Text, Tooltip } from '@/TabNewsUI';
-import { ChevronLeftIcon, ChevronRightIcon, CommentIcon } from '@/TabNewsUI/icons';
+import { Box, EmptyState, Link, Pagination, PastTime, TabCoinBalanceTooltip, Text, Tooltip } from '@/TabNewsUI';
+import { CommentIcon } from '@/TabNewsUI/icons';
 
 export default function ContentList({ contentList: list, pagination, paginationBasePath, emptyStateProps }) {
   const listNumberStart = pagination.perPage * (pagination.currentPage - 1) + 1;
-
-  const previousPageUrl = `${paginationBasePath}/${pagination.previousPage}`;
-  const nextPageUrl = `${paginationBasePath}/${pagination.nextPage}`;
 
   return (
     <>
@@ -28,42 +25,7 @@ export default function ContentList({ contentList: list, pagination, paginationB
         <RenderEmptyMessage {...emptyStateProps} />
       )}
 
-      {list.length > 0 ? (
-        <Box
-          sx={{
-            display: 'flex',
-            width: '100%',
-            justifyContent: 'center',
-            whiteSpace: 'nowrap',
-            gap: 4,
-            m: 4,
-            mb: 2,
-          }}>
-          {pagination.previousPage ? (
-            <Link href={previousPageUrl} scroll={false}>
-              <ChevronLeftIcon size={16} />
-              Anterior
-            </Link>
-          ) : (
-            <Text color="fg.muted">
-              <ChevronLeftIcon size={16} />
-              Anterior
-            </Text>
-          )}
-
-          {pagination.nextPage ? (
-            <Link href={nextPageUrl}>
-              Próximo
-              <ChevronRightIcon size={16} />
-            </Link>
-          ) : (
-            <Text color="fg.muted">
-              Próximo
-              <ChevronRightIcon size={16} />
-            </Text>
-          )}
-        </Box>
-      ) : null}
+      {list.length > 0 ? <Pagination {...pagination} basePath={paginationBasePath} /> : null}
     </>
   );
 

--- a/pages/interface/components/Pagination/index.js
+++ b/pages/interface/components/Pagination/index.js
@@ -1,0 +1,44 @@
+import { Box, Link, Text } from '@/TabNewsUI';
+import { ChevronLeftIcon, ChevronRightIcon } from '@/TabNewsUI/icons';
+
+export default function Pagination({ previousPage, nextPage, basePath }) {
+  const previousPageUrl = `${basePath}/${previousPage}`;
+  const nextPageUrl = `${basePath}/${nextPage}`;
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        width: '100%',
+        justifyContent: 'center',
+        whiteSpace: 'nowrap',
+        gap: 4,
+        m: 4,
+        mb: 2,
+      }}>
+      {previousPage ? (
+        <Link href={previousPageUrl} scroll={false}>
+          <ChevronLeftIcon size={16} />
+          Anterior
+        </Link>
+      ) : (
+        <Text color="fg.muted">
+          <ChevronLeftIcon size={16} />
+          Anterior
+        </Text>
+      )}
+
+      {nextPage ? (
+        <Link href={nextPageUrl}>
+          Próximo
+          <ChevronRightIcon size={16} />
+        </Link>
+      ) : (
+        <Text color="fg.muted">
+          Próximo
+          <ChevronRightIcon size={16} />
+        </Text>
+      )}
+    </Box>
+  );
+}

--- a/pages/interface/components/TabNewsUI/index.js
+++ b/pages/interface/components/TabNewsUI/index.js
@@ -12,6 +12,7 @@ export { Editor, default as Viewer } from '@/Markdown';
 export { EditorColors, EditorStyles, ViewerStyles } from '@/Markdown/styles';
 export { default as PasswordInput } from '@/PasswordInput';
 export { default as PastTime } from '@/PastTime';
+export { default as Pagination } from '@/Pagination';
 export { default as NextNProgress } from '@/Progressbar';
 export { default as ReadTime } from '@/ReadTime';
 export { default as RecentTabNav } from '@/RecentTabNav';

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,0 +1,48 @@
+// Copied and adapted from https://github.com/primer/react/blob/main/packages/react/src/utils/test-helpers.tsx.
+// Can't import it because it is using `jest` instead of `vitest`.
+
+import { TextEncoder } from 'node:util';
+
+// Mock only in jsdom environment.
+if (typeof document !== 'undefined') {
+  // JSDOM doesn't mock ResizeObserver
+  global.ResizeObserver = vi.fn().mockImplementation(() => {
+    return {
+      observe: vi.fn(),
+      disconnect: vi.fn(),
+      unobserve: vi.fn(),
+    };
+  });
+
+  global.CSS = {
+    escape: vi.fn(),
+    supports: vi.fn().mockImplementation(() => {
+      return false;
+    }),
+  };
+
+  global.TextEncoder = TextEncoder;
+
+  /**
+   * Required for internal usage of dialog in primer/react
+   * this is not implemented in JSDOM, and until it is we'll need to polyfill
+   * https://github.com/jsdom/jsdom/issues/3294
+   * https://vijs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
+   * bonus: we only want to mock browser globals in DOM (or js-dom) environments – not in SSR / node
+   */
+  global.HTMLDialogElement.prototype.showModal = vi.fn(function mock() {
+    // eslint-disable-next-line no-invalid-this
+    this.open = true;
+  });
+
+  global.HTMLDialogElement.prototype.close = vi.fn(function mock() {
+    // eslint-disable-next-line no-invalid-this
+    this.open = false;
+  });
+
+  // Add a fallback for scrollIntoView if it does not exist in the test
+  // environment.
+  if (global.Element.prototype.scrollIntoView === undefined) {
+    global.Element.prototype.scrollIntoView = vi.fn();
+  }
+}

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,48 +1,8 @@
-// Copied and adapted from https://github.com/primer/react/blob/main/packages/react/src/utils/test-helpers.tsx.
-// Can't import it because it is using `jest` instead of `vitest`.
-
-import { TextEncoder } from 'node:util';
-
 // Mock only in jsdom environment.
 if (typeof document !== 'undefined') {
-  // JSDOM doesn't mock ResizeObserver
-  global.ResizeObserver = vi.fn().mockImplementation(() => {
-    return {
-      observe: vi.fn(),
-      disconnect: vi.fn(),
-      unobserve: vi.fn(),
-    };
-  });
-
   global.CSS = {
-    escape: vi.fn(),
     supports: vi.fn().mockImplementation(() => {
       return false;
     }),
   };
-
-  global.TextEncoder = TextEncoder;
-
-  /**
-   * Required for internal usage of dialog in primer/react
-   * this is not implemented in JSDOM, and until it is we'll need to polyfill
-   * https://github.com/jsdom/jsdom/issues/3294
-   * https://vijs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
-   * bonus: we only want to mock browser globals in DOM (or js-dom) environments – not in SSR / node
-   */
-  global.HTMLDialogElement.prototype.showModal = vi.fn(function mock() {
-    // eslint-disable-next-line no-invalid-this
-    this.open = true;
-  });
-
-  global.HTMLDialogElement.prototype.close = vi.fn(function mock() {
-    // eslint-disable-next-line no-invalid-this
-    this.open = false;
-  });
-
-  // Add a fallback for scrollIntoView if it does not exist in the test
-  // environment.
-  if (global.Element.prototype.scrollIntoView === undefined) {
-    global.Element.prototype.scrollIntoView = vi.fn();
-  }
 }

--- a/tests/unit/interface/components/Pagination/index.test.js
+++ b/tests/unit/interface/components/Pagination/index.test.js
@@ -1,0 +1,30 @@
+import { render } from '@testing-library/react';
+
+import webserver from 'infra/webserver';
+import Pagination from 'pages/interface/components/Pagination';
+
+describe('Pagination', () => {
+  it('should not render links if there is no previous or next page', () => {
+    const { getByText } = render(<Pagination basePath="/pagina" />);
+    expect(getByText('Anterior')).not.toHaveProperty('href');
+    expect(getByText('Próximo')).not.toHaveProperty('href');
+  });
+
+  it('should not render a link to previous page if there is no previous page', () => {
+    const { getByText } = render(<Pagination basePath="/pagina" nextPage="2" />);
+    expect(getByText('Anterior')).not.toHaveProperty('href');
+    expect(getByText('Próximo')).toHaveProperty('href', `${webserver.host}/pagina/2`);
+  });
+
+  it('should not render a link to next page if there is no next page', () => {
+    const { getByText } = render(<Pagination basePath="/conteudos" previousPage="7" />);
+    expect(getByText('Anterior')).toHaveProperty('href', `${webserver.host}/conteudos/7`);
+    expect(getByText('Próximo')).not.toHaveProperty('href');
+  });
+
+  it('should render a link to previous and next pages', () => {
+    const { getByText } = render(<Pagination basePath="/recentes/comentarios" previousPage="1" nextPage="3" />);
+    expect(getByText('Anterior')).toHaveProperty('href', `${webserver.host}/recentes/comentarios/1`);
+    expect(getByText('Próximo')).toHaveProperty('href', `${webserver.host}/recentes/comentarios/3`);
+  });
+});

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -8,11 +8,13 @@ config();
 export default defineConfig({
   plugins: [react(), tsconfigPaths()],
   test: {
+    environmentMatchGlobs: [['**/interface/**/*', 'jsdom']],
     globals: true,
     fileParallelism: false,
     isolate: false,
     testTimeout: 60_000,
     hookTimeout: 30_000,
+    setupFiles: ['tests/setup.js'],
   },
   esbuild: {
     loader: 'jsx',


### PR DESCRIPTION
## Mudanças realizadas

1. Agora é possível realizar testes de unidade que envolvem componentes React com a biblioteca [`@testing-library/react`](https://github.com/testing-library/react-testing-library)  ([documentação](https://testing-library.com/docs/react-testing-library/intro/)).
2. Refatorei a paginação para um componente separado, assim podemos utilizá-lo em outras telas futuramente, mantendo o mesmo comportamento.

## Tipo de mudança

- [x] Refatoração

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.