### PR TITLE
Usa o módulo `crypto` para gerar UUIDs e move o `uuid` para `devDependencies`

### DIFF
--- a/errors/index.js
+++ b/errors/index.js
@@ -1,4 +1,4 @@
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'crypto';
 
 class BaseError extends Error {
   constructor({

--- a/models/content.js
+++ b/models/content.js
@@ -1,5 +1,5 @@
+import { randomUUID as uuidV4 } from 'node:crypto';
 import slug from 'slug';
-import { v4 as uuidV4 } from 'uuid';
 
 import { ForbiddenError, ValidationError } from 'errors';
 import database from 'infra/database.js';

--- a/models/controller.js
+++ b/models/controller.js
@@ -1,5 +1,5 @@
+import { randomUUID as uuidV4 } from 'node:crypto';
 import snakeize from 'snakeize';
-import { v4 as uuidV4 } from 'uuid';
 
 import {
   ForbiddenError,

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,6 @@
         "snakeize": "0.1.0",
         "styled-components": "5.3.11",
         "swr": "2.2.4",
-        "uuid": "9.0.1",
         "vis-network": "9.1.9"
       },
       "devDependencies": {
@@ -82,6 +81,7 @@
         "react-email": "2.0.0",
         "retry-cli": "0.7.0",
         "set-cookie-parser": "2.6.0",
+        "uuid": "9.0.1",
         "vite-tsconfig-paths": "4.3.1",
         "vitest": "1.3.1"
       },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "snakeize": "0.1.0",
     "styled-components": "5.3.11",
     "swr": "2.2.4",
-    "uuid": "9.0.1",
     "vis-network": "9.1.9"
   },
   "devDependencies": {
@@ -73,6 +72,7 @@
     "react-email": "2.0.0",
     "retry-cli": "0.7.0",
     "set-cookie-parser": "2.6.0",
+    "uuid": "9.0.1",
     "vite-tsconfig-paths": "4.3.1",
     "vitest": "1.3.1"
   },

--- a/pages/api/v1/_responses/rate-limit-reached-sessions.public.js
+++ b/pages/api/v1/_responses/rate-limit-reached-sessions.public.js
@@ -1,6 +1,6 @@
 import nextConnect from 'next-connect';
+import { randomUUID as uuidV4 } from 'node:crypto';
 import snakeize from 'snakeize';
-import { v4 as uuidV4 } from 'uuid';
 
 import { ForbiddenError, TooManyRequestsError, UnauthorizedError } from 'errors';
 import logger from 'infra/logger.js';

--- a/tests/integration/api/v1/status/votes/get.test.js
+++ b/tests/integration/api/v1/status/votes/get.test.js
@@ -1,4 +1,5 @@
-import { v4 as uuidV4, version as uuidVersion } from 'uuid';
+import { randomUUID as uuidV4 } from 'node:crypto';
+import { version as uuidVersion } from 'uuid';
 
 import orchestrator from 'tests/orchestrator.js';
 

--- a/tests/unit/models/prestige.test.js
+++ b/tests/unit/models/prestige.test.js
@@ -1,4 +1,4 @@
-import { v4 as uuidV4 } from 'uuid';
+import { randomUUID as uuidV4 } from 'node:crypto';
 
 import prestige from 'models/prestige';
 

--- a/tests/unit/models/reward.test.js
+++ b/tests/unit/models/reward.test.js
@@ -1,4 +1,4 @@
-import { v4 as uuidV4 } from 'uuid';
+import { randomUUID as uuidV4 } from 'node:crypto';
 
 import database, { mockQuery, mockRelease } from 'infra/database';
 import balance from 'models/balance';


### PR DESCRIPTION
## Mudanças realizadas

Esbarrei com o PR https://github.com/filipedeschamps/tabnews.com.br/pull/1018 e decidi reimplementar. Não foi possível remover a biblioteca `uuid`, porque usamos uma função dela para verificar a versão do UUID em testes, mas foi possível passar a biblioteca `uuid` para ser uma dependência de desenvolvimento e utilizar o módulo `crypto` para gerar os UUIDs com [`.randomUUID()`](https://nodejs.org/api/crypto.html#cryptorandomuuidoptions). 

O módulo deve ser importado como `crypto` ao invés de `node:crypto` nos arquivos que são executados em Middlewares Edge da Vercel, conforme documentação ([aqui](https://vercel.com/docs/functions/runtimes/edge-runtime#compatible-node.js-modules) e [aqui](https://vercel.com/docs/functions/runtimes/edge-runtime#crypto-apis)).

## Tipo de mudança

- [x] Refatoração

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
