### PR TITLE
Diminui idas ao banco de dados na criação e edição de conteúdos, e na edição de usuários

### DIFF
--- a/models/content.js
+++ b/models/content.js
@@ -270,7 +270,6 @@ async function create(postedContent, options = {}) {
   populateSlug(postedContent);
   populateStatus(postedContent);
   const validContent = validateCreateSchema(postedContent);
-  validContent.id = uuidV4();
 
   checkRootContentTitle(validContent);
 
@@ -432,6 +431,7 @@ function parseQueryErrorToCustomError(error) {
 
 function validateCreateSchema(content) {
   const cleanValues = validator(content, {
+    id: 'required',
     parent_id: 'optional',
     owner_id: 'required',
     slug: 'required',

--- a/models/content.js
+++ b/models/content.js
@@ -279,7 +279,7 @@ async function create(postedContent, options = {}) {
     transaction: options.transaction,
   });
 
-  throwIfParentIsNotInPath(newContent);
+  throwIfSpecifiedParentDoesNotExist(postedContent, newContent);
 
   await creditOrDebitTabCoins(null, newContent, {
     eventId: options.eventId,
@@ -401,8 +401,10 @@ function populateStatus(postedContent) {
   postedContent.status = postedContent.status || 'draft';
 }
 
-function throwIfParentIsNotInPath(newContent) {
-  if (newContent.parent_id && newContent.path.at(-1) !== newContent.parent_id) {
+function throwIfSpecifiedParentDoesNotExist(postedContent, newContent) {
+  const existingParentId = newContent.path.at(-1);
+
+  if (postedContent.parent_id && postedContent.parent_id !== existingParentId) {
     throw new ValidationError({
       message: `Você está tentando criar um comentário em um conteúdo que não existe.`,
       action: `Utilize um "parent_id" que aponte para um conteúdo existente.`,
@@ -545,7 +547,6 @@ async function creditOrDebitTabCoins(oldContent, newContent, options = {}) {
     }
 
     // We should not credit if the content has little or no value.
-    // Expected 5 or more words with 5 or more characters.
     if (newContent.body.split(/[a-z]{5,}/i, 6).length < 6) return;
 
     if (newContent.parent_id) {

--- a/models/content.js
+++ b/models/content.js
@@ -600,14 +600,16 @@ async function creditOrDebitTabCoins(oldContent, newContent, options = {}) {
 async function update(contentId, postedContent, options = {}) {
   const validPostedContent = validateUpdateSchema(postedContent);
 
-  const oldContent = await findOne(
-    {
-      where: {
-        id: contentId,
+  const oldContent =
+    options.oldContent ??
+    (await findOne(
+      {
+        where: {
+          id: contentId,
+        },
       },
-    },
-    options,
-  );
+      options,
+    ));
 
   const newContent = { ...oldContent, ...validPostedContent };
 

--- a/models/event.js
+++ b/models/event.js
@@ -14,27 +14,6 @@ async function create(object, options = {}) {
   return results.rows[0];
 }
 
-// Currently it only update "metadata" column.
-async function updateMetadata(eventId, object, options = {}) {
-  object = validateObject(object);
-
-  const query = {
-    text: `
-      UPDATE
-        events
-      SET
-        metadata = $1
-      WHERE
-        id = $2
-      RETURNING *
-    ;`,
-    values: [object.metadata, eventId],
-  };
-
-  const results = await database.query(query, options);
-  return results.rows[0];
-}
-
 function validateObject(object) {
   const cleanObject = validator(object, {
     event: 'required',
@@ -45,5 +24,4 @@ function validateObject(object) {
 
 export default Object.freeze({
   create,
-  updateMetadata,
 });

--- a/pages/api/v1/contents/[username]/[slug]/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/index.public.js
@@ -150,6 +150,9 @@ async function patchHandler(request, response) {
         type: contentToBeUpdated.parent_id ? 'update:content:text_child' : 'update:content:text_root',
         originatorUserId: request.context.user.id,
         originatorIp: request.context.clientIp,
+        metadata: {
+          id: contentToBeUpdated.id,
+        },
       },
       {
         transaction: transaction,
@@ -157,21 +160,10 @@ async function patchHandler(request, response) {
     );
 
     const updatedContent = await content.update(contentToBeUpdated.id, filteredBodyValues, {
+      oldContent: contentToBeUpdated,
       eventId: currentEvent.id,
       transaction: transaction,
     });
-
-    await event.updateMetadata(
-      currentEvent.id,
-      {
-        metadata: {
-          id: updatedContent.id,
-        },
-      },
-      {
-        transaction: transaction,
-      },
-    );
 
     await transaction.query('COMMIT');
     await transaction.release();

--- a/pages/api/v1/users/[username]/index.public.js
+++ b/pages/api/v1/users/[username]/index.public.js
@@ -112,24 +112,15 @@ async function patchHandler(request, response) {
   try {
     await transaction.query('BEGIN');
 
-    const currentEvent = await event.create(
-      {
-        type: 'update:user',
-        originatorUserId: request.context.user.id,
-        originatorIp: request.context.clientIp,
-      },
-      {
-        transaction: transaction,
-      },
-    );
-
     const updatedUser = await user.update(targetUsername, secureInputValues, {
       transaction: transaction,
     });
 
-    await event.updateMetadata(
-      currentEvent.id,
+    await event.create(
       {
+        type: 'update:user',
+        originatorUserId: request.context.user.id,
+        originatorIp: request.context.clientIp,
         metadata: getEventMetadata(targetUser, updatedUser),
       },
       {

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -177,13 +177,19 @@ async function findSessionByToken(token) {
 }
 
 async function createContent(contentObject) {
+  const contentId = contentObject?.id || randomUUID();
+
   const currentEvent = await event.create({
     type: contentObject?.parent_id ? 'create:content:text_child' : 'create:content:text_root',
     originatorUserId: contentObject?.owner_id,
+    metadata: {
+      id: contentId,
+    },
   });
 
   const createdContent = await content.create(
     {
+      id: contentId,
       parent_id: contentObject?.parent_id || undefined,
       owner_id: contentObject?.owner_id || undefined,
       title: contentObject?.title || undefined,
@@ -196,12 +202,6 @@ async function createContent(contentObject) {
       eventId: currentEvent.id,
     },
   );
-
-  await event.updateMetadata(currentEvent.id, {
-    metadata: {
-      id: createdContent.id,
-    },
-  });
 
   return createdContent;
 }


### PR DESCRIPTION
## Mudanças realizadas

Realizei algumas alterações como tentativa de melhoria de desempenho na criação e edição de um conteúdo. 

1. Na criação de conteúdo, busquei o `parent` na query de criação ao invés de buscar separadamente.
2. No `creditOrDebitTabCoins`, mudar a ordem dos `if`s evita uma consulta no banco de dados quando o conteúdo não é relevante. Além disso, buscar o conteúdo pai diretamente com SQL permite obter apenas o campo desejado (`owner_id`), ao invés de trazer todos os campos da tabela e ainda calcular os TabCoins do conteúdo.
3. Também em `creditOrDebitTabCoins`, buscar o pai no banco de dados apenas caso `newContent.parent_owner_id` seja `undefined` permite evitar buscar o pai duas vezes no `create`.
4. No `PATCH`, é possível definir `metadata.id` ao criar o `event`, removendo a necessidade do uso do `event.updateMetadata`. Além disso, ao aceitar receber um `options.oldContent` no `content.update`, evitamos buscar duas vezes o mesmo conteúdo durante o `PATCH`.

Talvez alguma mudança seja desnecessária, possa ter uma interface melhor, ou ainda exista alguma melhoria que não percebi. Estou aberto a sugestões.

## Tipo de mudança

- [x] Refatoração

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
