### PR TITLE
Corrige parâmetros de paginação para serem dinâmicos e incluir `with_root` e `with_children` em `GET /contents`

### DIFF
--- a/models/content.js
+++ b/models/content.js
@@ -261,6 +261,17 @@ async function findWithStrategy(options = {}) {
 }
 
 async function getPagination(values, options) {
+  values.query = {};
+  if (values.strategy) {
+    values.query.strategy = values.strategy;
+  }
+  if (values.with_root !== undefined) {
+    values.query.with_root = values.with_root;
+  }
+  if (values.with_children !== undefined) {
+    values.query.with_children = values.with_children;
+  }
+
   values.count = true;
   values.total_rows = values.total_rows ?? (await findAll(values, options))[0]?.total_rows ?? 0;
   return pagination.get(values);

--- a/models/content.js
+++ b/models/content.js
@@ -261,17 +261,6 @@ async function findWithStrategy(options = {}) {
 }
 
 async function getPagination(values, options) {
-  values.query = {};
-  if (values.strategy) {
-    values.query.strategy = values.strategy;
-  }
-  if (values.with_root !== undefined) {
-    values.query.with_root = values.with_root;
-  }
-  if (values.with_children !== undefined) {
-    values.query.with_children = values.with_children;
-  }
-
   values.count = true;
   values.total_rows = values.total_rows ?? (await findAll(values, options))[0]?.total_rows ?? 0;
   return pagination.get(values);

--- a/models/controller.js
+++ b/models/controller.js
@@ -170,11 +170,19 @@ function clearContext(context) {
   return cleanContext;
 }
 
-function injectPaginationHeaders(pagination, endpoint, response) {
+function injectPaginationHeaders(pagination, endpoint, request, response) {
   const links = [];
   const baseUrl = `${webserver.host}${endpoint}`;
 
-  const searchParams = new URLSearchParams(pagination.query);
+  const searchParams = new URLSearchParams();
+
+  const acceptedParams = ['strategy', 'with_root', 'with_children', 'page', 'per_page'];
+
+  acceptedParams.forEach((param) => {
+    if (request?.query?.[param] !== undefined) {
+      searchParams.set(param, request.query[param]);
+    }
+  });
 
   const pages = [
     { page: pagination.firstPage, rel: 'first' },

--- a/models/controller.js
+++ b/models/controller.js
@@ -174,11 +174,7 @@ function injectPaginationHeaders(pagination, endpoint, response) {
   const links = [];
   const baseUrl = `${webserver.host}${endpoint}`;
 
-  const searchParams = new URLSearchParams();
-
-  if (pagination.strategy) {
-    searchParams.set('strategy', pagination.strategy);
-  }
+  const searchParams = new URLSearchParams(pagination.query);
 
   const pages = [
     { page: pagination.firstPage, rel: 'first' },
@@ -190,7 +186,6 @@ function injectPaginationHeaders(pagination, endpoint, response) {
   for (const { page, rel } of pages) {
     if (page) {
       searchParams.set('page', page);
-      searchParams.set('per_page', pagination.perPage);
       links.push(`<${baseUrl}?${searchParams.toString()}>; rel="${rel}"`);
     }
   }

--- a/models/pagination.js
+++ b/models/pagination.js
@@ -1,8 +1,11 @@
-function get({ total_rows, page, per_page, strategy }) {
+function get({ total_rows, page, per_page, query = {} }) {
   const firstPage = 1;
   const lastPage = Math.ceil(total_rows / per_page) || 1;
   const nextPage = page >= lastPage ? null : page + 1;
   const previousPage = page <= 1 ? null : page > lastPage ? lastPage : page - 1;
+
+  query.page = page;
+  query.per_page = per_page;
 
   const pagination = {
     currentPage: page,
@@ -12,11 +15,8 @@ function get({ total_rows, page, per_page, strategy }) {
     nextPage: nextPage,
     previousPage: previousPage,
     lastPage: lastPage,
+    query: query,
   };
-
-  if (strategy) {
-    pagination.strategy = strategy;
-  }
 
   return pagination;
 }

--- a/models/pagination.js
+++ b/models/pagination.js
@@ -1,11 +1,8 @@
-function get({ total_rows, page, per_page, query = {} }) {
+function get({ total_rows, page, per_page }) {
   const firstPage = 1;
   const lastPage = Math.ceil(total_rows / per_page) || 1;
   const nextPage = page >= lastPage ? null : page + 1;
   const previousPage = page <= 1 ? null : page > lastPage ? lastPage : page - 1;
-
-  query.page = page;
-  query.per_page = per_page;
 
   const pagination = {
     currentPage: page,
@@ -15,7 +12,6 @@ function get({ total_rows, page, per_page, query = {} }) {
     nextPage: nextPage,
     previousPage: previousPage,
     lastPage: lastPage,
-    query: query,
   };
 
   return pagination;

--- a/pages/api/v1/contents/[username]/index.public.js
+++ b/pages/api/v1/contents/[username]/index.public.js
@@ -46,8 +46,6 @@ async function getHandler(request, response) {
     },
     page: request.query.page,
     per_page: request.query.per_page,
-    with_root: request.query.with_root,
-    with_children: request.query.with_children,
   });
   const contentListFound = results.rows;
 
@@ -61,7 +59,12 @@ async function getHandler(request, response) {
     }
   }
 
-  controller.injectPaginationHeaders(results.pagination, `/api/v1/contents/${request.query.username}`, response);
+  controller.injectPaginationHeaders(
+    results.pagination,
+    `/api/v1/contents/${request.query.username}`,
+    request,
+    response,
+  );
 
   return response.status(200).json(secureOutputValues);
 }

--- a/pages/api/v1/contents/[username]/index.public.js
+++ b/pages/api/v1/contents/[username]/index.public.js
@@ -46,6 +46,8 @@ async function getHandler(request, response) {
     },
     page: request.query.page,
     per_page: request.query.per_page,
+    with_root: request.query.with_root,
+    with_children: request.query.with_children,
   });
   const contentListFound = results.rows;
 

--- a/pages/api/v1/contents/index.public.js
+++ b/pages/api/v1/contents/index.public.js
@@ -61,8 +61,6 @@ async function getHandler(request, response) {
     },
     page: request.query.page,
     per_page: request.query.per_page,
-    with_root: request.query.with_root,
-    with_children: request.query.with_children,
   });
 
   const contentList = results.rows;
@@ -79,7 +77,7 @@ async function getHandler(request, response) {
     }
   }
 
-  controller.injectPaginationHeaders(results.pagination, '/api/v1/contents', response);
+  controller.injectPaginationHeaders(results.pagination, '/api/v1/contents', request, response);
 
   return response.status(200).json(secureOutputValues);
 }

--- a/pages/api/v1/contents/index.public.js
+++ b/pages/api/v1/contents/index.public.js
@@ -61,6 +61,8 @@ async function getHandler(request, response) {
     },
     page: request.query.page,
     per_page: request.query.per_page,
+    with_root: request.query.with_root,
+    with_children: request.query.with_children,
   });
 
   const contentList = results.rows;

--- a/pages/api/v1/users/index.public.js
+++ b/pages/api/v1/users/index.public.js
@@ -50,7 +50,7 @@ async function getHandler(request, response) {
 
   const secureOutputValues = authorization.filterOutput(userTryingToList, 'read:user:list', userList);
 
-  controller.injectPaginationHeaders(results.pagination, '/api/v1/users', response);
+  controller.injectPaginationHeaders(results.pagination, '/api/v1/users', request, response);
 
   return response.status(200).json(secureOutputValues);
 }

--- a/tests/integration/api/v1/contents/[username]/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/get.test.js
@@ -859,6 +859,14 @@ describe('GET /api/v1/contents/[username]', () => {
       expect(uuidVersion(responseBody[0].owner_id)).toEqual(4);
       expect(uuidVersion(responseBody[1].owner_id)).toEqual(4);
       expect(responseBody[0].published_at > responseBody[1].published_at).toEqual(true);
+
+      const responseLinkHeader = parseLinkHeader(response.headers.get('Link'));
+      expect(responseLinkHeader.first.url).toBe(
+        `${orchestrator.webserverUrl}/api/v1/contents/${firstUser.username}?strategy=new&with_children=false&page=1&per_page=30`,
+      );
+      expect(responseLinkHeader.last.url).toBe(
+        `${orchestrator.webserverUrl}/api/v1/contents/${firstUser.username}?strategy=new&with_children=false&page=1&per_page=30`,
+      );
     });
 
     test('"username" existent with 5 contents, but only 2 "root" "published", and with_root "false"', async () => {
@@ -965,6 +973,14 @@ describe('GET /api/v1/contents/[username]', () => {
       expect(uuidVersion(responseBody[0].owner_id)).toEqual(4);
       expect(uuidVersion(responseBody[1].owner_id)).toEqual(4);
       expect(responseBody[0].published_at > responseBody[1].published_at).toEqual(true);
+
+      const responseLinkHeader = parseLinkHeader(response.headers.get('Link'));
+      expect(responseLinkHeader.first.url).toBe(
+        `${orchestrator.webserverUrl}/api/v1/contents/${firstUser.username}?strategy=new&with_root=false&page=1&per_page=30`,
+      );
+      expect(responseLinkHeader.last.url).toBe(
+        `${orchestrator.webserverUrl}/api/v1/contents/${firstUser.username}?strategy=new&with_root=false&page=1&per_page=30`,
+      );
     });
   });
 });

--- a/tests/integration/api/v1/contents/get.test.js
+++ b/tests/integration/api/v1/contents/get.test.js
@@ -1358,16 +1358,19 @@ describe('GET /api/v1/contents', () => {
         {
           content: 'relevant root',
           params: [],
+          responseLinkParams: ['strategy=relevant'],
           getExpected: () => rootSortedByTabCoins,
         },
         {
           content: 'relevant root',
           params: ['with_children=false'],
+          responseLinkParams: ['strategy=relevant', 'with_children=false'],
           getExpected: () => rootSortedByTabCoins,
         },
         {
           content: 'relevant root and children',
           params: ['with_children=true'],
+          responseLinkParams: ['strategy=relevant', 'with_children=true'],
           getExpected: () => [
             rootSortedByTabCoins[0],
             childSortedByTabCoins[0],
@@ -1378,38 +1381,48 @@ describe('GET /api/v1/contents', () => {
         {
           content: 'new root',
           params: ['with_children=false', 'with_root=true', 'strategy=new'],
-          getExpected: () => rootSortedByNew,
-        },
-        {
-          content: 'new root',
-          params: ['with_children=false', 'with_root=true', 'strategy=new'],
+          responseLinkParams: ['strategy=new', 'with_root=true', 'with_children=false'],
           getExpected: () => rootSortedByNew,
         },
         {
           content: 'new children',
           params: ['with_children=true', 'with_root=false', 'strategy=new'],
+          responseLinkParams: ['strategy=new', 'with_root=false', 'with_children=true'],
           getExpected: () => childSortedByNew,
         },
         {
           content: 'new root and children',
           params: ['with_children=true', 'strategy=new'],
+          responseLinkParams: ['strategy=new', 'with_children=true'],
           getExpected: () => [...childSortedByNew, ...rootSortedByNew],
         },
         {
           content: 'new root and children',
           params: ['with_children=true', 'with_root=true', 'strategy=new'],
+          responseLinkParams: ['strategy=new', 'with_root=true', 'with_children=true'],
           getExpected: () => [...childSortedByNew, ...rootSortedByNew],
         },
         {
           content: 'new root',
           params: ['with_root=true', 'strategy=new'],
+          responseLinkParams: ['strategy=new', 'with_root=true'],
           getExpected: () => rootSortedByNew,
         },
-      ])('get $content with params: $params', async ({ params, getExpected }) => {
+      ])('get $content with params: $params', async ({ params, responseLinkParams, getExpected }) => {
         const { response, responseBody } = await contentsRequestBuilder.get(`?${params.join('&')}`);
 
         expect(response.status).toEqual(200);
         expect(responseBody).toStrictEqual(getExpected());
+
+        const linkParamsString = responseLinkParams.join('&');
+        const responseLinkHeader = parseLinkHeader(response.headers.get('Link'));
+
+        expect(responseLinkHeader.first.url).toBe(
+          `${orchestrator.webserverUrl}/api/v1/contents?${linkParamsString}&page=1&per_page=30`,
+        );
+        expect(responseLinkHeader.last.url).toBe(
+          `${orchestrator.webserverUrl}/api/v1/contents?${linkParamsString}&page=1&per_page=30`,
+        );
       });
     });
   });


### PR DESCRIPTION
## Mudanças realizadas

Conforme discutido [nesse comentário](https://github.com/filipedeschamps/tabnews.com.br/pull/1698#discussion_r1621260895), a alteração visa permitir a inclusão de diferentes parâmetros a serem considerados na paginação em diferentes endpoints. Um exemplo é que agora o `strategy` não é verificado na paginação de `users`, apenas de `contents`.

Além disso, agora os parâmetros `with_root` e `with_child` são retornados nos links de paginação.

A implementação não ficou tão simples quanto eu gostaria, então caso alguém enxergue uma simplificação, será de grande valia.

## Tipo de mudança

- [x] Refatoração

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
