### PR TITLE
Remove `async` desnecessário de `pagination.get`

### DIFF
--- a/models/pagination.js
+++ b/models/pagination.js
@@ -1,4 +1,4 @@
-async function get({ total_rows, page, per_page, strategy }) {
+function get({ total_rows, page, per_page, strategy }) {
   const firstPage = 1;
   const lastPage = Math.ceil(total_rows / per_page);
   const nextPage = page >= lastPage ? null : page + 1;

--- a/models/pagination.js
+++ b/models/pagination.js
@@ -1,6 +1,6 @@
 function get({ total_rows, page, per_page, strategy }) {
   const firstPage = 1;
-  const lastPage = Math.ceil(total_rows / per_page);
+  const lastPage = Math.ceil(total_rows / per_page) || 1;
   const nextPage = page >= lastPage ? null : page + 1;
   const previousPage = page <= 1 ? null : page > lastPage ? lastPage : page - 1;
 

--- a/models/user.js
+++ b/models/user.js
@@ -64,7 +64,7 @@ async function findAllWithPagination(values) {
 
   values.total_rows = results.rows[0]?.total_rows ?? (await countTotalRows());
 
-  results.pagination = await pagination.get(values);
+  results.pagination = pagination.get(values);
 
   return results;
 }

--- a/tests/integration/api/v1/contents/get.test.js
+++ b/tests/integration/api/v1/contents/get.test.js
@@ -43,7 +43,9 @@ describe('GET /api/v1/contents', () => {
         'access-control-allow-headers': [
           'X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version',
         ],
-        link: [`<${orchestrator.webserverUrl}/api/v1/contents?strategy=relevant&page=1&per_page=30>; rel="first"`],
+        link: [
+          `<${orchestrator.webserverUrl}/api/v1/contents?strategy=relevant&page=1&per_page=30>; rel="first", <${orchestrator.webserverUrl}/api/v1/contents?strategy=relevant&page=1&per_page=30>; rel="last"`,
+        ],
         'x-pagination-total-rows': ['0'],
         'content-type': ['application/json; charset=utf-8'],
         etag: responseHeaders.etag,


### PR DESCRIPTION
## Mudanças realizadas

Remove marcação `async` desnecessária, já que a função é síncrona, conforme mencionado [nesse comentário](https://github.com/filipedeschamps/tabnews.com.br/pull/1698#discussion_r1610839266).

## Tipo de mudança

- [x] Correção de bug  / refatoração

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
