### PR TITLE
Diminui a quantidade de campos e o tamanho total dos logs enviados para o Axiom

### DIFF
--- a/infra/logger.js
+++ b/infra/logger.js
@@ -10,15 +10,11 @@ function getLogger() {
       nestedKey: 'payload',
       redact: {
         paths: [
-          'headers.cookie',
-          'headers["x-vercel-ip-continent"]',
-          'headers["x-vercel-ip-as-number"]',
           'password',
           'email',
-          'body.password',
-          'body.email',
           'context.user.password',
           'context.user.email',
+          'context.user.description',
           'context.session.token',
         ],
         remove: true,

--- a/tests/unit/models/controller.test.js
+++ b/tests/unit/models/controller.test.js
@@ -1,0 +1,214 @@
+import logger from 'infra/logger.js';
+import controller from 'models/controller.js';
+
+const { logRequest } = controller;
+
+vi.mock('infra/logger.js');
+
+describe('Controller', () => {
+  describe('logRequest', () => {
+    const next = vi.fn();
+
+    beforeEach(() => {
+      logger.info.mockClear();
+      next.mockClear();
+    });
+
+    it('should log request information', () => {
+      const request = {
+        headers: {
+          'x-forwarded-for': 'test',
+          'user-agent': 'test',
+        },
+        body: {
+          body: 'test',
+        },
+        context: {
+          test: 'test',
+        },
+      };
+
+      logRequest(request, {}, next);
+
+      expect(logger.info).toHaveBeenCalledWith({
+        headers: [request.headers],
+        body: [request.body],
+        context: request.context,
+      });
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('should call logger.info only with headers and body in array format', () => {
+      logRequest({}, {}, next);
+
+      expect(logger.info).toHaveBeenCalledWith({
+        headers: [{}],
+        body: [{}],
+        context: {},
+      });
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('should not log extra request params', () => {
+      const request = {
+        other: {
+          'x-forwarded-for': 'test',
+          'user-agent': 'test',
+        },
+      };
+
+      logRequest(request, {}, next);
+
+      expect(logger.info).toHaveBeenCalledWith({
+        headers: [{}],
+        body: [{}],
+        context: {},
+      });
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('should truncate long "requestBody.body"', () => {
+      const request = {
+        headers: {
+          'x-forwarded-for': 'test',
+          'user-agent': 'test',
+        },
+        body: {
+          body: 'test'.repeat(1000),
+        },
+        context: {
+          test: 'test',
+        },
+      };
+
+      logRequest(request, {}, next);
+
+      expect(logger.info).toHaveBeenCalledWith({
+        headers: [request.headers],
+        body: [{ body: 'test'.repeat(75) }],
+        context: request.context,
+      });
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('should redact sensitive data', () => {
+      const request = {
+        headers: {
+          authorization: 'sensitive',
+          cookie: 'sensitive',
+          'access-control-allow-headers': 'omit',
+          forwarded: 'omit',
+          'x-vercel-proxy-signature': 'omit',
+          'x-vercel-sc-headers': 'omit',
+          'other-header': 'test',
+        },
+        body: {
+          body: 'test',
+          email: 'test@email.com',
+          password: 'password',
+        },
+        context: {
+          test: 'test',
+        },
+      };
+
+      logRequest(request, {}, next);
+
+      expect(logger.info).toHaveBeenCalledWith({
+        headers: [
+          {
+            authorization: '**',
+            cookie: '**',
+            'other-header': 'test',
+          },
+        ],
+        body: [{ body: 'test', email: '**', password: '**' }],
+        context: request.context,
+      });
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('should redact sensitive data with long "body"', () => {
+      const request = {
+        headers: {
+          authorization: 'sensitive',
+          cookie: 'sensitive',
+          'other-header': 'test',
+        },
+        body: {
+          body: 'test'.repeat(1000),
+          email: 'test',
+          password: 'test',
+        },
+        context: {
+          test: 'test',
+        },
+      };
+
+      logRequest(request, {}, next);
+
+      expect(logger.info).toHaveBeenCalledWith({
+        headers: [
+          {
+            authorization: '**',
+            cookie: '**',
+            'other-header': 'test',
+          },
+        ],
+        body: [{ body: 'test'.repeat(75), email: '**', password: '**' }],
+        context: request.context,
+      });
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('should log only "id" and "username" among the user data', () => {
+      const request = {
+        context: {
+          user: {
+            id: 'test_id',
+            username: 'username',
+            description: 'description',
+          },
+        },
+      };
+
+      logRequest(request, {}, next);
+
+      expect(logger.info).toHaveBeenCalledWith({
+        headers: [{}],
+        body: [{}],
+        context: {
+          user: {
+            id: request.context.user.id,
+            username: request.context.user.username,
+          },
+        },
+      });
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('should log non string "requestBody.body"', () => {
+      const request = {
+        headers: {
+          'x-forwarded-for': 'test',
+          'user-agent': 'test',
+        },
+        body: {
+          body: { test: 'test' },
+        },
+        context: {
+          test: 'test',
+        },
+      };
+
+      logRequest(request, {}, next);
+
+      expect(logger.info).toHaveBeenCalledWith({
+        headers: [request.headers],
+        body: [request.body],
+        context: request.context,
+      });
+      expect(next).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Mudanças realizadas

Continuando o ajuste nos logs realizado em #1680, agora os dados que não estão totalmente no nosso controle, como os presentes nos cabeçalhos e no corpo das requisições, não irão mais ser salvos em campos individuais no Axiom.

Para conseguir isso, agora os headers e body são enviados para o Axiom dentro de um array. Pensando somente na limitação de campos, também funcionaria enviar os objetos como strings, mas isso adicionaria muitos caracteres de escape (mais de 500 só nos headers), o que aumentaria as perdas de registros por ultrapassar o [limite de 4KB dos logs da Vercel](https://vercel.com/docs/observability/runtime-logs#limits), algo que já ocorre eventualmente.

Ainda pensando no limite de 4KB, agora são registrados menos dados dos usuários e dos conteúdos, já que podemos buscar diretamente no PostgreSQL os dados completos. Dados redundantes também foram removidos, pois a Vercel já insere o método e a URL das requisições em todos os logs.

## Tipo de mudança

- [x] Correção de bug

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
