### PR TITLE
Refatora `validator` e corrige validação de `null` caso o campo seja obrigatório

### DIFF
--- a/models/validator.js
+++ b/models/validator.js
@@ -55,6 +55,31 @@ export default function validator(object, keys) {
   return value;
 }
 
+const defaultValidationMessages = {
+  'any.invalid': `{#label} possui o valor inválido "{#value}".`,
+  'any.only': `{#label} não aceita o valor "{#value}".`,
+  'any.required': `{#label} é um campo obrigatório.`,
+  'array.base': `{#label} deve ser do tipo Array.`,
+  'boolean.base': `{#label} deve ser do tipo Boolean.`,
+  'date.base': `{#label} deve conter uma data válida.`,
+  'markdown.empty': `Markdown deve conter algum texto.`,
+  'number.base': `{#label} deve ser do tipo Number.`,
+  'number.integer': `{#label} deve ser um Inteiro.`,
+  'number.max': `{#label} deve possuir um valor máximo de {#limit}.`,
+  'number.min': `{#label} deve possuir um valor mínimo de {#limit}.`,
+  'object.base': `{#label} deve ser do tipo Object.`,
+  'string.alphanum': `{#label} deve conter apenas caracteres alfanuméricos.`,
+  'string.base': `{#label} deve ser do tipo String.`,
+  'string.email': `{#label} deve conter um email válido.`,
+  'string.empty': `{#label} não pode estar em branco.`,
+  'string.length': `{#label} deve possuir {#limit} {if(#limit==1, "caractere", "caracteres")}.`,
+  'string.ip': `{#label} deve possuir um IP válido.`,
+  'string.guid': `{#label} deve possuir um token UUID na versão 4.`,
+  'string.max': `{#label} deve conter no máximo {#limit} {if(#limit==1, "caractere", "caracteres")}.`,
+  'string.min': `{#label} deve conter no mínimo {#limit} {if(#limit==1, "caractere", "caracteres")}.`,
+  'username.reserved': `Este nome de usuário não está disponível para uso.`,
+};
+
 const schemas = {
   id: function () {
     return Joi.object({
@@ -62,12 +87,7 @@ const schemas = {
         .trim()
         .guid({ version: 'uuidv4' })
         .when('$required.id', { is: 'required', then: Joi.required(), otherwise: Joi.optional().allow(null) })
-        .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'string.base': `{#label} deve ser do tipo String.`,
-          'string.guid': `{#label} deve possuir um token UUID na versão 4.`,
-        }),
+        .messages(defaultValidationMessages),
     });
   },
 
@@ -81,16 +101,7 @@ const schemas = {
         .invalid(null)
         .custom(checkReservedUsernames, 'check if username is reserved')
         .when('$required.username', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
-        .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'string.base': `{#label} deve ser do tipo String.`,
-          'string.alphanum': `{#label} deve conter apenas caracteres alfanuméricos.`,
-          'string.min': `{#label} deve conter no mínimo {#limit} caracteres.`,
-          'string.max': `{#label} deve conter no máximo {#limit} caracteres.`,
-          'any.invalid': `{#label} possui o valor inválido "{#value}".`,
-          'username.reserved': `Este nome de usuário não está disponível para uso.`,
-        }),
+        .messages(defaultValidationMessages),
     });
   },
 
@@ -104,16 +115,7 @@ const schemas = {
         .invalid(null)
         .custom(checkReservedUsernames, 'check if username is reserved')
         .when('$required.owner_username', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
-        .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'string.base': `{#label} deve ser do tipo String.`,
-          'string.alphanum': `{#label} deve conter apenas caracteres alfanuméricos.`,
-          'string.min': `{#label} deve conter no mínimo {#limit} caracteres.`,
-          'string.max': `{#label} deve conter no máximo {#limit} caracteres.`,
-          'any.invalid': `{#label} possui o valor inválido "{#value}".`,
-          'username.reserved': `Este nome de usuário não está disponível para uso.`,
-        }),
+        .messages(defaultValidationMessages),
     });
   },
 
@@ -127,13 +129,7 @@ const schemas = {
         .trim()
         .invalid(null)
         .when('$required.email', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
-        .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'string.base': `{#label} deve ser do tipo String.`,
-          'string.email': `{#label} deve conter um email válido.`,
-          'any.invalid': `{#label} possui o valor inválido "{#value}".`,
-        }),
+        .messages(defaultValidationMessages),
     });
   },
 
@@ -146,14 +142,7 @@ const schemas = {
         .trim()
         .invalid(null)
         .when('$required.password', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
-        .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'string.base': `{#label} deve ser do tipo String.`,
-          'string.min': `{#label} deve conter no mínimo {#limit} caracteres.`,
-          'string.max': `{#label} deve conter no máximo {#limit} caracteres.`,
-          'any.invalid': `{#label} possui o valor inválido "{#value}".`,
-        }),
+        .messages(defaultValidationMessages),
     });
   },
 
@@ -165,12 +154,7 @@ const schemas = {
         .invalid(null)
         .allow('')
         .when('$required.description', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
-        .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.base': `{#label} deve ser do tipo String.`,
-          'string.max': `{#label} deve conter no máximo {#limit} caracteres.`,
-          'any.invalid': `{#label} possui o valor inválido "{#value}".`,
-        }),
+        .messages(defaultValidationMessages),
     });
   },
 
@@ -179,12 +163,7 @@ const schemas = {
       notifications: Joi.boolean()
         .invalid(null)
         .when('$required.notifications', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
-        .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'boolean.base': `{#label} deve ser do tipo Boolean.`,
-          'any.invalid': `{#label} possui o valor inválido "{#value}".`,
-        }),
+        .messages(defaultValidationMessages),
     });
   },
 
@@ -194,12 +173,7 @@ const schemas = {
         .trim()
         .guid({ version: 'uuidv4' })
         .when('$required.token_id', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
-        .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'string.base': `{#label} deve ser do tipo String.`,
-          'string.guid': `{#label} deve possuir um token UUID na versão 4.`,
-        }),
+        .messages(defaultValidationMessages),
     });
   },
 
@@ -209,13 +183,7 @@ const schemas = {
         .length(96)
         .alphanum()
         .when('$required.session_id', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
-        .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'string.base': `{#label} deve ser do tipo String.`,
-          'string.length': `{#label} deve possuir {#limit} caracteres.`,
-          'string.alphanum': `{#label} deve conter apenas caracteres alfanuméricos.`,
-        }),
+        .messages(defaultValidationMessages),
     });
   },
 
@@ -225,12 +193,7 @@ const schemas = {
         .trim()
         .guid({ version: 'uuidv4' })
         .when('$required.parent_id', { is: 'required', then: Joi.required(), otherwise: Joi.optional().allow(null) })
-        .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'string.base': `{#label} deve ser do tipo String.`,
-          'string.guid': `{#label} deve possuir um token UUID na versão 4.`,
-        }),
+        .messages(defaultValidationMessages),
     });
   },
 
@@ -245,12 +208,8 @@ const schemas = {
         .pattern(/^[a-z0-9](-?[a-z0-9])*$/)
         .when('$required.slug', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'string.base': `{#label} deve ser do tipo String.`,
-          'string.min': `{#label} deve conter no mínimo {#limit} caractere.`,
+          ...defaultValidationMessages,
           'string.pattern.base': `{#label} está no formato errado.`,
-          'any.invalid': `{#label} possui o valor inválido "{#value}".`,
         }),
     });
   },
@@ -265,13 +224,7 @@ const schemas = {
         .min(1)
         .max(255)
         .when('$required.title', { is: 'required', then: Joi.required(), otherwise: Joi.optional().allow(null) })
-        .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'string.base': `{#label} deve ser do tipo String.`,
-          'string.min': `{#label} deve conter no mínimo {#limit} caracteres.`,
-          'string.max': `{#label} deve conter no máximo {#limit} caracteres.`,
-        }),
+        .messages(defaultValidationMessages),
     });
   },
 
@@ -286,14 +239,8 @@ const schemas = {
         .custom(withoutMarkdown, 'check if is empty without markdown')
         .when('$required.body', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'string.base': `{#label} deve ser do tipo String.`,
-          'string.min': `{#label} deve conter no mínimo {#limit} caracteres.`,
-          'string.max': `{#label} deve conter no máximo {#limit} caracteres.`,
-          'any.invalid': `{#label} possui o valor inválido "{#value}".`,
+          ...defaultValidationMessages,
           'string.pattern.invert.base': `{#label} deve começar com caracteres visíveis.`,
-          'markdown.empty': `Markdown deve conter algum texto.`,
         }),
     });
   },
@@ -306,12 +253,7 @@ const schemas = {
         .invalid(null)
         .when('$required.status', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'string.base': `{#label} deve ser do tipo String.`,
-          'string.min': `{#label} deve conter no mínimo {#limit} caracteres.`,
-          'string.max': `{#label} deve conter no máximo {#limit} caracteres.`,
-          'any.invalid': `{#label} possui o valor inválido "{#value}".`,
+          ...defaultValidationMessages,
           'any.only': `{#label} deve possuir um dos seguintes valores: "draft", "published" ou "deleted".`,
         }),
     });
@@ -326,11 +268,7 @@ const schemas = {
         .pattern(/^https?:\/\/([-\p{Ll}\d_]{1,255}\.)+[-a-z0-9]{2,24}(:[0-9]{1,5})?([/?#]\S*)?$/u)
         .when('$required.source_url', { is: 'required', then: Joi.required(), otherwise: Joi.optional().allow(null) })
         .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'string.base': `{#label} deve ser do tipo String.`,
-          'string.max': `{#label} deve conter no máximo {#limit} caracteres.`,
-          'any.invalid': `{#label} possui o valor inválido "{#value}".`,
+          ...defaultValidationMessages,
           'string.pattern.base': `{#label} deve possuir uma URL válida e utilizando os protocolos HTTP ou HTTPS.`,
         }),
     });
@@ -342,12 +280,7 @@ const schemas = {
         .trim()
         .guid({ version: 'uuidv4' })
         .when('$required.owner_id', { is: 'required', then: Joi.required(), otherwise: Joi.optional().allow(null) })
-        .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'string.base': `{#label} deve ser do tipo String.`,
-          'string.guid': `{#label} deve possuir um token UUID na versão 4.`,
-        }),
+        .messages(defaultValidationMessages),
     });
   },
 
@@ -355,11 +288,7 @@ const schemas = {
     return Joi.object({
       created_at: Joi.date()
         .when('$required.created_at', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
-        .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'string.base': `{#label} deve ser do tipo Date.`,
-        }),
+        .messages(defaultValidationMessages),
     });
   },
 
@@ -367,11 +296,7 @@ const schemas = {
     return Joi.object({
       updated_at: Joi.date()
         .when('$required.updated_at', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
-        .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'string.base': `{#label} deve ser do tipo Date.`,
-        }),
+        .messages(defaultValidationMessages),
     });
   },
 
@@ -379,11 +304,7 @@ const schemas = {
     return Joi.object({
       published_at: Joi.date()
         .when('$required.published_at', { is: 'required', then: Joi.required(), otherwise: Joi.optional().allow(null) })
-        .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'string.base': `{#label} deve ser do tipo Date.`,
-        }),
+        .messages(defaultValidationMessages),
     });
   },
 
@@ -391,11 +312,7 @@ const schemas = {
     return Joi.object({
       deleted_at: Joi.date()
         .when('$required.deleted_at', { is: 'required', then: Joi.required(), otherwise: Joi.optional().allow(null) })
-        .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'string.base': `{#label} deve ser do tipo Date.`,
-        }),
+        .messages(defaultValidationMessages),
     });
   },
 
@@ -403,11 +320,7 @@ const schemas = {
     return Joi.object({
       expires_at: Joi.date()
         .when('$required.expires_at', { is: 'required', then: Joi.required(), otherwise: Joi.optional().allow(null) })
-        .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'string.base': `{#label} deve ser do tipo Date.`,
-        }),
+        .messages(defaultValidationMessages),
     });
   },
 
@@ -416,11 +329,7 @@ const schemas = {
       used: Joi.boolean()
         .allow(false)
         .when('$required.used', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
-        .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'boolean.base': `{#label} deve ser do tipo Boolean.`,
-        }),
+        .messages(defaultValidationMessages),
     });
   },
 
@@ -435,12 +344,7 @@ const schemas = {
         .default(1)
         .when('$required.page', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'number.base': `{#label} deve ser do tipo Number.`,
-          'number.integer': `{#label} deve ser um Inteiro.`,
-          'number.min': `{#label} deve possuir um valor mínimo de {#limit}.`,
-          'number.max': `{#label} deve possuir um valor máximo de {#limit}.`,
+          ...defaultValidationMessages,
           'number.unsafe': `{#label} deve possuir um valor entre ${min} e ${max}.`,
         }),
     });
@@ -457,12 +361,7 @@ const schemas = {
         .default(30)
         .when('$required.per_page', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'number.base': `{#label} deve ser do tipo Number.`,
-          'number.integer': `{#label} deve ser um Inteiro.`,
-          'number.min': `{#label} deve possuir um valor mínimo de {#limit}.`,
-          'number.max': `{#label} deve possuir um valor máximo de {#limit}.`,
+          ...defaultValidationMessages,
           'number.unsafe': `{#label} deve possuir um valor entre ${min} e ${max}.`,
         }),
     });
@@ -477,10 +376,7 @@ const schemas = {
         .invalid(null)
         .when('$required.strategy', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'string.base': `{#label} deve ser do tipo String.`,
-          'any.invalid': `{#label} possui o valor inválido "{#value}".`,
+          ...defaultValidationMessages,
           'any.only': `{#label} deve possuir um dos seguintes valores: "new", "old" ou "relevant".`,
         }),
     });
@@ -495,18 +391,14 @@ const schemas = {
         .valid('created_at DESC', 'created_at ASC', 'published_at DESC', 'published_at ASC')
         .when('$required.order', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'string.base': `{#label} deve ser do tipo String.`,
+          ...defaultValidationMessages,
           'any.only': `{#label} deve possuir um dos seguintes valores: "created_at DESC", "created_at ASC", "published_at DESC" ou "published_at ASC".`,
         }),
     });
   },
 
   where: function () {
-    let whereSchema = Joi.object({}).optional().min(1).messages({
-      'object.base': `{#label} deve ser do tipo Object.`,
-    });
+    let whereSchema = Joi.object({}).optional().min(1).messages(defaultValidationMessages);
 
     for (const key of [
       'id',
@@ -543,12 +435,7 @@ const schemas = {
         .default(null)
         .when('$required.limit', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'number.base': `{#label} deve ser do tipo Number.`,
-          'number.integer': `{#label} deve ser um Inteiro.`,
-          'number.min': `{#label} deve possuir um valor mínimo de {#limit}.`,
-          'number.max': `{#label} deve possuir um valor máximo de {#limit}.`,
+          ...defaultValidationMessages,
           'number.unsafe': `{#label} deve possuir um valor entre ${min} e ${max}.`,
         }),
     });
@@ -561,19 +448,20 @@ const schemas = {
       $or: Joi.array()
         .optional()
         .items(Joi.link('#status'))
-        .messages({
-          'array.base': `{#label} deve ser do tipo Array.`,
-        })
+        .messages(defaultValidationMessages)
         .shared(statusSchemaWithId),
     });
   },
 
   $not_null: function () {
     return Joi.object({
-      $not_null: Joi.array().optional().items(Joi.string().valid('parent_id')).messages({
-        'array.base': `{#label} deve ser do tipo Array.`,
-        'any.only': `{#label} deve conter um dos seguintes valores: "parent_id".`,
-      }),
+      $not_null: Joi.array()
+        .optional()
+        .items(Joi.string().valid('parent_id'))
+        .messages({
+          ...defaultValidationMessages,
+          'any.only': `{#label} deve conter um dos seguintes valores: "parent_id".`,
+        }),
     });
   },
 
@@ -590,11 +478,7 @@ const schemas = {
       count: Joi.boolean()
         .default(false)
         .when('$required.count', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
-        .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'boolean.base': `{#label} deve ser do tipo Boolean.`,
-        }),
+        .messages(defaultValidationMessages),
     });
   },
 
@@ -602,18 +486,13 @@ const schemas = {
     return Joi.object({
       children_deep_count: Joi.number()
         .when('$required.children_deep_count', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
-        .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'number.integer': `{#label} deve ser um Inteiro.`,
-        }),
+        .messages(defaultValidationMessages),
     });
   },
 
   content: function () {
     let contentSchema = Joi.object({
-      children: Joi.array().optional().items(Joi.link('#content')).messages({
-        'array.base': `{#label} deve ser do tipo Array.`,
-      }),
+      children: Joi.array().optional().items(Joi.link('#content')).messages(defaultValidationMessages),
     })
       .required()
       .min(1)
@@ -653,11 +532,7 @@ const schemas = {
       with_children: Joi.boolean()
         .allow(false)
         .when('$required.with_children', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
-        .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'boolean.base': `{#label} deve ser do tipo Boolean.`,
-        }),
+        .messages(defaultValidationMessages),
     });
   },
 
@@ -666,11 +541,7 @@ const schemas = {
       with_root: Joi.boolean()
         .allow(false)
         .when('$required.with_root', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
-        .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'boolean.base': `{#label} deve ser do tipo Boolean.`,
-        }),
+        .messages(defaultValidationMessages),
     });
   },
 
@@ -692,27 +563,14 @@ const schemas = {
           'reward:user:tabcoins',
           'system:update:tabcoins',
         )
-        .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'string.base': `{#label} deve ser do tipo String.`,
-          'any.only': `{#label} não possui um valor válido.`,
-        }),
-      originatorUserId: Joi.string().guid({ version: 'uuidv4' }).optional().messages({
-        'string.empty': `{#label} não pode estar em branco.`,
-        'string.base': `{#label} deve ser do tipo String.`,
-        'string.guid': `{#label} deve possuir um token UUID na versão 4.`,
-      }),
+        .messages(defaultValidationMessages),
+      originatorUserId: Joi.string().guid({ version: 'uuidv4' }).optional().messages(defaultValidationMessages),
       originatorIp: Joi.string()
         .ip({
           version: ['ipv4', 'ipv6'],
         })
         .optional()
-        .messages({
-          'string.empty': `{#label} não pode estar em branco.`,
-          'string.base': `{#label} deve ser do tipo String.`,
-          'string.ip': `{#label} deve possuir um IP válido.`,
-        }),
+        .messages(defaultValidationMessages),
       metadata: Joi.when('type', [
         {
           is: 'create:user',
@@ -777,12 +635,7 @@ const schemas = {
         .max(MAX_INTEGER)
         .when('$required.tabcoins', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'number.base': `{#label} deve ser do tipo Number.`,
-          'number.integer': `{#label} deve ser um Inteiro.`,
-          'number.min': `{#label} deve possuir um valor mínimo de {#limit}.`,
-          'number.max': `{#label} deve possuir um valor máximo de {#limit}.`,
+          ...defaultValidationMessages,
           'number.unsafe': `{#label} deve possuir um valor entre ${MIN_INTEGER} e ${MAX_INTEGER}.`,
         }),
     });
@@ -797,12 +650,7 @@ const schemas = {
         .max(MAX_INTEGER)
         .when('$required.tabcoins', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'number.base': `{#label} deve ser do tipo Number.`,
-          'number.integer': `{#label} deve ser um Inteiro.`,
-          'number.min': `{#label} deve possuir um valor mínimo de {#limit}.`,
-          'number.max': `{#label} deve possuir um valor máximo de {#limit}.`,
+          ...defaultValidationMessages,
           'number.unsafe': `{#label} deve possuir um valor entre ${min} e ${MAX_INTEGER}.`,
         }),
     });
@@ -817,12 +665,7 @@ const schemas = {
         .max(max)
         .when('$required.tabcoins', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'number.base': `{#label} deve ser do tipo Number.`,
-          'number.integer': `{#label} deve ser um Inteiro.`,
-          'number.min': `{#label} deve possuir um valor mínimo de {#limit}.`,
-          'number.max': `{#label} deve possuir um valor máximo de {#limit}.`,
+          ...defaultValidationMessages,
           'number.unsafe': `{#label} deve possuir um valor entre ${MIN_INTEGER} e ${max}.`,
         }),
     });
@@ -836,12 +679,7 @@ const schemas = {
         .max(MAX_INTEGER)
         .when('$required.tabcash', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'number.base': `{#label} deve ser do tipo Number.`,
-          'number.integer': `{#label} deve ser um Inteiro.`,
-          'number.min': `{#label} deve possuir um valor mínimo de {#limit}.`,
-          'number.max': `{#label} deve possuir um valor máximo de {#limit}.`,
+          ...defaultValidationMessages,
           'number.unsafe': `{#label} deve possuir um valor entre ${MIN_INTEGER} e ${MAX_INTEGER}.`,
         }),
     });
@@ -855,10 +693,7 @@ const schemas = {
         .invalid(null)
         .when('$required.transaction_type', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'string.base': `{#label} deve ser do tipo String.`,
-          'any.invalid': `{#label} possui o valor inválido "{#value}".`,
+          ...defaultValidationMessages,
           'any.only': `{#label} deve possuir um dos seguintes valores: "credit" e "debit".`,
         }),
     });
@@ -872,10 +707,7 @@ const schemas = {
         .invalid(null)
         .when('$required.ban_type', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `{#label} é um campo obrigatório.`,
-          'string.empty': `{#label} não pode estar em branco.`,
-          'string.base': `{#label} deve ser do tipo String.`,
-          'any.invalid': `{#label} possui o valor inválido "{#value}".`,
+          ...defaultValidationMessages,
           'any.only': `{#label} deve possuir um dos seguintes valores: "nuke".`,
         }),
     });

--- a/models/validator.js
+++ b/models/validator.js
@@ -15,7 +15,7 @@ const defaultSchema = Joi.object()
   .min(1)
   .messages({
     'any.invalid': '{#label} possui o valor inválido "{#value}".',
-    'any.only': '{#label} não aceita o valor "{#value}".',
+    'any.only': '{#label} deve possuir um dos seguintes valores: {#valids}.',
     'any.required': '{#label} é um campo obrigatório.',
     'array.base': '{#label} deve ser do tipo Array.',
     'boolean.base': '{#label} deve ser do tipo Boolean.',
@@ -77,6 +77,10 @@ export default function validator(object, keys) {
     },
     errors: {
       escapeHtml: true,
+      wrap: {
+        array: false,
+        string: '"',
+      },
     },
   });
 
@@ -242,10 +246,7 @@ const schemas = {
       status: Joi.string()
         .trim()
         .valid('draft', 'published', 'deleted')
-        .when('$required.status', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
-        .messages({
-          'any.only': `{#label} deve possuir um dos seguintes valores: "draft", "published" ou "deleted".`,
-        }),
+        .when('$required.status', { is: 'required', then: Joi.required(), otherwise: Joi.optional() }),
     });
   },
 
@@ -366,10 +367,7 @@ const schemas = {
         .trim()
         .valid('new', 'old', 'relevant')
         .default('relevant')
-        .when('$required.strategy', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
-        .messages({
-          'any.only': `{#label} deve possuir um dos seguintes valores: "new", "old" ou "relevant".`,
-        }),
+        .when('$required.strategy', { is: 'required', then: Joi.required(), otherwise: Joi.optional() }),
     });
   },
 
@@ -380,10 +378,7 @@ const schemas = {
       order: Joi.string()
         .trim()
         .valid('created_at DESC', 'created_at ASC', 'published_at DESC', 'published_at ASC')
-        .when('$required.order', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
-        .messages({
-          'any.only': `{#label} deve possuir um dos seguintes valores: "created_at DESC", "created_at ASC", "published_at DESC" ou "published_at ASC".`,
-        }),
+        .when('$required.order', { is: 'required', then: Joi.required(), otherwise: Joi.optional() }),
     });
   },
 
@@ -440,9 +435,7 @@ const schemas = {
 
   $not_null: function () {
     return Joi.object({
-      $not_null: Joi.array().optional().items(Joi.string().valid('parent_id')).messages({
-        'any.only': `{#label} deve conter um dos seguintes valores: "parent_id".`,
-      }),
+      $not_null: Joi.array().optional().items(Joi.string().valid('parent_id')),
     });
   },
 
@@ -528,21 +521,25 @@ const schemas = {
 
   event: function () {
     return Joi.object({
-      type: Joi.string().valid(
-        'create:user',
-        'update:user',
-        'ban:user',
-        'create:content:text_root',
-        'create:content:text_child',
-        'update:content:text_root',
-        'update:content:text_child',
-        'update:content:tabcoins',
-        'firewall:block_users',
-        'firewall:block_contents:text_root',
-        'firewall:block_contents:text_child',
-        'reward:user:tabcoins',
-        'system:update:tabcoins',
-      ),
+      type: Joi.string()
+        .valid(
+          'create:user',
+          'update:user',
+          'ban:user',
+          'create:content:text_root',
+          'create:content:text_child',
+          'update:content:text_root',
+          'update:content:text_child',
+          'update:content:tabcoins',
+          'firewall:block_users',
+          'firewall:block_contents:text_root',
+          'firewall:block_contents:text_child',
+          'reward:user:tabcoins',
+          'system:update:tabcoins',
+        )
+        .messages({
+          'any.only': '{#label} não aceita o valor "{#value}".',
+        }),
       originatorUserId: Joi.string().guid({ version: 'uuidv4' }).optional(),
       originatorIp: Joi.string()
         .ip({
@@ -658,10 +655,7 @@ const schemas = {
       transaction_type: Joi.string()
         .trim()
         .valid('credit', 'debit')
-        .when('$required.transaction_type', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
-        .messages({
-          'any.only': `{#label} deve possuir um dos seguintes valores: "credit" e "debit".`,
-        }),
+        .when('$required.transaction_type', { is: 'required', then: Joi.required(), otherwise: Joi.optional() }),
     });
   },
 
@@ -670,10 +664,7 @@ const schemas = {
       ban_type: Joi.string()
         .trim()
         .valid('nuke')
-        .when('$required.ban_type', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
-        .messages({
-          'any.only': `{#label} deve possuir um dos seguintes valores: "nuke".`,
-        }),
+        .when('$required.ban_type', { is: 'required', then: Joi.required(), otherwise: Joi.optional() }),
     });
   },
 };

--- a/models/validator.js
+++ b/models/validator.js
@@ -59,10 +59,9 @@ const schemas = {
   id: function () {
     return Joi.object({
       id: Joi.string()
-        .allow(null)
         .trim()
         .guid({ version: 'uuidv4' })
-        .when('$required.id', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
+        .when('$required.id', { is: 'required', then: Joi.required(), otherwise: Joi.optional().allow(null) })
         .messages({
           'any.required': `"id" é um campo obrigatório.`,
           'string.empty': `"id" não pode estar em branco.`,
@@ -223,10 +222,9 @@ const schemas = {
   parent_id: function () {
     return Joi.object({
       parent_id: Joi.string()
-        .allow(null)
         .trim()
         .guid({ version: 'uuidv4' })
-        .when('$required.parent_id', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
+        .when('$required.parent_id', { is: 'required', then: Joi.required(), otherwise: Joi.optional().allow(null) })
         .messages({
           'any.required': `"parent_id" é um campo obrigatório.`,
           'string.empty': `"parent_id" não pode estar em branco.`,
@@ -264,10 +262,9 @@ const schemas = {
           /^(\s|\p{C}|\u2800|\u034f|\u115f|\u1160|\u17b4|\u17b5|\u3164|\uffa0)+|(\s|\p{C}|\u2800|\u034f|\u115f|\u1160|\u17b4|\u17b5|\u3164|\uffa0)+$|\u0000/gu,
           '',
         )
-        .allow(null)
         .min(1)
         .max(255)
-        .when('$required.title', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
+        .when('$required.title', { is: 'required', then: Joi.required(), otherwise: Joi.optional().allow(null) })
         .messages({
           'any.required': `"title" é um campo obrigatório.`,
           'string.empty': `"title" não pode estar em branco.`,
@@ -323,12 +320,11 @@ const schemas = {
   source_url: function () {
     return Joi.object({
       source_url: Joi.string()
-        .allow(null)
         .replace(/\u0000/g, '')
         .trim()
         .max(2000)
         .pattern(/^https?:\/\/([-\p{Ll}\d_]{1,255}\.)+[-a-z0-9]{2,24}(:[0-9]{1,5})?([/?#]\S*)?$/u)
-        .when('$required.source_url', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
+        .when('$required.source_url', { is: 'required', then: Joi.required(), otherwise: Joi.optional().allow(null) })
         .messages({
           'any.required': `"source_url" é um campo obrigatório.`,
           'string.empty': `"source_url" não pode estar em branco.`,
@@ -343,10 +339,9 @@ const schemas = {
   owner_id: function () {
     return Joi.object({
       owner_id: Joi.string()
-        .allow(null)
         .trim()
         .guid({ version: 'uuidv4' })
-        .when('$required.owner_id', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
+        .when('$required.owner_id', { is: 'required', then: Joi.required(), otherwise: Joi.optional().allow(null) })
         .messages({
           'any.required': `"owner_id" é um campo obrigatório.`,
           'string.empty': `"owner_id" não pode estar em branco.`,
@@ -383,8 +378,7 @@ const schemas = {
   published_at: function () {
     return Joi.object({
       published_at: Joi.date()
-        .allow(null)
-        .when('$required.published_at', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
+        .when('$required.published_at', { is: 'required', then: Joi.required(), otherwise: Joi.optional().allow(null) })
         .messages({
           'any.required': `"published_at" é um campo obrigatório.`,
           'string.empty': `"published_at" não pode estar em branco.`,
@@ -396,8 +390,7 @@ const schemas = {
   deleted_at: function () {
     return Joi.object({
       deleted_at: Joi.date()
-        .allow(null)
-        .when('$required.deleted_at', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
+        .when('$required.deleted_at', { is: 'required', then: Joi.required(), otherwise: Joi.optional().allow(null) })
         .messages({
           'any.required': `"deleted_at" é um campo obrigatório.`,
           'string.empty': `"deleted_at" não pode estar em branco.`,
@@ -409,8 +402,7 @@ const schemas = {
   expires_at: function () {
     return Joi.object({
       expires_at: Joi.date()
-        .allow(null)
-        .when('$required.expires_at', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
+        .when('$required.expires_at', { is: 'required', then: Joi.required(), otherwise: Joi.optional().allow(null) })
         .messages({
           'any.required': `"expires_at" é um campo obrigatório.`,
           'string.empty': `"expires_at" não pode estar em branco.`,

--- a/models/validator.js
+++ b/models/validator.js
@@ -63,10 +63,10 @@ const schemas = {
         .guid({ version: 'uuidv4' })
         .when('$required.id', { is: 'required', then: Joi.required(), otherwise: Joi.optional().allow(null) })
         .messages({
-          'any.required': `"id" é um campo obrigatório.`,
-          'string.empty': `"id" não pode estar em branco.`,
-          'string.base': `"id" deve ser do tipo String.`,
-          'string.guid': `"id" deve possuir um token UUID na versão 4.`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'string.base': `{#label} deve ser do tipo String.`,
+          'string.guid': `{#label} deve possuir um token UUID na versão 4.`,
         }),
     });
   },
@@ -82,13 +82,13 @@ const schemas = {
         .custom(checkReservedUsernames, 'check if username is reserved')
         .when('$required.username', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `"username" é um campo obrigatório.`,
-          'string.empty': `"username" não pode estar em branco.`,
-          'string.base': `"username" deve ser do tipo String.`,
-          'string.alphanum': `"username" deve conter apenas caracteres alfanuméricos.`,
-          'string.min': `"username" deve conter no mínimo {#limit} caracteres.`,
-          'string.max': `"username" deve conter no máximo {#limit} caracteres.`,
-          'any.invalid': `"username" possui o valor inválido "null".`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'string.base': `{#label} deve ser do tipo String.`,
+          'string.alphanum': `{#label} deve conter apenas caracteres alfanuméricos.`,
+          'string.min': `{#label} deve conter no mínimo {#limit} caracteres.`,
+          'string.max': `{#label} deve conter no máximo {#limit} caracteres.`,
+          'any.invalid': `{#label} possui o valor inválido "{#value}".`,
           'username.reserved': `Este nome de usuário não está disponível para uso.`,
         }),
     });
@@ -105,13 +105,13 @@ const schemas = {
         .custom(checkReservedUsernames, 'check if username is reserved')
         .when('$required.owner_username', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `"owner_username" é um campo obrigatório.`,
-          'string.empty': `"owner_username" não pode estar em branco.`,
-          'string.base': `"owner_username" deve ser do tipo String.`,
-          'string.alphanum': `"owner_username" deve conter apenas caracteres alfanuméricos.`,
-          'string.min': `"owner_username" deve conter no mínimo {#limit} caracteres.`,
-          'string.max': `"owner_username" deve conter no máximo {#limit} caracteres.`,
-          'any.invalid': `"owner_username" possui o valor inválido "null".`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'string.base': `{#label} deve ser do tipo String.`,
+          'string.alphanum': `{#label} deve conter apenas caracteres alfanuméricos.`,
+          'string.min': `{#label} deve conter no mínimo {#limit} caracteres.`,
+          'string.max': `{#label} deve conter no máximo {#limit} caracteres.`,
+          'any.invalid': `{#label} possui o valor inválido "{#value}".`,
           'username.reserved': `Este nome de usuário não está disponível para uso.`,
         }),
     });
@@ -128,11 +128,11 @@ const schemas = {
         .invalid(null)
         .when('$required.email', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `"email" é um campo obrigatório.`,
-          'string.empty': `"email" não pode estar em branco.`,
-          'string.base': `"email" deve ser do tipo String.`,
-          'string.email': `"email" deve conter um email válido.`,
-          'any.invalid': `"email" possui o valor inválido "null".`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'string.base': `{#label} deve ser do tipo String.`,
+          'string.email': `{#label} deve conter um email válido.`,
+          'any.invalid': `{#label} possui o valor inválido "{#value}".`,
         }),
     });
   },
@@ -147,12 +147,12 @@ const schemas = {
         .invalid(null)
         .when('$required.password', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `"password" é um campo obrigatório.`,
-          'string.empty': `"password" não pode estar em branco.`,
-          'string.base': `"password" deve ser do tipo String.`,
-          'string.min': `"password" deve conter no mínimo {#limit} caracteres.`,
-          'string.max': `"password" deve conter no máximo {#limit} caracteres.`,
-          'any.invalid': `"password" possui o valor inválido "null".`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'string.base': `{#label} deve ser do tipo String.`,
+          'string.min': `{#label} deve conter no mínimo {#limit} caracteres.`,
+          'string.max': `{#label} deve conter no máximo {#limit} caracteres.`,
+          'any.invalid': `{#label} possui o valor inválido "{#value}".`,
         }),
     });
   },
@@ -166,10 +166,10 @@ const schemas = {
         .allow('')
         .when('$required.description', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `"description" é um campo obrigatório.`,
-          'string.base': `"description" deve ser do tipo String.`,
-          'string.max': `"description" deve conter no máximo {#limit} caracteres.`,
-          'any.invalid': `"description" possui o valor inválido "null".`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.base': `{#label} deve ser do tipo String.`,
+          'string.max': `{#label} deve conter no máximo {#limit} caracteres.`,
+          'any.invalid': `{#label} possui o valor inválido "{#value}".`,
         }),
     });
   },
@@ -180,10 +180,10 @@ const schemas = {
         .invalid(null)
         .when('$required.notifications', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `"notifications" é um campo obrigatório.`,
-          'string.empty': `"notifications" não pode estar em branco.`,
-          'boolean.base': `"notifications" deve ser do tipo Boolean.`,
-          'any.invalid': `"notifications" possui o valor inválido "null".`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'boolean.base': `{#label} deve ser do tipo Boolean.`,
+          'any.invalid': `{#label} possui o valor inválido "{#value}".`,
         }),
     });
   },
@@ -195,10 +195,10 @@ const schemas = {
         .guid({ version: 'uuidv4' })
         .when('$required.token_id', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `"token_id" é um campo obrigatório.`,
-          'string.empty': `"token_id" não pode estar em branco.`,
-          'string.base': `"token_id" deve ser do tipo String.`,
-          'string.guid': `"token_id" deve possuir um token UUID na versão 4.`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'string.base': `{#label} deve ser do tipo String.`,
+          'string.guid': `{#label} deve possuir um token UUID na versão 4.`,
         }),
     });
   },
@@ -210,11 +210,11 @@ const schemas = {
         .alphanum()
         .when('$required.session_id', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `"session_id" é um campo obrigatório.`,
-          'string.empty': `"session_id" não pode estar em branco.`,
-          'string.base': `"session_id" deve ser do tipo String.`,
-          'string.length': `"session_id" deve possuir {#limit} caracteres.`,
-          'string.alphanum': `"session_id" deve conter apenas caracteres alfanuméricos.`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'string.base': `{#label} deve ser do tipo String.`,
+          'string.length': `{#label} deve possuir {#limit} caracteres.`,
+          'string.alphanum': `{#label} deve conter apenas caracteres alfanuméricos.`,
         }),
     });
   },
@@ -226,10 +226,10 @@ const schemas = {
         .guid({ version: 'uuidv4' })
         .when('$required.parent_id', { is: 'required', then: Joi.required(), otherwise: Joi.optional().allow(null) })
         .messages({
-          'any.required': `"parent_id" é um campo obrigatório.`,
-          'string.empty': `"parent_id" não pode estar em branco.`,
-          'string.base': `"parent_id" deve ser do tipo String.`,
-          'string.guid': `"parent_id" deve possuir um token UUID na versão 4.`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'string.base': `{#label} deve ser do tipo String.`,
+          'string.guid': `{#label} deve possuir um token UUID na versão 4.`,
         }),
     });
   },
@@ -245,12 +245,12 @@ const schemas = {
         .pattern(/^[a-z0-9](-?[a-z0-9])*$/)
         .when('$required.slug', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `"slug" é um campo obrigatório.`,
-          'string.empty': `"slug" não pode estar em branco.`,
-          'string.base': `"slug" deve ser do tipo String.`,
-          'string.min': `"slug" deve conter no mínimo {#limit} caractere.`,
-          'string.pattern.base': `"slug" está no formato errado.`,
-          'any.invalid': `"slug" possui o valor inválido "null".`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'string.base': `{#label} deve ser do tipo String.`,
+          'string.min': `{#label} deve conter no mínimo {#limit} caractere.`,
+          'string.pattern.base': `{#label} está no formato errado.`,
+          'any.invalid': `{#label} possui o valor inválido "{#value}".`,
         }),
     });
   },
@@ -266,11 +266,11 @@ const schemas = {
         .max(255)
         .when('$required.title', { is: 'required', then: Joi.required(), otherwise: Joi.optional().allow(null) })
         .messages({
-          'any.required': `"title" é um campo obrigatório.`,
-          'string.empty': `"title" não pode estar em branco.`,
-          'string.base': `"title" deve ser do tipo String.`,
-          'string.min': `"title" deve conter no mínimo {#limit} caracteres.`,
-          'string.max': `"title" deve conter no máximo {#limit} caracteres.`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'string.base': `{#label} deve ser do tipo String.`,
+          'string.min': `{#label} deve conter no mínimo {#limit} caracteres.`,
+          'string.max': `{#label} deve conter no máximo {#limit} caracteres.`,
         }),
     });
   },
@@ -286,14 +286,14 @@ const schemas = {
         .custom(withoutMarkdown, 'check if is empty without markdown')
         .when('$required.body', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `"body" é um campo obrigatório.`,
-          'string.empty': `"body" não pode estar em branco.`,
-          'string.base': `"body" deve ser do tipo String.`,
-          'string.min': `"body" deve conter no mínimo {#limit} caracteres.`,
-          'string.max': `"body" deve conter no máximo {#limit} caracteres.`,
-          'any.invalid': `"body" possui o valor inválido "null".`,
-          'string.pattern.invert.base': `"body" deve começar com caracteres visíveis.`,
-          'markdown.empty': `Markdown deve conter algum texto`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'string.base': `{#label} deve ser do tipo String.`,
+          'string.min': `{#label} deve conter no mínimo {#limit} caracteres.`,
+          'string.max': `{#label} deve conter no máximo {#limit} caracteres.`,
+          'any.invalid': `{#label} possui o valor inválido "{#value}".`,
+          'string.pattern.invert.base': `{#label} deve começar com caracteres visíveis.`,
+          'markdown.empty': `Markdown deve conter algum texto.`,
         }),
     });
   },
@@ -306,13 +306,13 @@ const schemas = {
         .invalid(null)
         .when('$required.status', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `"status" é um campo obrigatório.`,
-          'string.empty': `"status" não pode estar em branco.`,
-          'string.base': `"status" deve ser do tipo String.`,
-          'string.min': `"status" deve conter no mínimo {#limit} caracteres.`,
-          'string.max': `"status" deve conter no máximo {#limit} caracteres.`,
-          'any.invalid': `"status" possui o valor inválido "null".`,
-          'any.only': `"status" deve possuir um dos seguintes valores: "draft", "published" ou "deleted".`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'string.base': `{#label} deve ser do tipo String.`,
+          'string.min': `{#label} deve conter no mínimo {#limit} caracteres.`,
+          'string.max': `{#label} deve conter no máximo {#limit} caracteres.`,
+          'any.invalid': `{#label} possui o valor inválido "{#value}".`,
+          'any.only': `{#label} deve possuir um dos seguintes valores: "draft", "published" ou "deleted".`,
         }),
     });
   },
@@ -326,12 +326,12 @@ const schemas = {
         .pattern(/^https?:\/\/([-\p{Ll}\d_]{1,255}\.)+[-a-z0-9]{2,24}(:[0-9]{1,5})?([/?#]\S*)?$/u)
         .when('$required.source_url', { is: 'required', then: Joi.required(), otherwise: Joi.optional().allow(null) })
         .messages({
-          'any.required': `"source_url" é um campo obrigatório.`,
-          'string.empty': `"source_url" não pode estar em branco.`,
-          'string.base': `"source_url" deve ser do tipo String.`,
-          'string.max': `"source_url" deve conter no máximo {#limit} caracteres.`,
-          'any.invalid': `"source_url" possui o valor inválido "null".`,
-          'string.pattern.base': `"source_url" deve possuir uma URL válida e utilizando os protocolos HTTP ou HTTPS.`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'string.base': `{#label} deve ser do tipo String.`,
+          'string.max': `{#label} deve conter no máximo {#limit} caracteres.`,
+          'any.invalid': `{#label} possui o valor inválido "{#value}".`,
+          'string.pattern.base': `{#label} deve possuir uma URL válida e utilizando os protocolos HTTP ou HTTPS.`,
         }),
     });
   },
@@ -343,10 +343,10 @@ const schemas = {
         .guid({ version: 'uuidv4' })
         .when('$required.owner_id', { is: 'required', then: Joi.required(), otherwise: Joi.optional().allow(null) })
         .messages({
-          'any.required': `"owner_id" é um campo obrigatório.`,
-          'string.empty': `"owner_id" não pode estar em branco.`,
-          'string.base': `"owner_id" deve ser do tipo String.`,
-          'string.guid': `"owner_id" deve possuir um token UUID na versão 4.`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'string.base': `{#label} deve ser do tipo String.`,
+          'string.guid': `{#label} deve possuir um token UUID na versão 4.`,
         }),
     });
   },
@@ -356,9 +356,9 @@ const schemas = {
       created_at: Joi.date()
         .when('$required.created_at', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `"created_at" é um campo obrigatório.`,
-          'string.empty': `"created_at" não pode estar em branco.`,
-          'string.base': `"created_at" deve ser do tipo Date.`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'string.base': `{#label} deve ser do tipo Date.`,
         }),
     });
   },
@@ -368,9 +368,9 @@ const schemas = {
       updated_at: Joi.date()
         .when('$required.updated_at', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `"updated_at" é um campo obrigatório.`,
-          'string.empty': `"updated_at" não pode estar em branco.`,
-          'string.base': `"updated_at" deve ser do tipo Date.`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'string.base': `{#label} deve ser do tipo Date.`,
         }),
     });
   },
@@ -380,9 +380,9 @@ const schemas = {
       published_at: Joi.date()
         .when('$required.published_at', { is: 'required', then: Joi.required(), otherwise: Joi.optional().allow(null) })
         .messages({
-          'any.required': `"published_at" é um campo obrigatório.`,
-          'string.empty': `"published_at" não pode estar em branco.`,
-          'string.base': `"published_at" deve ser do tipo Date.`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'string.base': `{#label} deve ser do tipo Date.`,
         }),
     });
   },
@@ -392,9 +392,9 @@ const schemas = {
       deleted_at: Joi.date()
         .when('$required.deleted_at', { is: 'required', then: Joi.required(), otherwise: Joi.optional().allow(null) })
         .messages({
-          'any.required': `"deleted_at" é um campo obrigatório.`,
-          'string.empty': `"deleted_at" não pode estar em branco.`,
-          'string.base': `"deleted_at" deve ser do tipo Date.`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'string.base': `{#label} deve ser do tipo Date.`,
         }),
     });
   },
@@ -404,9 +404,9 @@ const schemas = {
       expires_at: Joi.date()
         .when('$required.expires_at', { is: 'required', then: Joi.required(), otherwise: Joi.optional().allow(null) })
         .messages({
-          'any.required': `"expires_at" é um campo obrigatório.`,
-          'string.empty': `"expires_at" não pode estar em branco.`,
-          'string.base': `"expires_at" deve ser do tipo Date.`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'string.base': `{#label} deve ser do tipo Date.`,
         }),
     });
   },
@@ -417,49 +417,53 @@ const schemas = {
         .allow(false)
         .when('$required.used', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `"used" é um campo obrigatório.`,
-          'string.empty': `"used" não pode estar em branco.`,
-          'boolean.base': `"used" deve ser do tipo Boolean.`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'boolean.base': `{#label} deve ser do tipo Boolean.`,
         }),
     });
   },
 
   page: function () {
+    const min = 1;
+    const max = 9007199254740990;
     return Joi.object({
       page: Joi.number()
         .integer()
-        .min(1)
-        .max(9007199254740990)
+        .min(min)
+        .max(max)
         .default(1)
         .when('$required.page', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `"page" é um campo obrigatório.`,
-          'string.empty': `"page" não pode estar em branco.`,
-          'number.base': `"page" deve ser do tipo Number.`,
-          'number.integer': `"page" deve ser um Inteiro.`,
-          'number.min': `"page" deve possuir um valor mínimo de 1.`,
-          'number.max': `"page" deve possuir um valor máximo de 9007199254740990.`,
-          'number.unsafe': `"page" deve possuir um valor máximo de 9007199254740990.`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'number.base': `{#label} deve ser do tipo Number.`,
+          'number.integer': `{#label} deve ser um Inteiro.`,
+          'number.min': `{#label} deve possuir um valor mínimo de {#limit}.`,
+          'number.max': `{#label} deve possuir um valor máximo de {#limit}.`,
+          'number.unsafe': `{#label} deve possuir um valor entre ${min} e ${max}.`,
         }),
     });
   },
 
   per_page: function () {
+    const min = 1;
+    const max = 100;
     return Joi.object({
       per_page: Joi.number()
         .integer()
-        .min(1)
-        .max(100)
+        .min(min)
+        .max(max)
         .default(30)
         .when('$required.per_page', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `"per_page" é um campo obrigatório.`,
-          'string.empty': `"per_page" não pode estar em branco.`,
-          'number.base': `"per_page" deve ser do tipo Number.`,
-          'number.integer': `"per_page" deve ser um Inteiro.`,
-          'number.min': `"per_page" deve possuir um valor mínimo de 1.`,
-          'number.max': `"per_page" deve possuir um valor máximo de 100.`,
-          'number.unsafe': `"per_page" deve possuir um valor máximo de 100.`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'number.base': `{#label} deve ser do tipo Number.`,
+          'number.integer': `{#label} deve ser um Inteiro.`,
+          'number.min': `{#label} deve possuir um valor mínimo de {#limit}.`,
+          'number.max': `{#label} deve possuir um valor máximo de {#limit}.`,
+          'number.unsafe': `{#label} deve possuir um valor entre ${min} e ${max}.`,
         }),
     });
   },
@@ -473,11 +477,11 @@ const schemas = {
         .invalid(null)
         .when('$required.strategy', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `"strategy" é um campo obrigatório.`,
-          'string.empty': `"strategy" não pode estar em branco.`,
-          'string.base': `"strategy" deve ser do tipo String.`,
-          'any.invalid': `"strategy" possui o valor inválido "null".`,
-          'any.only': `"strategy" deve possuir um dos seguintes valores: "new", "old" ou "relevant".`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'string.base': `{#label} deve ser do tipo String.`,
+          'any.invalid': `{#label} possui o valor inválido "{#value}".`,
+          'any.only': `{#label} deve possuir um dos seguintes valores: "new", "old" ou "relevant".`,
         }),
     });
   },
@@ -491,17 +495,17 @@ const schemas = {
         .valid('created_at DESC', 'created_at ASC', 'published_at DESC', 'published_at ASC')
         .when('$required.order', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `"order" é um campo obrigatório.`,
-          'string.empty': `"order" não pode estar em branco.`,
-          'string.base': `"order" deve ser do tipo String.`,
-          'any.only': `"order" deve possuir um dos seguintes valores: "created_at DESC", "created_at ASC", "published_at DESC" ou "published_at ASC".`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'string.base': `{#label} deve ser do tipo String.`,
+          'any.only': `{#label} deve possuir um dos seguintes valores: "created_at DESC", "created_at ASC", "published_at DESC" ou "published_at ASC".`,
         }),
     });
   },
 
   where: function () {
     let whereSchema = Joi.object({}).optional().min(1).messages({
-      'object.base': `"where" deve ser do tipo Object.`,
+      'object.base': `{#label} deve ser do tipo Object.`,
     });
 
     for (const key of [
@@ -529,21 +533,23 @@ const schemas = {
   },
 
   limit: function () {
+    const min = 1;
+    const max = 9007199254740990;
     return Joi.object({
       limit: Joi.number()
         .integer()
-        .min(1)
-        .max(9007199254740990)
+        .min(min)
+        .max(max)
         .default(null)
         .when('$required.limit', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `"limit" é um campo obrigatório.`,
-          'string.empty': `"limit" não pode estar em branco.`,
-          'number.base': `"limit" deve ser do tipo Number.`,
-          'number.integer': `"limit" deve ser um Inteiro.`,
-          'number.min': `"limit" deve possuir um valor mínimo de 1.`,
-          'number.max': `"limit" deve possuir um valor máximo de 9007199254740990.`,
-          'number.unsafe': `"limit" deve possuir um valor máximo de 9007199254740990.`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'number.base': `{#label} deve ser do tipo Number.`,
+          'number.integer': `{#label} deve ser um Inteiro.`,
+          'number.min': `{#label} deve possuir um valor mínimo de {#limit}.`,
+          'number.max': `{#label} deve possuir um valor máximo de {#limit}.`,
+          'number.unsafe': `{#label} deve possuir um valor entre ${min} e ${max}.`,
         }),
     });
   },
@@ -556,7 +562,7 @@ const schemas = {
         .optional()
         .items(Joi.link('#status'))
         .messages({
-          'array.base': `"#or" deve ser do tipo Array.`,
+          'array.base': `{#label} deve ser do tipo Array.`,
         })
         .shared(statusSchemaWithId),
     });
@@ -565,8 +571,8 @@ const schemas = {
   $not_null: function () {
     return Joi.object({
       $not_null: Joi.array().optional().items(Joi.string().valid('parent_id')).messages({
-        'array.base': `"#not_null" deve ser do tipo Array.`,
-        'any.only': `"#not_null" deve conter um dos seguintes valores: "parent_id".`,
+        'array.base': `{#label} deve ser do tipo Array.`,
+        'any.only': `{#label} deve conter um dos seguintes valores: "parent_id".`,
       }),
     });
   },
@@ -585,9 +591,9 @@ const schemas = {
         .default(false)
         .when('$required.count', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `"count" é um campo obrigatório.`,
-          'string.empty': `"count" não pode estar em branco.`,
-          'boolean.base': `"count" deve ser do tipo Boolean.`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'boolean.base': `{#label} deve ser do tipo Boolean.`,
         }),
     });
   },
@@ -597,8 +603,8 @@ const schemas = {
       children_deep_count: Joi.number()
         .when('$required.children_deep_count', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `"children_deep_count" é um campo obrigatório.`,
-          'number.integer': `"children_deep_count" deve ser um Inteiro.`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'number.integer': `{#label} deve ser um Inteiro.`,
         }),
     });
   },
@@ -606,7 +612,7 @@ const schemas = {
   content: function () {
     let contentSchema = Joi.object({
       children: Joi.array().optional().items(Joi.link('#content')).messages({
-        'array.base': `"children" deve ser do tipo Array.`,
+        'array.base': `{#label} deve ser do tipo Array.`,
       }),
     })
       .required()
@@ -648,9 +654,9 @@ const schemas = {
         .allow(false)
         .when('$required.with_children', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `"with_children" é um campo obrigatório.`,
-          'string.empty': `"with_children" não pode estar em branco.`,
-          'boolean.base': `"with_children" deve ser do tipo Boolean.`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'boolean.base': `{#label} deve ser do tipo Boolean.`,
         }),
     });
   },
@@ -661,9 +667,9 @@ const schemas = {
         .allow(false)
         .when('$required.with_root', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `"with_root" é um campo obrigatório.`,
-          'string.empty': `"with_root" não pode estar em branco.`,
-          'boolean.base': `"with_root" deve ser do tipo Boolean.`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'boolean.base': `{#label} deve ser do tipo Boolean.`,
         }),
     });
   },
@@ -687,15 +693,15 @@ const schemas = {
           'system:update:tabcoins',
         )
         .messages({
-          'any.required': `"type" é um campo obrigatório.`,
-          'string.empty': `"type" não pode estar em branco.`,
-          'string.base': `"type" deve ser do tipo String.`,
-          'any.only': `"type" não possui um valor válido.`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'string.base': `{#label} deve ser do tipo String.`,
+          'any.only': `{#label} não possui um valor válido.`,
         }),
       originatorUserId: Joi.string().guid({ version: 'uuidv4' }).optional().messages({
-        'string.empty': `"originatorId" não pode estar em branco.`,
-        'string.base': `"originatorId" deve ser do tipo String.`,
-        'string.guid': `"originatorId" deve possuir um token UUID na versão 4.`,
+        'string.empty': `{#label} não pode estar em branco.`,
+        'string.base': `{#label} deve ser do tipo String.`,
+        'string.guid': `{#label} deve possuir um token UUID na versão 4.`,
       }),
       originatorIp: Joi.string()
         .ip({
@@ -703,9 +709,9 @@ const schemas = {
         })
         .optional()
         .messages({
-          'string.empty': `"originatorIp" não pode estar em branco.`,
-          'string.base': `"originatorIp" deve ser do tipo String.`,
-          'string.ip': `"originatorIp" deve possuir um IP válido`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'string.base': `{#label} deve ser do tipo String.`,
+          'string.ip': `{#label} deve possuir um IP válido.`,
         }),
       metadata: Joi.when('type', [
         {
@@ -771,51 +777,53 @@ const schemas = {
         .max(MAX_INTEGER)
         .when('$required.tabcoins', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `"tabcoins" é um campo obrigatório.`,
-          'string.empty': `"tabcoins" não pode estar em branco.`,
-          'number.base': `"tabcoins" deve ser do tipo Number.`,
-          'number.integer': `"tabcoins" deve ser um Inteiro.`,
-          'number.min': `"tabcoins" deve possuir um valor mínimo de ${MIN_INTEGER}.`,
-          'number.max': `"tabcoins" deve possuir um valor máximo de ${MAX_INTEGER}.`,
-          'number.unsafe': `"tabcoins" deve possuir um valor máximo de ${MAX_INTEGER}.`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'number.base': `{#label} deve ser do tipo Number.`,
+          'number.integer': `{#label} deve ser um Inteiro.`,
+          'number.min': `{#label} deve possuir um valor mínimo de {#limit}.`,
+          'number.max': `{#label} deve possuir um valor máximo de {#limit}.`,
+          'number.unsafe': `{#label} deve possuir um valor entre ${MIN_INTEGER} e ${MAX_INTEGER}.`,
         }),
     });
   },
 
   tabcoins_credit: function () {
+    const min = 0;
     return Joi.object({
       tabcoins_credit: Joi.number()
         .integer()
-        .min(0)
+        .min(min)
         .max(MAX_INTEGER)
         .when('$required.tabcoins', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `"tabcoins_credit" é um campo obrigatório.`,
-          'string.empty': `"tabcoins_credit" não pode estar em branco.`,
-          'number.base': `"tabcoins_credit" deve ser do tipo Number.`,
-          'number.integer': `"tabcoins_credit" deve ser um Inteiro.`,
-          'number.min': `"tabcoins_credit" deve possuir um valor mínimo de 0.`,
-          'number.max': `"tabcoins_credit" deve possuir um valor máximo de ${MAX_INTEGER}.`,
-          'number.unsafe': `"tabcoins_credit" deve possuir um valor máximo de ${MAX_INTEGER}.`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'number.base': `{#label} deve ser do tipo Number.`,
+          'number.integer': `{#label} deve ser um Inteiro.`,
+          'number.min': `{#label} deve possuir um valor mínimo de {#limit}.`,
+          'number.max': `{#label} deve possuir um valor máximo de {#limit}.`,
+          'number.unsafe': `{#label} deve possuir um valor entre ${min} e ${MAX_INTEGER}.`,
         }),
     });
   },
 
   tabcoins_debit: function () {
+    const max = 0;
     return Joi.object({
       tabcoins_debit: Joi.number()
         .integer()
         .min(MIN_INTEGER)
-        .max(0)
+        .max(max)
         .when('$required.tabcoins', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `"tabcoins_debit" é um campo obrigatório.`,
-          'string.empty': `"tabcoins_debit" não pode estar em branco.`,
-          'number.base': `"tabcoins_debit" deve ser do tipo Number.`,
-          'number.integer': `"tabcoins_debit" deve ser um Inteiro.`,
-          'number.min': `"tabcoins_debit" deve possuir um valor mínimo de ${MIN_INTEGER}.`,
-          'number.max': `"tabcoins_debit" deve possuir um valor máximo de 0.`,
-          'number.unsafe': `"tabcoins_debit" deve possuir um valor máximo de 0.`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'number.base': `{#label} deve ser do tipo Number.`,
+          'number.integer': `{#label} deve ser um Inteiro.`,
+          'number.min': `{#label} deve possuir um valor mínimo de {#limit}.`,
+          'number.max': `{#label} deve possuir um valor máximo de {#limit}.`,
+          'number.unsafe': `{#label} deve possuir um valor entre ${MIN_INTEGER} e ${max}.`,
         }),
     });
   },
@@ -828,13 +836,13 @@ const schemas = {
         .max(MAX_INTEGER)
         .when('$required.tabcash', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `"tabcash" é um campo obrigatório.`,
-          'string.empty': `"tabcash" não pode estar em branco.`,
-          'number.base': `"tabcash" deve ser do tipo Number.`,
-          'number.integer': `"tabcash" deve ser um Inteiro.`,
-          'number.min': `"tabcash" deve possuir um valor mínimo de ${MIN_INTEGER}.`,
-          'number.max': `"tabcash" deve possuir um valor máximo de ${MAX_INTEGER}.`,
-          'number.unsafe': `"tabcash" deve possuir um valor máximo de ${MAX_INTEGER}.`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'number.base': `{#label} deve ser do tipo Number.`,
+          'number.integer': `{#label} deve ser um Inteiro.`,
+          'number.min': `{#label} deve possuir um valor mínimo de {#limit}.`,
+          'number.max': `{#label} deve possuir um valor máximo de {#limit}.`,
+          'number.unsafe': `{#label} deve possuir um valor entre ${MIN_INTEGER} e ${MAX_INTEGER}.`,
         }),
     });
   },
@@ -847,11 +855,11 @@ const schemas = {
         .invalid(null)
         .when('$required.transaction_type', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `"transaction_type" é um campo obrigatório.`,
-          'string.empty': `"transaction_type" não pode estar em branco.`,
-          'string.base': `"transaction_type" deve ser do tipo String.`,
-          'any.invalid': `"transaction_type" possui o valor inválido "null".`,
-          'any.only': `"transaction_type" deve possuir um dos seguintes valores: "credit" e "debit".`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'string.base': `{#label} deve ser do tipo String.`,
+          'any.invalid': `{#label} possui o valor inválido "{#value}".`,
+          'any.only': `{#label} deve possuir um dos seguintes valores: "credit" e "debit".`,
         }),
     });
   },
@@ -864,11 +872,11 @@ const schemas = {
         .invalid(null)
         .when('$required.ban_type', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
-          'any.required': `"ban_type" é um campo obrigatório.`,
-          'string.empty': `"ban_type" não pode estar em branco.`,
-          'string.base': `"ban_type" deve ser do tipo String.`,
-          'any.invalid': `"ban_type" possui o valor inválido "null".`,
-          'any.only': `"ban_type" deve possuir um dos seguintes valores: "nuke".`,
+          'any.required': `{#label} é um campo obrigatório.`,
+          'string.empty': `{#label} não pode estar em branco.`,
+          'string.base': `{#label} deve ser do tipo String.`,
+          'any.invalid': `{#label} possui o valor inválido "{#value}".`,
+          'any.only': `{#label} deve possuir um dos seguintes valores: "nuke".`,
         }),
     });
   },

--- a/models/validator.js
+++ b/models/validator.js
@@ -98,7 +98,6 @@ const schemas = {
         .min(3)
         .max(30)
         .trim()
-        .invalid(null)
         .custom(checkReservedUsernames, 'check if username is reserved')
         .when('$required.username', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages(defaultValidationMessages),
@@ -112,7 +111,6 @@ const schemas = {
         .min(3)
         .max(30)
         .trim()
-        .invalid(null)
         .custom(checkReservedUsernames, 'check if username is reserved')
         .when('$required.owner_username', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages(defaultValidationMessages),
@@ -127,7 +125,6 @@ const schemas = {
         .max(254)
         .lowercase()
         .trim()
-        .invalid(null)
         .when('$required.email', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages(defaultValidationMessages),
     });
@@ -140,7 +137,6 @@ const schemas = {
         .min(8)
         .max(72)
         .trim()
-        .invalid(null)
         .when('$required.password', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages(defaultValidationMessages),
     });
@@ -151,7 +147,6 @@ const schemas = {
       description: Joi.string()
         .replace(/(\s|\p{C}|\u2800|\u034f|\u115f|\u1160|\u17b4|\u17b5|\u3164|\uffa0)+$|\u0000/gsu, '')
         .max(5000)
-        .invalid(null)
         .allow('')
         .when('$required.description', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages(defaultValidationMessages),
@@ -161,7 +156,6 @@ const schemas = {
   notifications: function () {
     return Joi.object({
       notifications: Joi.boolean()
-        .invalid(null)
         .when('$required.notifications', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages(defaultValidationMessages),
     });
@@ -204,7 +198,6 @@ const schemas = {
         .max(226, 'utf8')
         .trim()
         .truncate()
-        .invalid(null)
         .pattern(/^[a-z0-9](-?[a-z0-9])*$/)
         .when('$required.slug', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
@@ -235,7 +228,6 @@ const schemas = {
         .replace(/(\s|\p{C}|\u2800|\u034f|\u115f|\u1160|\u17b4|\u17b5|\u3164|\uffa0)+$|\u0000/gsu, '')
         .min(1)
         .max(20000)
-        .invalid(null)
         .custom(withoutMarkdown, 'check if is empty without markdown')
         .when('$required.body', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
@@ -250,7 +242,6 @@ const schemas = {
       status: Joi.string()
         .trim()
         .valid('draft', 'published', 'deleted')
-        .invalid(null)
         .when('$required.status', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
           ...defaultValidationMessages,
@@ -327,7 +318,6 @@ const schemas = {
   used: function () {
     return Joi.object({
       used: Joi.boolean()
-        .allow(false)
         .when('$required.used', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages(defaultValidationMessages),
     });
@@ -373,7 +363,6 @@ const schemas = {
         .trim()
         .valid('new', 'old', 'relevant')
         .default('relevant')
-        .invalid(null)
         .when('$required.strategy', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
           ...defaultValidationMessages,
@@ -530,7 +519,6 @@ const schemas = {
   with_children: function () {
     return Joi.object({
       with_children: Joi.boolean()
-        .allow(false)
         .when('$required.with_children', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages(defaultValidationMessages),
     });
@@ -539,7 +527,6 @@ const schemas = {
   with_root: function () {
     return Joi.object({
       with_root: Joi.boolean()
-        .allow(false)
         .when('$required.with_root', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages(defaultValidationMessages),
     });
@@ -690,7 +677,6 @@ const schemas = {
       transaction_type: Joi.string()
         .trim()
         .valid('credit', 'debit')
-        .invalid(null)
         .when('$required.transaction_type', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
           ...defaultValidationMessages,
@@ -704,7 +690,6 @@ const schemas = {
       ban_type: Joi.string()
         .trim()
         .valid('nuke')
-        .invalid(null)
         .when('$required.ban_type', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({
           ...defaultValidationMessages,

--- a/tests/integration/api/v1/activation/patch.test.js
+++ b/tests/integration/api/v1/activation/patch.test.js
@@ -22,7 +22,7 @@ describe('PATCH /api/v1/activation', () => {
       expect(response.status).toEqual(400);
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('Body enviado deve ser do tipo Object.');
+      expect(responseBody.message).toEqual('"body" enviado deve ser do tipo Object.');
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);

--- a/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
@@ -849,7 +849,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       expect(response.status).toEqual(400);
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"body" possui o valor inválido "null".');
+      expect(responseBody.message).toEqual('"body" deve ser do tipo String.');
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
@@ -1244,7 +1244,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       expect(response.status).toEqual(400);
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"slug" possui o valor inválido "null".');
+      expect(responseBody.message).toEqual('"slug" deve ser do tipo String.');
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);

--- a/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
@@ -590,7 +590,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       expect(response.status).toEqual(400);
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('Markdown deve conter algum texto');
+      expect(responseBody.message).toEqual('Markdown deve conter algum texto.');
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);

--- a/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
@@ -1931,7 +1931,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
       expect(responseBody.message).toEqual(
-        '"status" deve possuir um dos seguintes valores: "draft", "published" ou "deleted".',
+        '"status" deve possuir um dos seguintes valores: "draft", "published", "deleted".',
       );
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
@@ -1970,7 +1970,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
       expect(responseBody.message).toEqual(
-        '"status" deve possuir um dos seguintes valores: "draft", "published" ou "deleted".',
+        '"status" deve possuir um dos seguintes valores: "draft", "published", "deleted".',
       );
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
@@ -2009,7 +2009,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
       expect(responseBody.message).toEqual(
-        '"status" deve possuir um dos seguintes valores: "draft", "published" ou "deleted".',
+        '"status" deve possuir um dos seguintes valores: "draft", "published", "deleted".',
       );
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);

--- a/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
@@ -130,7 +130,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       expect(response.status).toEqual(400);
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('Body enviado deve ser do tipo Object.');
+      expect(responseBody.message).toEqual('"body" enviado deve ser do tipo Object.');
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
@@ -155,7 +155,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       expect(response.status).toEqual(400);
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('Body enviado deve ser do tipo Object.');
+      expect(responseBody.message).toEqual('"body" enviado deve ser do tipo Object.');
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);

--- a/tests/integration/api/v1/contents/get.test.js
+++ b/tests/integration/api/v1/contents/get.test.js
@@ -1107,7 +1107,7 @@ describe('GET /api/v1/contents', () => {
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
-        message: '"page" deve possuir um valor máximo de 9007199254740990.',
+        message: `"page" deve possuir um valor entre 1 e 9007199254740990.`,
         action: 'Ajuste os dados enviados e tente novamente.',
         status_code: 400,
         error_id: responseBody.error_id,
@@ -1217,7 +1217,7 @@ describe('GET /api/v1/contents', () => {
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
-        message: '"per_page" deve possuir um valor máximo de 100.',
+        message: '"per_page" deve possuir um valor entre 1 e 100.',
         action: 'Ajuste os dados enviados e tente novamente.',
         status_code: 400,
         error_id: responseBody.error_id,

--- a/tests/integration/api/v1/contents/get.test.js
+++ b/tests/integration/api/v1/contents/get.test.js
@@ -73,7 +73,7 @@ describe('GET /api/v1/contents', () => {
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
-        message: '"strategy" deve possuir um dos seguintes valores: "new", "old" ou "relevant".',
+        message: '"strategy" deve possuir um dos seguintes valores: "new", "old", "relevant".',
         action: 'Ajuste os dados enviados e tente novamente.',
         status_code: 400,
         error_id: responseBody.error_id,

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -1329,7 +1329,7 @@ describe('POST /api/v1/contents', () => {
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
       expect(responseBody.message).toEqual(
-        '"status" deve possuir um dos seguintes valores: "draft", "published" ou "deleted".',
+        '"status" deve possuir um dos seguintes valores: "draft", "published", "deleted".',
       );
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
@@ -1361,7 +1361,7 @@ describe('POST /api/v1/contents', () => {
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
       expect(responseBody.message).toEqual(
-        '"status" deve possuir um dos seguintes valores: "draft", "published" ou "deleted".',
+        '"status" deve possuir um dos seguintes valores: "draft", "published", "deleted".',
       );
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
@@ -1393,7 +1393,7 @@ describe('POST /api/v1/contents', () => {
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
       expect(responseBody.message).toEqual(
-        '"status" deve possuir um dos seguintes valores: "draft", "published" ou "deleted".',
+        '"status" deve possuir um dos seguintes valores: "draft", "published", "deleted".',
       );
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -134,7 +134,7 @@ describe('POST /api/v1/contents', () => {
       expect(response.status).toEqual(400);
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('Body enviado deve ser do tipo Object.');
+      expect(responseBody.message).toEqual('"body" enviado deve ser do tipo Object.');
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
@@ -159,7 +159,7 @@ describe('POST /api/v1/contents', () => {
       expect(response.status).toEqual(400);
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('Body enviado deve ser do tipo Object.');
+      expect(responseBody.message).toEqual('"body" enviado deve ser do tipo Object.');
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -347,7 +347,7 @@ describe('POST /api/v1/contents', () => {
       expect(response.status).toEqual(400);
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('Markdown deve conter algum texto');
+      expect(responseBody.message).toEqual('Markdown deve conter algum texto.');
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -2062,11 +2062,11 @@ describe('POST /api/v1/contents', () => {
       expect(response.status).toEqual(400);
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"title" é um campo obrigatório.');
+      expect(responseBody.message).toEqual('"title" deve ser do tipo String.');
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:CONTENT:CHECK_ROOT_CONTENT_TITLE:MISSING_TITLE');
+      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('"child" content with minimum valid data', async () => {

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -554,7 +554,7 @@ describe('POST /api/v1/contents', () => {
       expect(response.status).toEqual(400);
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"body" possui o valor inválido "null".');
+      expect(responseBody.message).toEqual('"body" deve ser do tipo String.');
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
@@ -736,7 +736,7 @@ describe('POST /api/v1/contents', () => {
       expect(response.status).toEqual(400);
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"slug" possui o valor inválido "null".');
+      expect(responseBody.message).toEqual('"slug" deve ser do tipo String.');
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);

--- a/tests/integration/api/v1/email-confirmation/patch.test.js
+++ b/tests/integration/api/v1/email-confirmation/patch.test.js
@@ -25,7 +25,7 @@ describe('PATCH /api/v1/email-confirmation', () => {
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
-        message: 'Body enviado deve ser do tipo Object.',
+        message: '"body" enviado deve ser do tipo Object.',
         action: 'Ajuste os dados enviados e tente novamente.',
         status_code: 400,
         error_id: responseBody.error_id,

--- a/tests/integration/api/v1/recovery/patch.test.js
+++ b/tests/integration/api/v1/recovery/patch.test.js
@@ -364,7 +364,7 @@ describe('PATCH /api/v1/recovery', () => {
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
-        message: 'Body enviado deve ser do tipo Object.',
+        message: '"body" enviado deve ser do tipo Object.',
         action: 'Ajuste os dados enviados e tente novamente.',
         status_code: 400,
         error_id: responseBody.error_id,

--- a/tests/integration/api/v1/recovery/post.test.js
+++ b/tests/integration/api/v1/recovery/post.test.js
@@ -222,7 +222,7 @@ describe('POST /api/v1/recovery', () => {
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
-        message: 'Body enviado deve ser do tipo Object.',
+        message: '"body" enviado deve ser do tipo Object.',
         action: 'Ajuste os dados enviados e tente novamente.',
         status_code: 400,
         error_id: responseBody.error_id,

--- a/tests/integration/api/v1/sessions/post.test.js
+++ b/tests/integration/api/v1/sessions/post.test.js
@@ -408,7 +408,7 @@ describe('POST /api/v1/sessions', () => {
       expect(response.status).toEqual(400);
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('Body enviado deve ser do tipo Object.');
+      expect(responseBody.message).toEqual('"body" enviado deve ser do tipo Object.');
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);

--- a/tests/integration/api/v1/users/[username]/patch.test.js
+++ b/tests/integration/api/v1/users/[username]/patch.test.js
@@ -331,7 +331,7 @@ describe('PATCH /api/v1/users/[username]', () => {
       expect(response.status).toEqual(400);
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"username" possui o valor inválido "null".');
+      expect(responseBody.message).toEqual('"username" deve ser do tipo String.');
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
@@ -760,9 +760,9 @@ describe('PATCH /api/v1/users/[username]', () => {
       expect(response.status).toEqual(400);
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"description" possui o valor inválido "null".');
+      expect(responseBody.message).toEqual('"description" deve ser do tipo String.');
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(responseBody.type).toEqual('any.invalid');
+      expect(responseBody.type).toEqual('string.base');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
       expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');

--- a/tests/integration/api/v1/users/[username]/patch.test.js
+++ b/tests/integration/api/v1/users/[username]/patch.test.js
@@ -536,7 +536,7 @@ describe('PATCH /api/v1/users/[username]', () => {
       expect(response.status).toEqual(400);
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('Body enviado deve ser do tipo Object.');
+      expect(responseBody.message).toEqual('"body" enviado deve ser do tipo Object.');
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
@@ -562,7 +562,7 @@ describe('PATCH /api/v1/users/[username]', () => {
       expect(response.status).toEqual(400);
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('Body enviado deve ser do tipo Object.');
+      expect(responseBody.message).toEqual('"body" enviado deve ser do tipo Object.');
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);

--- a/tests/integration/api/v1/users/post.test.js
+++ b/tests/integration/api/v1/users/post.test.js
@@ -252,7 +252,7 @@ describe('POST /api/v1/users', () => {
       expect(response.status).toEqual(400);
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"username" possui o valor inválido "null".');
+      expect(responseBody.message).toEqual('"username" deve ser do tipo String.');
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);

--- a/tests/integration/api/v1/users/post.test.js
+++ b/tests/integration/api/v1/users/post.test.js
@@ -710,7 +710,7 @@ describe('POST /api/v1/users', () => {
       expect(response.status).toEqual(400);
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('Body enviado deve ser do tipo Object.');
+      expect(responseBody.message).toEqual('"body" enviado deve ser do tipo Object.');
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
@@ -729,7 +729,7 @@ describe('POST /api/v1/users', () => {
       expect(response.status).toEqual(400);
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('Body enviado deve ser do tipo Object.');
+      expect(responseBody.message).toEqual('"body" enviado deve ser do tipo Object.');
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);


### PR DESCRIPTION
## Mudanças realizadas

Fiz algumas refatorações no `validator` e separei cada etapa da refatoração em um commit, assim fica mais fácil entender o motivo de cada uma delas, revisar individualmente e desfazer, se necessário.

* [`b01421f`](https://github.com/filipedeschamps/tabnews.com.br/commit/b01421f1edd26507541582af7171e69fed844968): Permite `null` apenas se o campo não for obrigatório. Notei isso ao usar a validação de `title` em outra tarefa, onde o `validator` considerava válido um `title` obrigatório receber `null` (basta ver o teste que precisei atualizar em `contents/post.test.js`). Hoje isso não é um problema porque o único caso que poderia seria percebido é no `title`, onde a condição é tratada no model.
* [`e2bde04`](https://github.com/filipedeschamps/tabnews.com.br/commit/e2bde044ccf1b1607f3aab97775a24788eb68a72): Uso de templates nas mensagens de erro: `{#label}` para permitir o reuso de uma validação em uma propriedade de nome diferente, mantendo uma mensagem de erro consistente; `{#limit}` e `{#value}` para garantir que o valor correto é exibido nas mensagens de erro.
    Nesse ponto também corrigi as mensagens de `number.unsafe` conforme a validação do Joi ([veja aqui](https://github.com/hapijs/joi/blob/5b96852fe07a742a8733f2bff1303d50853ca65c/lib/types/number.js#L104-L108)), que verifica tanto o limite negativo quanto positivo. Como não é possível acessar os valores das validações de `min` e `max` pelo template do Joi, usei variáveis em JavaScript mesmo.
* [`0376e24`](https://github.com/filipedeschamps/tabnews.com.br/commit/0376e24d98601cd8646c472eee6e3dd3afc94278): Criei um objeto com as mensagens de erro padrão, assim não é necessário tanto Ctrl+C e Ctrl+V, ou pequenas variações em mensagens de erro.
* [`f89fc7d`](https://github.com/filipedeschamps/tabnews.com.br/commit/f89fc7de572ca52d132a685731004b62c2f82fe8): Remove validações desnecessárias: `.invalid(null)` onde já há outra validação que garante isso (como `.string()` ou `.boolean()`); `.allow(false)` que já é permitido por `.boolean()`.

Também tentei deixar o nome da propriedade dinâmico em `when('$required.<NOME>, ...` mas não consegui descobrir se é possível pelo Joi.

Quem quiser entender melhor sobre a sintaxe de template do Joi: [documentação](https://joi.dev/api/?v=17.13.0#template-syntax). Como complemento para saber os argumentos disponíveis, vi o [código fonte](https://github.com/hapijs/joi/tree/5b96852fe07a742a8733f2bff1303d50853ca65c/lib/types).

## Tipo de mudança

- [x] Correção de bug
- [x] Refatoração

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
