### PR TITLE
Remove a tabela `balance_operations`

### DIFF
--- a/infra/migrations/1712744727715_drop-balance-operations.js
+++ b/infra/migrations/1712744727715_drop-balance-operations.js
@@ -1,0 +1,106 @@
+exports.up = (pgm) => {
+  pgm.dropTable('balance_operations');
+
+  pgm.dropFunction(
+    'get_current_balance',
+    [
+      {
+        name: 'balance_type_input',
+        mode: 'IN',
+        type: 'text',
+      },
+      {
+        name: 'recipient_id_input',
+        mode: 'IN',
+        type: 'uuid',
+      },
+    ],
+    { ifExists: true },
+  );
+};
+
+exports.down = (pgm) => {
+  pgm.createTable('balance_operations', {
+    id: {
+      type: 'uuid',
+      default: pgm.func('gen_random_uuid()'),
+      notNull: true,
+      primaryKey: true,
+    },
+
+    sequence: {
+      type: 'serial',
+      notNull: true,
+    },
+
+    balance_type: {
+      type: 'text',
+      notNull: true,
+    },
+
+    recipient_id: {
+      type: 'uuid',
+      notNull: true,
+    },
+
+    amount: {
+      type: 'integer',
+      notNull: true,
+    },
+
+    originator_type: {
+      type: 'text',
+      notNull: true,
+    },
+
+    originator_id: {
+      type: 'uuid',
+      notNull: true,
+    },
+
+    created_at: {
+      type: 'timestamp with time zone',
+      notNull: true,
+      default: pgm.func("(now() at time zone 'utc')"),
+    },
+  });
+
+  pgm.createFunction(
+    'get_current_balance',
+    [
+      {
+        name: 'balance_type_input',
+        mode: 'IN',
+        type: 'text',
+      },
+      {
+        name: 'recipient_id_input',
+        mode: 'IN',
+        type: 'uuid',
+      },
+    ],
+    {
+      returns: 'integer',
+      language: 'plpgsql',
+      replace: true,
+    },
+    `
+    DECLARE
+      total_balance integer;
+    BEGIN
+      SELECT COALESCE(SUM(amount), 0)
+      INTO total_balance
+      FROM balance_operations
+      WHERE
+        (CASE
+            WHEN balance_type_input = 'content:tabcoin' THEN true
+            ELSE balance_type = balance_type_input 
+        END)
+        AND recipient_id = recipient_id_input;
+
+      RETURN total_balance;
+    END;`,
+  );
+
+  pgm.createIndex('balance_operations', ['recipient_id', 'balance_type']);
+};


### PR DESCRIPTION
## Mudanças realizadas

A migração de `balance_operations` para as três novas tabelas (`content_tabcoin_operations`, `user_tabcoin_operations` e `user_tabcash_operations`) foi concluída, vide https://github.com/filipedeschamps/tabnews.com.br/pull/1661#issuecomment-2046659596. Este PR remove a tabela `balance_operations`, que não é mais utilizada, e a função `get_current_balance`, que acessava a tabela.

## Tipo de mudança

- [x] Refatoração

## Checklist:

- [x] Os testes antigos estão passando localmente.
