### PR TITLE
Permite acessar a URL usando `http://ip:porta` durante o desenvolvimento

### DIFF
--- a/pages/interface/components/Head/index.js
+++ b/pages/interface/components/Head/index.js
@@ -51,7 +51,9 @@ export function DefaultHead() {
       <link rel="manifest" href="/manifest.json" crossOrigin="use-credentials" />
       <meta name="mobile-web-app-capable" content="yes" />
       <meta name="apple-mobile-web-app-capable" content="yes" />
-      <meta httpEquiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+      {webserverHost.startsWith('https') && (
+        <meta httpEquiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+      )}
     </NextHead>
   );
 }


### PR DESCRIPTION
## Mudanças realizadas

O problema foi introduzido em #1110. Como utilizamos HTTP durante o desenvolvimento, e não HTTPS, não é possível fazer o upgrade no protocolo. Para resolver, agora a metatag CSP `upgrade-insecure-requests` está presente apenas quando o `webserver.host` utiliza o protocolo `https`.

Resolve #1263

## Tipo de mudança

- [x] Correção de bug