### PR TITLE
Estabiliza testes que falham eventualmente

### DIFF
--- a/tests/integration/api/v1/contents/rss/get.test.js
+++ b/tests/integration/api/v1/contents/rss/get.test.js
@@ -84,7 +84,7 @@ describe('GET /recentes/rss', () => {
         <title>TabNews</title>
         <link>${orchestrator.webserverUrl}/recentes/rss</link>
         <description>Conteúdos para quem trabalha com Programação e Tecnologia</description>
-        <lastBuildDate>${new Date(secondRootContent.published_at).toUTCString()}</lastBuildDate>
+        <lastBuildDate>${new Date(secondRootContent.updated_at).toUTCString()}</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
         <generator>https://github.com/jpmonette/feed</generator>
         <language>pt</language>

--- a/tests/integration/api/v1/user/get.test.js
+++ b/tests/integration/api/v1/user/get.test.js
@@ -171,7 +171,7 @@ describe('GET /api/v1/user', () => {
 
     test('With expired session', async () => {
       vi.useFakeTimers({
-        now: new Date(Date.now() - 1000 * 60 * 60 * 24 * 30), // 30 days ago
+        now: new Date(Date.now() - 1000 - 1000 * 60 * 60 * 24 * 30), // 30 days and 1 second ago
       });
 
       const defaultUser = await orchestrator.createUser();
@@ -263,7 +263,7 @@ describe('GET /api/v1/user', () => {
 
       test('Should be able to renew with 9 day token', async () => {
         vi.useFakeTimers({
-          now: new Date(Date.now() - 1000 * 60 * 60 * 24 * 9), // 9 days ago
+          now: new Date(Date.now() - 1000 - 1000 * 60 * 60 * 24 * 9), // 9 days and 1 second ago
         });
 
         let defaultUser = await orchestrator.createUser();
@@ -384,7 +384,7 @@ describe('GET /api/v1/user', () => {
 
         await orchestrator.updateRewardedAt(
           defaultUser.id,
-          new Date(Date.now() - 1000 * 60 * 60 * 24), // 1 day ago
+          new Date(Date.now() - 1000 - 1000 * 60 * 60 * 24), // 1 day and 1 second ago
         );
 
         const rewardUserResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/user`, {
@@ -440,7 +440,7 @@ describe('GET /api/v1/user', () => {
 
         await orchestrator.updateRewardedAt(
           defaultUser.id,
-          new Date(Date.now() - 1000 * 60 * 60 * 24), // 1 day ago
+          new Date(Date.now() - 1000 - 1000 * 60 * 60 * 24), // 1 day and 1 second ago
         );
 
         const simultaneousResults = await Promise.all([fetchUser(), fetchUser()]);
@@ -488,7 +488,7 @@ describe('GET /api/v1/user', () => {
 
         await orchestrator.updateRewardedAt(
           defaultUser.id,
-          new Date(Date.now() - 1000 * 60 * 60 * 24), // 1 day ago
+          new Date(Date.now() - 1000 * 60 * 60 * 36), // 36 hours ago
         );
 
         const simultaneousResults = await Promise.all([fetchUser(), fetchUser()]);
@@ -533,7 +533,7 @@ describe('GET /api/v1/user', () => {
 
         await orchestrator.updateRewardedAt(
           defaultUser.id,
-          new Date(Date.now() - 1000 * 60 * 60 * 24), // 1 day ago
+          new Date(Date.now() - 1000 * 60 * 60 * 36), // 36 hours ago
         );
 
         const simultaneousResults = await Promise.all([fetchUser(), fetchUser()]);
@@ -584,7 +584,7 @@ describe('GET /api/v1/user', () => {
 
         await orchestrator.updateRewardedAt(
           defaultUser.id,
-          new Date(Date.now() - 1000 * 60 * 60 * 24), // 1 day ago
+          new Date(Date.now() - 1000 * 60 * 60 * 36), // 36 hours ago
         );
 
         const simultaneousResults = await Promise.all([fetchUser(), fetchUser()]);

--- a/tests/integration/api/v1/users/[username]/patch.test.js
+++ b/tests/integration/api/v1/users/[username]/patch.test.js
@@ -73,7 +73,7 @@ describe('PATCH /api/v1/users/[username]', () => {
 
     test('With expired session', async () => {
       vi.useFakeTimers({
-        now: new Date(Date.now() - 1000 * 60 * 60 * 24 * 30), // 30 days ago
+        now: new Date(Date.now() - 1000 - 1000 * 60 * 60 * 24 * 30), // 30 days and 1 second ago
       });
 
       let defaultUser = await orchestrator.createUser();

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -121,10 +121,36 @@ async function getLastEmail() {
   return lastEmailItem;
 }
 
+const usedFakeUsernames = new Set();
+const usedFakeEmails = new Set();
+
 async function createUser(userObject) {
+  let username = userObject?.username;
+  let email = userObject?.email;
+
+  while (!username) {
+    username = faker.internet.userName().replace(/[_.-]/g, '').substring(0, 30);
+
+    if (usedFakeUsernames.has(username)) {
+      username = undefined;
+    } else {
+      usedFakeUsernames.add(username);
+    }
+  }
+
+  while (!email) {
+    email = faker.internet.email();
+
+    if (usedFakeEmails.has(email)) {
+      email = undefined;
+    } else {
+      usedFakeEmails.add(email);
+    }
+  }
+
   return await user.create({
-    username: userObject?.username || faker.internet.userName().replace('_', '').replace('.', '').replace('-', ''),
-    email: userObject?.email || faker.internet.email(),
+    username,
+    email,
     password: userObject?.password || 'password',
     description: userObject?.description || '',
   });


### PR DESCRIPTION
Inspirado pelo assunto que vem sendo abordado nas últimas aulas do curso.dev, sobre a estabilização dos testes, resolvi corrigir alguns testes que falhavam muito raramente, ou por diferenças de relógio, ou pela falta de aleatoriedade na geração de usuários falsos.

## Diferenças de horário

Eventual diferença no relógio do PostgreSQL e do Vitest causa alguns comportamentos indesejados.

### RSS

O campo `lastBuildDate` do feed RSS é preenchido com o valor do `updated_at` do conteúdo mais atual, mas o teste verificava se o valor batia com o `published_at` desse conteúdo. Quase sempre batia, mas em alguns poucos casos existia alguma pequena diferença que acusava erro no teste.

Agora a comparação ocorre corretamente entre `lastBuildDate` e o `updated_at`.

### Expiração e revalidação do token de sessão

Os testes verificavam a expiração simulando a passagem de tempos exatos, mas eventualmente o teste falhava pelo token ainda não ter expirado. 

Agora é simulada a passagem de um tempo extra, além do tempo normal.

## Criação de usuários

Utilizamos a biblioteca [@faker-js/faker](https://www.npmjs.com/package/@faker-js/faker) para preencher campos com dados aleatórios, mas de vez em quando a aleatoriedade falha, e isso causa erros de duplicidade.

### `username` ou `email` duplicados

Era raro, mas de vez em quando ocorria algum erro porque a biblioteca gerava duas vezes o mesmo nome de usuário, ou endereço de email, na mesma bateria de testes.

Agora são armazenados todos os nomes e emails já utilizados durante a bateria de testes, e assim podemos garantir que não haverá tentativa de criar usuários duplicados, a menos que estejamos propositalmente testando essa condição.

### `username` muito longo

A biblioteca não permite limitar o tamanho do `username` criado, então eventualmente o `username` gerado passava dos 30 caracteres permitidos.

Agora temos `substring(0, 30)` para garantir que os nomes aleatórios não passem de 30 caracteres.


## Tipo de mudança

<!-- Descomente a linha abaixo que corresponde ao tipo de mudança realizada no PR. -->

- [x] Correção de bug nos testes

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Os testes antigos estão passando localmente.
