### PR TITLE
Remove propriedade obsoleta `version` do Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Rodar o TabNews em sua máquina local é uma tarefa extremamente simples.
 Você precisa ter duas principais dependências instaladas:
 
 - Node.js LTS v18 (ou qualquer versão superior)
-- Docker Engine v17.12.0 com Docker Compose v1.24.1 (ou qualquer versão superior)
+- Docker Engine v17.12.0 com Docker Compose v1.29.2 (ou qualquer versão superior)
 
 ### Dependências locais
 

--- a/infra/docker-compose.development.yml
+++ b/infra/docker-compose.development.yml
@@ -1,4 +1,4 @@
-version: '2.4'
+name: 'tabnews'
 services:
   postgres_dev:
     container_name: 'postgres-dev'


### PR DESCRIPTION
## Mudanças realizadas

Ter `version` definido causa um warning nas [actions do GitHub](https://github.com/filipedeschamps/tabnews.com.br/actions/runs/9555328572/job/26338346349#step:3:13):

```bash
time="2024-06-17T21:57:29Z" level=warning msg="/home/runner/work/tabnews.com.br/tabnews.com.br/infra/docker-compose.development.yml: `version` is obsolete"
```

Detalhes sobre `version` estar obsoleta podem ser encontrados [aqui](https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-and-name-top-level-elements). Como não é uma propriedade utilizada, a remoção não causará nenhuma mudança, apenas removerá o aviso.

> Compose doesn't use `version` to select an exact schema to validate the Compose file, but prefers the most recent schema when it's implemented.

Essa alteração foi realizada na **versão [1.27.0](https://docs.docker.com/compose/release-notes/#1270) do Docker Compose**, lançada em 07/09/2020 (3 anos e 9 meses atrás), então atualizei o README. Talvez faça sentido sugerir o uso da versão 1.27.4, que contém patches de algumas correções, ou mesmo uma versão mais recente.

## Tipo de mudança

- [x] Correção de warning (CI)
- [x] Atualização de documentação

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Os testes antigos estão passando localmente.