### PR TITLE
Diminui a quantidade de campos enviados para o Axiom para ficarmos dentro do limite de 256 diferentes campos

### DIFF
--- a/infra/logger.js
+++ b/infra/logger.js
@@ -8,16 +8,21 @@ function getLogger() {
         environment: process.env.VERCEL_ENV,
       },
       nestedKey: 'payload',
-      redact: [
-        'headers.cookie',
-        'password',
-        'email',
-        'body.password',
-        'body.email',
-        'context.user.password',
-        'context.user.email',
-        'context.session.token',
-      ],
+      redact: {
+        paths: [
+          'headers.cookie',
+          'headers["x-vercel-ip-continent"]',
+          'headers["x-vercel-ip-as-number"]',
+          'password',
+          'email',
+          'body.password',
+          'body.email',
+          'context.user.password',
+          'context.user.email',
+          'context.session.token',
+        ],
+        remove: true,
+      },
     });
 
     return pinoLogger;


### PR DESCRIPTION
## Mudanças realizadas

Remove campos desnecessários dos dados enviados para o Axiom, pois atingimos o limite de 256 diferentes campos, e isso impede a gravação de qualquer novo registro que contenha campos diferentes dos 256 já existentes.

Removi os 2 campos que notei que estavam impedindo a gravação de alguns registros:

- `headers["x-vercel-ip-continent"]`
- `headers["x-vercel-ip-as-number"]`

E como já estamos no limite, mudei a configuração para remover os campos sensíveis ao invés de apenas deixar eles como `redacted`.

Isso vai abrir a possibilidade de novos campos serem inseridos daqui a 30 dias, quando não houverem mais logs antigos com campos `redacted`.

Essa é uma solução emergencial por estarmos perdendo parte dos nossos logs, já que o Axiom passou a ignorar completamente os envios com campos extras, ao invés de salvar apenas os campos já existentes.

Após essa solução emergencial, sugiro fazermos uma revisão dos campos que estão sendo armazenados, já que mais da metade são `headers` das requisições, e alguns podem trazer informações redundantes ou desnecessárias.

## Tipo de mudança

- [x] Correção de bug

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Os testes antigos estão passando localmente.
