### PR TITLE
Remove a biblioteca `cross-fetch` e muda a `set-cookie-parser` para `devDependencies`

### DIFF
--- a/models/authentication.js
+++ b/models/authentication.js
@@ -1,5 +1,3 @@
-import setCookieParser from 'set-cookie-parser';
-
 import { ForbiddenError, UnauthorizedError } from 'errors';
 import authorization from 'models/authorization.js';
 import password from 'models/password.js';
@@ -65,13 +63,6 @@ async function injectAnonymousOrUser(request, response, next, options = {}) {
   }
 }
 
-//TODO: this should be here or inside the session model?
-function parseSetCookies(response) {
-  const setCookieHeaderValues = response.headers.raw()['set-cookie'];
-  const parsedCookies = setCookieParser.parse(setCookieHeaderValues, { map: true });
-  return parsedCookies;
-}
-
 async function createSessionAndSetCookies(userId, response) {
   const sessionObject = await session.create(userId);
   session.setSessionIdCookieInResponse(sessionObject.token, response);
@@ -82,6 +73,5 @@ export default Object.freeze({
   hashPassword,
   comparePasswords,
   injectAnonymousOrUser,
-  parseSetCookies,
   createSessionAndSetCookies,
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,6 @@
         "@vitejs/plugin-react": "4.2.1",
         "autoprefixer": "10.4.17",
         "concurrently": "8.2.2",
-        "cross-fetch": "4.0.0",
         "cz-conventional-changelog": "3.3.0",
         "dotenv": "16.4.1",
         "dotenv-expand": "10.0.0",
@@ -6147,15 +6146,6 @@
         "@types/node": "*",
         "cosmiconfig": ">=8.2",
         "typescript": ">=4"
-      }
-    },
-    "node_modules/cross-fetch": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
-      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
-      "dev": true,
-      "dependencies": {
-        "node-fetch": "^2.6.12"
       }
     },
     "node_modules/cross-spawn": {
@@ -12676,26 +12666,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dev": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/node-getopt": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/node-getopt/-/node-getopt-0.3.2.tgz",
@@ -16748,12 +16718,6 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
-    },
     "node_modules/tree-cli": {
       "version": "0.6.7",
       "resolved": "https://registry.npmjs.org/tree-cli/-/tree-cli-0.6.7.tgz",
@@ -18386,12 +18350,6 @@
       "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.2.0.tgz",
       "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA=="
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
-    },
     "node_modules/webpack": {
       "version": "5.90.1",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.90.1.tgz",
@@ -18507,16 +18465,6 @@
       "peer": true,
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -22938,15 +22886,6 @@
       "dev": true,
       "requires": {
         "jiti": "^1.19.1"
-      }
-    },
-    "cross-fetch": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
-      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
-      "dev": true,
-      "requires": {
-        "node-fetch": "^2.6.12"
       }
     },
     "cross-spawn": {
@@ -27621,15 +27560,6 @@
       "integrity": "sha512-s9sN51sHybDA6qeTwWE2tQZtArXyNyr3hUToB6CuwTRwK06ax67nPOZVyqjYmiTJx7IBbxmBT7xMHe46lRqglg==",
       "requires": {}
     },
-    "node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dev": true,
-      "requires": {
-        "whatwg-url": "^5.0.0"
-      }
-    },
     "node-getopt": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/node-getopt/-/node-getopt-0.3.2.tgz",
@@ -30536,12 +30466,6 @@
         }
       }
     },
-    "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
-    },
     "tree-cli": {
       "version": "0.6.7",
       "resolved": "https://registry.npmjs.org/tree-cli/-/tree-cli-0.6.7.tgz",
@@ -31512,12 +31436,6 @@
       "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.2.0.tgz",
       "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA=="
     },
-    "webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
-    },
     "webpack": {
       "version": "5.90.1",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.90.1.tgz",
@@ -31605,16 +31523,6 @@
       "dev": true,
       "optional": true,
       "peer": true
-    },
-    "whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
-      "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "which": {
       "version": "2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,6 @@
         "rehype-external-links": "3.0.0",
         "rehype-slug": "6.0.0",
         "satori": "0.10.13",
-        "set-cookie-parser": "2.6.0",
         "slug": "8.2.3",
         "snakeize": "0.1.0",
         "styled-components": "5.3.11",
@@ -83,6 +82,7 @@
         "prettier": "3.2.5",
         "react-email": "2.0.0",
         "retry-cli": "0.7.0",
+        "set-cookie-parser": "2.6.0",
         "vite-tsconfig-paths": "4.3.1",
         "vitest": "1.3.1"
       },
@@ -15537,7 +15537,8 @@
     "node_modules/set-cookie-parser": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
-      "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ=="
+      "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==",
+      "dev": true
     },
     "node_modules/set-function-length": {
       "version": "1.2.1",
@@ -29626,7 +29627,8 @@
     "set-cookie-parser": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
-      "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ=="
+      "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==",
+      "dev": true
     },
     "set-function-length": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "rehype-external-links": "3.0.0",
     "rehype-slug": "6.0.0",
     "satori": "0.10.13",
-    "set-cookie-parser": "2.6.0",
     "slug": "8.2.3",
     "snakeize": "0.1.0",
     "styled-components": "5.3.11",
@@ -74,6 +73,7 @@
     "prettier": "3.2.5",
     "react-email": "2.0.0",
     "retry-cli": "0.7.0",
+    "set-cookie-parser": "2.6.0",
     "vite-tsconfig-paths": "4.3.1",
     "vitest": "1.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@vitejs/plugin-react": "4.2.1",
     "autoprefixer": "10.4.17",
     "concurrently": "8.2.2",
-    "cross-fetch": "4.0.0",
     "cz-conventional-changelog": "3.3.0",
     "dotenv": "16.4.1",
     "dotenv-expand": "10.0.0",

--- a/tests/integration/api/v1/_use-cases/registration-flow.test.js
+++ b/tests/integration/api/v1/_use-cases/registration-flow.test.js
@@ -1,4 +1,3 @@
-import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
 
 import activation from 'models/activation.js';
@@ -22,7 +21,7 @@ describe('Use case: Registration Flow (all successfully)', () => {
 
   test('Create account (successfully)', async () => {
     const postUserResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
-      method: 'post',
+      method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
@@ -105,7 +104,7 @@ describe('Use case: Registration Flow (all successfully)', () => {
 
   test('Login (successfully)', async () => {
     const postSessionResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/sessions`, {
-      method: 'post',
+      method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
@@ -137,7 +136,7 @@ describe('Use case: Registration Flow (all successfully)', () => {
 
   test('Get user (successfully)', async () => {
     const getUserResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/user`, {
-      method: 'get',
+      method: 'GET',
       headers: {
         cookie: `session_id=${parsedCookiesFromPost.session_id.value}`,
       },

--- a/tests/integration/api/v1/_use-cases/registration-flow.test.js
+++ b/tests/integration/api/v1/_use-cases/registration-flow.test.js
@@ -2,7 +2,6 @@ import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
 
 import activation from 'models/activation.js';
-import authentication from 'models/authentication';
 import password from 'models/password.js';
 import session from 'models/session.js';
 import user from 'models/user.js';
@@ -128,7 +127,7 @@ describe('Use case: Registration Flow (all successfully)', () => {
     const sessionObjectInDatabase = await session.findOneById(postSessionResponseBody.id);
     expect(sessionObjectInDatabase.user_id).toEqual(postUserResponseBody.id);
 
-    parsedCookiesFromPost = authentication.parseSetCookies(postSessionResponse);
+    parsedCookiesFromPost = orchestrator.parseSetCookies(postSessionResponse);
     expect(parsedCookiesFromPost.session_id.name).toEqual('session_id');
     expect(parsedCookiesFromPost.session_id.value).toEqual(postSessionResponseBody.token);
     expect(parsedCookiesFromPost.session_id.maxAge).toEqual(60 * 60 * 24 * 30);

--- a/tests/integration/api/v1/activation/patch.test.js
+++ b/tests/integration/api/v1/activation/patch.test.js
@@ -1,4 +1,3 @@
-import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
 
 import activation from 'models/activation.js';
@@ -14,7 +13,7 @@ describe('PATCH /api/v1/activation', () => {
   describe('Anonymous user', () => {
     test('Activating with blank body', async () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/activation`, {
-        method: 'patch',
+        method: 'PATCH',
       });
 
       const responseBody = await response.json();
@@ -32,7 +31,7 @@ describe('PATCH /api/v1/activation', () => {
 
     test('Activating using a null token', async () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/activation`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -57,7 +56,7 @@ describe('PATCH /api/v1/activation', () => {
 
     test('Activating using a malformatted number token', async () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/activation`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -82,7 +81,7 @@ describe('PATCH /api/v1/activation', () => {
 
     test('Activating using an empty string token', async () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/activation`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -107,7 +106,7 @@ describe('PATCH /api/v1/activation', () => {
 
     test('Activating using a malformatted string token', async () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/activation`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -143,7 +142,7 @@ describe('PATCH /api/v1/activation', () => {
       expect(activationToken.expires_at - activationToken.created_at).toBe(900000); // 15 minutes
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/activation`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -169,7 +168,7 @@ describe('PATCH /api/v1/activation', () => {
       const activationToken = await activation.create(defaultUser);
 
       const firstTryResponde = await fetch(`${orchestrator.webserverUrl}/api/v1/activation`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -182,7 +181,7 @@ describe('PATCH /api/v1/activation', () => {
       const firstTryRespondeBody = await firstTryResponde.json();
 
       const secondTryResponde = await fetch(`${orchestrator.webserverUrl}/api/v1/activation`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -214,7 +213,7 @@ describe('PATCH /api/v1/activation', () => {
       });
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/activation`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -245,7 +244,7 @@ describe('PATCH /api/v1/activation', () => {
       const activationToken = await activation.create(defaultUser);
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/activation`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -276,7 +275,7 @@ describe('PATCH /api/v1/activation', () => {
       let defaultUserSession = await orchestrator.createSession(defaultUser);
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/activation`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
           cookie: `session_id=${defaultUserSession.token}`,

--- a/tests/integration/api/v1/contents/[username]/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/get.test.js
@@ -1,4 +1,3 @@
-import fetch from 'cross-fetch';
 import parseLinkHeader from 'parse-link-header';
 import { version as uuidVersion } from 'uuid';
 

--- a/tests/integration/api/v1/contents/firewall.post.test.js
+++ b/tests/integration/api/v1/contents/firewall.post.test.js
@@ -1,4 +1,3 @@
-import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
 
 import content from 'models/content.js';
@@ -20,7 +19,7 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
       const sessionObject = await orchestrator.createSession(defaultUser);
 
       const request1 = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           cookie: `session_id=${sessionObject.token}`,
@@ -33,7 +32,7 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
       });
 
       const request2 = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           cookie: `session_id=${sessionObject.token}`,
@@ -46,7 +45,7 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
       });
 
       const request3 = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           cookie: `session_id=${sessionObject.token}`,
@@ -117,7 +116,7 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
       const sessionObject = await orchestrator.createSession(defaultUser);
 
       const rootContent = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           cookie: `session_id=${sessionObject.token}`,
@@ -132,7 +131,7 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
       const rootContentBody = await rootContent.json();
 
       const request1 = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           cookie: `session_id=${sessionObject.token}`,
@@ -146,7 +145,7 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
       });
 
       const request2 = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           cookie: `session_id=${sessionObject.token}`,
@@ -160,7 +159,7 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
       });
 
       const request3 = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           cookie: `session_id=${sessionObject.token}`,

--- a/tests/integration/api/v1/email-confirmation/patch.test.js
+++ b/tests/integration/api/v1/email-confirmation/patch.test.js
@@ -1,4 +1,3 @@
-import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
 
 import emailConfirmation from 'models/email-confirmation.js';
@@ -161,7 +160,7 @@ describe('PATCH /api/v1/email-confirmation', () => {
       const defaultUserSession = await orchestrator.createSession(defaultUser);
 
       const updateUserResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
           cookie: `session_id=${defaultUserSession.token}`,
@@ -294,7 +293,7 @@ describe('PATCH /api/v1/email-confirmation', () => {
       });
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${firstUser.username}`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
           cookie: `session_id=${firstUserSession.token}`,

--- a/tests/integration/api/v1/events/get.test.js
+++ b/tests/integration/api/v1/events/get.test.js
@@ -1,4 +1,3 @@
-import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
 
 import event from 'models/event.js';
@@ -14,7 +13,7 @@ describe('GET /api/v1/events [NOT YET IMPLEMENTED]', () => {
   describe('Anonymous user', () => {
     test('Returning all types of events', async () => {
       const createUserResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },

--- a/tests/integration/api/v1/migrations/get.test.js
+++ b/tests/integration/api/v1/migrations/get.test.js
@@ -1,4 +1,3 @@
-import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
 
 import orchestrator from 'tests/orchestrator.js';

--- a/tests/integration/api/v1/migrations/post.test.js
+++ b/tests/integration/api/v1/migrations/post.test.js
@@ -1,4 +1,3 @@
-import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
 
 import orchestrator from 'tests/orchestrator.js';

--- a/tests/integration/api/v1/recovery/patch.test.js
+++ b/tests/integration/api/v1/recovery/patch.test.js
@@ -1,4 +1,3 @@
-import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
 
 import recovery from 'models/recovery.js';

--- a/tests/integration/api/v1/recovery/post.test.js
+++ b/tests/integration/api/v1/recovery/post.test.js
@@ -1,4 +1,3 @@
-import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
 
 import recovery from 'models/recovery.js';

--- a/tests/integration/api/v1/sessions/delete.test.js
+++ b/tests/integration/api/v1/sessions/delete.test.js
@@ -1,4 +1,3 @@
-import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
 
 import orchestrator from 'tests/orchestrator.js';

--- a/tests/integration/api/v1/sessions/post.test.js
+++ b/tests/integration/api/v1/sessions/post.test.js
@@ -1,7 +1,6 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
 
-import authentication from 'models/authentication';
 import session from 'models/session';
 import orchestrator from 'tests/orchestrator.js';
 
@@ -44,7 +43,7 @@ describe('POST /api/v1/sessions', () => {
       const sessionObjectInDatabase = await session.findOneById(responseBody.id);
       expect(sessionObjectInDatabase.user_id).toEqual(defaultUser.id);
 
-      const parsedCookiesFromResponse = authentication.parseSetCookies(response);
+      const parsedCookiesFromResponse = orchestrator.parseSetCookies(response);
       expect(parsedCookiesFromResponse.session_id.name).toEqual('session_id');
       expect(parsedCookiesFromResponse.session_id.value).toEqual(responseBody.token);
       expect(parsedCookiesFromResponse.session_id.maxAge).toEqual(60 * 60 * 24 * 30);

--- a/tests/integration/api/v1/sessions/post.test.js
+++ b/tests/integration/api/v1/sessions/post.test.js
@@ -1,4 +1,3 @@
-import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
 
 import session from 'models/session';

--- a/tests/integration/api/v1/status/get.test.js
+++ b/tests/integration/api/v1/status/get.test.js
@@ -1,5 +1,3 @@
-import fetch from 'cross-fetch';
-
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/status/votes/get.test.js
+++ b/tests/integration/api/v1/status/votes/get.test.js
@@ -1,4 +1,3 @@
-import fetch from 'cross-fetch';
 import { v4 as uuidV4, version as uuidVersion } from 'uuid';
 
 import orchestrator from 'tests/orchestrator.js';

--- a/tests/integration/api/v1/swr/get.test.js
+++ b/tests/integration/api/v1/swr/get.test.js
@@ -1,5 +1,3 @@
-import fetch from 'cross-fetch';
-
 import orchestrator from 'tests/orchestrator.js';
 
 describe('GET /swr', () => {

--- a/tests/integration/api/v1/user/get.test.js
+++ b/tests/integration/api/v1/user/get.test.js
@@ -1,7 +1,6 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
 
-import authentication from 'models/authentication';
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {
@@ -26,7 +25,7 @@ describe('GET /api/v1/user', () => {
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
       expect(responseBody.error_location_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
 
-      const parsedCookiesFromGet = authentication.parseSetCookies(response);
+      const parsedCookiesFromGet = orchestrator.parseSetCookies(response);
       expect(parsedCookiesFromGet).toStrictEqual({});
     });
 
@@ -50,7 +49,7 @@ describe('GET /api/v1/user', () => {
       expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
       expect(responseBody.key).toEqual('session_id');
 
-      const parsedCookiesFromGet = authentication.parseSetCookies(response);
+      const parsedCookiesFromGet = orchestrator.parseSetCookies(response);
       expect(parsedCookiesFromGet).toStrictEqual({});
     });
 
@@ -74,7 +73,7 @@ describe('GET /api/v1/user', () => {
       expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
       expect(responseBody.key).toEqual('session_id');
 
-      const parsedCookiesFromGet = authentication.parseSetCookies(response);
+      const parsedCookiesFromGet = orchestrator.parseSetCookies(response);
       expect(parsedCookiesFromGet).toStrictEqual({});
     });
 
@@ -98,7 +97,7 @@ describe('GET /api/v1/user', () => {
       expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
       expect(responseBody.key).toEqual('session_id');
 
-      const parsedCookiesFromGet = authentication.parseSetCookies(response);
+      const parsedCookiesFromGet = orchestrator.parseSetCookies(response);
       expect(parsedCookiesFromGet).toStrictEqual({});
     });
   });
@@ -132,7 +131,7 @@ describe('GET /api/v1/user', () => {
         updated_at: defaultUser.updated_at.toISOString(),
       });
 
-      const parsedCookiesFromGet = authentication.parseSetCookies(response);
+      const parsedCookiesFromGet = orchestrator.parseSetCookies(response);
       expect(parsedCookiesFromGet).toStrictEqual({});
 
       const sessionObject = await orchestrator.findSessionByToken(defaultUserSession.token);
@@ -167,7 +166,7 @@ describe('GET /api/v1/user', () => {
         'MODEL:AUTHENTICATION:INJECT_AUTHENTICATED_USER:USER_CANT_READ_SESSION',
       );
 
-      const parsedCookiesFromGet = authentication.parseSetCookies(response);
+      const parsedCookiesFromGet = orchestrator.parseSetCookies(response);
       expect(parsedCookiesFromGet).toStrictEqual({});
     });
 
@@ -199,7 +198,7 @@ describe('GET /api/v1/user', () => {
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
 
-      const parsedCookiesFromGet = authentication.parseSetCookies(response);
+      const parsedCookiesFromGet = orchestrator.parseSetCookies(response);
       expect(parsedCookiesFromGet.session_id.name).toEqual('session_id');
       expect(parsedCookiesFromGet.session_id.value).toEqual('invalid');
       expect(parsedCookiesFromGet.session_id.maxAge).toEqual(-1);
@@ -248,7 +247,7 @@ describe('GET /api/v1/user', () => {
           updated_at: defaultUser.updated_at.toISOString(),
         });
 
-        const parsedCookiesFromGet = authentication.parseSetCookies(response);
+        const parsedCookiesFromGet = orchestrator.parseSetCookies(response);
         expect(parsedCookiesFromGet.session_id.name).toEqual('session_id');
         expect(parsedCookiesFromGet.session_id.value).toEqual(sessionObjectBeforeRenew.token);
         expect(parsedCookiesFromGet.session_id.maxAge).toEqual(60 * 60 * 24 * 30);
@@ -301,7 +300,7 @@ describe('GET /api/v1/user', () => {
           updated_at: defaultUser.updated_at.toISOString(),
         });
 
-        const parsedCookiesFromGet = authentication.parseSetCookies(response);
+        const parsedCookiesFromGet = orchestrator.parseSetCookies(response);
         expect(parsedCookiesFromGet.session_id.name).toEqual('session_id');
         expect(parsedCookiesFromGet.session_id.value).toEqual(sessionObjectBeforeRenew.token);
         expect(parsedCookiesFromGet.session_id.maxAge).toEqual(60 * 60 * 24 * 30);
@@ -353,7 +352,7 @@ describe('GET /api/v1/user', () => {
           updated_at: defaultUser.updated_at.toISOString(),
         });
 
-        const parsedCookiesFromGet = authentication.parseSetCookies(response);
+        const parsedCookiesFromGet = orchestrator.parseSetCookies(response);
         expect(parsedCookiesFromGet).toStrictEqual({});
 
         const sessionObjectAfterRenew = await orchestrator.findSessionByToken(defaultUserSession.token);

--- a/tests/integration/api/v1/user/get.test.js
+++ b/tests/integration/api/v1/user/get.test.js
@@ -1,4 +1,3 @@
-import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
 
 import orchestrator from 'tests/orchestrator.js';

--- a/tests/integration/api/v1/users/[username]/delete.test.js
+++ b/tests/integration/api/v1/users/[username]/delete.test.js
@@ -1,4 +1,3 @@
-import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
 
 import orchestrator from 'tests/orchestrator.js';

--- a/tests/integration/api/v1/users/[username]/get.test.js
+++ b/tests/integration/api/v1/users/[username]/get.test.js
@@ -1,4 +1,3 @@
-import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
 
 import orchestrator from 'tests/orchestrator.js';

--- a/tests/integration/api/v1/users/[username]/patch.test.js
+++ b/tests/integration/api/v1/users/[username]/patch.test.js
@@ -1,7 +1,6 @@
 import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
 
-import authentication from 'models/authentication';
 import emailConfirmation from 'models/email-confirmation.js';
 import password from 'models/password.js';
 import user from 'models/user.js';
@@ -106,7 +105,7 @@ describe('PATCH /api/v1/users/[username]', () => {
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
 
-      const parsedCookiesFromGet = authentication.parseSetCookies(response);
+      const parsedCookiesFromGet = orchestrator.parseSetCookies(response);
       expect(parsedCookiesFromGet.session_id.name).toEqual('session_id');
       expect(parsedCookiesFromGet.session_id.value).toEqual('invalid');
       expect(parsedCookiesFromGet.session_id.maxAge).toEqual(-1);

--- a/tests/integration/api/v1/users/[username]/patch.test.js
+++ b/tests/integration/api/v1/users/[username]/patch.test.js
@@ -1,4 +1,3 @@
-import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
 
 import emailConfirmation from 'models/email-confirmation.js';
@@ -18,7 +17,7 @@ describe('PATCH /api/v1/users/[username]', () => {
       const defaultUser = await orchestrator.createUser();
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -49,7 +48,7 @@ describe('PATCH /api/v1/users/[username]', () => {
       let secondUser = await orchestrator.createUser();
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${secondUser.username}`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
           cookie: `session_id=${defaultUserSession.token}`,
@@ -84,7 +83,7 @@ describe('PATCH /api/v1/users/[username]', () => {
       vi.useRealTimers();
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
           cookie: `session_id=${defaultUserSession.token}`,
@@ -122,7 +121,7 @@ describe('PATCH /api/v1/users/[username]', () => {
       const defaultUserSession = await orchestrator.createSession(defaultUser);
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
           cookie: `session_id=${defaultUserSession.token}`,
@@ -167,7 +166,7 @@ describe('PATCH /api/v1/users/[username]', () => {
       const defaultUserSession = await orchestrator.createSession(defaultUser);
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
           cookie: `session_id=${defaultUserSession.token}`,
@@ -210,7 +209,7 @@ describe('PATCH /api/v1/users/[username]', () => {
       const defaultUserSession = await orchestrator.createSession(defaultUser);
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
           cookie: `session_id=${defaultUserSession.token}`,
@@ -251,7 +250,7 @@ describe('PATCH /api/v1/users/[username]', () => {
       const defaultUserSession = await orchestrator.createSession(defaultUser);
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
           cookie: `session_id=${defaultUserSession.token}`,
@@ -284,7 +283,7 @@ describe('PATCH /api/v1/users/[username]', () => {
       const defaultUserSession = await orchestrator.createSession(defaultUser);
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
           cookie: `session_id=${defaultUserSession.token}`,
@@ -314,7 +313,7 @@ describe('PATCH /api/v1/users/[username]', () => {
       const defaultUserSession = await orchestrator.createSession(defaultUser);
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
           cookie: `session_id=${defaultUserSession.token}`,
@@ -344,7 +343,7 @@ describe('PATCH /api/v1/users/[username]', () => {
       const defaultUserSession = await orchestrator.createSession(defaultUser);
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
           cookie: `session_id=${defaultUserSession.token}`,
@@ -374,7 +373,7 @@ describe('PATCH /api/v1/users/[username]', () => {
       const defaultUserSession = await orchestrator.createSession(defaultUser);
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
           cookie: `session_id=${defaultUserSession.token}`,
@@ -404,7 +403,7 @@ describe('PATCH /api/v1/users/[username]', () => {
       const defaultUserSession = await orchestrator.createSession(defaultUser);
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
           cookie: `session_id=${defaultUserSession.token}`,
@@ -434,7 +433,7 @@ describe('PATCH /api/v1/users/[username]', () => {
       const defaultUserSession = await orchestrator.createSession(defaultUser);
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
           cookie: `session_id=${defaultUserSession.token}`,
@@ -464,7 +463,7 @@ describe('PATCH /api/v1/users/[username]', () => {
       const defaultUserSession = await orchestrator.createSession(defaultUser);
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
           cookie: `session_id=${defaultUserSession.token}`,
@@ -494,7 +493,7 @@ describe('PATCH /api/v1/users/[username]', () => {
       const defaultUserSession = await orchestrator.createSession(defaultUser);
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
           cookie: `session_id=${defaultUserSession.token}`,
@@ -524,7 +523,7 @@ describe('PATCH /api/v1/users/[username]', () => {
       const defaultUserSession = await orchestrator.createSession(defaultUser);
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           cookie: `session_id=${defaultUserSession.token}`,
         },
@@ -549,7 +548,7 @@ describe('PATCH /api/v1/users/[username]', () => {
       const defaultUserSession = await orchestrator.createSession(defaultUser);
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           cookie: `session_id=${defaultUserSession.token}`,
         },
@@ -575,7 +574,7 @@ describe('PATCH /api/v1/users/[username]', () => {
       const defaultUserSession = await orchestrator.createSession(defaultUser);
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
           cookie: `session_id=${defaultUserSession.token}`,
@@ -605,7 +604,7 @@ describe('PATCH /api/v1/users/[username]', () => {
       const defaultUserSession = await orchestrator.createSession(defaultUser);
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
           cookie: `session_id=${defaultUserSession.token}`,
@@ -651,7 +650,7 @@ describe('PATCH /api/v1/users/[username]', () => {
       const defaultUserSession = await orchestrator.createSession(defaultUser);
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
           cookie: `session_id=${defaultUserSession.token}`,
@@ -674,7 +673,7 @@ describe('PATCH /api/v1/users/[username]', () => {
       const defaultUserSession = await orchestrator.createSession(defaultUser);
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
           cookie: `session_id=${defaultUserSession.token}`,
@@ -715,7 +714,7 @@ describe('PATCH /api/v1/users/[username]', () => {
       const defaultUserSession = await orchestrator.createSession(defaultUser);
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
           cookie: `session_id=${defaultUserSession.token}`,
@@ -744,7 +743,7 @@ describe('PATCH /api/v1/users/[username]', () => {
       const defaultUserSession = await orchestrator.createSession(defaultUser);
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
           cookie: `session_id=${defaultUserSession.token}`,
@@ -776,7 +775,7 @@ describe('PATCH /api/v1/users/[username]', () => {
         const defaultUserSession = await orchestrator.createSession(defaultUser);
 
         const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
-          method: 'patch',
+          method: 'PATCH',
           headers: {
             'Content-Type': 'application/json',
             cookie: `session_id=${defaultUserSession.token}`,
@@ -809,7 +808,7 @@ describe('PATCH /api/v1/users/[username]', () => {
       secondUser = await orchestrator.activateUser(secondUser);
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${secondUser.username}`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
           cookie: `session_id=${privilegedUserSession.token}`,
@@ -848,7 +847,7 @@ describe('PATCH /api/v1/users/[username]', () => {
       secondUser = await orchestrator.activateUser(secondUser);
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${secondUser.username}`, {
-        method: 'patch',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
           cookie: `session_id=${privilegedUserSession.token}`,

--- a/tests/integration/api/v1/users/firewall.post.test.js
+++ b/tests/integration/api/v1/users/firewall.post.test.js
@@ -1,4 +1,3 @@
-import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
 
 import event from 'models/event.js';
@@ -16,7 +15,7 @@ describe('POST /api/v1/users [FIREWALL]', () => {
   describe('Anonymous user', () => {
     test('Spamming valid users', async () => {
       const request1 = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -28,7 +27,7 @@ describe('POST /api/v1/users [FIREWALL]', () => {
       });
 
       const request2 = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -40,7 +39,7 @@ describe('POST /api/v1/users [FIREWALL]', () => {
       });
 
       const request3 = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },

--- a/tests/integration/api/v1/users/get.test.js
+++ b/tests/integration/api/v1/users/get.test.js
@@ -1,4 +1,3 @@
-import fetch from 'cross-fetch';
 import parseLinkHeader from 'parse-link-header';
 import { version as uuidVersion } from 'uuid';
 

--- a/tests/integration/api/v1/users/post.test.js
+++ b/tests/integration/api/v1/users/post.test.js
@@ -1,4 +1,3 @@
-import fetch from 'cross-fetch';
 import { version as uuidVersion } from 'uuid';
 
 import password from 'models/password.js';
@@ -15,7 +14,7 @@ describe('POST /api/v1/users', () => {
   describe('Anonymous user', () => {
     test('With unique and valid data', async () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -55,7 +54,7 @@ describe('POST /api/v1/users', () => {
 
     test('With unique and valid data, and an unknown key', async () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -92,7 +91,7 @@ describe('POST /api/v1/users', () => {
 
     test('With unique and valid data, but with "untrimmed" values', async () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -134,7 +133,7 @@ describe('POST /api/v1/users', () => {
     test('With "username" duplicated exactly (same uppercase letters)', async () => {
       // firstResponse
       await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -146,7 +145,7 @@ describe('POST /api/v1/users', () => {
       });
 
       const secondResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -173,7 +172,7 @@ describe('POST /api/v1/users', () => {
     test('With "username" duplicated (different uppercase letters)', async () => {
       // firstResponse
       await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -185,7 +184,7 @@ describe('POST /api/v1/users', () => {
       });
 
       const secondResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -211,7 +210,7 @@ describe('POST /api/v1/users', () => {
 
     test('With "username" missing', async () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -236,7 +235,7 @@ describe('POST /api/v1/users', () => {
 
     test('With "username" with a null value', async () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -262,7 +261,7 @@ describe('POST /api/v1/users', () => {
 
     test('With "username" with an empty string', async () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -288,7 +287,7 @@ describe('POST /api/v1/users', () => {
 
     test('With "username" that\'s not a String', async () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -314,7 +313,7 @@ describe('POST /api/v1/users', () => {
 
     test('With "username" containing non alphanumeric characters', async () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -340,7 +339,7 @@ describe('POST /api/v1/users', () => {
 
     test('With "username" too long', async () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -366,7 +365,7 @@ describe('POST /api/v1/users', () => {
 
     test('With "username" in blocked list', async () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -393,7 +392,7 @@ describe('POST /api/v1/users', () => {
     test('With "email" duplicated (same uppercase letters)', async () => {
       // firstResponse
       await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -405,7 +404,7 @@ describe('POST /api/v1/users', () => {
       });
 
       const secondResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -432,7 +431,7 @@ describe('POST /api/v1/users', () => {
     test('With "email" duplicated (different uppercase letters)', async () => {
       // firstResponse
       await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -444,7 +443,7 @@ describe('POST /api/v1/users', () => {
       });
 
       const secondResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -470,7 +469,7 @@ describe('POST /api/v1/users', () => {
 
     test('With "email" missing', async () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -495,7 +494,7 @@ describe('POST /api/v1/users', () => {
 
     test('With "email" with an empty string', async () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -521,7 +520,7 @@ describe('POST /api/v1/users', () => {
 
     test('With "email" that\'s not a String', async () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -547,7 +546,7 @@ describe('POST /api/v1/users', () => {
 
     test('With "email" with invalid format', async () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -573,7 +572,7 @@ describe('POST /api/v1/users', () => {
 
     test('With "password" missing', async () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -598,7 +597,7 @@ describe('POST /api/v1/users', () => {
 
     test('With "password" with an empty string', async () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -624,7 +623,7 @@ describe('POST /api/v1/users', () => {
 
     test('With "password" that\'s not a String', async () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -650,7 +649,7 @@ describe('POST /api/v1/users', () => {
 
     test('With "password" too short', async () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -676,7 +675,7 @@ describe('POST /api/v1/users', () => {
 
     test('With "password" too long', async () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
-        method: 'post',
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -702,7 +701,7 @@ describe('POST /api/v1/users', () => {
 
     test('With "body" totally blank', async () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
-        method: 'post',
+        method: 'POST',
       });
 
       const responseBody = await response.json();
@@ -720,7 +719,7 @@ describe('POST /api/v1/users', () => {
 
     test('With "body" containing a String', async () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
-        method: 'post',
+        method: 'POST',
         body: "Please don't hack us, we are the good guys!",
       });
 

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -3,6 +3,7 @@ import { faker } from '@faker-js/faker';
 import retry from 'async-retry';
 import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
+import setCookieParser from 'set-cookie-parser';
 
 import database from 'infra/database.js';
 import migrator from 'infra/migrator.js';
@@ -367,6 +368,12 @@ async function updateRewardedAt(userId, rewardedAt) {
   return await database.query(query);
 }
 
+function parseSetCookies(response) {
+  const setCookieHeaderValues = response.headers.get('set-cookie');
+  const parsedCookies = setCookieParser.parse(setCookieHeaderValues, { map: true });
+  return parsedCookies;
+}
+
 const orchestrator = {
   waitForAllServices,
   dropAllTables,
@@ -388,6 +395,7 @@ const orchestrator = {
   createPrestige,
   createRate,
   updateRewardedAt,
+  parseSetCookies,
 };
 
 export default orchestrator;


### PR DESCRIPTION
Com o PR #1708, fiquei curioso se já poderíamos remover completamente a `cross-fetch` e usar apenas o `fetch` nativo. Na busca por código que usava o padrão dessa biblioteca, que só deveria estar presente nos testes, acabei descobrindo a função `parseSetCookies` no model `authentication`.

## Mudanças realizadas

Como, de fato, a função só era chamada nos testes, movi ela para `/tests/orchestrator`, e isso abriu a possibilidade de tornar a `set-cookie-parser` uma dependência apenas de desenvolvimento. E isso foi feito no commit 2941d89d46474e0dc2cb88a2cfc5b690fe45163c.

Obs.: Hoje o `/tests/orchestrator` contém funções que talvez ficassem melhor em uma `/tests/utils`, mas, para não iniciar essa refatoração nesse PR, optei por deixar a `parseSetCookies()` também no `orchestrator`.

Após isso, o commit 4bb2ba2e7564b88da9c5272cfd9c362146b9aa26 remove completamente a `cross-fetch` e faz as adequações necessárias.

Obs. 2: Com o `fetch` nativo, apenas o método `PATCH` não funcionou com letras minúsculas (`method: 'patch'`), mas como não havia padrão nos testes, resolvi alterar para maiúsculo também onde tinha `get` ou `post`.

## Tipo de mudança

- [x] Refatoração

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Os testes antigos foram adequados e estão passando localmente.