### PR TITLE
Habilita mais regras do ESLint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -30,7 +30,9 @@
       ],
       "rules": {
         "vitest/no-conditional-in-test": "error",
-        "vitest/no-disabled-tests": "warn"
+        "vitest/no-disabled-tests": "warn",
+        "vitest/no-focused-tests": "error",
+        "vitest/require-to-throw-message": "error"
       },
       "env": {
         "vitest-globals/env": true
@@ -86,6 +88,7 @@
         "vars": "all",
         "args": "after-used"
       }
-    ]
+    ],
+    "prefer-const": "error"
   }
 }

--- a/models/content.js
+++ b/models/content.js
@@ -853,7 +853,7 @@ async function findTree(options = {}) {
   }
 
   function validateWhereSchema(where) {
-    let options = {};
+    const options = {};
 
     if (where.parent_id) {
       options.parent_id = 'required';

--- a/pages/interface/components/PasswordInput/index.js
+++ b/pages/interface/components/PasswordInput/index.js
@@ -9,7 +9,7 @@ export default function PasswordInput({ inputRef, id, name, label, errorObject, 
 
   function focusAfterEnd(ref) {
     setTimeout(() => {
-      let len = ref.current.value.length;
+      const len = ref.current.value.length;
       ref.current.focus();
       ref.current.setSelectionRange(len, len);
     }, 5);

--- a/pages/interface/hooks/useCollapse/index.js
+++ b/pages/interface/hooks/useCollapse/index.js
@@ -20,7 +20,7 @@ export default function useCollapse({
     setChildrenState((lastState) => {
       const childIndex = lastState.findIndex((child) => child.id === id);
       let grouperIndex = childIndex;
-      let childrenToExpand = [];
+      const childrenToExpand = [];
 
       while (lastState[grouperIndex]?.renderIntent === 0) {
         childrenToExpand.push(lastState[grouperIndex]);
@@ -42,7 +42,7 @@ export default function useCollapse({
   function handleCollapse(id) {
     setChildrenState((lastState) => {
       const childIndex = lastState.findIndex((child) => child.id === id);
-      let children = [...lastState];
+      const children = [...lastState];
 
       if (childIndex < 0) return children;
 

--- a/tests/integration/api/v1/activation/patch.test.js
+++ b/tests/integration/api/v1/activation/patch.test.js
@@ -272,7 +272,7 @@ describe('PATCH /api/v1/activation', () => {
       let defaultUser = await orchestrator.createUser();
       defaultUser = await orchestrator.activateUser(defaultUser);
       const activationToken = await activation.create(defaultUser);
-      let defaultUserSession = await orchestrator.createSession(defaultUser);
+      const defaultUserSession = await orchestrator.createSession(defaultUser);
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/activation`, {
         method: 'PATCH',

--- a/tests/integration/api/v1/contents/[username]/[slug]/tabcoins/post.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/tabcoins/post.test.js
@@ -512,7 +512,7 @@ describe('POST /api/v1/contents/tabcoins', () => {
 
       const postTabCoinsResponsesStatus = postTabCoinsResponses.map(({ response }) => response.status);
 
-      let successPostIndexes = [postTabCoinsResponsesStatus.indexOf(201)];
+      const successPostIndexes = [postTabCoinsResponsesStatus.indexOf(201)];
 
       for (let i = 0; i < timesSuccessfully; i++) {
         successPostIndexes.push(postTabCoinsResponsesStatus.indexOf(201, successPostIndexes[i] + 1));

--- a/tests/integration/api/v1/migrations/get.test.js
+++ b/tests/integration/api/v1/migrations/get.test.js
@@ -30,7 +30,7 @@ describe('GET /api/v1/migrations', () => {
     test('Retrieving pending migrations', async () => {
       let defaultUser = await orchestrator.createUser();
       defaultUser = await orchestrator.activateUser(defaultUser);
-      let defaultUserSession = await orchestrator.createSession(defaultUser);
+      const defaultUserSession = await orchestrator.createSession(defaultUser);
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/migrations`, {
         method: 'GET',

--- a/tests/integration/api/v1/migrations/post.test.js
+++ b/tests/integration/api/v1/migrations/post.test.js
@@ -33,9 +33,9 @@ describe('POST /api/v1/migrations', () => {
 
   describe('User with default features', () => {
     test('Running pending migrations', async () => {
-      let defaultUser = await orchestrator.createUser();
+      const defaultUser = await orchestrator.createUser();
       await orchestrator.activateUser(defaultUser);
-      let defaultUserSession = await orchestrator.createSession(defaultUser);
+      const defaultUserSession = await orchestrator.createSession(defaultUser);
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/migrations`, {
         method: 'POST',
@@ -60,11 +60,11 @@ describe('POST /api/v1/migrations', () => {
 
   describe('User with "create:migration" feature', () => {
     test('Running pending migrations', async () => {
-      let privilegedUser = await orchestrator.createUser();
+      const privilegedUser = await orchestrator.createUser();
       await orchestrator.activateUser(privilegedUser);
       await orchestrator.addFeaturesToUser(privilegedUser, ['create:migration']);
 
-      let privilegedUserSession = await orchestrator.createSession(privilegedUser);
+      const privilegedUserSession = await orchestrator.createSession(privilegedUser);
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/migrations`, {
         method: 'POST',

--- a/tests/integration/api/v1/status/votes/get.test.js
+++ b/tests/integration/api/v1/status/votes/get.test.js
@@ -30,7 +30,7 @@ describe('GET /api/v1/status/votes', () => {
     test('Should not retrieve voting data', async () => {
       let defaultUser = await orchestrator.createUser();
       defaultUser = await orchestrator.activateUser(defaultUser);
-      let defaultUserSession = await orchestrator.createSession(defaultUser);
+      const defaultUserSession = await orchestrator.createSession(defaultUser);
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/status/votes`, {
         method: 'GET',

--- a/tests/integration/api/v1/users/[username]/patch.test.js
+++ b/tests/integration/api/v1/users/[username]/patch.test.js
@@ -45,7 +45,7 @@ describe('PATCH /api/v1/users/[username]', () => {
       let defaultUser = await orchestrator.createUser();
       defaultUser = await orchestrator.activateUser(defaultUser);
       const defaultUserSession = await orchestrator.createSession(defaultUser);
-      let secondUser = await orchestrator.createUser();
+      const secondUser = await orchestrator.createUser();
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${secondUser.username}`, {
         method: 'PATCH',

--- a/tests/integration/api/v1/users/firewall.post.test.js
+++ b/tests/integration/api/v1/users/firewall.post.test.js
@@ -69,7 +69,9 @@ describe('POST /api/v1/users [FIREWALL]', () => {
 
       const user1 = await user.findOneById(request1Body.id);
       const user2 = await user.findOneById(request2Body.id);
-      await expect(user.findOneByUsername('request3')).rejects.toThrow();
+      await expect(user.findOneByUsername('request3')).rejects.toThrow(
+        'O "username" informado não foi encontrado no sistema.',
+      );
 
       expect(user1.features).toStrictEqual([]);
       expect(user2.features).toStrictEqual([]);

--- a/tests/integration/api/v1/users/get.test.js
+++ b/tests/integration/api/v1/users/get.test.js
@@ -49,7 +49,7 @@ describe('GET /api/v1/users', () => {
 
   describe('Default user', () => {
     test('User without "read:user:list" feature', async () => {
-      let defaultUserSession = await orchestrator.createSession(defaultUser);
+      const defaultUserSession = await orchestrator.createSession(defaultUser);
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users`, {
         method: 'GET',


### PR DESCRIPTION
## Mudanças realizadas

Estou habilitando algumas regras úteis do ESLint para facilitar revisões de PR e também para evitar erros ao criar um commit.

- [`prefer-const`](https://eslint.org/docs/latest/rules/prefer-const): percebi a necessidade no PR #1716, onde algumas variáveis eram declaradas com `let`, apesar de serem constantes.
- [`vitest/no-focused-tests`](https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/no-focused-tests.md): essa eu habilitei no PR #1638 (ainda não mesclado) há alguns meses porque já quase esqueci de remover o `.only` em alguns testes.
- [`vitest/require-to-throw-message`](https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/require-to-throw-message.md): pequena melhoria que ajuda a garantir que o `expect` realmente testa o que é esperado. Resultou em uma modificação no teste `Spamming valid users` em `/api/v1/users/firewall.post.test.js`.