### PR TITLE
Altera `onClick` para `onSelect` para itens de menu serem acessíveis via teclado

### DIFF
--- a/pages/[username]/index.public.js
+++ b/pages/[username]/index.public.js
@@ -134,7 +134,7 @@ export default function Page({ userFound: userFoundFallback }) {
               </NavItem>
             )}
             {canNuke && (
-              <ActionList.Item variant="danger" onClick={handleClickNuke}>
+              <ActionList.Item variant="danger" onSelect={handleClickNuke}>
                 <ActionList.LeadingVisual>
                   <CircleSlashIcon />
                 </ActionList.LeadingVisual>

--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -109,13 +109,13 @@ function ViewModeOptionsMenu({ onDelete, onComponentModeChange }) {
 
           <ActionMenu.Overlay>
             <ActionList>
-              <ActionList.Item onClick={() => onComponentModeChange('edit')}>
+              <ActionList.Item onSelect={() => onComponentModeChange('edit')}>
                 <ActionList.LeadingVisual>
                   <PencilIcon />
                 </ActionList.LeadingVisual>
                 Editar
               </ActionList.Item>
-              <ActionList.Item variant="danger" onClick={onDelete}>
+              <ActionList.Item variant="danger" onSelect={onDelete}>
                 <ActionList.LeadingVisual>
                   <TrashIcon />
                 </ActionList.LeadingVisual>


### PR DESCRIPTION
## Mudanças realizadas

Resolve #1681 

## Tipo de mudança

- [x] Correção de bug

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
