### PR TITLE
Refatoração da validação da presença do título nos conteúdos

### DIFF
--- a/pages/api/v1/contents/index.public.js
+++ b/pages/api/v1/contents/index.public.js
@@ -85,7 +85,7 @@ function postValidationHandler(request, response, next) {
   const cleanValues = validator(request.body, {
     parent_id: 'optional',
     slug: 'optional',
-    title: request.body.parent_id ? 'optional' : 'required',
+    title: 'optional',
     body: 'required',
     status: 'optional',
     source_url: 'optional',

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -1524,7 +1524,7 @@ describe('POST /api/v1/contents', () => {
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.error_location_code).toEqual('MODEL:CONTENT:CHECK_ROOT_CONTENT_TITLE:MISSING_TITLE');
     });
 
     test('"root" content with "title" containing Null value', async () => {
@@ -1539,11 +1539,11 @@ describe('POST /api/v1/contents', () => {
       expect(response.status).toEqual(400);
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"title" deve ser do tipo String.');
+      expect(responseBody.message).toEqual('"title" é um campo obrigatório.');
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.error_location_code).toEqual('MODEL:CONTENT:CHECK_ROOT_CONTENT_TITLE:MISSING_TITLE');
     });
 
     test('"child" content with minimum valid data', async () => {


### PR DESCRIPTION
## Mudanças realizadas

Na criação de conteúdos, dependendo da presença ou não de `parent_id`, a verificação da presença do título ocorria no `models/validator` ou no `models/contents`, e isso era decidido em:

https://github.com/filipedeschamps/tabnews.com.br/blob/884181d5f5f2cb3e18e13770002f2b6d0912da67/pages/api/v1/contents/index.public.js#L88-L88

Já no `patch` dos conteúdos, a verificação sempre ocorria em `models/contents`, então a mudança proposta é para a validação ocorrer sempre em `models/contents`, o que padroniza a mensagem de erro e o `error_location_code`:

- `"title" é um campo obrigatório.`
- `MODEL:CONTENT:CHECK_ROOT_CONTENT_TITLE:MISSING_TITLE`

## Tipo de mudança

- [x] Refatoração

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.