### PR TITLE
Diminui idas ao banco de dados na edição de usuários e na validação do token de confirmação do e-mail

### DIFF
--- a/models/balance.js
+++ b/models/balance.js
@@ -77,18 +77,6 @@ async function create({ balanceType, recipientId, amount, originatorType, origin
   return results.rows[0];
 }
 
-async function getTotal({ balanceType, recipientId }, options) {
-  const sqlFunction = sqlFunctionMap[balanceType] || sqlFunctionMap.default;
-
-  const query = {
-    text: `SELECT ${sqlFunction}($1) AS total;`,
-    values: [recipientId],
-  };
-
-  const results = await database.query(query, options);
-  return results.rows[0].total;
-}
-
 async function getContentTabcoinsCreditDebit({ recipientId }, options = {}) {
   const query = {
     text: 'SELECT * FROM get_content_balance_credit_debit($1);',
@@ -200,7 +188,6 @@ async function undo(balanceOperation, options) {
 export default Object.freeze({
   findAllByOriginatorId,
   create,
-  getTotal,
   getContentTabcoinsCreditDebit,
   rateContent,
   undo,

--- a/models/email-confirmation.js
+++ b/models/email-confirmation.js
@@ -160,27 +160,13 @@ async function markTokenAsUsed(tokenId) {
   return results.rows[0];
 }
 
-async function updateUserEmail(userId, newEmail) {
-  const currentUser = await user.findOneById(userId);
-
-  await user.update(
-    currentUser.username,
-    {
-      email: newEmail,
-    },
-    {
-      skipEmailConfirmation: true,
-    },
-  );
-}
-
 async function confirmEmailUpdate(tokenId) {
   const tokenObject = await findOneTokenById(tokenId);
 
   if (!tokenObject.used) {
     const validToken = await findOneValidTokenById(tokenId);
     const usedToken = await markTokenAsUsed(validToken.id);
-    await updateUserEmail(validToken.user_id, validToken.email);
+    await user.update(validToken.user_id, { email: validToken.email }, { skipEmailConfirmation: true });
     return usedToken;
   }
 

--- a/models/email-confirmation.js
+++ b/models/email-confirmation.js
@@ -115,7 +115,7 @@ async function markTokenAsUsedById(tokenId) {
 
 async function confirmEmailUpdate(tokenId) {
   const usedToken = await markTokenAsUsedById(tokenId);
-  await user.update(usedToken.user_id, { email: usedToken.email }, { skipEmailConfirmation: true });
+  await user.update({ id: usedToken.user_id }, { email: usedToken.email }, { skipEmailConfirmation: true });
 
   return usedToken;
 }

--- a/models/email-confirmation.js
+++ b/models/email-confirmation.js
@@ -5,10 +5,9 @@ import webserver from 'infra/webserver.js';
 import { ConfirmationEmail } from 'models/transactional';
 import user from 'models/user.js';
 
-async function createAndSendEmail(userId, newEmail, options) {
-  const userFound = await user.findOneById(userId, options);
-  const tokenObject = await create(userFound.id, newEmail, options);
-  await sendEmailToUser(userFound, newEmail, tokenObject.id);
+async function createAndSendEmail(user, newEmail, options) {
+  const tokenObject = await create(user.id, newEmail, options);
+  await sendEmailToUser(user, newEmail, tokenObject.id);
 
   return tokenObject;
 }

--- a/models/recovery.js
+++ b/models/recovery.js
@@ -76,7 +76,7 @@ async function resetUserPassword(secureInputValues) {
   if (!tokenObject.used) {
     const userToken = await markTokenAsUsed(tokenObject.id);
     await session.expireAllFromUserId(tokenObject.user_id);
-    await updateUserPassword(tokenObject.user_id, secureInputValues.password);
+    await user.update(tokenObject.user_id, { password: secureInputValues.password });
     return userToken;
   }
 
@@ -166,11 +166,6 @@ async function markTokenAsUsed(tokenId) {
 
   const results = await database.query(query);
   return results.rows[0];
-}
-
-async function updateUserPassword(userId, password) {
-  const currentUser = await user.findOneById(userId);
-  await user.update(currentUser.username, { password });
 }
 
 async function update(tokenId, tokenBody) {

--- a/models/recovery.js
+++ b/models/recovery.js
@@ -76,7 +76,7 @@ async function resetUserPassword(secureInputValues) {
   if (!tokenObject.used) {
     const userToken = await markTokenAsUsed(tokenObject.id);
     await session.expireAllFromUserId(tokenObject.user_id);
-    await user.update(tokenObject.user_id, { password: secureInputValues.password });
+    await user.update({ id: tokenObject.user_id }, { password: secureInputValues.password });
     return userToken;
   }
 

--- a/models/user.js
+++ b/models/user.js
@@ -290,7 +290,7 @@ async function update(userId, postedUserData, options = {}) {
     await validateUniqueUsername(validPostedUserData.username, { transaction: options.transaction });
   }
 
-  if ('email' in validPostedUserData) {
+  if ('email' in validPostedUserData && validPostedUserData.email.toLowerCase() !== currentUser.email.toLowerCase()) {
     await validateUniqueEmail(validPostedUserData.email, { transaction: options.transaction });
 
     if (!options.skipEmailConfirmation) {

--- a/models/user.js
+++ b/models/user.js
@@ -281,10 +281,9 @@ function validatePostSchema(postedUserData) {
 
 // TODO: Refactor the interface of this function
 // and the code inside to make it more future proof
-// and to accept update using "userId".
-async function update(username, postedUserData, options = {}) {
+async function update(userId, postedUserData, options = {}) {
   const validPostedUserData = await validatePatchSchema(postedUserData);
-  const currentUser = await findOneByUsername(username, { transaction: options.transaction });
+  const currentUser = await findOneById(userId, { transaction: options.transaction });
 
   if (
     'username' in validPostedUserData &&

--- a/pages/api/v1/users/[username]/index.public.js
+++ b/pages/api/v1/users/[username]/index.public.js
@@ -140,7 +140,6 @@ async function patchHandler(request, response) {
     if (error instanceof ValidationError && error.key === 'email') {
       updatedUser = {
         ...targetUser,
-        ...secureInputValues,
         updated_at: new Date(),
       };
     } else {

--- a/pages/api/v1/users/[username]/index.public.js
+++ b/pages/api/v1/users/[username]/index.public.js
@@ -78,7 +78,8 @@ function patchValidationHandler(request, response, next) {
 async function patchHandler(request, response) {
   const userTryingToPatch = request.context.user;
   const targetUsername = request.query.username;
-  const targetUser = await user.findOneByUsername(targetUsername);
+  const targetUser =
+    targetUsername === userTryingToPatch.username ? userTryingToPatch : await user.findOneByUsername(targetUsername);
   const insecureInputValues = request.body;
 
   let updateAnotherUser = false;
@@ -114,8 +115,7 @@ async function patchHandler(request, response) {
   try {
     await transaction.query('BEGIN');
 
-    updatedUser = await user.update(targetUser.id, secureInputValues, {
-      oldUser: targetUser,
+    updatedUser = await user.update(targetUser, secureInputValues, {
       transaction: transaction,
     });
 

--- a/pages/api/v1/users/[username]/index.public.js
+++ b/pages/api/v1/users/[username]/index.public.js
@@ -115,6 +115,7 @@ async function patchHandler(request, response) {
     await transaction.query('BEGIN');
 
     updatedUser = await user.update(targetUser.id, secureInputValues, {
+      oldUser: targetUser,
       transaction: transaction,
     });
 

--- a/pages/api/v1/users/[username]/index.public.js
+++ b/pages/api/v1/users/[username]/index.public.js
@@ -114,7 +114,7 @@ async function patchHandler(request, response) {
   try {
     await transaction.query('BEGIN');
 
-    updatedUser = await user.update(targetUsername, secureInputValues, {
+    updatedUser = await user.update(targetUser.id, secureInputValues, {
       transaction: transaction,
     });
 

--- a/tests/integration/api/v1/email-confirmation/patch.test.js
+++ b/tests/integration/api/v1/email-confirmation/patch.test.js
@@ -311,7 +311,7 @@ describe('PATCH /api/v1/email-confirmation', () => {
       expect(responseBody).toStrictEqual({
         id: firstUser.id,
         username: firstUser.username,
-        email: 'other.user.email@before.com',
+        email: firstUser.email,
         description: firstUser.description,
         features: firstUser.features,
         notifications: firstUser.notifications,

--- a/tests/integration/api/v1/email-confirmation/patch.test.js
+++ b/tests/integration/api/v1/email-confirmation/patch.test.js
@@ -234,7 +234,7 @@ describe('PATCH /api/v1/email-confirmation', () => {
         email: 'already.used.token@email.com',
       });
 
-      const emailConfirmationToken = await emailConfirmation.create(defaultUser.id, 'idempotent@patch.com');
+      const emailConfirmationToken = await emailConfirmation.create(defaultUser.id, 'not.idempotent@patch.com');
 
       const firstTryResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/email-confirmation`, {
         method: 'PATCH',
@@ -247,10 +247,10 @@ describe('PATCH /api/v1/email-confirmation', () => {
         }),
       });
 
-      const userInDatabase = await user.findOneById(defaultUser.id);
-      expect(userInDatabase.email).toBe('idempotent@patch.com');
+      expect(firstTryResponse.status).toBe(200);
 
-      const firstTryResponseBody = await firstTryResponse.json();
+      const userInDatabase = await user.findOneById(defaultUser.id);
+      expect(userInDatabase.email).toBe('not.idempotent@patch.com');
 
       const secondTryResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/email-confirmation`, {
         method: 'PATCH',
@@ -265,20 +265,18 @@ describe('PATCH /api/v1/email-confirmation', () => {
 
       const secondTryResponseBody = await secondTryResponse.json();
 
-      expect(secondTryResponse.status).toBe(200);
+      expect(secondTryResponse.status).toBe(404);
 
       expect(secondTryResponseBody).toStrictEqual({
-        id: emailConfirmationToken.id,
-        used: true,
-        expires_at: emailConfirmationToken.expires_at.toISOString(),
-        created_at: emailConfirmationToken.created_at.toISOString(),
-        updated_at: secondTryResponseBody.updated_at,
+        name: 'NotFoundError',
+        message: 'O token de confirmação de email utilizado não foi encontrado no sistema ou expirou.',
+        action: 'Solicite uma nova alteração de email.',
+        status_code: 404,
+        error_id: secondTryResponseBody.error_id,
+        request_id: secondTryResponseBody.request_id,
+        error_location_code: 'MODEL:EMAIL_CONFIRMATION:FIND_ONE_VALID_TOKEN_BY_ID:NOT_FOUND',
+        key: 'token_id',
       });
-
-      expect(secondTryResponseBody.updated_at > emailConfirmationToken.updated_at.toISOString()).toBe(true);
-
-      expect(firstTryResponse.status).toStrictEqual(secondTryResponse.status);
-      expect(firstTryResponseBody).toStrictEqual(secondTryResponseBody);
     });
 
     test('With an already used email (before creating the token)', async () => {
@@ -382,7 +380,7 @@ describe('PATCH /api/v1/email-confirmation', () => {
         'expired.token.will.reject@email.com',
       );
 
-      await emailConfirmation.update(emailConfirmationToken.id, {
+      await orchestrator.updateEmailConfirmationToken(emailConfirmationToken.id, {
         expires_at: new Date(Date.now() - 1000),
       });
 

--- a/tests/integration/api/v1/users/[username]/patch.test.js
+++ b/tests/integration/api/v1/users/[username]/patch.test.js
@@ -802,6 +802,40 @@ describe('PATCH /api/v1/users/[username]', () => {
       expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
+    test('Patching itself with the user having TabCoins and TabCash', async () => {
+      const usersRequestBuilder = new RequestBuilder('/api/v1/users');
+      const defaultUser = await usersRequestBuilder.buildUser();
+
+      await orchestrator.createBalance({
+        balanceType: 'user:tabcoin',
+        recipientId: defaultUser.id,
+        amount: 200,
+      });
+      await orchestrator.createBalance({
+        balanceType: 'user:tabcash',
+        recipientId: defaultUser.id,
+        amount: 55,
+      });
+
+      const { response, responseBody } = await usersRequestBuilder.patch(`/${defaultUser.username}`, {
+        description: 'new description',
+      });
+
+      expect(response.status).toBe(200);
+      expect(responseBody).toStrictEqual({
+        id: defaultUser.id,
+        username: defaultUser.username,
+        description: 'new description',
+        email: defaultUser.email,
+        features: defaultUser.features,
+        notifications: defaultUser.notifications,
+        tabcoins: 200,
+        tabcash: 55,
+        created_at: defaultUser.created_at.toISOString(),
+        updated_at: responseBody.updated_at,
+      });
+    });
+
     describe('TEMPORARY BEHAVIOR', () => {
       test('Patching itself with another "password"', async () => {
         let defaultUser = await orchestrator.createUser({

--- a/tests/integration/api/v1/users/[username]/patch.test.js
+++ b/tests/integration/api/v1/users/[username]/patch.test.js
@@ -678,6 +678,33 @@ describe('PATCH /api/v1/users/[username]', () => {
       expect(confirmationEmail.html).toContain(emailConfirmationPageEndpoint);
     });
 
+    test('Patching itself with the same "email"', async () => {
+      await orchestrator.deleteAllEmails();
+      const usersRequestBuilder = new RequestBuilder('/api/v1/users');
+      const defaultUser = await usersRequestBuilder.buildUser();
+
+      const { response, responseBody } = await usersRequestBuilder.patch(`/${defaultUser.username}`, {
+        email: defaultUser.email,
+      });
+
+      expect(response.status).toBe(200);
+      expect(responseBody).toStrictEqual({
+        id: defaultUser.id,
+        username: defaultUser.username,
+        description: defaultUser.description,
+        email: defaultUser.email,
+        features: defaultUser.features,
+        notifications: defaultUser.notifications,
+        tabcoins: 0,
+        tabcash: 0,
+        created_at: defaultUser.created_at.toISOString(),
+        updated_at: responseBody.updated_at,
+      });
+
+      const confirmationEmail = await orchestrator.getLastEmail();
+      expect(confirmationEmail).toBeNull();
+    });
+
     test('Patching itself with "notifications"', async () => {
       const defaultUser = await orchestrator.createUser({
         notifications: true,

--- a/tests/integration/api/v1/users/[username]/patch.test.js
+++ b/tests/integration/api/v1/users/[username]/patch.test.js
@@ -614,7 +614,7 @@ describe('PATCH /api/v1/users/[username]', () => {
       expect(responseBody).toStrictEqual({
         id: defaultUser.id,
         username: defaultUser.username,
-        email: 'someone@example.com',
+        email: defaultUser.email,
         description: defaultUser.description,
         features: defaultUser.features,
         notifications: defaultUser.notifications,
@@ -632,11 +632,53 @@ describe('PATCH /api/v1/users/[username]', () => {
       expect(foundUser.email).toBe(defaultUser.email);
     });
 
+    test('Patching itself with "email" duplicated exactly and other fields', async () => {
+      await orchestrator.deleteAllEmails();
+      await orchestrator.createUser({
+        email: 'this_user_already_exists@example.com',
+      });
+
+      const usersRequestBuilder = new RequestBuilder('/api/v1/users');
+      const defaultUser = await usersRequestBuilder.buildUser();
+
+      const { response, responseBody } = await usersRequestBuilder.patch(`/${defaultUser.username}`, {
+        description: 'New description',
+        email: 'this_user_already_exists@example.com',
+        notifications: false,
+      });
+
+      expect.soft(response.status).toBe(200);
+      expect(responseBody).toStrictEqual({
+        id: defaultUser.id,
+        username: defaultUser.username,
+        email: defaultUser.email,
+        description: 'New description',
+        features: defaultUser.features,
+        notifications: false,
+        tabcoins: 0,
+        tabcash: 0,
+        created_at: defaultUser.created_at.toISOString(),
+        updated_at: responseBody.updated_at,
+      });
+
+      expect(responseBody.updated_at).not.toBe(defaultUser.updated_at.toISOString());
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+
+      const confirmationEmail = await orchestrator.getLastEmail();
+      expect(confirmationEmail).toBeNull();
+
+      const foundUser = await user.findOneById(defaultUser.id);
+      expect(foundUser.email).toBe(defaultUser.email);
+      expect(foundUser.description).toBe('New description');
+      expect(foundUser.notifications).toBe(false);
+      expect(foundUser.updated_at.toISOString()).toBe(responseBody.updated_at);
+    });
+
     test('Patching itself with another "email"', async () => {
-      const defaultUser = await orchestrator.createUser({
+      let defaultUser = await orchestrator.createUser({
         email: 'original@email.com',
       });
-      await orchestrator.activateUser(defaultUser);
+      defaultUser = await orchestrator.activateUser(defaultUser);
       const defaultUserSession = await orchestrator.createSession(defaultUser);
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${defaultUser.username}`, {
@@ -651,7 +693,19 @@ describe('PATCH /api/v1/users/[username]', () => {
         }),
       });
 
-      expect(response.status).toBe(200);
+      const responseBody = await response.json();
+
+      expect.soft(response.status).toBe(200);
+      expect(responseBody).toStrictEqual({
+        id: defaultUser.id,
+        username: defaultUser.username,
+        description: defaultUser.description,
+        email: defaultUser.email,
+        features: defaultUser.features,
+        notifications: defaultUser.notifications,
+        created_at: defaultUser.created_at.toISOString(),
+        updated_at: responseBody.updated_at,
+      });
 
       // Attention: it should not update the email in the database
       // before the user clicks on the confirmation link sent to the new email.
@@ -861,6 +915,48 @@ describe('PATCH /api/v1/users/[username]', () => {
         created_at: defaultUser.created_at.toISOString(),
         updated_at: responseBody.updated_at,
       });
+    });
+
+    test('Patching itself with "email", "username", "description" and "notifications"', async () => {
+      await orchestrator.deleteAllEmails();
+
+      const usersRequestBuilder = new RequestBuilder('/api/v1/users');
+      const defaultUser = await usersRequestBuilder.buildUser();
+
+      const { response, responseBody } = await usersRequestBuilder.patch(`/${defaultUser.username}`, {
+        description: 'Updating all possible fields.',
+        email: 'random_new_email@example.com',
+        username: 'UpdatedUsername',
+        notifications: false,
+      });
+
+      expect.soft(response.status).toBe(200);
+      expect(responseBody).toStrictEqual({
+        id: defaultUser.id,
+        username: 'UpdatedUsername',
+        email: defaultUser.email,
+        description: 'Updating all possible fields.',
+        features: defaultUser.features,
+        notifications: false,
+        tabcoins: 0,
+        tabcash: 0,
+        created_at: defaultUser.created_at.toISOString(),
+        updated_at: responseBody.updated_at,
+      });
+
+      expect(responseBody.updated_at).not.toBe(defaultUser.updated_at.toISOString());
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+
+      const foundUser = await user.findOneById(defaultUser.id);
+      expect(foundUser.email).toBe(defaultUser.email);
+      expect(foundUser.description).toBe('Updating all possible fields.');
+      expect(foundUser.notifications).toBe(false);
+      expect(foundUser.username).toBe('UpdatedUsername');
+      expect(foundUser.updated_at.toISOString()).toBe(responseBody.updated_at);
+
+      const confirmationEmail = await orchestrator.getLastEmail();
+      expect(confirmationEmail.recipients).toStrictEqual(['<random_new_email@example.com>']);
+      expect(confirmationEmail.subject).toBe('Confirme seu novo email');
     });
 
     describe('TEMPORARY BEHAVIOR', () => {

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -298,6 +298,25 @@ async function createRecoveryToken(userObject) {
   return await recovery.create(userObject);
 }
 
+async function updateEmailConfirmationToken(tokenId, tokenBody) {
+  const query = {
+    text: `
+      UPDATE
+        email_confirmation_tokens
+      SET
+        expires_at = $2
+      WHERE
+        id = $1
+      RETURNING
+        *
+    ;`,
+    values: [tokenId, tokenBody.expires_at],
+  };
+
+  const results = await database.query(query);
+  return results.rows[0];
+}
+
 async function createFirewallTestFunctions() {
   const procedures = fs.readdirSync('infra/stored-procedures');
 
@@ -456,6 +475,7 @@ const orchestrator = {
   removeFeaturesFromUser,
   runPendingMigrations,
   updateContent,
+  updateEmailConfirmationToken,
   updateEventCreatedAt,
   updateRewardedAt,
   waitForAllServices,


### PR DESCRIPTION
## Mudanças realizadas

Fiz algumas melhorias para diminuir as idas ao banco de dados e isso também acabou simplificando algumas coisas. Similar ao processo que fizemos em #1729. Assim como no outro PR, fiz as alterações em commits pequenos para facilitar a identificação (e possível reversão) de cada etapa.

1. A atualização do usuário ocorria apenas pelo `username`, e em alguns lugares ocorria um `user.findOneById` apenas para poder passar o `username` para `user.update`. Como em todos os lugares que `user.update` é chamado o `id` é conhecido, agora o `user.update` utiliza `id` ao invés de `username`.
2. No `user.update`,  recebe `options.oldUser` para evitar uma nova busca pelo usuário sem necessidade. Interface similar ao `content.update`, que recebe `options.oldContent`.
3. No `user.update`, ao invés de chamar `balance.getTotal` duas vezes, faz como em `findOneById` e outras funções, buscando na mesma query que está sendo executada. Também criei um teste onde o usuário tem `tabcoins` e `tabcash` para garantir que o retorno estava correto.
4. Não valida o e-mail enviado caso seja o e-mail atual do usuário.
5. Valida o `username` e `email` com uma única query.
6. Não busca o token de confirmação de e-mail novamente apenas para validar se está expirado.

Também corrigi a função `validatePatchSchema`, que estava marcada como assíncrona desnecessariamente.

Houve a mudança no valor de `error_location_code` de um erro lançado em `models/email-confirmation.js` e outro em `models/user.js`, não sei se isso é considerado breaking change. Se for, posso renomear o commit e marcar no PR que houve breaking change, ou então manter o `error_location_code` antigo (não sei se isso faz sentido).

## Tipo de mudança

- [x] Refatoração

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.