### PR TITLE
Melhorando experiência do usuário nos formulários

### DIFF
--- a/pages/cadastro/index.public.js
+++ b/pages/cadastro/index.public.js
@@ -128,7 +128,7 @@ function SignUpForm() {
             contrast
             sx={{ px: 2, '&:focus-within': { backgroundColor: 'canvas.default' } }}
           />
-          {!(errorObject?.key === 'username') && (
+          {errorObject?.key !== 'username' && (
             <FormControl.Caption>Assim que os outros verão você na plataforma.</FormControl.Caption>
           )}
 
@@ -191,15 +191,13 @@ function SignUpForm() {
           setErrorObject={setErrorObject}
         />
 
-        <Box>
-          <FormControl>
-            <Checkbox checked={isTermsAccepted} onClick={() => setIsTermsAccepted(!isTermsAccepted)} />
-            <FormControl.Label>
-              Li e estou de acordo com os
-              <Link href="/termos-de-uso"> Termos de Uso.</Link>
-            </FormControl.Label>
-          </FormControl>
-        </Box>
+        <FormControl>
+          <Checkbox checked={isTermsAccepted} onChange={() => setIsTermsAccepted(!isTermsAccepted)} />
+          <FormControl.Label>
+            Li e estou de acordo com os
+            <Link href="/termos-de-uso"> Termos de Uso.</Link>
+          </FormControl.Label>
+        </FormControl>
 
         <FormControl>
           <FormControl.Label visuallyHidden>Criar cadastro</FormControl.Label>

--- a/pages/cadastro/index.public.js
+++ b/pages/cadastro/index.public.js
@@ -128,16 +128,16 @@ function SignUpForm() {
             contrast
             sx={{ px: 2, '&:focus-within': { backgroundColor: 'canvas.default' } }}
           />
-          {errorObject?.key !== 'username' && (
-            <FormControl.Caption>Assim que os outros verão você na plataforma.</FormControl.Caption>
+          <FormControl.Caption>Este nome será exibido publicamente.</FormControl.Caption>
+
+          {errorObject?.key === 'username' && errorObject?.type === 'string.alphanum' && (
+            <FormControl.Validation variant="error">
+              Nome de usuário deve conter apenas letras e números. (ex: nomeSobrenome4)
+            </FormControl.Validation>
           )}
 
           {errorObject?.key === 'username' && (
             <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
-          )}
-
-          {errorObject?.type === 'string.alphanum' && (
-            <FormControl.Caption>Dica: use somente letras e números, por exemplo: nomeSobrenome4 </FormControl.Caption>
           )}
         </FormControl>
         <FormControl id="email">

--- a/pages/cadastro/index.public.js
+++ b/pages/cadastro/index.public.js
@@ -128,6 +128,10 @@ function SignUpForm() {
             contrast
             sx={{ px: 2, '&:focus-within': { backgroundColor: 'canvas.default' } }}
           />
+          {!(errorObject?.key === 'username') && (
+            <FormControl.Caption>Assim que os outros verão você na plataforma.</FormControl.Caption>
+          )}
+
           {errorObject?.key === 'username' && (
             <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
           )}

--- a/pages/cadastro/index.public.js
+++ b/pages/cadastro/index.public.js
@@ -128,11 +128,11 @@ function SignUpForm() {
             contrast
             sx={{ px: 2, '&:focus-within': { backgroundColor: 'canvas.default' } }}
           />
-          <FormControl.Caption>Este nome será exibido publicamente.</FormControl.Caption>
+          <FormControl.Caption>Esse nome será exibido publicamente.</FormControl.Caption>
 
           {errorObject?.key === 'username' && errorObject?.type === 'string.alphanum' && (
             <FormControl.Validation variant="error">
-              Nome de usuário deve conter apenas letras e números. (ex: nomeSobrenome4)
+              Nome de usuário deve conter apenas letras e números, por exemplo: &quot;nomeSobrenome4&quot;.
             </FormControl.Validation>
           )}
 

--- a/pages/cadastro/index.public.js
+++ b/pages/cadastro/index.public.js
@@ -12,7 +12,6 @@ import {
   Heading,
   Link,
   PasswordInput,
-  Text,
   TextInput,
 } from '@/TabNewsUI';
 import { createErrorMessage, suggestEmail } from 'pages/interface';
@@ -188,12 +187,14 @@ function SignUpForm() {
           setErrorObject={setErrorObject}
         />
 
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 3 }}>
-          <Checkbox checked={isTermsAccepted} onClick={() => setIsTermsAccepted(!isTermsAccepted)} />
-          <Text>
-            Li e estou de acordo com os
-            <Link href="/termos-de-uso"> Termos de Uso.</Link>
-          </Text>
+        <Box>
+          <FormControl>
+            <Checkbox checked={isTermsAccepted} onClick={() => setIsTermsAccepted(!isTermsAccepted)} />
+            <FormControl.Label>
+              Li e estou de acordo com os
+              <Link href="/termos-de-uso"> Termos de Uso.</Link>
+            </FormControl.Label>
+          </FormControl>
         </Box>
 
         <FormControl>

--- a/pages/perfil/index.public.js
+++ b/pages/perfil/index.public.js
@@ -44,6 +44,7 @@ function EditProfileForm() {
   const [errorObject, setErrorObject] = useState(undefined);
   const [emailDisabled, setEmailDisabled] = useState(false);
   const [description, setDescription] = useState(user?.description || '');
+  const [showUsernameCaption, setShowUsernameCaption] = useState(false);
 
   useEffect(() => {
     if (router && !user && !userIsLoading) {
@@ -78,7 +79,7 @@ function EditProfileForm() {
     if (user.username !== username) {
       const confirmChangeUsername = await confirm({
         title: `Você realmente deseja alterar seu nome de usuário?`,
-        content: `Isso irá quebrar todas as URLs dos seus conteúdos e comentários.`,
+        content: `Isso irá quebrar todas as URLs das suas publicações e comentários.`,
         cancelButtonContent: 'Cancelar',
         confirmButtonContent: 'Sim',
       });
@@ -197,10 +198,12 @@ function EditProfileForm() {
             aria-label="Seu nome de usuário"
             contrast
             sx={{ px: 2, '&:focus-within': { backgroundColor: 'canvas.default' } }}
+            onFocus={() => setShowUsernameCaption(true)}
+            onBlur={() => setShowUsernameCaption(false)}
           />
-          {!(errorObject?.key === 'username') && (
+          {showUsernameCaption && (
             <FormControl.Caption>
-              Alterar o nome de usuário irá quebrar todas as URLs dos seus conteúdos e comentários.
+              Alterar o nome de usuário irá quebrar todas as URLs das suas publicações e comentários.
             </FormControl.Caption>
           )}
 

--- a/pages/perfil/index.public.js
+++ b/pages/perfil/index.public.js
@@ -64,6 +64,12 @@ function EditProfileForm() {
     setGlobalMessageObject(undefined);
   }
 
+  function handleUsernameChange() {
+    const username = usernameRef.current.value;
+    const currentUser = user.username || '';
+    setShowUsernameCaption(username.toLowerCase() !== currentUser.toLowerCase());
+  }
+
   async function handleSubmit(event) {
     event.preventDefault();
 
@@ -77,12 +83,14 @@ function EditProfileForm() {
     const payload = {};
 
     if (user.username !== username) {
-      const confirmChangeUsername = await confirm({
-        title: `Você realmente deseja alterar seu nome de usuário?`,
-        content: `Isso irá quebrar todas as URLs das suas publicações e comentários.`,
-        cancelButtonContent: 'Cancelar',
-        confirmButtonContent: 'Sim',
-      });
+      const confirmChangeUsername =
+        user.username.toLowerCase() === username.toLowerCase() ||
+        (await confirm({
+          title: `Você realmente deseja alterar seu nome de usuário?`,
+          content: `Isso irá quebrar todas as URLs das suas publicações e comentários.`,
+          cancelButtonContent: 'Cancelar',
+          confirmButtonContent: 'Sim',
+        }));
 
       if (!confirmChangeUsername) {
         setIsLoading(false);
@@ -156,6 +164,7 @@ function EditProfileForm() {
         }
 
         setIsLoading(false);
+        setShowUsernameCaption(false);
         return;
       }
 
@@ -198,8 +207,7 @@ function EditProfileForm() {
             aria-label="Seu nome de usuário"
             contrast
             sx={{ px: 2, '&:focus-within': { backgroundColor: 'canvas.default' } }}
-            onFocus={() => setShowUsernameCaption(true)}
-            onBlur={() => setShowUsernameCaption(false)}
+            onChange={handleUsernameChange}
           />
           {showUsernameCaption && (
             <FormControl.Caption>
@@ -207,12 +215,14 @@ function EditProfileForm() {
             </FormControl.Caption>
           )}
 
-          {errorObject?.key === 'username' && (
-            <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
+          {errorObject?.key === 'username' && errorObject?.type === 'string.alphanum' && (
+            <FormControl.Validation variant="error">
+              Nome de usuário deve conter apenas letras e números. (ex: nomeSobrenome4)
+            </FormControl.Validation>
           )}
 
-          {errorObject?.type === 'string.alphanum' && (
-            <FormControl.Caption>Dica: use somente letras e números, por exemplo: nomeSobrenome4 </FormControl.Caption>
+          {errorObject?.key === 'username' && (
+            <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
           )}
         </FormControl>
 

--- a/pages/perfil/index.public.js
+++ b/pages/perfil/index.public.js
@@ -198,6 +198,12 @@ function EditProfileForm() {
             contrast
             sx={{ px: 2, '&:focus-within': { backgroundColor: 'canvas.default' } }}
           />
+          {!(errorObject?.key === 'username') && (
+            <FormControl.Caption>
+              Alterar o nome de usuário irá quebrar todas as URLs dos seus conteúdos e comentários.
+            </FormControl.Caption>
+          )}
+
           {errorObject?.key === 'username' && (
             <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
           )}

--- a/pages/perfil/index.public.js
+++ b/pages/perfil/index.public.js
@@ -64,12 +64,6 @@ function EditProfileForm() {
     setGlobalMessageObject(undefined);
   }
 
-  function handleUsernameChange() {
-    const username = usernameRef.current.value;
-    const currentUser = user.username || '';
-    setShowUsernameCaption(username.toLowerCase() !== currentUser.toLowerCase());
-  }
-
   async function handleSubmit(event) {
     event.preventDefault();
 
@@ -164,7 +158,6 @@ function EditProfileForm() {
         }
 
         setIsLoading(false);
-        setShowUsernameCaption(false);
         return;
       }
 
@@ -207,17 +200,17 @@ function EditProfileForm() {
             aria-label="Seu nome de usuário"
             contrast
             sx={{ px: 2, '&:focus-within': { backgroundColor: 'canvas.default' } }}
-            onChange={handleUsernameChange}
+            onChange={() => setShowUsernameCaption(true)}
           />
           {showUsernameCaption && (
             <FormControl.Caption>
-              Alterar o nome de usuário irá quebrar todas as URLs das suas publicações e comentários.
+              Alterar o nome de usuário pode quebrar todas as URLs das suas publicações e comentários.
             </FormControl.Caption>
           )}
 
           {errorObject?.key === 'username' && errorObject?.type === 'string.alphanum' && (
             <FormControl.Validation variant="error">
-              Nome de usuário deve conter apenas letras e números. (ex: nomeSobrenome4)
+              Nome de usuário deve conter apenas letras e números, por exemplo: &quot;nomeSobrenome4&quot;.
             </FormControl.Validation>
           )}
 

--- a/pages/perfil/index.public.js
+++ b/pages/perfil/index.public.js
@@ -78,7 +78,7 @@ function EditProfileForm() {
     if (user.username !== username) {
       const confirmChangeUsername = await confirm({
         title: `Você realmente deseja alterar seu nome de usuário?`,
-        content: `Isso irá quebrar todas as URLs das suas publicações e comentários.`,
+        content: `Isso irá quebrar todas as URLs dos seus conteúdos e comentários.`,
         cancelButtonContent: 'Cancelar',
         confirmButtonContent: 'Sim',
       });


### PR DESCRIPTION
## Mudanças realizadas

<!-- Por favor, inclua uma descrição sobre o que foi modificado nesse PR. Inclua também qualquer motivação ou contexto relevante.  -->

Essa PR conta com algumas modificações na interface para melhorar o entendimento do usuário nos formulários de `cadastro` e de `perfil`.

Para evitar o excesso de componentes que tirariam o foco do usuário, o @Rafatcb sugeriu a utilização de um componente que já está presente no `primer/react`, sendo ele o Caption (mais especificamente o FormControl.Caption).

### Alterações

`/cadastro`
Antes
![image](https://github.com/filipedeschamps/tabnews.com.br/assets/60831308/cfb3057a-0eb8-4a5f-b8ff-88c474dcd30f)

Depois
![image](https://github.com/filipedeschamps/tabnews.com.br/assets/60831308/a06b0c08-2600-4318-bbc7-963ad98f318e)

`/perfil`
Antes
![image](https://github.com/filipedeschamps/tabnews.com.br/assets/60831308/5dd9640d-e083-44ac-9b6e-5cad19b012eb)
![image](https://github.com/filipedeschamps/tabnews.com.br/assets/60831308/cf67550e-2647-4925-8539-6ddcd2ea8585)

Depois
![image](https://github.com/filipedeschamps/tabnews.com.br/assets/60831308/d1cb59b0-5df8-4625-818b-af77b8af0009)
![image](https://github.com/filipedeschamps/tabnews.com.br/assets/60831308/608ab394-8645-404a-862e-756feada194a)

### Observação
Decidi manter o "e comentários" na confirmação e na caption da página de perfil, pois como um usuário eu não estava conseguindo visualizar os comentários lendo apenas "conteúdos". Mas, claro, essa é minha visão de usuário e gostaria que discutíssemos sobre caso haja alguma opinião diferente.


Resolve #1529 

## Tipo de mudança

- [x] Refactor

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [ ] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
