### PR TITLE
Refatoração dos testes para diminuir boilerplate (criação, ativação e features de usuário, e fetch)

### DIFF
--- a/tests/integration/api/v1/contents/rss/get.test.js
+++ b/tests/integration/api/v1/contents/rss/get.test.js
@@ -1,6 +1,5 @@
-import fetch from 'cross-fetch';
-
 import orchestrator from 'tests/orchestrator.js';
+import RequestBuilder from 'tests/request-builder';
 
 describe('GET /recentes/rss', () => {
   beforeAll(async () => {
@@ -11,18 +10,20 @@ describe('GET /recentes/rss', () => {
 
   describe('Anonymous user', () => {
     test('With `/rss` alias`', async () => {
-      const response = await fetch(`${orchestrator.webserverUrl}/rss`);
+      const rssRequestBuilder = new RequestBuilder('/rss');
+      const { response } = await rssRequestBuilder.get();
       expect(response.status).toEqual(200);
     });
 
     test('With `/rss.xml` alias`', async () => {
-      const response = await fetch(`${orchestrator.webserverUrl}/rss.xml`);
+      const rssRequestBuilder = new RequestBuilder('/rss.xml');
+      const { response } = await rssRequestBuilder.get();
       expect(response.status).toEqual(200);
     });
 
     test('With 0 contents', async () => {
-      const response = await fetch(`${orchestrator.webserverUrl}/recentes/rss`);
-      const responseBody = await response.text();
+      const rssRequestBuilder = new RequestBuilder('/recentes/rss');
+      const { response, responseBody } = await rssRequestBuilder.get();
 
       const lastBuildDateFromResponseBody = /<lastBuildDate>(.*?)<\/lastBuildDate>/.exec(responseBody)[1];
 
@@ -76,8 +77,8 @@ describe('GET /recentes/rss', () => {
         status: 'draft',
       });
 
-      const response = await fetch(`${orchestrator.webserverUrl}/rss`);
-      const responseBody = await response.text();
+      const rssRequestBuilder = new RequestBuilder('/rss');
+      const { response, responseBody } = await rssRequestBuilder.get();
 
       expect(response.status).toEqual(200);
       expect(responseBody).toStrictEqual(`<?xml version="1.0" encoding="utf-8"?>

--- a/tests/request-builder.js
+++ b/tests/request-builder.js
@@ -1,0 +1,111 @@
+import orchestrator from './orchestrator';
+
+export default class RequestBuilder {
+  url = '';
+  sessionObject;
+  headers;
+
+  constructor(endpointPath) {
+    this.url = endpointPath.startsWith('http') ? endpointPath : `${orchestrator.webserverUrl}${endpointPath}`;
+  }
+
+  async buildUser(features = { with: [], without: [] }) {
+    let userObject = await orchestrator.createUser();
+    userObject = await orchestrator.activateUser(userObject);
+
+    if (features.with?.length) {
+      userObject = await orchestrator.addFeaturesToUser(userObject, features.with);
+    }
+    if (features.without?.length) {
+      userObject = await orchestrator.removeFeaturesFromUser(userObject, features.without);
+    }
+
+    await this.setUser(userObject);
+
+    return userObject;
+  }
+
+  async setUser(userObject) {
+    this.sessionObject = await orchestrator.createSession(userObject);
+
+    if (this.headers) {
+      this.headers.cookie = `session_id=${this.sessionObject.token}`;
+    }
+  }
+
+  buildHeaders(customHeaders) {
+    const headers = {
+      'Content-Type': 'application/json',
+    };
+
+    if (this.sessionObject) {
+      headers.cookie = `session_id=${this.sessionObject.token}`;
+    }
+
+    this.headers = { ...headers, ...customHeaders };
+    return this.headers;
+  }
+
+  async get(urlParams) {
+    if (!this.headers) {
+      this.buildHeaders();
+    }
+
+    const url = urlParams ? `${this.url}${urlParams}` : this.url;
+
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: this.headers,
+    });
+
+    let responseBody = response.headers.get('Content-Type').includes('text/')
+      ? await response.text()
+      : await response.json();
+
+    return { response, responseBody };
+  }
+
+  async post(requestBody) {
+    if (!this.headers) {
+      this.buildHeaders();
+    }
+
+    const fetchData = {
+      method: 'POST',
+      headers: this.headers,
+    };
+
+    if (requestBody) {
+      fetchData.body = typeof requestBody === 'object' ? JSON.stringify(requestBody) : requestBody;
+    }
+
+    const response = await fetch(this.url, fetchData);
+
+    const responseBody = await response.json();
+
+    return { response, responseBody };
+  }
+
+  async patch(urlParams, requestBody) {
+    if (!this.headers) {
+      this.buildHeaders();
+    }
+
+    const fetchData = {
+      method: 'PATCH',
+      headers: this.headers,
+    };
+
+    if (requestBody) {
+      fetchData.body = typeof requestBody === 'object' ? JSON.stringify(requestBody) : requestBody;
+    }
+
+    const url = urlParams ? `${this.url}${urlParams}` : this.url;
+
+    const response = await fetch(url, fetchData);
+
+    const responseBody = await response.json();
+
+    return { response, responseBody };
+  }
+}


### PR DESCRIPTION
## Mudanças realizadas

Estava desenvolvendo uma outra funcionalidade do TabNews e nos testes me deparei com uma repetição que já havia me incomodado em #1638, onde criei funções como `createContentViaApi`, `reviewFirewallViaApi` etc., e nos novos testes eu estava fazendo as mesmas coisas.

Experimentei, então, criar uma abstração inspirada na proposta do PR #1409. O objetivo é:

1. Facilitar a escrita dos testes, diminuindo a repetição da criação do usuário, ativação, obtenção do token, inserção ou remoção de `feature`, e por fim o `fetch` (que é verboso por natureza).
2. Deixar claro o que está sendo feito, para continuar claro como o teste funciona ao lê-lo.

Isso deve facilitar tanto para os mantenedores desenvolverem os testes como para novos contribuidores.

Optei por iniciar modificando os testes de `/contents`, pois envolvem diferentes cenários (com token, sem token, com usuário autorizado, sem usuário, sem `feature`, com header diferente etc.).

Quero saber a opinião de outras pessoas, se assim está melhor ou se eu abstraí demais.

Se a alteração for aprovada como está, podemos realizar o merge modificando apenas os testes do `/contents` e passar a usar o `RequestBuilder` nos novos testes e refatorar os outros depois, conforme mexermos nos arquivos.

## Tipo de mudança

- [x] Refatoração de testes.
