### PR TITLE
Corrige a validação do `slug` truncado terminando com hífen

### DIFF
--- a/models/content.js
+++ b/models/content.js
@@ -377,24 +377,24 @@ function populateSlug(postedContent) {
   }
 }
 
+slug.extend({
+  '%': ' por cento',
+  '>': '-',
+  '<': '-',
+  '@': '-',
+  '.': '-',
+  ',': '-',
+  '&': ' e ',
+  _: '-',
+  '/': '-',
+});
+
 function getSlug(title) {
   if (!title) {
     return;
   }
 
-  slug.extend({
-    '%': ' por cento',
-    '>': '-',
-    '<': '-',
-    '@': '-',
-    '.': '-',
-    ',': '-',
-    '&': ' e ',
-    _: '-',
-    '/': '-',
-  });
-
-  const generatedSlug = slug(title, {
+  const generatedSlug = slug(title.substring(0, 226), {
     trim: true,
   });
 

--- a/models/content.js
+++ b/models/content.js
@@ -394,7 +394,7 @@ function getSlug(title) {
     return;
   }
 
-  const generatedSlug = slug(title.substring(0, 226), {
+  const generatedSlug = slug(title.substring(0, 160), {
     trim: true,
   });
 
@@ -433,7 +433,7 @@ function parseQueryErrorToCustomError(error) {
   if (error.databaseErrorCode === database.errorCodes.UNIQUE_CONSTRAINT_VIOLATION) {
     return new ValidationError({
       message: `O conteúdo enviado parece ser duplicado.`,
-      action: `Utilize um "title" ou "slug" diferente.`,
+      action: `Utilize um "title" ou "slug" com começo diferente.`,
       stack: new Error().stack,
       errorLocationCode: 'MODEL:CONTENT:CHECK_FOR_CONTENT_UNIQUENESS:ALREADY_EXISTS',
       statusCode: 400,

--- a/models/validator.js
+++ b/models/validator.js
@@ -208,6 +208,7 @@ const schemas = {
         .max(226, 'utf8')
         .trim()
         .truncate()
+        .custom(noTrailingHyphen)
         .pattern(/^[a-z0-9](-?[a-z0-9])*$/)
         .when('$required.slug', { is: 'required', then: Joi.required(), otherwise: Joi.optional() }),
     });
@@ -667,6 +668,13 @@ const schemas = {
         .when('$required.ban_type', { is: 'required', then: Joi.required(), otherwise: Joi.optional() }),
     });
   },
+};
+
+const noTrailingHyphen = (value) => {
+  while (value.endsWith('-')) {
+    value = value.slice(0, -1);
+  }
+  return value;
 };
 
 const withoutMarkdown = (value, helpers) => {

--- a/models/validator.js
+++ b/models/validator.js
@@ -205,7 +205,7 @@ const schemas = {
     return Joi.object({
       slug: Joi.string()
         .min(1)
-        .max(226, 'utf8')
+        .max(160, 'utf8')
         .trim()
         .truncate()
         .custom(noTrailingHyphen)

--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -372,6 +372,9 @@ export const getStaticProps = getStaticPropsRevalidate(async (context) => {
     modified_time: secureContentFound.updated_at,
     author: secureContentFound.owner_username,
     type: 'article',
+    canonical: secureContentFound.parent_id
+      ? undefined
+      : `${webserver.host}/${secureContentFound.owner_username}/${secureContentFound.slug}`,
   };
 
   let secureRootContentFound = null;

--- a/tests/constants-for-tests.js
+++ b/tests/constants-for-tests.js
@@ -1,1 +1,2 @@
 export const maxSlugLength = 160;
+export const maxTitleLength = 255;

--- a/tests/constants-for-tests.js
+++ b/tests/constants-for-tests.js
@@ -1,0 +1,1 @@
+export const maxSlugLength = 160;

--- a/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
@@ -934,6 +934,50 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
+    test('Content with "slug" with trailing hyphen', async () => {
+      const contentsRequestBuilder = new RequestBuilder('/api/v1/contents');
+      const defaultUser = await contentsRequestBuilder.buildUser();
+
+      const defaultUserContent = await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Título velho',
+        body: 'Body velho',
+      });
+
+      const { response, responseBody } = await contentsRequestBuilder.patch(
+        `/${defaultUser.username}/${defaultUserContent.slug}`,
+        {
+          slug: 'slug-with-trailing-hyphen---',
+        },
+      );
+
+      expect(response.status).toEqual(200);
+
+      expect(responseBody).toStrictEqual({
+        id: responseBody.id,
+        owner_id: defaultUser.id,
+        parent_id: null,
+        slug: 'slug-with-trailing-hyphen',
+        title: 'Título velho',
+        body: 'Body velho',
+        status: 'draft',
+        source_url: null,
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+        published_at: null,
+        deleted_at: null,
+        tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
+        owner_username: defaultUser.username,
+      });
+
+      expect(uuidVersion(responseBody.id)).toEqual(4);
+      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toEqual(true);
+    });
+
     test('Content with "title" declared solely', async () => {
       const contentsRequestBuilder = new RequestBuilder('/api/v1/contents');
       const defaultUser = await contentsRequestBuilder.buildUser();

--- a/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
@@ -1,6 +1,6 @@
 import { version as uuidVersion } from 'uuid';
 
-import { maxSlugLength } from 'tests/constants-for-tests';
+import { maxSlugLength, maxTitleLength } from 'tests/constants-for-tests';
 import orchestrator from 'tests/orchestrator.js';
 import RequestBuilder from 'tests/request-builder';
 
@@ -1087,7 +1087,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
     });
 
-    test('Content with "title" containing more than 255 characters', async () => {
+    test(`Content with "title" containing more than ${maxTitleLength} characters`, async () => {
       const contentsRequestBuilder = new RequestBuilder('/api/v1/contents');
       const defaultUser = await contentsRequestBuilder.buildUser();
 
@@ -1100,15 +1100,14 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       const { response, responseBody } = await contentsRequestBuilder.patch(
         `/${defaultUser.username}/${defaultUserContent.slug}`,
         {
-          title:
-            'Este título possui 256 caracteressssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss',
+          title: `Este título possui ${1 + maxTitleLength} caracteres`.padEnd(1 + maxTitleLength, 's'),
         },
       );
 
       expect(response.status).toEqual(400);
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"title" deve conter no máximo 255 caracteres.');
+      expect(responseBody.message).toEqual(`"title" deve conter no máximo ${maxTitleLength} caracteres.`);
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);

--- a/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
@@ -1,5 +1,6 @@
 import { version as uuidVersion } from 'uuid';
 
+import { maxSlugLength } from 'tests/constants-for-tests';
 import orchestrator from 'tests/orchestrator.js';
 import RequestBuilder from 'tests/request-builder';
 
@@ -707,7 +708,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
         message: 'O conteúdo enviado parece ser duplicado.',
-        action: 'Utilize um "title" ou "slug" diferente.',
+        action: 'Utilize um "title" ou "slug" com começo diferente.',
         status_code: 400,
         error_id: responseBody.error_id,
         request_id: responseBody.request_id,
@@ -749,7 +750,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
         message: 'O conteúdo enviado parece ser duplicado.',
-        action: 'Utilize um "title" ou "slug" diferente.',
+        action: 'Utilize um "title" ou "slug" com começo diferente.',
         status_code: 400,
         error_id: responseBody.error_id,
         request_id: responseBody.request_id,
@@ -840,7 +841,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
-    test('Content with "slug" containing more than 226 bytes', async () => {
+    test(`Content with "slug" containing more than ${maxSlugLength} bytes`, async () => {
       const contentsRequestBuilder = new RequestBuilder('/api/v1/contents');
       const defaultUser = await contentsRequestBuilder.buildUser();
 
@@ -853,7 +854,10 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       const { response, responseBody } = await contentsRequestBuilder.patch(
         `/${defaultUser.username}/${defaultUserContent.slug}`,
         {
-          slug: 'this-slug-must-be-changed-from-227-to-226-bytes'.padEnd(227, 's'),
+          slug: `this-slug-must-be-changed-from-${1 + maxSlugLength}-to-${maxSlugLength}-bytes`.padEnd(
+            1 + maxSlugLength,
+            's',
+          ),
         },
       );
 
@@ -863,7 +867,10 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         id: responseBody.id,
         owner_id: defaultUser.id,
         parent_id: null,
-        slug: 'this-slug-must-be-changed-from-227-to-226-bytes'.padEnd(226, 's'),
+        slug: `this-slug-must-be-changed-from-${1 + maxSlugLength}-to-${maxSlugLength}-bytes`.padEnd(
+          maxSlugLength,
+          's',
+        ),
         title: 'Título velho',
         body: 'Body velho',
         status: 'draft',

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -1,7 +1,7 @@
 import { version as uuidVersion } from 'uuid';
 
 import database from 'infra/database';
-import { maxSlugLength } from 'tests/constants-for-tests';
+import { maxSlugLength, maxTitleLength } from 'tests/constants-for-tests';
 import orchestrator from 'tests/orchestrator.js';
 import RequestBuilder from 'tests/request-builder';
 
@@ -734,34 +734,33 @@ describe('POST /api/v1/contents', () => {
       expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
-    test('Content with "title" containing more than 255 characters', async () => {
+    test(`Content with "title" containing more than ${maxTitleLength} characters`, async () => {
       const contentsRequestBuilder = new RequestBuilder('/api/v1/contents');
       await contentsRequestBuilder.buildUser();
 
       const { response, responseBody } = await contentsRequestBuilder.post({
-        title:
-          'Este título possui 256 caracteressssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss',
+        title: `Este título possui ${1 + maxTitleLength} caracteres`.padEnd(1 + maxTitleLength, 's'),
         body: 'Qualquer coisa.',
       });
 
       expect(response.status).toEqual(400);
       expect(responseBody.status_code).toEqual(400);
       expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"title" deve conter no máximo 255 caracteres.');
+      expect(responseBody.message).toEqual(`"title" deve conter no máximo ${maxTitleLength} caracteres.`);
       expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
       expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
-    test('Content with "title" containing 255 characters but more than 255 bytes', async () => {
+    test(`Content with "title" containing ${maxTitleLength} characters but more than ${maxTitleLength} bytes`, async () => {
       const contentsRequestBuilder = new RequestBuilder('/api/v1/contents');
       const defaultUser = await contentsRequestBuilder.buildUser();
 
       const { response, responseBody } = await contentsRequestBuilder.post({
         title:
-          `Este título possui 255 caracteres ocupando 256 bytes e deve com 100% de certeza gerar um slug limitado a ${maxSlugLength} bytes`.padEnd(
-            255,
+          `Este título possui ${maxTitleLength} caracteres ocupando ${1 + maxTitleLength} bytes e deve com 100% de certeza gerar um slug limitado a ${maxSlugLength} bytes`.padEnd(
+            maxTitleLength,
             's',
           ),
         body: 'Instale o Node.js',
@@ -773,13 +772,13 @@ describe('POST /api/v1/contents', () => {
         id: responseBody.id,
         owner_id: defaultUser.id,
         parent_id: null,
-        slug: `este-titulo-possui-255-caracteres-ocupando-256-bytes-e-deve-com-100-por-cento-de-certeza-gerar-um-slug-limitado-a-${maxSlugLength}-bytes`.padEnd(
+        slug: `este-titulo-possui-${maxTitleLength}-caracteres-ocupando-${1 + maxTitleLength}-bytes-e-deve-com-100-por-cento-de-certeza-gerar-um-slug-limitado-a-${maxSlugLength}-bytes`.padEnd(
           maxSlugLength,
           's',
         ),
         title:
-          `Este título possui 255 caracteres ocupando 256 bytes e deve com 100% de certeza gerar um slug limitado a ${maxSlugLength} bytes`.padEnd(
-            255,
+          `Este título possui ${maxTitleLength} caracteres ocupando ${1 + maxTitleLength} bytes e deve com 100% de certeza gerar um slug limitado a ${maxSlugLength} bytes`.padEnd(
+            maxTitleLength,
             's',
           ),
         body: 'Instale o Node.js',
@@ -835,13 +834,13 @@ describe('POST /api/v1/contents', () => {
       expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
     });
 
-    test('Content with "title" containing special characters occupying more than 255 bytes', async () => {
+    test(`Content with "title" containing special characters occupying more than ${maxTitleLength} bytes`, async () => {
       const contentsRequestBuilder = new RequestBuilder('/api/v1/contents');
       const defaultUser = await contentsRequestBuilder.buildUser();
 
       const { response, responseBody } = await contentsRequestBuilder.post({
-        title: '♥'.repeat(255),
-        body: `The title is 255 characters but 765 bytes and the slug should only be ${maxSlugLength} bytes`,
+        title: '♥'.repeat(maxTitleLength),
+        body: `The title is ${maxTitleLength} characters but 765 bytes and the slug should only be ${maxSlugLength} bytes`,
       });
 
       expect(response.status).toEqual(201);
@@ -851,8 +850,8 @@ describe('POST /api/v1/contents', () => {
         owner_id: defaultUser.id,
         parent_id: null,
         slug: ''.padEnd(maxSlugLength, '4pml'),
-        title: '♥'.repeat(255),
-        body: `The title is 255 characters but 765 bytes and the slug should only be ${maxSlugLength} bytes`,
+        title: '♥'.repeat(maxTitleLength),
+        body: `The title is ${maxTitleLength} characters but 765 bytes and the slug should only be ${maxSlugLength} bytes`,
         status: 'draft',
         source_url: null,
         created_at: responseBody.created_at,

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -1,6 +1,7 @@
 import { version as uuidVersion } from 'uuid';
 
 import database from 'infra/database';
+import { maxSlugLength } from 'tests/constants-for-tests';
 import orchestrator from 'tests/orchestrator.js';
 import RequestBuilder from 'tests/request-builder';
 
@@ -480,14 +481,17 @@ describe('POST /api/v1/contents', () => {
       expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
-    test('Content with "slug" containing more than 226 bytes', async () => {
+    test(`Content with "slug" containing more than ${maxSlugLength} bytes`, async () => {
       const contentsRequestBuilder = new RequestBuilder('/api/v1/contents');
       const defaultUser = await contentsRequestBuilder.buildUser();
 
       const { response, responseBody } = await contentsRequestBuilder.post({
         title: 'Mini curso de Node.js',
         body: 'Instale o Node.js',
-        slug: 'this-slug-must-be-changed-from-227-to-226-bytes'.padEnd(227, 's'),
+        slug: `this-slug-must-be-changed-from-${1 + maxSlugLength}-to-${maxSlugLength}-bytes`.padEnd(
+          1 + maxSlugLength,
+          's',
+        ),
       });
 
       expect(response.status).toEqual(201);
@@ -496,7 +500,10 @@ describe('POST /api/v1/contents', () => {
         id: responseBody.id,
         owner_id: defaultUser.id,
         parent_id: null,
-        slug: 'this-slug-must-be-changed-from-227-to-226-bytes'.padEnd(226, 's'),
+        slug: `this-slug-must-be-changed-from-${1 + maxSlugLength}-to-${maxSlugLength}-bytes`.padEnd(
+          maxSlugLength,
+          's',
+        ),
         title: 'Mini curso de Node.js',
         body: 'Instale o Node.js',
         status: 'draft',
@@ -579,7 +586,7 @@ describe('POST /api/v1/contents', () => {
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
         message: 'O conteúdo enviado parece ser duplicado.',
-        action: 'Utilize um "title" ou "slug" diferente.',
+        action: 'Utilize um "title" ou "slug" com começo diferente.',
         status_code: 400,
         error_id: responseBody.error_id,
         request_id: responseBody.request_id,
@@ -613,7 +620,7 @@ describe('POST /api/v1/contents', () => {
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
         message: 'O conteúdo enviado parece ser duplicado.',
-        action: 'Utilize um "title" ou "slug" diferente.',
+        action: 'Utilize um "title" ou "slug" com começo diferente.',
         status_code: 400,
         error_id: responseBody.error_id,
         request_id: responseBody.request_id,
@@ -753,7 +760,10 @@ describe('POST /api/v1/contents', () => {
 
       const { response, responseBody } = await contentsRequestBuilder.post({
         title:
-          'Este título possui 255 caracteres ocupando 256 bytes e deve com 100% de certeza gerar um slug ocupando menos de 256 bytesssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss',
+          `Este título possui 255 caracteres ocupando 256 bytes e deve com 100% de certeza gerar um slug limitado a ${maxSlugLength} bytes`.padEnd(
+            255,
+            's',
+          ),
         body: 'Instale o Node.js',
       });
 
@@ -763,9 +773,15 @@ describe('POST /api/v1/contents', () => {
         id: responseBody.id,
         owner_id: defaultUser.id,
         parent_id: null,
-        slug: 'este-titulo-possui-255-caracteres-ocupando-256-bytes-e-deve-com-100-por-cento-de-certeza-gerar-um-slug-ocupando-menos-de-256-bytesssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss',
+        slug: `este-titulo-possui-255-caracteres-ocupando-256-bytes-e-deve-com-100-por-cento-de-certeza-gerar-um-slug-limitado-a-${maxSlugLength}-bytes`.padEnd(
+          maxSlugLength,
+          's',
+        ),
         title:
-          'Este título possui 255 caracteres ocupando 256 bytes e deve com 100% de certeza gerar um slug ocupando menos de 256 bytesssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss',
+          `Este título possui 255 caracteres ocupando 256 bytes e deve com 100% de certeza gerar um slug limitado a ${maxSlugLength} bytes`.padEnd(
+            255,
+            's',
+          ),
         body: 'Instale o Node.js',
         status: 'draft',
         source_url: null,
@@ -825,7 +841,7 @@ describe('POST /api/v1/contents', () => {
 
       const { response, responseBody } = await contentsRequestBuilder.post({
         title: '♥'.repeat(255),
-        body: 'The title is 255 characters but 765 bytes and the slug should only be 255 bytes',
+        body: `The title is 255 characters but 765 bytes and the slug should only be ${maxSlugLength} bytes`,
       });
 
       expect(response.status).toEqual(201);
@@ -834,9 +850,9 @@ describe('POST /api/v1/contents', () => {
         id: responseBody.id,
         owner_id: defaultUser.id,
         parent_id: null,
-        slug: '4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4pml4p',
+        slug: ''.padEnd(maxSlugLength, '4pml'),
         title: '♥'.repeat(255),
-        body: 'The title is 255 characters but 765 bytes and the slug should only be 255 bytes',
+        body: `The title is 255 characters but 765 bytes and the slug should only be ${maxSlugLength} bytes`,
         status: 'draft',
         source_url: null,
         created_at: responseBody.created_at,

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -672,6 +672,42 @@ describe('POST /api/v1/contents', () => {
       expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
     });
 
+    test('Content with "slug" with trailing hyphen', async () => {
+      const contentsRequestBuilder = new RequestBuilder('/api/v1/contents');
+      const defaultUser = await contentsRequestBuilder.buildUser();
+
+      const { response, responseBody } = await contentsRequestBuilder.post({
+        title: 'Mini curso de Node.js',
+        body: 'Instale o Node.js',
+        slug: 'slug-with-trailing-hyphen---',
+      });
+
+      expect(response.status).toEqual(201);
+
+      expect(responseBody).toStrictEqual({
+        id: responseBody.id,
+        owner_id: defaultUser.id,
+        parent_id: null,
+        slug: 'slug-with-trailing-hyphen',
+        title: 'Mini curso de Node.js',
+        body: 'Instale o Node.js',
+        status: 'draft',
+        source_url: null,
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+        published_at: null,
+        deleted_at: null,
+        tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
+        owner_username: defaultUser.username,
+      });
+
+      expect(uuidVersion(responseBody.id)).toEqual(4);
+      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+    });
+
     test('Content with "title" containing a blank String', async () => {
       const contentsRequestBuilder = new RequestBuilder('/api/v1/contents');
       await contentsRequestBuilder.buildUser();


### PR DESCRIPTION
## Mudanças realizadas

Cria uma validação customizada para remover o hífen final do `slug` quando necessário.

```js
const noTrailingHyphen = (value) => {
  while (value.endsWith('-')) {
    value = value.slice(0, -1);
  }
  return value;
};
```

Apenas essa mudança no validador já é suficiente para corrigir o bug, independentemente do `slug` ser fornecido pelo criador do conteúdo ou gerado automaticamente, mas aproveitei o PR para otimizar o modo que utilizamos a biblioteca [`slug`](https://www.npmjs.com/package/slug) para geração baseada no `title`:

- Tirei a configuração `slug.extend` de dentro da função `getSlug` para que a configuração da biblioteca ocorra apenas uma vez.
- Trunquei o título antes de passar para a biblioteca, pois assim diminuímos o trabalho realizado em grandes títulos, e garantimos que o `slug` gerado nunca será barrado pelo validador.

Resolve #1721

## Tipo de mudança

- [x] Correção de bug

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
