### PR TITLE
Remove validação de existência do `parent_id` ao modificar um conteúdo

### DIFF
--- a/models/content.js
+++ b/models/content.js
@@ -417,8 +417,8 @@ async function checkIfParentIdExists(content, options) {
 
   if (!existingContent) {
     throw new ValidationError({
-      message: `Você está tentando criar ou atualizar um sub-conteúdo para um conteúdo que não existe.`,
-      action: `Utilize um "parent_id" que aponte para um conteúdo que existe.`,
+      message: `Você está tentando criar um comentário em um conteúdo que não existe.`,
+      action: `Utilize um "parent_id" que aponte para um conteúdo existente.`,
       stack: new Error().stack,
       errorLocationCode: 'MODEL:CONTENT:CHECK_IF_PARENT_ID_EXISTS:NOT_FOUND',
       statusCode: 400,
@@ -625,13 +625,6 @@ async function update(contentId, postedContent, options = {}) {
   throwIfContentIsAlreadyDeleted(oldContent);
   throwIfContentPublishedIsChangedToDraft(oldContent, newContent);
   checkRootContentTitle(newContent);
-  checkForParentIdRecursion(newContent);
-
-  if (newContent.parent_id) {
-    await checkIfParentIdExists(newContent, {
-      transaction: options.transaction,
-    });
-  }
 
   populatePublishedAtValue(oldContent, newContent);
   populateDeletedAtValue(newContent);
@@ -727,19 +720,6 @@ function validateUpdateSchema(content) {
   });
 
   return cleanValues;
-}
-
-function checkForParentIdRecursion(content) {
-  if (content.parent_id === content.id) {
-    throw new ValidationError({
-      message: `"parent_id" não deve apontar para o próprio conteúdo.`,
-      action: `Utilize um "parent_id" diferente do "id" do mesmo conteúdo.`,
-      stack: new Error().stack,
-      errorLocationCode: 'MODEL:CONTENT:CHECK_FOR_PARENT_ID_RECURSION:RECURSION_FOUND',
-      statusCode: 400,
-      key: 'parent_id',
-    });
-  }
 }
 
 function populateDeletedAtValue(contentObject) {

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -1805,15 +1805,18 @@ describe('POST /api/v1/contents', () => {
       });
 
       expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual(
-        'Você está tentando criar ou atualizar um sub-conteúdo para um conteúdo que não existe.',
-      );
-      expect(responseBody.action).toEqual('Utilize um "parent_id" que aponte para um conteúdo que existe.');
+      expect(responseBody).toStrictEqual({
+        status_code: 400,
+        name: 'ValidationError',
+        message: 'Você está tentando criar um comentário em um conteúdo que não existe.',
+        action: 'Utilize um "parent_id" que aponte para um conteúdo existente.',
+        error_location_code: 'MODEL:CONTENT:CHECK_IF_PARENT_ID_EXISTS:NOT_FOUND',
+        key: 'parent_id',
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+      });
       expect(uuidVersion(responseBody.error_id)).toEqual(4);
       expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:CONTENT:CHECK_IF_PARENT_ID_EXISTS:NOT_FOUND');
     });
 
     describe('Notifications', () => {


### PR DESCRIPTION
## Mudanças realizadas

Sempre que o `parent_id` é enviado na atualização de um conteúdo, há uma chamada ao banco de dados para validar que ele existe. Porém, não é possível atualizar o `parent_id` desde o PR #1419, então podemos remover essa validação.

Como consequência, modifiquei a mensagem de erro, visto que agora a validação é utilizada apenas na criação, e aproveitei para atualizar o teste para utilizar `.toStrictEqual` e testar a propriedade `key` da resposta.

## Tipo de mudança

- [x] Correção de bug

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.