### PR TITLE
Adiciona paginação ao endpoint GET /users

### DIFF
--- a/models/content.js
+++ b/models/content.js
@@ -12,13 +12,13 @@ import queries from 'queries/rankingQueries';
 async function findAll(values = {}, options = {}) {
   values = validateValues(values);
   await replaceOwnerUsernameWithOwnerId(values);
-  const offset = (values.page - 1) * values.per_page;
 
   const query = {
     values: [],
   };
 
   if (!values.count) {
+    const offset = (values.page - 1) * values.per_page;
     query.values = [values.limit || values.per_page, offset];
   }
 

--- a/models/controller.js
+++ b/models/controller.js
@@ -125,22 +125,27 @@ function logRequest(request, response, next) {
 
 function injectPaginationHeaders(pagination, endpoint, response) {
   const links = [];
-  const baseUrl = `${webserver.host}${endpoint}?strategy=${pagination.strategy}`;
+  const baseUrl = `${webserver.host}${endpoint}`;
 
-  if (pagination.firstPage) {
-    links.push(`<${baseUrl}&page=${pagination.firstPage}&per_page=${pagination.perPage}>; rel="first"`);
+  const searchParams = new URLSearchParams();
+
+  if (pagination.strategy) {
+    searchParams.set('strategy', pagination.strategy);
   }
 
-  if (pagination.previousPage) {
-    links.push(`<${baseUrl}&page=${pagination.previousPage}&per_page=${pagination.perPage}>; rel="prev"`);
-  }
+  const pages = [
+    { page: pagination.firstPage, rel: 'first' },
+    { page: pagination.previousPage, rel: 'prev' },
+    { page: pagination.nextPage, rel: 'next' },
+    { page: pagination.lastPage, rel: 'last' },
+  ];
 
-  if (pagination.nextPage) {
-    links.push(`<${baseUrl}&page=${pagination.nextPage}&per_page=${pagination.perPage}>; rel="next"`);
-  }
-
-  if (pagination.lastPage) {
-    links.push(`<${baseUrl}&page=${pagination.lastPage}&per_page=${pagination.perPage}>; rel="last"`);
+  for (const { page, rel } of pages) {
+    if (page) {
+      searchParams.set('page', page);
+      searchParams.set('per_page', pagination.perPage);
+      links.push(`<${baseUrl}?${searchParams.toString()}>; rel="${rel}"`);
+    }
   }
 
   const linkHeaderString = links.join(', ');

--- a/models/pagination.js
+++ b/models/pagination.js
@@ -1,0 +1,26 @@
+async function get({ total_rows, page, per_page, strategy }) {
+  const firstPage = 1;
+  const lastPage = Math.ceil(total_rows / per_page);
+  const nextPage = page >= lastPage ? null : page + 1;
+  const previousPage = page <= 1 ? null : page > lastPage ? lastPage : page - 1;
+
+  const pagination = {
+    currentPage: page,
+    totalRows: total_rows,
+    perPage: per_page,
+    firstPage: firstPage,
+    nextPage: nextPage,
+    previousPage: previousPage,
+    lastPage: lastPage,
+  };
+
+  if (strategy) {
+    pagination.strategy = strategy;
+  }
+
+  return pagination;
+}
+
+export default Object.freeze({
+  get,
+});

--- a/tests/integration/api/v1/contents/[username]/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/get.test.js
@@ -558,21 +558,21 @@ describe('GET /api/v1/contents/[username]', () => {
           per_page: '30',
           rel: 'first',
           strategy: 'new',
-          url: `http://localhost:3000/api/v1/contents/${defaultUser.username}?strategy=new&page=1&per_page=30`,
+          url: `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}?strategy=new&page=1&per_page=30`,
         },
         next: {
           page: '2',
           per_page: '30',
           rel: 'next',
           strategy: 'new',
-          url: `http://localhost:3000/api/v1/contents/${defaultUser.username}?strategy=new&page=2&per_page=30`,
+          url: `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}?strategy=new&page=2&per_page=30`,
         },
         last: {
           page: '2',
           per_page: '30',
           rel: 'last',
           strategy: 'new',
-          url: `http://localhost:3000/api/v1/contents/${defaultUser.username}?strategy=new&page=2&per_page=30`,
+          url: `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}?strategy=new&page=2&per_page=30`,
         },
       });
 
@@ -599,21 +599,21 @@ describe('GET /api/v1/contents/[username]', () => {
           per_page: '30',
           rel: 'first',
           strategy: 'new',
-          url: `http://localhost:3000/api/v1/contents/${defaultUser.username}?strategy=new&page=1&per_page=30`,
+          url: `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}?strategy=new&page=1&per_page=30`,
         },
         prev: {
           page: '1',
           per_page: '30',
           rel: 'prev',
           strategy: 'new',
-          url: `http://localhost:3000/api/v1/contents/${defaultUser.username}?strategy=new&page=1&per_page=30`,
+          url: `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}?strategy=new&page=1&per_page=30`,
         },
         last: {
           page: '2',
           per_page: '30',
           rel: 'last',
           strategy: 'new',
-          url: `http://localhost:3000/api/v1/contents/${defaultUser.username}?strategy=new&page=2&per_page=30`,
+          url: `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}?strategy=new&page=2&per_page=30`,
         },
       });
 
@@ -700,21 +700,21 @@ describe('GET /api/v1/contents/[username]', () => {
           per_page: '30',
           rel: 'first',
           strategy: 'relevant',
-          url: `http://localhost:3000/api/v1/contents/${defaultUser.username}?strategy=relevant&page=1&per_page=30`,
+          url: `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}?strategy=relevant&page=1&per_page=30`,
         },
         next: {
           page: '2',
           per_page: '30',
           rel: 'next',
           strategy: 'relevant',
-          url: `http://localhost:3000/api/v1/contents/${defaultUser.username}?strategy=relevant&page=2&per_page=30`,
+          url: `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}?strategy=relevant&page=2&per_page=30`,
         },
         last: {
           page: '2',
           per_page: '30',
           rel: 'last',
           strategy: 'relevant',
-          url: `http://localhost:3000/api/v1/contents/${defaultUser.username}?strategy=relevant&page=2&per_page=30`,
+          url: `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}?strategy=relevant&page=2&per_page=30`,
         },
       });
 
@@ -743,21 +743,21 @@ describe('GET /api/v1/contents/[username]', () => {
           per_page: '30',
           rel: 'first',
           strategy: 'relevant',
-          url: `http://localhost:3000/api/v1/contents/${defaultUser.username}?strategy=relevant&page=1&per_page=30`,
+          url: `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}?strategy=relevant&page=1&per_page=30`,
         },
         prev: {
           page: '1',
           per_page: '30',
           rel: 'prev',
           strategy: 'relevant',
-          url: `http://localhost:3000/api/v1/contents/${defaultUser.username}?strategy=relevant&page=1&per_page=30`,
+          url: `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}?strategy=relevant&page=1&per_page=30`,
         },
         last: {
           page: '2',
           per_page: '30',
           rel: 'last',
           strategy: 'relevant',
-          url: `http://localhost:3000/api/v1/contents/${defaultUser.username}?strategy=relevant&page=2&per_page=30`,
+          url: `${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}?strategy=relevant&page=2&per_page=30`,
         },
       });
 

--- a/tests/integration/api/v1/contents/get.test.js
+++ b/tests/integration/api/v1/contents/get.test.js
@@ -39,7 +39,7 @@ describe('GET /api/v1/contents', () => {
         'access-control-allow-headers': [
           'X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version',
         ],
-        link: ['<http://localhost:3000/api/v1/contents?strategy=relevant&page=1&per_page=30>; rel="first"'],
+        link: [`<${orchestrator.webserverUrl}/api/v1/contents?strategy=relevant&page=1&per_page=30>; rel="first"`],
         'x-pagination-total-rows': ['0'],
         'content-type': ['application/json; charset=utf-8'],
         etag: responseHeaders.etag,
@@ -374,21 +374,21 @@ describe('GET /api/v1/contents', () => {
           per_page: '30',
           rel: 'first',
           strategy: 'new',
-          url: 'http://localhost:3000/api/v1/contents?strategy=new&page=1&per_page=30',
+          url: `${orchestrator.webserverUrl}/api/v1/contents?strategy=new&page=1&per_page=30`,
         },
         next: {
           page: '2',
           per_page: '30',
           rel: 'next',
           strategy: 'new',
-          url: 'http://localhost:3000/api/v1/contents?strategy=new&page=2&per_page=30',
+          url: `${orchestrator.webserverUrl}/api/v1/contents?strategy=new&page=2&per_page=30`,
         },
         last: {
           page: '2',
           per_page: '30',
           rel: 'last',
           strategy: 'new',
-          url: 'http://localhost:3000/api/v1/contents?strategy=new&page=2&per_page=30',
+          url: `${orchestrator.webserverUrl}/api/v1/contents?strategy=new&page=2&per_page=30`,
         },
       });
 
@@ -735,21 +735,21 @@ describe('GET /api/v1/contents', () => {
           per_page: '30',
           rel: 'first',
           strategy: 'relevant',
-          url: 'http://localhost:3000/api/v1/contents?strategy=relevant&page=1&per_page=30',
+          url: `${orchestrator.webserverUrl}/api/v1/contents?strategy=relevant&page=1&per_page=30`,
         },
         next: {
           page: '2',
           per_page: '30',
           rel: 'next',
           strategy: 'relevant',
-          url: 'http://localhost:3000/api/v1/contents?strategy=relevant&page=2&per_page=30',
+          url: `${orchestrator.webserverUrl}/api/v1/contents?strategy=relevant&page=2&per_page=30`,
         },
         last: {
           page: '2',
           per_page: '30',
           rel: 'last',
           strategy: 'relevant',
-          url: 'http://localhost:3000/api/v1/contents?strategy=relevant&page=2&per_page=30',
+          url: `${orchestrator.webserverUrl}/api/v1/contents?strategy=relevant&page=2&per_page=30`,
         },
       });
 
@@ -805,21 +805,21 @@ describe('GET /api/v1/contents', () => {
           per_page: '30',
           rel: 'first',
           strategy: 'relevant',
-          url: 'http://localhost:3000/api/v1/contents?strategy=relevant&page=1&per_page=30',
+          url: `${orchestrator.webserverUrl}/api/v1/contents?strategy=relevant&page=1&per_page=30`,
         },
         prev: {
           page: '1',
           per_page: '30',
           rel: 'prev',
           strategy: 'relevant',
-          url: 'http://localhost:3000/api/v1/contents?strategy=relevant&page=1&per_page=30',
+          url: `${orchestrator.webserverUrl}/api/v1/contents?strategy=relevant&page=1&per_page=30`,
         },
         last: {
           page: '2',
           per_page: '30',
           rel: 'last',
           strategy: 'relevant',
-          url: 'http://localhost:3000/api/v1/contents?strategy=relevant&page=2&per_page=30',
+          url: `${orchestrator.webserverUrl}/api/v1/contents?strategy=relevant&page=2&per_page=30`,
         },
       });
 
@@ -859,21 +859,21 @@ describe('GET /api/v1/contents', () => {
           per_page: '3',
           rel: 'first',
           strategy: 'new',
-          url: 'http://localhost:3000/api/v1/contents?strategy=new&page=1&per_page=3',
+          url: `${orchestrator.webserverUrl}/api/v1/contents?strategy=new&page=1&per_page=3`,
         },
         next: {
           page: '2',
           per_page: '3',
           rel: 'next',
           strategy: 'new',
-          url: 'http://localhost:3000/api/v1/contents?strategy=new&page=2&per_page=3',
+          url: `${orchestrator.webserverUrl}/api/v1/contents?strategy=new&page=2&per_page=3`,
         },
         last: {
           page: '3',
           per_page: '3',
           rel: 'last',
           strategy: 'new',
-          url: 'http://localhost:3000/api/v1/contents?strategy=new&page=3&per_page=3',
+          url: `${orchestrator.webserverUrl}/api/v1/contents?strategy=new&page=3&per_page=3`,
         },
       });
 
@@ -896,28 +896,28 @@ describe('GET /api/v1/contents', () => {
           per_page: '3',
           rel: 'first',
           strategy: 'new',
-          url: 'http://localhost:3000/api/v1/contents?strategy=new&page=1&per_page=3',
+          url: `${orchestrator.webserverUrl}/api/v1/contents?strategy=new&page=1&per_page=3`,
         },
         prev: {
           page: '1',
           per_page: '3',
           rel: 'prev',
           strategy: 'new',
-          url: 'http://localhost:3000/api/v1/contents?strategy=new&page=1&per_page=3',
+          url: `${orchestrator.webserverUrl}/api/v1/contents?strategy=new&page=1&per_page=3`,
         },
         next: {
           page: '3',
           per_page: '3',
           rel: 'next',
           strategy: 'new',
-          url: 'http://localhost:3000/api/v1/contents?strategy=new&page=3&per_page=3',
+          url: `${orchestrator.webserverUrl}/api/v1/contents?strategy=new&page=3&per_page=3`,
         },
         last: {
           page: '3',
           per_page: '3',
           rel: 'last',
           strategy: 'new',
-          url: 'http://localhost:3000/api/v1/contents?strategy=new&page=3&per_page=3',
+          url: `${orchestrator.webserverUrl}/api/v1/contents?strategy=new&page=3&per_page=3`,
         },
       });
 
@@ -940,21 +940,21 @@ describe('GET /api/v1/contents', () => {
           per_page: '3',
           rel: 'first',
           strategy: 'new',
-          url: 'http://localhost:3000/api/v1/contents?strategy=new&page=1&per_page=3',
+          url: `${orchestrator.webserverUrl}/api/v1/contents?strategy=new&page=1&per_page=3`,
         },
         prev: {
           page: '2',
           per_page: '3',
           rel: 'prev',
           strategy: 'new',
-          url: 'http://localhost:3000/api/v1/contents?strategy=new&page=2&per_page=3',
+          url: `${orchestrator.webserverUrl}/api/v1/contents?strategy=new&page=2&per_page=3`,
         },
         last: {
           page: '3',
           per_page: '3',
           rel: 'last',
           strategy: 'new',
-          url: 'http://localhost:3000/api/v1/contents?strategy=new&page=3&per_page=3',
+          url: `${orchestrator.webserverUrl}/api/v1/contents?strategy=new&page=3&per_page=3`,
         },
       });
 
@@ -1012,21 +1012,21 @@ describe('GET /api/v1/contents', () => {
           per_page: '3',
           rel: 'first',
           strategy: 'new',
-          url: 'http://localhost:3000/api/v1/contents?strategy=new&page=1&per_page=3',
+          url: `${orchestrator.webserverUrl}/api/v1/contents?strategy=new&page=1&per_page=3`,
         },
         prev: {
           page: '3',
           per_page: '3',
           rel: 'prev',
           strategy: 'new',
-          url: 'http://localhost:3000/api/v1/contents?strategy=new&page=3&per_page=3',
+          url: `${orchestrator.webserverUrl}/api/v1/contents?strategy=new&page=3&per_page=3`,
         },
         last: {
           page: '3',
           per_page: '3',
           rel: 'last',
           strategy: 'new',
-          url: 'http://localhost:3000/api/v1/contents?strategy=new&page=3&per_page=3',
+          url: `${orchestrator.webserverUrl}/api/v1/contents?strategy=new&page=3&per_page=3`,
         },
       });
 

--- a/tests/integration/api/v1/contents/rss/get.test.js
+++ b/tests/integration/api/v1/contents/rss/get.test.js
@@ -32,7 +32,7 @@ describe('GET /recentes/rss', () => {
 <rss version="2.0">
     <channel>
         <title>TabNews</title>
-        <link>http://localhost:3000/recentes/rss</link>
+        <link>${orchestrator.webserverUrl}/recentes/rss</link>
         <description>Conteúdos para quem trabalha com Programação e Tecnologia</description>
         <lastBuildDate>${lastBuildDateFromResponseBody}</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
@@ -40,8 +40,8 @@ describe('GET /recentes/rss', () => {
         <language>pt</language>
         <image>
             <title>TabNews</title>
-            <url>http://localhost:3000/favicon-mobile.png</url>
-            <link>http://localhost:3000/recentes/rss</link>
+            <url>${orchestrator.webserverUrl}/favicon-mobile.png</url>
+            <link>${orchestrator.webserverUrl}/recentes/rss</link>
         </image>
     </channel>
 </rss>`);
@@ -84,7 +84,7 @@ describe('GET /recentes/rss', () => {
 <rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/">
     <channel>
         <title>TabNews</title>
-        <link>http://localhost:3000/recentes/rss</link>
+        <link>${orchestrator.webserverUrl}/recentes/rss</link>
         <description>Conteúdos para quem trabalha com Programação e Tecnologia</description>
         <lastBuildDate>${new Date(secondRootContent.published_at).toUTCString()}</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
@@ -92,21 +92,21 @@ describe('GET /recentes/rss', () => {
         <language>pt</language>
         <image>
             <title>TabNews</title>
-            <url>http://localhost:3000/favicon-mobile.png</url>
-            <link>http://localhost:3000/recentes/rss</link>
+            <url>${orchestrator.webserverUrl}/favicon-mobile.png</url>
+            <link>${orchestrator.webserverUrl}/recentes/rss</link>
         </image>
         <item>
             <title><![CDATA[Conteúdo #2 (mais novo)]]></title>
-            <link>http://localhost:3000/${secondRootContent.owner_username}/${secondRootContent.slug}</link>
-            <guid>http://localhost:3000/${secondRootContent.owner_username}/${secondRootContent.slug}</guid>
+            <link>${orchestrator.webserverUrl}/${secondRootContent.owner_username}/${secondRootContent.slug}</link>
+            <guid>${orchestrator.webserverUrl}/${secondRootContent.owner_username}/${secondRootContent.slug}</guid>
             <pubDate>${new Date(secondRootContent.published_at).toUTCString()}</pubDate>
             <description><![CDATA[Este é um corpo bastante longo, vamos ver como que a propriedade description irá reagir, pois por padrão ela deverá cortar após um número X de caracteres. Não vou tomar nota aqui da quant...]]></description>
             <content:encoded><![CDATA[<div class="markdown-body"><p>Este é um corpo bastante longo, vamos ver como que a propriedade description irá reagir, pois por padrão ela deverá cortar após um número X de caracteres. Não vou tomar nota aqui da quantidade exata de caracteres, pois isso pode mudar ao longo do tempo.</p></div>]]></content:encoded>
         </item>
         <item>
             <title><![CDATA[Conteúdo #1 (mais antigo)]]></title>
-            <link>http://localhost:3000/${firstRootContent.owner_username}/${firstRootContent.slug}</link>
-            <guid>http://localhost:3000/${firstRootContent.owner_username}/${firstRootContent.slug}</guid>
+            <link>${orchestrator.webserverUrl}/${firstRootContent.owner_username}/${firstRootContent.slug}</link>
+            <guid>${orchestrator.webserverUrl}/${firstRootContent.owner_username}/${firstRootContent.slug}</guid>
             <pubDate>${new Date(firstRootContent.published_at).toUTCString()}</pubDate>
             <description><![CDATA[Corpo com HTML É importante lidar corretamente com o HTML, incluindo estilos especiais do GFM.]]></description>
             <content:encoded><![CDATA[<div class="markdown-body"><h1 id="${defaultUser.username.toLowerCase()}-content-corpo-com-html">Corpo com HTML</h1><p>É <strong>importante</strong> lidar corretamente com o <code>HTML</code>, incluindo estilos <del>especiais</del> do <code>GFM</code>.</p></div>]]></content:encoded>

--- a/tests/integration/api/v1/users/get.test.js
+++ b/tests/integration/api/v1/users/get.test.js
@@ -1,45 +1,55 @@
 import fetch from 'cross-fetch';
+import parseLinkHeader from 'parse-link-header';
 import { version as uuidVersion } from 'uuid';
 
 import orchestrator from 'tests/orchestrator.js';
+
+let firstUser;
+let secondUser;
+let privilegedUser;
+let privilegedUserSession;
+let defaultUser;
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();
   await orchestrator.dropAllTables();
   await orchestrator.runPendingMigrations();
+
+  firstUser = await orchestrator.createUser();
+  firstUser = await orchestrator.activateUser(firstUser);
+  defaultUser = firstUser;
+
+  secondUser = await orchestrator.createUser();
+  await orchestrator.activateUser(secondUser);
+  secondUser = await orchestrator.addFeaturesToUser(secondUser, ['read:user:list']);
+  privilegedUser = secondUser;
+  privilegedUserSession = await orchestrator.createSession(privilegedUser);
 });
 
 describe('GET /api/v1/users', () => {
   describe('Anonymous user', () => {
     test('Anonymous user trying to retrieve user list', async () => {
-      let defaultUser = await orchestrator.createUser();
-      await orchestrator.activateUser(defaultUser);
-      let privilegedUser = await orchestrator.createUser();
-      privilegedUser = await orchestrator.activateUser(privilegedUser);
-      await orchestrator.addFeaturesToUser(privilegedUser, ['read:user:list']);
-
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users`);
       const responseBody = await response.json();
 
       expect(response.status).toEqual(403);
-      expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('Usuário não pode executar esta operação.');
-      expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "read:user:list".');
-      expect(responseBody.status_code).toEqual(403);
+
+      expect(responseBody).toStrictEqual({
+        name: 'ForbiddenError',
+        message: 'Usuário não pode executar esta operação.',
+        action: 'Verifique se este usuário possui a feature "read:user:list".',
+        status_code: 403,
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND',
+      });
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
     });
   });
 
   describe('Default user', () => {
     test('User without "read:user:list" feature', async () => {
-      let defaultUser = await orchestrator.createUser();
-      defaultUser = await orchestrator.activateUser(defaultUser);
-      let privilegedUser = await orchestrator.createUser();
-      privilegedUser = await orchestrator.activateUser(privilegedUser);
-      await orchestrator.addFeaturesToUser(privilegedUser, ['read:user:list']);
-
       let defaultUserSession = await orchestrator.createSession(defaultUser);
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
@@ -52,46 +62,155 @@ describe('GET /api/v1/users', () => {
       const responseBody = await response.json();
 
       expect(response.status).toEqual(403);
-      expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('Usuário não pode executar esta operação.');
-      expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "read:user:list".');
-      expect(responseBody.status_code).toEqual(403);
+
+      expect(responseBody).toStrictEqual({
+        name: 'ForbiddenError',
+        message: 'Usuário não pode executar esta operação.',
+        action: 'Verifique se este usuário possui a feature "read:user:list".',
+        status_code: 403,
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND',
+      });
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
     });
   });
 
   describe('User with "read:user:list" feature', () => {
-    test('Retrieving user list with users', async () => {
-      let defaultUser = await orchestrator.createUser();
-      defaultUser = await orchestrator.activateUser(defaultUser);
-      let privilegedUser = await orchestrator.createUser();
-      privilegedUser = await orchestrator.activateUser(privilegedUser);
-      privilegedUser = await orchestrator.addFeaturesToUser(privilegedUser, ['read:user:list']);
+    test('With a large value for "per_page"', async () => {
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users?per_page=150`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          cookie: `session_id=${privilegedUserSession.token}`,
+        },
+      });
+      const responseBody = await response.json();
 
-      let privilegedUserSession = await orchestrator.createSession(privilegedUser);
+      expect(response.status).toEqual(400);
+      expect(responseBody).toStrictEqual({
+        name: 'ValidationError',
+        message: '"per_page" deve possuir um valor máximo de 100.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        status_code: 400,
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
+        key: 'per_page',
+        type: 'number.max',
+      });
 
-      const firstUser = {
-        id: defaultUser.id,
-        username: defaultUser.username,
-        description: defaultUser.description,
-        features: defaultUser.features,
-        tabcoins: 0,
-        tabcash: 0,
-        created_at: defaultUser.created_at.toISOString(),
-        updated_at: defaultUser.updated_at.toISOString(),
-      };
-      const secondUser = {
-        id: privilegedUser.id,
-        username: privilegedUser.username,
-        description: privilegedUser.description,
-        features: privilegedUser.features,
-        tabcoins: 0,
-        tabcash: 0,
-        created_at: privilegedUser.created_at.toISOString(),
-        updated_at: privilegedUser.updated_at.toISOString(),
-      };
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+    });
+
+    test('With an invalid value for "page"', async () => {
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents?page=first`);
+      const responseBody = await response.json();
+
+      expect(response.status).toEqual(400);
+
+      expect(responseBody).toStrictEqual({
+        name: 'ValidationError',
+        message: '"page" deve ser do tipo Number.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        status_code: 400,
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
+        key: 'page',
+        type: 'number.base',
+      });
+
+      expect(uuidVersion(responseBody.error_id)).toEqual(4);
+      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+    });
+
+    test('Retrieving user list with 2 users', async () => {
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          cookie: `session_id=${privilegedUserSession.token}`,
+        },
+      });
+      const responseBody = await response.json();
+
+      const responseLinkHeader = parseLinkHeader(response.headers.get('Link'));
+      const responseTotalRowsHeader = response.headers.get('X-Pagination-Total-Rows');
+
+      expect(response.status).toEqual(200);
+      expect(responseTotalRowsHeader).toEqual('2');
+      expect(responseLinkHeader).toStrictEqual({
+        first: {
+          page: '1',
+          per_page: '30',
+          rel: 'first',
+          url: `${orchestrator.webserverUrl}/api/v1/users?page=1&per_page=30`,
+        },
+        last: {
+          page: '1',
+          per_page: '30',
+          rel: 'last',
+          url: `${orchestrator.webserverUrl}/api/v1/users?page=1&per_page=30`,
+        },
+      });
+
+      expect(responseBody).toStrictEqual([
+        {
+          id: secondUser.id,
+          username: secondUser.username,
+          description: secondUser.description,
+          features: secondUser.features,
+          tabcoins: 0,
+          tabcash: 0,
+          created_at: secondUser.created_at.toISOString(),
+          updated_at: secondUser.updated_at.toISOString(),
+        },
+        {
+          id: firstUser.id,
+          username: firstUser.username,
+          description: firstUser.description,
+          features: firstUser.features,
+          tabcoins: 0,
+          tabcash: 0,
+          created_at: firstUser.created_at.toISOString(),
+          updated_at: firstUser.updated_at.toISOString(),
+        },
+      ]);
+
+      expect(uuidVersion(responseBody[0].id)).toEqual(4);
+      expect(Date.parse(responseBody[0].created_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody[0].updated_at)).not.toEqual(NaN);
+
+      expect(uuidVersion(responseBody[1].id)).toEqual(4);
+      expect(Date.parse(responseBody[1].created_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody[1].updated_at)).not.toEqual(NaN);
+    });
+
+    test('Retrieving user list with TabCoins and TabCash', async () => {
+      await orchestrator.createBalance({
+        balanceType: 'user:tabcoin',
+        recipientId: firstUser.id,
+        amount: 8,
+      });
+      await orchestrator.createBalance({
+        balanceType: 'user:tabcash',
+        recipientId: firstUser.id,
+        amount: 3,
+      });
+
+      await orchestrator.createBalance({
+        balanceType: 'user:tabcoin',
+        recipientId: secondUser.id,
+        amount: -2,
+      });
+      await orchestrator.createBalance({
+        balanceType: 'user:tabcash',
+        recipientId: secondUser.id,
+        amount: 200,
+      });
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
         method: 'GET',
@@ -104,19 +223,250 @@ describe('GET /api/v1/users', () => {
 
       expect(response.status).toEqual(200);
 
-      expect(responseBody).toStrictEqual(expect.arrayContaining([firstUser, secondUser]));
+      expect(responseBody).toStrictEqual([
+        {
+          id: secondUser.id,
+          username: secondUser.username,
+          description: secondUser.description,
+          features: secondUser.features,
+          tabcoins: -2,
+          tabcash: 200,
+          created_at: secondUser.created_at.toISOString(),
+          updated_at: secondUser.updated_at.toISOString(),
+        },
+        {
+          id: firstUser.id,
+          username: firstUser.username,
+          description: firstUser.description,
+          features: firstUser.features,
+          tabcoins: 8,
+          tabcash: 3,
+          created_at: firstUser.created_at.toISOString(),
+          updated_at: firstUser.updated_at.toISOString(),
+        },
+      ]);
 
       expect(uuidVersion(responseBody[0].id)).toEqual(4);
       expect(Date.parse(responseBody[0].created_at)).not.toEqual(NaN);
       expect(Date.parse(responseBody[0].updated_at)).not.toEqual(NaN);
-      expect(responseBody[0]).not.toHaveProperty('password');
-      expect(responseBody[0]).not.toHaveProperty('email');
 
       expect(uuidVersion(responseBody[1].id)).toEqual(4);
       expect(Date.parse(responseBody[1].created_at)).not.toEqual(NaN);
       expect(Date.parse(responseBody[1].updated_at)).not.toEqual(NaN);
-      expect(responseBody[1]).not.toHaveProperty('password');
-      expect(responseBody[1]).not.toHaveProperty('email');
+    });
+
+    test('With a "page" out of bounds', async () => {
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users?page=5`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          cookie: `session_id=${privilegedUserSession.token}`,
+        },
+      });
+      const responseBody = await response.json();
+
+      const responseLinkHeader = parseLinkHeader(response.headers.get('Link'));
+      const responseTotalRowsHeader = response.headers.get('X-Pagination-Total-Rows');
+
+      expect(response.status).toEqual(200);
+      expect(responseTotalRowsHeader).toEqual('2');
+      expect(responseLinkHeader).toStrictEqual({
+        first: {
+          page: '1',
+          per_page: '30',
+          rel: 'first',
+          url: `${orchestrator.webserverUrl}/api/v1/users?page=1&per_page=30`,
+        },
+        prev: {
+          page: '1',
+          per_page: '30',
+          rel: 'prev',
+          url: `${orchestrator.webserverUrl}/api/v1/users?page=1&per_page=30`,
+        },
+        last: {
+          page: '1',
+          per_page: '30',
+          rel: 'last',
+          url: `${orchestrator.webserverUrl}/api/v1/users?page=1&per_page=30`,
+        },
+      });
+
+      expect(responseBody).toStrictEqual([]);
+    });
+  });
+
+  describe('User with "read:user:list" feature (dropAllTables beforeAll)', () => {
+    describe('With 60 users', () => {
+      const sortedByRecentlyUpdated = [];
+
+      let privilegedUserSession;
+
+      beforeAll(async () => {
+        await orchestrator.dropAllTables();
+        await orchestrator.runPendingMigrations();
+
+        const numberOfUsers = 60;
+        const sortedByNew = [];
+
+        for (let index = 0; index < numberOfUsers; index++) {
+          const user = await orchestrator.createUser({
+            username: `user${index + 1}`,
+          });
+          sortedByNew.unshift({
+            id: user.id,
+            username: user.username,
+            description: user.description,
+            features: user.features,
+            tabcoins: 0,
+            tabcash: 0,
+            created_at: user.created_at.toISOString(),
+            updated_at: user.updated_at.toISOString(),
+          });
+        }
+
+        // Oldest user will have 'read:user:list' feature
+        await orchestrator.activateUser(sortedByNew.at(-1));
+        let privilegedUser = await orchestrator.addFeaturesToUser(sortedByNew.at(-1), ['read:user:list']);
+        privilegedUserSession = await orchestrator.createSession(privilegedUser);
+        privilegedUser = {
+          id: privilegedUser.id,
+          username: privilegedUser.username,
+          description: privilegedUser.description,
+          features: privilegedUser.features,
+          tabcoins: 0,
+          tabcash: 0,
+          created_at: privilegedUser.created_at.toISOString(),
+          updated_at: privilegedUser.updated_at.toISOString(),
+        };
+
+        sortedByNew.pop();
+        sortedByNew.push(privilegedUser);
+
+        let updatedUser50 = await orchestrator.activateUser(sortedByNew.at(-49));
+        updatedUser50 = {
+          ...sortedByNew.at(-49),
+          features: updatedUser50.features,
+          updated_at: updatedUser50.updated_at.toISOString(),
+        };
+
+        sortedByRecentlyUpdated.push(...sortedByNew);
+
+        const indexOfUpdatedUser1 = sortedByRecentlyUpdated.findIndex((user) => user.id === privilegedUser.id);
+        const indexOfUpdatedUser50 = sortedByRecentlyUpdated.findIndex((user) => user.id === updatedUser50.id);
+
+        sortedByRecentlyUpdated.splice(indexOfUpdatedUser1, 1);
+        sortedByRecentlyUpdated.splice(indexOfUpdatedUser50, 1);
+
+        sortedByRecentlyUpdated.unshift(privilegedUser);
+        sortedByRecentlyUpdated.unshift(updatedUser50);
+      });
+
+      test('Navigating to next page', async () => {
+        const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${privilegedUserSession.token}`,
+          },
+        });
+        const responseBody = await response.json();
+
+        const responseLinkHeader = parseLinkHeader(response.headers.get('Link'));
+        const responseTotalRowsHeader = response.headers.get('X-Pagination-Total-Rows');
+
+        expect(response.status).toEqual(200);
+        expect(responseTotalRowsHeader).toEqual('60');
+        expect(responseLinkHeader).toStrictEqual({
+          first: {
+            page: '1',
+            per_page: '30',
+            rel: 'first',
+            url: `${orchestrator.webserverUrl}/api/v1/users?page=1&per_page=30`,
+          },
+          next: {
+            page: '2',
+            per_page: '30',
+            rel: 'next',
+            url: `${orchestrator.webserverUrl}/api/v1/users?page=2&per_page=30`,
+          },
+          last: {
+            page: '2',
+            per_page: '30',
+            rel: 'last',
+            url: `${orchestrator.webserverUrl}/api/v1/users?page=2&per_page=30`,
+          },
+        });
+
+        expect(responseBody).toStrictEqual(sortedByRecentlyUpdated.slice(0, 30));
+
+        const page2Response = await fetch(responseLinkHeader.next.url, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${privilegedUserSession.token}`,
+          },
+        });
+        const page2ResponseBody = await page2Response.json();
+
+        const page2ResponseLinkHeader = parseLinkHeader(page2Response.headers.get('Link'));
+        const page2ResponseTotalRowsHeader = page2Response.headers.get('X-Pagination-Total-Rows');
+
+        expect(page2Response.status).toEqual(200);
+        expect(page2ResponseTotalRowsHeader).toEqual('60');
+        expect(page2ResponseLinkHeader).toStrictEqual({
+          first: {
+            page: '1',
+            per_page: '30',
+            rel: 'first',
+            url: `${orchestrator.webserverUrl}/api/v1/users?page=1&per_page=30`,
+          },
+          prev: {
+            page: '1',
+            per_page: '30',
+            rel: 'prev',
+            url: `${orchestrator.webserverUrl}/api/v1/users?page=1&per_page=30`,
+          },
+          last: {
+            page: '2',
+            per_page: '30',
+            rel: 'last',
+            url: `${orchestrator.webserverUrl}/api/v1/users?page=2&per_page=30`,
+          },
+        });
+
+        expect(page2ResponseBody).toStrictEqual(sortedByRecentlyUpdated.slice(30));
+      });
+
+      test.each([
+        {
+          content: 'most recently updated users first',
+          params: [],
+          getExpected: () => sortedByRecentlyUpdated.slice(0, 30),
+        },
+        {
+          content: 'first 15 users',
+          params: ['per_page=15'],
+          getExpected: () => sortedByRecentlyUpdated.slice(0, 15),
+        },
+        {
+          content: 'second page with 10 users',
+          params: ['per_page=10', 'page=2'],
+          getExpected: () => sortedByRecentlyUpdated.slice(10, 20),
+        },
+      ])('Retrieving $content with params: $params', async ({ params, getExpected }) => {
+        const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users?${params.join('&')}`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: `session_id=${privilegedUserSession.token}`,
+          },
+        });
+
+        const responseBody = await response.json();
+
+        expect(response.status).toEqual(200);
+        expect(responseBody).toStrictEqual(getExpected());
+      });
     });
   });
 });


### PR DESCRIPTION
## Mudanças realizadas

Resolve a parte do backend do issue #1675.

Passei o `getPagination` para um outro arquivo para poder ser reutilizado e também aproveitei para refatorar algumas coisas simples, como substituir `http://localhost:3000` por `orchestrator.webserverUrl` em alguns testes.

* Paginação em `GET /api/v1/users` com `per_page` e `page`, ordenado pela data de atualização (`updated_at`, mais recentes primeiro).

## Tipo de mudança

 - [x] Nova funcionalidade.

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
