### PR TITLE
Rota para criar publicação patrocinada

### DIFF
--- a/infra/migrations/1714225738656_create-sponsored-contents-table.js
+++ b/infra/migrations/1714225738656_create-sponsored-contents-table.js
@@ -1,0 +1,116 @@
+exports.up = async (pgm) => {
+  pgm.createTable('sponsored_contents', {
+    id: {
+      type: 'uuid',
+      default: pgm.func('gen_random_uuid()'),
+      primaryKey: true,
+    },
+
+    slug: {
+      type: 'varchar',
+      check: 'length(slug) <= 160',
+      notNull: true,
+    },
+
+    title: {
+      type: 'varchar',
+      check: 'length(title) <= 255',
+      notNull: false,
+    },
+
+    body: {
+      type: 'text',
+      check: 'length(body) <= 20000',
+      notNull: true,
+    },
+
+    owner_id: {
+      type: 'uuid',
+      notNull: true,
+    },
+
+    link: {
+      type: 'varchar',
+      check: 'length(link) <= 2000',
+      notNull: false,
+    },
+
+    bid: {
+      type: 'integer',
+      notNull: true,
+    },
+
+    activated_at: {
+      type: 'timestamp with time zone',
+      notNull: false,
+    },
+
+    deactivated_at: {
+      type: 'timestamp with time zone',
+      notNull: false,
+    },
+
+    created_at: {
+      type: 'timestamp with time zone',
+      notNull: true,
+      default: pgm.func("(now() at time zone 'utc')"),
+    },
+
+    updated_at: {
+      type: 'timestamp with time zone',
+      notNull: true,
+      default: pgm.func("(now() at time zone 'utc')"),
+    },
+  });
+
+  pgm.createIndex('sponsored_contents', ['owner_id', 'slug'], {
+    name: 'sponsored_contents_owner_id_slug_unique_index',
+    unique: true,
+  });
+
+  pgm.createTrigger(
+    'sponsored_contents',
+    'unique_sponsored_contents_contents_owner_id_slug_trigger',
+    {
+      when: 'BEFORE',
+      operation: ['INSERT', 'UPDATE'],
+      language: 'plpgsql',
+      level: 'row',
+    },
+    `
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM contents WHERE owner_id = NEW.owner_id AND slug = NEW.slug AND deleted_at IS NULL
+      ) THEN
+        RAISE EXCEPTION 'This "owner_id" and "slug" already exists in "contents" table.'
+        USING ERRCODE = '23505';
+      END IF;
+      RETURN NEW;
+    END;
+    `,
+  );
+
+  pgm.createTrigger(
+    'contents',
+    'unique_contents_sponsored_contents_owner_id_slug_trigger',
+    {
+      when: 'BEFORE',
+      operation: ['INSERT', 'UPDATE'],
+      language: 'plpgsql',
+      level: 'row',
+    },
+    `
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM sponsored_contents WHERE owner_id = NEW.owner_id AND slug = NEW.slug
+      ) THEN
+        RAISE EXCEPTION 'This "owner_id" and "slug" already exists in "sponsored_contents" table.'
+        USING ERRCODE = '23505';
+      END IF;
+      RETURN NEW;
+    END;
+    `,
+  );
+};
+
+exports.down = false;

--- a/infra/scripts/seed-database.js
+++ b/infra/scripts/seed-database.js
@@ -39,6 +39,7 @@ async function seedDevelopmentUsers() {
     'create:recovery_token:username',
     'read:votes:others',
     'read:user:list',
+    'create:ads',
   ]);
   await insertUser('user', 'user@user.com', '$2a$04$v0hvAu/y6pJ17LzeCfcKG.rDStO9x5ficm2HTLZIfeDBG8oR/uQXi', [
     'create:session',
@@ -48,6 +49,7 @@ async function seedDevelopmentUsers() {
     'create:content:text_child',
     'update:content',
     'update:user',
+    'create:ads',
   ]);
 
   console.log('------------------------------');

--- a/models/authorization.js
+++ b/models/authorization.js
@@ -34,6 +34,10 @@ const availableFeatures = new Set([
   'read:content:list',
   'read:content:tabcoins',
 
+  // ADS
+  'create:ads',
+  'read:ads',
+
   // MODERATION
   'read:user:list',
   'read:votes:others',
@@ -130,6 +134,18 @@ function filterInput(user, feature, input, target) {
       body: input.body,
       status: input.status,
       source_url: input.source_url,
+    };
+  }
+
+  if (feature === 'create:ads' && can(user, feature)) {
+    filteredInputValues = {
+      slug: input.slug,
+      title: input.title,
+      body: input.body,
+      link: input.link,
+      deactivated_at: input.deactivated_at,
+      bid: input.bid,
+      budget: input.budget,
     };
   }
 
@@ -243,6 +259,12 @@ function filterOutput(user, feature, output) {
 
     filteredOutputValues = validator(clonedOutput, {
       content: 'required',
+    });
+  }
+
+  if (feature === 'read:ads') {
+    filteredOutputValues = validator(output, {
+      sponsored_content: 'required',
     });
   }
 

--- a/models/content.js
+++ b/models/content.js
@@ -369,7 +369,7 @@ async function create(postedContent, options = {}) {
 
 function populateSlug(postedContent) {
   if (!postedContent.slug) {
-    postedContent.slug = getSlug(postedContent.title) || uuidV4();
+    postedContent.slug = generateSlug(postedContent.title) || uuidV4();
   }
 }
 
@@ -385,7 +385,7 @@ slug.extend({
   '/': '-',
 });
 
-function getSlug(title) {
+function generateSlug(title) {
   if (!title) {
     return;
   }
@@ -929,4 +929,6 @@ export default Object.freeze({
   findWithStrategy,
   create,
   update,
+  generateSlug,
+  parseQueryErrorToCustomError,
 });

--- a/models/sponsored-content.js
+++ b/models/sponsored-content.js
@@ -1,0 +1,121 @@
+import { randomUUID as uuidV4 } from 'node:crypto';
+
+import { ValidationError } from 'errors';
+import database from 'infra/database';
+import balance from 'models/balance';
+import content from 'models/content';
+import validator from 'models/validator';
+
+async function create(postedSponsoredContent, options = {}) {
+  validateBidAndBudget(postedSponsoredContent);
+  validateSetDeactivateAt(postedSponsoredContent);
+
+  if (!postedSponsoredContent.slug) {
+    postedSponsoredContent.slug = content.generateSlug(postedSponsoredContent.title) || uuidV4();
+  }
+
+  const validSponsoredContent = validateCreateSchema(postedSponsoredContent);
+
+  validSponsoredContent.activated_at = new Date();
+
+  const query = {
+    text: `
+      WITH inserted_sponsored_content AS (
+        INSERT INTO
+          sponsored_contents (id, slug, title, body, owner_id, link, bid, activated_at, deactivated_at)
+        VALUES
+          ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+        RETURNING
+          *
+      )
+      SELECT
+        inserted_sponsored_content.*,
+        users.username as owner_username
+      FROM
+        inserted_sponsored_content
+      INNER JOIN
+        users ON inserted_sponsored_content.owner_id = users.id
+    ;`,
+    values: [
+      validSponsoredContent.id, // $1
+      validSponsoredContent.slug, // $2
+      validSponsoredContent.title, // $3
+      validSponsoredContent.body, // $4
+      validSponsoredContent.owner_id, // $5
+      validSponsoredContent.link, // $6
+      validSponsoredContent.bid, // $7
+      validSponsoredContent.activated_at, // $8
+      validSponsoredContent.deactivated_at, // $9
+    ],
+  };
+
+  let createdSponsoredContent;
+  try {
+    const results = await database.query(query, { transaction: options.transaction });
+    createdSponsoredContent = results.rows[0];
+  } catch (error) {
+    throw content.parseQueryErrorToCustomError(error);
+  }
+
+  await balance.sponsorContent(
+    {
+      contentOwnerId: validSponsoredContent.owner_id,
+      tabcash: validSponsoredContent.budget,
+    },
+    {
+      eventId: options.eventId,
+      transaction: options.transaction,
+    },
+  );
+
+  createdSponsoredContent.budget = validSponsoredContent.budget;
+
+  return createdSponsoredContent;
+}
+
+function validateBidAndBudget(sponsoredContent) {
+  if (sponsoredContent.bid > sponsoredContent.budget) {
+    throw new ValidationError({
+      message: 'O lance não pode ser maior do que o orçamento.',
+      action: 'Diminua o lance ou aumente o orçamento.',
+      stack: new Error().stack,
+      errorLocationCode: 'MODEL:SPONSORED_CONTENT:VALIDATE_BID_AND_BUDGET:BID_HIGHER_THAN_BUDGET',
+      key: 'bid',
+    });
+  }
+}
+
+function validateSetDeactivateAt(sponsoredContent) {
+  if (sponsoredContent.deactivated_at) {
+    const deactivateAt = new Date(sponsoredContent.deactivated_at);
+    if (deactivateAt <= new Date()) {
+      throw new ValidationError({
+        message: 'A data de desativação não pode ser no passado.',
+        action: 'Utilize uma data de desativação no futuro.',
+        stack: new Error().stack,
+        errorLocationCode: 'MODEL:SPONSORED_CONTENT:VALIDATE_DEACTIVATED_AT:DATE_IN_PAST',
+        key: 'deactivated_at',
+      });
+    }
+  }
+}
+
+function validateCreateSchema(sponsoredContent) {
+  const cleanValues = validator(sponsoredContent, {
+    id: 'required',
+    owner_id: 'required',
+    slug: 'required',
+    title: 'required',
+    body: 'required',
+    link: 'optional',
+    deactivated_at: 'optional',
+    bid: 'required',
+    budget: 'required',
+  });
+
+  return cleanValues;
+}
+
+export default Object.freeze({
+  create,
+});

--- a/models/validator.js
+++ b/models/validator.js
@@ -265,6 +265,15 @@ const schemas = {
     });
   },
 
+  link: function () {
+    return Joi.object({
+      link: schemas
+        .source_url()
+        .extract('source_url')
+        .when('$required.link', { is: 'required', then: Joi.required(), otherwise: Joi.optional().allow(null) }),
+    });
+  },
+
   owner_id: function () {
     return Joi.object({
       owner_id: Joi.string()
@@ -307,6 +316,26 @@ const schemas = {
   deleted_at: function () {
     return Joi.object({
       deleted_at: Joi.date().when('$required.deleted_at', {
+        is: 'required',
+        then: Joi.required(),
+        otherwise: Joi.optional().allow(null),
+      }),
+    });
+  },
+
+  activated_at: function () {
+    return Joi.object({
+      activated_at: Joi.date().when('$required.activated_at', {
+        is: 'required',
+        then: Joi.required(),
+        otherwise: Joi.optional().allow(null),
+      }),
+    });
+  },
+
+  deactivated_at: function () {
+    return Joi.object({
+      deactivated_at: Joi.date().when('$required.deactivated_at', {
         is: 'required',
         then: Joi.required(),
         otherwise: Joi.optional().allow(null),
@@ -500,6 +529,50 @@ const schemas = {
     return contentSchema;
   },
 
+  sponsored_content: function () {
+    return Joi.object()
+      .required()
+      .concat(schemas.id())
+      .concat(schemas.owner_id())
+      .concat(schemas.slug())
+      .concat(schemas.title())
+      .concat(schemas.body())
+      .concat(schemas.link())
+      .concat(schemas.created_at())
+      .concat(schemas.updated_at())
+      .concat(schemas.activated_at())
+      .concat(schemas.deactivated_at())
+      .concat(schemas.owner_username());
+  },
+
+  bid: function () {
+    const min = 1;
+    return Joi.object({
+      bid: Joi.number()
+        .integer()
+        .min(min)
+        .max(MAX_INTEGER)
+        .when('$required.bid', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
+        .messages({
+          'number.unsafe': `{#label} deve possuir um valor entre ${min} e ${MAX_INTEGER}.`,
+        }),
+    });
+  },
+
+  budget: function () {
+    const min = 1;
+    return Joi.object({
+      budget: Joi.number()
+        .integer()
+        .min(min)
+        .max(MAX_INTEGER)
+        .when('$required.budget', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
+        .messages({
+          'number.unsafe': `{#label} deve possuir um valor entre ${min} e ${MAX_INTEGER}.`,
+        }),
+    });
+  },
+
   with_children: function () {
     return Joi.object({
       with_children: Joi.boolean().when('$required.with_children', {
@@ -532,6 +605,7 @@ const schemas = {
           'update:content:text_root',
           'update:content:text_child',
           'update:content:tabcoins',
+          'create:sponsored_content',
           'firewall:block_users',
           'firewall:block_contents:text_root',
           'firewall:block_contents:text_child',

--- a/pages/api/v1/sponsored_contents/index.public.js
+++ b/pages/api/v1/sponsored_contents/index.public.js
@@ -1,0 +1,85 @@
+import nextConnect from 'next-connect';
+import { randomUUID as uuidV4 } from 'node:crypto';
+
+import database from 'infra/database';
+import authentication from 'models/authentication';
+import authorization from 'models/authorization';
+import cacheControl from 'models/cache-control';
+import controller from 'models/controller';
+import event from 'models/event';
+import sponsoredContent from 'models/sponsored-content';
+import validator from 'models/validator';
+
+export default nextConnect({
+  attachParams: true,
+  onNoMatch: controller.onNoMatchHandler,
+  onError: controller.onErrorHandler,
+})
+  .use(controller.injectRequestMetadata)
+  .use(controller.logRequest)
+  .post(
+    cacheControl.noCache,
+    authentication.injectAnonymousOrUser,
+    postValidationHandler,
+    authorization.canRequest('create:ads'),
+    postHandler,
+  );
+
+function postValidationHandler(request, response, next) {
+  const cleanValues = validator(request.body, {
+    slug: 'optional',
+    title: 'required',
+    body: 'required',
+    link: 'optional',
+    deactivated_at: 'optional',
+    bid: 'required',
+    budget: 'required',
+  });
+
+  request.body = cleanValues;
+
+  next();
+}
+
+async function postHandler(request, response) {
+  const userTryingToCreate = request.context.user;
+  const insecureInputValues = request.body;
+  const secureInputValues = authorization.filterInput(userTryingToCreate, 'create:ads', insecureInputValues);
+
+  secureInputValues.owner_id = userTryingToCreate.id;
+  secureInputValues.id = uuidV4();
+
+  const transaction = await database.transaction();
+
+  try {
+    await transaction.query('BEGIN');
+
+    const currentEvent = await event.create(
+      {
+        type: 'create:sponsored_content',
+        originatorUserId: request.context.user.id,
+        originatorIp: request.context.clientIp,
+        metadata: {
+          id: secureInputValues.id,
+        },
+      },
+      { transaction: transaction },
+    );
+
+    const createdSponsoredContent = await sponsoredContent.create(secureInputValues, {
+      eventId: currentEvent.id,
+      transaction: transaction,
+    });
+
+    await transaction.query('COMMIT');
+
+    const secureOutputValues = authorization.filterOutput(userTryingToCreate, 'read:ads', createdSponsoredContent);
+
+    response.status(201).json(secureOutputValues);
+  } catch (error) {
+    await transaction.query('ROLLBACK');
+    throw error;
+  } finally {
+    await transaction.release();
+  }
+}

--- a/tests/integration/api/v1/sponsored_contents/post.test.js
+++ b/tests/integration/api/v1/sponsored_contents/post.test.js
@@ -1,0 +1,1189 @@
+import { version as uuidVersion } from 'uuid';
+
+import user from 'models/user';
+import { maxSlugLength, maxTitleLength } from 'tests/constants-for-tests';
+import orchestrator from 'tests/orchestrator';
+import RequestBuilder from 'tests/request-builder';
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.dropAllTables();
+  await orchestrator.runPendingMigrations();
+});
+
+describe('POST /api/v1/sponsored_contents', () => {
+  describe('Anonymous user', () => {
+    test('sponsored content with valid data', async () => {
+      const sponsoredContentsRequestBuilder = new RequestBuilder('/api/v1/sponsored_contents');
+
+      const { response, responseBody } = await sponsoredContentsRequestBuilder.post({
+        title: 'By anonymous user',
+        body: 'Body',
+        bid: 4,
+        budget: 44,
+      });
+
+      expect(response.status).toBe(403);
+
+      expect(responseBody).toStrictEqual({
+        status_code: 403,
+        name: 'ForbiddenError',
+        message: 'Usuário não pode executar esta operação.',
+        action: 'Verifique se este usuário possui a feature "create:ads".',
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND',
+      });
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+    });
+  });
+
+  describe('User without "create:ads" feature', () => {
+    test('sponsored content with valid data', async () => {
+      const sponsoredContentsRequestBuilder = new RequestBuilder('/api/v1/sponsored_contents');
+      await sponsoredContentsRequestBuilder.buildUser({ without: ['create:ads'] });
+
+      const { response, responseBody } = await sponsoredContentsRequestBuilder.post({
+        title: 'By user without permission',
+        body: 'Body',
+        bid: 5,
+        budget: 30,
+      });
+
+      expect(response.status).toBe(403);
+
+      expect(responseBody).toStrictEqual({
+        status_code: 403,
+        name: 'ForbiddenError',
+        message: 'Usuário não pode executar esta operação.',
+        action: 'Verifique se este usuário possui a feature "create:ads".',
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND',
+      });
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+    });
+  });
+
+  describe('Default user', () => {
+    test('sponsored content without "body"', async () => {
+      const sponsoredContentsRequestBuilder = new RequestBuilder('/api/v1/sponsored_contents');
+      await sponsoredContentsRequestBuilder.buildUser();
+
+      const { response, responseBody } = await sponsoredContentsRequestBuilder.post({
+        title: 'No body',
+        bid: 2,
+        budget: 50,
+      });
+
+      expect(response.status).toBe(400);
+
+      expect(responseBody).toStrictEqual({
+        status_code: 400,
+        name: 'ValidationError',
+        message: '"body" é um campo obrigatório.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        key: 'body',
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
+        type: 'any.required',
+      });
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+    });
+
+    test('sponsored content with "body" containing an empty string', async () => {
+      const sponsoredContentsRequestBuilder = new RequestBuilder('/api/v1/sponsored_contents');
+      await sponsoredContentsRequestBuilder.buildUser();
+
+      const { response, responseBody } = await sponsoredContentsRequestBuilder.post({
+        title: 'Empty body',
+        body: '',
+        bid: 2,
+        budget: 50,
+      });
+
+      expect(response.status).toBe(400);
+
+      expect(responseBody).toStrictEqual({
+        status_code: 400,
+        name: 'ValidationError',
+        message: '"body" não pode estar em branco.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        key: 'body',
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
+        type: 'string.empty',
+      });
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+    });
+
+    test('sponsored content with "body" containing an empty markdown', async () => {
+      const sponsoredContentsRequestBuilder = new RequestBuilder('/api/v1/sponsored_contents');
+      await sponsoredContentsRequestBuilder.buildUser();
+
+      const { response, responseBody } = await sponsoredContentsRequestBuilder.post({
+        title: 'Empty markdown',
+        body: `![](https://example.com/image.png)
+              <div>\u00a0</div>
+              <b>\u2800</b>
+              <!-- some 
+              comments -->
+              <>\u200e</>
+              <p>\u200f</p>
+              <h1>\u0009</h1>
+              <strong>\u0020</strong>
+              <em><\u00ad/em>
+              <abbr>͏</abbr>
+              <address>\u061c</address>
+              <bdo>\u180e</bdo>
+              <q>\u2000</q>
+              <code>\u2001</code>
+              <ins>\u2002</ins>
+              <del>\u2003</del>
+              <dfn>\u2004</dfn>
+              <kbd>\u2005</kbd>
+              <pre>\u2006</pre>
+              <samp>\u2007</samp>
+              <var>\u2008</var>
+              <br>\u2009</br>
+              <div>\u200a</div>
+              <a>\u200b</a>
+              <base>\u200c</base>
+              <img>\u200d</img>
+              <area>\u200e</area>
+              <map>\u200f</map>
+              <param>\u205f</param>
+              <object>\u2060</object>
+              <ul>\u2061</ul>
+              <ol>\u2062</ol>
+              <li>\u2063</li>
+              <dl>\u2064</dl>
+              <dd>\u206a</dd>
+              <h1>\u206b</h1>
+              <h2>\u206c</h2>
+              <h3>\u206d</h3>
+              <h4>\u3000</h4>
+              <h5>\ufeff</h5>
+              <h6>𝅳</h6>
+              <>𝅴</>
+              <>𝅵</>
+              <>𝅶</>
+              <>𝅷</>
+              <>𝅸</>
+              <>𝅹</>
+              <>𝅺</>
+              <>\u115f</>
+              <>\u1160</>
+              <>\u17b4</>
+              <>\u17b5</>
+              <>\u3164</>
+              <>\uffa0</>
+              </code></a></div></other>
+              <code><a><div><other>
+              `,
+        bid: 2,
+        budget: 50,
+      });
+
+      expect(response.status).toBe(400);
+
+      expect(responseBody).toStrictEqual({
+        status_code: 400,
+        name: 'ValidationError',
+        message: 'Markdown deve conter algum texto.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        key: 'body',
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
+        type: 'markdown.empty',
+      });
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+    });
+
+    test('sponsored content with "slug" containing an empty string', async () => {
+      const sponsoredContentsRequestBuilder = new RequestBuilder('/api/v1/sponsored_contents');
+      await sponsoredContentsRequestBuilder.buildUser();
+
+      const { response, responseBody } = await sponsoredContentsRequestBuilder.post({
+        title: 'Blank slug',
+        body: 'Body',
+        slug: '',
+        bid: 2,
+        budget: 50,
+      });
+
+      expect(response.status).toBe(400);
+
+      expect(responseBody).toStrictEqual({
+        status_code: 400,
+        name: 'ValidationError',
+        message: '"slug" não pode estar em branco.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        key: 'slug',
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
+        type: 'string.empty',
+      });
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+    });
+
+    test('sponsored content without "title"', async () => {
+      const sponsoredContentsRequestBuilder = new RequestBuilder('/api/v1/sponsored_contents');
+      await sponsoredContentsRequestBuilder.buildUser();
+
+      const { response, responseBody } = await sponsoredContentsRequestBuilder.post({
+        body: 'Body.',
+        bid: 2,
+        budget: 50,
+      });
+
+      expect(response.status).toBe(400);
+
+      expect(responseBody).toStrictEqual({
+        status_code: 400,
+        name: 'ValidationError',
+        message: '"title" é um campo obrigatório.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        key: 'title',
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
+        type: 'any.required',
+      });
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+    });
+
+    test('sponsored content with "title" null', async () => {
+      const sponsoredContentsRequestBuilder = new RequestBuilder('/api/v1/sponsored_contents');
+      await sponsoredContentsRequestBuilder.buildUser();
+
+      const { response, responseBody } = await sponsoredContentsRequestBuilder.post({
+        title: null,
+        body: 'Body.',
+        bid: 2,
+        budget: 50,
+      });
+
+      expect(response.status).toBe(400);
+
+      expect(responseBody).toStrictEqual({
+        status_code: 400,
+        name: 'ValidationError',
+        message: '"title" deve ser do tipo String.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        key: 'title',
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
+        type: 'string.base',
+      });
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+    });
+
+    test('sponsored content with "title" containing an empty string', async () => {
+      const sponsoredContentsRequestBuilder = new RequestBuilder('/api/v1/sponsored_contents');
+      await sponsoredContentsRequestBuilder.buildUser();
+
+      const { response, responseBody } = await sponsoredContentsRequestBuilder.post({
+        title: '',
+        body: 'Body.',
+        bid: 2,
+        budget: 50,
+      });
+
+      expect(response.status).toBe(400);
+
+      expect(responseBody).toStrictEqual({
+        status_code: 400,
+        name: 'ValidationError',
+        message: '"title" não pode estar em branco.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        key: 'title',
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
+        type: 'string.empty',
+      });
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+    });
+
+    test('sponsored content with "title" containing more than 255 characters', async () => {
+      const sponsoredContentsRequestBuilder = new RequestBuilder('/api/v1/sponsored_contents');
+      await sponsoredContentsRequestBuilder.buildUser();
+
+      const { response, responseBody } = await sponsoredContentsRequestBuilder.post({
+        title: 'T'.repeat(256),
+        body: 'Body.',
+        bid: 2,
+        budget: 50,
+      });
+
+      expect(response.status).toBe(400);
+
+      expect(responseBody).toStrictEqual({
+        status_code: 400,
+        name: 'ValidationError',
+        message: '"title" deve conter no máximo 255 caracteres.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        key: 'title',
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
+        type: 'string.max',
+      });
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+    });
+
+    test('sponsored content with "link" containing an empty string', async () => {
+      const sponsoredContentsRequestBuilder = new RequestBuilder('/api/v1/sponsored_contents');
+      await sponsoredContentsRequestBuilder.buildUser();
+
+      const { response, responseBody } = await sponsoredContentsRequestBuilder.post({
+        title: 'Empty link',
+        body: 'Body',
+        link: '',
+        bid: 2,
+        budget: 50,
+      });
+
+      expect(response.status).toBe(400);
+
+      expect(responseBody).toStrictEqual({
+        status_code: 400,
+        name: 'ValidationError',
+        message: '"link" não pode estar em branco.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        key: 'link',
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
+        type: 'string.empty',
+      });
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+    });
+
+    test('sponsored content with "link" containing an unaccepted protocol', async () => {
+      const sponsoredContentsRequestBuilder = new RequestBuilder('/api/v1/sponsored_contents');
+      await sponsoredContentsRequestBuilder.buildUser();
+
+      const { response, responseBody } = await sponsoredContentsRequestBuilder.post({
+        title: 'FTP protocol',
+        body: 'Body',
+        link: 'ftp://www.tabnews.com.br',
+        bid: 2,
+        budget: 50,
+      });
+
+      expect(response.status).toBe(400);
+
+      expect(responseBody).toStrictEqual({
+        status_code: 400,
+        name: 'ValidationError',
+        message: '"link" deve possuir uma URL válida e utilizando os protocolos HTTP ou HTTPS.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        key: 'link',
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
+        type: 'string.pattern.base',
+      });
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+    });
+
+    test('sponsored content with "link" without a protocol', async () => {
+      const sponsoredContentsRequestBuilder = new RequestBuilder('/api/v1/sponsored_contents');
+      await sponsoredContentsRequestBuilder.buildUser();
+
+      const { response, responseBody } = await sponsoredContentsRequestBuilder.post({
+        title: 'No protocol',
+        body: 'Body',
+        link: 'www.tabnews.com.br',
+        bid: 2,
+        budget: 50,
+      });
+
+      expect(response.status).toBe(400);
+
+      expect(responseBody).toStrictEqual({
+        status_code: 400,
+        name: 'ValidationError',
+        message: '"link" deve possuir uma URL válida e utilizando os protocolos HTTP ou HTTPS.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        key: 'link',
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
+        type: 'string.pattern.base',
+      });
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+    });
+
+    test('sponsored content without "budget"', async () => {
+      const sponsoredContentsRequestBuilder = new RequestBuilder('/api/v1/sponsored_contents');
+      await sponsoredContentsRequestBuilder.buildUser();
+
+      const { response, responseBody } = await sponsoredContentsRequestBuilder.post({
+        title: 'No "budget"',
+        body: 'Body',
+        bid: 3,
+      });
+
+      expect(response.status).toBe(400);
+
+      expect(responseBody).toStrictEqual({
+        status_code: 400,
+        name: 'ValidationError',
+        message: '"budget" é um campo obrigatório.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        key: 'budget',
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
+        type: 'any.required',
+      });
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+    });
+
+    test('sponsored content with zero "budget"', async () => {
+      const sponsoredContentsRequestBuilder = new RequestBuilder('/api/v1/sponsored_contents');
+      await sponsoredContentsRequestBuilder.buildUser();
+
+      const { response, responseBody } = await sponsoredContentsRequestBuilder.post({
+        title: 'Zero "budget"',
+        body: 'Body',
+        bid: 5,
+        budget: 0,
+      });
+
+      expect(response.status).toBe(400);
+
+      expect(responseBody).toStrictEqual({
+        status_code: 400,
+        name: 'ValidationError',
+        message: '"budget" deve possuir um valor mínimo de 1.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        key: 'budget',
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
+        type: 'number.min',
+      });
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+    });
+
+    test('sponsored content without "bid"', async () => {
+      const sponsoredContentsRequestBuilder = new RequestBuilder('/api/v1/sponsored_contents');
+      await sponsoredContentsRequestBuilder.buildUser();
+
+      const { response, responseBody } = await sponsoredContentsRequestBuilder.post({
+        title: 'No "bid"',
+        body: 'Body',
+        budget: 10,
+      });
+
+      expect(response.status).toBe(400);
+
+      expect(responseBody).toStrictEqual({
+        status_code: 400,
+        name: 'ValidationError',
+        message: '"bid" é um campo obrigatório.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        key: 'bid',
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
+        type: 'any.required',
+      });
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+    });
+
+    test('sponsored content with zero "bid"', async () => {
+      const sponsoredContentsRequestBuilder = new RequestBuilder('/api/v1/sponsored_contents');
+      await sponsoredContentsRequestBuilder.buildUser();
+
+      const { response, responseBody } = await sponsoredContentsRequestBuilder.post({
+        title: 'Zero "bid"',
+        body: 'Body',
+        bid: 0,
+        budget: 30,
+      });
+
+      expect(response.status).toBe(400);
+
+      expect(responseBody).toStrictEqual({
+        status_code: 400,
+        name: 'ValidationError',
+        message: '"bid" deve possuir um valor mínimo de 1.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        key: 'bid',
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
+        type: 'number.min',
+      });
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+    });
+
+    test('sponsored content with invalid "deactivated_at"', async () => {
+      const sponsoredContentsRequestBuilder = new RequestBuilder('/api/v1/sponsored_contents');
+      await sponsoredContentsRequestBuilder.buildUser();
+
+      const { response, responseBody } = await sponsoredContentsRequestBuilder.post({
+        title: 'Invalid deactivated_at date',
+        body: 'Body',
+        bid: 1,
+        budget: 1,
+        deactivated_at: 'date',
+      });
+
+      expect(response.status).toBe(400);
+
+      expect(responseBody).toStrictEqual({
+        status_code: 400,
+        name: 'ValidationError',
+        message: '"deactivated_at" deve conter uma data válida.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        key: 'deactivated_at',
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
+        type: 'date.base',
+      });
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+    });
+
+    test('sponsored content with a "deactivated_at" date that has already passed', async () => {
+      const sponsoredContentsRequestBuilder = new RequestBuilder('/api/v1/sponsored_contents');
+      await sponsoredContentsRequestBuilder.buildUser();
+
+      const { response, responseBody } = await sponsoredContentsRequestBuilder.post({
+        title: 'Deactivates in the past',
+        body: 'Body',
+        bid: 1,
+        budget: 1,
+        deactivated_at: '2024-04-30T10:22:33.000Z',
+      });
+
+      expect(response.status).toBe(400);
+
+      expect(responseBody).toStrictEqual({
+        status_code: 400,
+        name: 'ValidationError',
+        message: 'A data de desativação não pode ser no passado.',
+        action: 'Utilize uma data de desativação no futuro.',
+        key: 'deactivated_at',
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:SPONSORED_CONTENT:VALIDATE_DEACTIVATED_AT:DATE_IN_PAST',
+      });
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+    });
+
+    test('sponsored content with valid "bid" higher than "budget"', async () => {
+      const sponsoredContentsRequestBuilder = new RequestBuilder('/api/v1/sponsored_contents');
+      await sponsoredContentsRequestBuilder.buildUser();
+
+      const { response, responseBody } = await sponsoredContentsRequestBuilder.post({
+        title: '"Bid" higher than "budget"',
+        body: 'Body',
+        bid: 10,
+        budget: 9,
+      });
+
+      expect(response.status).toBe(400);
+
+      expect(responseBody).toStrictEqual({
+        status_code: 400,
+        name: 'ValidationError',
+        message: 'O lance não pode ser maior do que o orçamento.',
+        action: 'Diminua o lance ou aumente o orçamento.',
+        key: 'bid',
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:SPONSORED_CONTENT:VALIDATE_BID_AND_BUDGET:BID_HIGHER_THAN_BUDGET',
+      });
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+    });
+
+    test('sponsored content with valid data', async () => {
+      const sponsoredContentsRequestBuilder = new RequestBuilder('/api/v1/sponsored_contents');
+      const defaultUser = await sponsoredContentsRequestBuilder.buildUser();
+      await orchestrator.createBalance({
+        balanceType: 'user:tabcash',
+        recipientId: defaultUser.id,
+        amount: 100,
+      });
+
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+
+      const { response, responseBody } = await sponsoredContentsRequestBuilder.post({
+        title: 'First valid sponsored content',
+        body: 'First body',
+        deactivated_at: tomorrow.toISOString(),
+        bid: 9,
+        budget: 9,
+        link: 'https://curso.dev/',
+      });
+
+      expect(response.status).toBe(201);
+
+      expect(responseBody).toStrictEqual({
+        id: responseBody.id,
+        owner_id: defaultUser.id,
+        slug: 'first-valid-sponsored-content',
+        title: 'First valid sponsored content',
+        body: 'First body',
+        link: 'https://curso.dev/',
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+        activated_at: responseBody.activated_at,
+        deactivated_at: tomorrow.toISOString(),
+        owner_username: defaultUser.username,
+      });
+
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.activated_at)).not.toBe(NaN);
+    });
+
+    test(`sponsored content with "slug" containing more than ${maxSlugLength} bytes`, async () => {
+      const sponsoredContentsRequestBuilder = new RequestBuilder('/api/v1/sponsored_contents');
+      const defaultUser = await sponsoredContentsRequestBuilder.buildUser();
+      await orchestrator.createBalance({
+        balanceType: 'user:tabcash',
+        recipientId: defaultUser.id,
+        amount: 300,
+      });
+
+      const { response, responseBody } = await sponsoredContentsRequestBuilder.post({
+        title: `Slug with more than ${maxSlugLength} bytes`,
+        body: 'Sponsored content body',
+        slug: `this-slug-must-be-changed-from-${1 + maxSlugLength}-to-${maxSlugLength}-bytes`.padEnd(
+          1 + maxSlugLength,
+          's',
+        ),
+        bid: 10,
+        budget: 300,
+      });
+
+      expect(response.status).toBe(201);
+
+      expect(responseBody).toStrictEqual({
+        id: responseBody.id,
+        owner_id: defaultUser.id,
+        slug: `this-slug-must-be-changed-from-${1 + maxSlugLength}-to-${maxSlugLength}-bytes`.padEnd(
+          maxSlugLength,
+          's',
+        ),
+        title: `Slug with more than ${maxSlugLength} bytes`,
+        body: 'Sponsored content body',
+        link: null,
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+        activated_at: responseBody.activated_at,
+        deactivated_at: null,
+        owner_username: defaultUser.username,
+      });
+
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.activated_at)).not.toBe(NaN);
+    });
+
+    test(`sponsored content with "title" containing special characters occupying more than ${maxTitleLength} bytes`, async () => {
+      const sponsoredContentsRequestBuilder = new RequestBuilder('/api/v1/sponsored_contents');
+      const defaultUser = await sponsoredContentsRequestBuilder.buildUser();
+      await orchestrator.createBalance({
+        balanceType: 'user:tabcash',
+        recipientId: defaultUser.id,
+        amount: 300,
+      });
+
+      const { response, responseBody } = await sponsoredContentsRequestBuilder.post({
+        title: '♥'.repeat(maxTitleLength),
+        body: `The title is ${maxTitleLength} characters but ${maxTitleLength * 3} bytes and the slug should only be ${maxSlugLength} bytes`,
+        bid: 5,
+        budget: 300,
+      });
+
+      expect(response.status).toBe(201);
+
+      expect(responseBody).toStrictEqual({
+        id: responseBody.id,
+        owner_id: defaultUser.id,
+        slug: ''.padStart(maxSlugLength, '4pml'),
+        title: '♥'.repeat(255),
+        body: `The title is ${maxTitleLength} characters but ${maxTitleLength * 3} bytes and the slug should only be ${maxSlugLength} bytes`,
+        link: null,
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+        activated_at: responseBody.activated_at,
+        deactivated_at: null,
+        owner_username: defaultUser.username,
+      });
+
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.activated_at)).not.toBe(NaN);
+    });
+
+    test('sponsored content with "slug" containing the same value of another sponsored content from the same user', async () => {
+      const sponsoredContentsRequestBuilder = new RequestBuilder('/api/v1/sponsored_contents');
+      const defaultUser = await sponsoredContentsRequestBuilder.buildUser();
+      await orchestrator.createBalance({
+        balanceType: 'user:tabcash',
+        recipientId: defaultUser.id,
+        amount: 400,
+      });
+
+      const { response: firstResponse } = await sponsoredContentsRequestBuilder.post({
+        title: 'First sponsored content',
+        body: 'First body',
+        slug: 'two-sponsored-contents-with-the-same-slug',
+        bid: 50,
+        budget: 200,
+      });
+
+      expect(firstResponse.status).toBe(201);
+
+      const { response: secondResponse, responseBody: secondResponseBody } = await sponsoredContentsRequestBuilder.post(
+        {
+          title: 'Second sponsored content with the same slug as the first one',
+          body: 'Second body',
+          slug: 'two-sponsored-contents-with-the-same-slug',
+          bid: 20,
+          budget: 200,
+        },
+      );
+
+      expect(secondResponse.status).toBe(400);
+
+      expect(secondResponseBody).toStrictEqual({
+        name: 'ValidationError',
+        message: 'O conteúdo enviado parece ser duplicado.',
+        action: 'Utilize um "title" ou "slug" com começo diferente.',
+        status_code: 400,
+        error_id: secondResponseBody.error_id,
+        request_id: secondResponseBody.request_id,
+        error_location_code: 'MODEL:CONTENT:CHECK_FOR_CONTENT_UNIQUENESS:ALREADY_EXISTS',
+        key: 'slug',
+      });
+      expect(uuidVersion(secondResponseBody.error_id)).toBe(4);
+      expect(uuidVersion(secondResponseBody.request_id)).toBe(4);
+    });
+
+    test('sponsored content with "slug" containing the same value of another sponsored content deactivated', async () => {
+      const sponsoredContentsRequestBuilder = new RequestBuilder('/api/v1/sponsored_contents');
+      const defaultUser = await sponsoredContentsRequestBuilder.buildUser();
+      await orchestrator.createBalance({
+        balanceType: 'user:tabcash',
+        recipientId: defaultUser.id,
+        amount: 300,
+      });
+
+      vi.useFakeTimers();
+
+      const deactivateAt = new Date();
+      deactivateAt.setDate(deactivateAt.getTime() - 60 * 1000);
+
+      const { response: firstResponse } = await sponsoredContentsRequestBuilder.post({
+        title: 'Two sponsored contents with the same slug, but this one is deactivated',
+        body: 'First body',
+        slug: 'same-sponsored-content-slug-with-one-deactivated',
+        bid: 10,
+        budget: 130,
+        owner_id: defaultUser.id,
+        deactivated_at: deactivateAt,
+      });
+
+      expect(firstResponse.status).toBe(201);
+
+      vi.advanceTimersByTime(60 * 1000);
+
+      const { response: secondResponse, responseBody: secondResponseBody } = await sponsoredContentsRequestBuilder.post(
+        {
+          title: 'Two sponsored contents with the same slug, where the first is deactivated',
+          body: 'Second body',
+          slug: 'same-sponsored-content-slug-with-one-deactivated',
+          bid: 5,
+          budget: 170,
+        },
+      );
+
+      vi.useRealTimers();
+
+      expect(secondResponse.status).toBe(400);
+
+      expect(secondResponseBody).toStrictEqual({
+        name: 'ValidationError',
+        message: 'O conteúdo enviado parece ser duplicado.',
+        action: 'Utilize um "title" ou "slug" com começo diferente.',
+        status_code: 400,
+        error_id: secondResponseBody.error_id,
+        request_id: secondResponseBody.request_id,
+        error_location_code: 'MODEL:CONTENT:CHECK_FOR_CONTENT_UNIQUENESS:ALREADY_EXISTS',
+        key: 'slug',
+      });
+      expect(uuidVersion(secondResponseBody.error_id)).toBe(4);
+      expect(uuidVersion(secondResponseBody.request_id)).toBe(4);
+    });
+
+    test('sponsored content with "slug" containing the same value of a content from the same user', async () => {
+      const sponsoredContentsRequestBuilder = new RequestBuilder('/api/v1/sponsored_contents');
+      const defaultUser = await sponsoredContentsRequestBuilder.buildUser();
+      await orchestrator.createBalance({
+        balanceType: 'user:tabcash',
+        recipientId: defaultUser.id,
+        amount: 200,
+      });
+
+      await orchestrator.createContent({
+        title: 'A normal content (and a sponsored content will use the same slug)',
+        body: 'First body',
+        slug: 'duplicate-content-and-sponsored-content',
+        status: 'published',
+        owner_id: defaultUser.id,
+      });
+
+      const { response, responseBody } = await sponsoredContentsRequestBuilder.post({
+        title: 'A sponsored content with the same slug of a normal content',
+        body: 'Second body',
+        slug: 'duplicate-content-and-sponsored-content',
+        bid: 150,
+        budget: 200,
+      });
+
+      expect(response.status).toBe(400);
+
+      expect(responseBody).toStrictEqual({
+        name: 'ValidationError',
+        message: 'O conteúdo enviado parece ser duplicado.',
+        action: 'Utilize um "title" ou "slug" com começo diferente.',
+        status_code: 400,
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:CONTENT:CHECK_FOR_CONTENT_UNIQUENESS:ALREADY_EXISTS',
+        key: 'slug',
+      });
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+    });
+
+    test('sponsored content with "slug" containing the same value of a deleted content from the same user', async () => {
+      const sponsoredContentsRequestBuilder = new RequestBuilder('/api/v1/sponsored_contents');
+      const defaultUser = await sponsoredContentsRequestBuilder.buildUser();
+      await orchestrator.createBalance({
+        balanceType: 'user:tabcash',
+        recipientId: defaultUser.id,
+        amount: 30,
+      });
+
+      const createdContent = await orchestrator.createContent({
+        title: 'A content that will be deleted',
+        body: 'Body',
+        slug: 'same-slug-content-deleted',
+        status: 'published',
+        owner_id: defaultUser.id,
+      });
+
+      await orchestrator.updateContent(createdContent.id, { status: 'deleted' });
+
+      const { response, responseBody } = await sponsoredContentsRequestBuilder.post({
+        title: 'Sponsored content with the same slug of a deleted content',
+        body: 'Body',
+        slug: 'same-slug-content-deleted',
+        bid: 7,
+        budget: 30,
+      });
+
+      expect(response.status).toBe(201);
+
+      expect(responseBody).toStrictEqual({
+        id: responseBody.id,
+        owner_id: defaultUser.id,
+        slug: 'same-slug-content-deleted',
+        title: 'Sponsored content with the same slug of a deleted content',
+        body: 'Body',
+        link: null,
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+        activated_at: responseBody.activated_at,
+        deactivated_at: null,
+        owner_username: defaultUser.username,
+      });
+    });
+
+    test('sponsored content with "link" containing query parameters', async () => {
+      const sponsoredContentsRequestBuilder = new RequestBuilder('/api/v1/sponsored_contents');
+      const defaultUser = await sponsoredContentsRequestBuilder.buildUser();
+      await orchestrator.createBalance({
+        balanceType: 'user:tabcash',
+        recipientId: defaultUser.id,
+        amount: 200,
+      });
+
+      const { response, responseBody } = await sponsoredContentsRequestBuilder.post({
+        title: 'Title',
+        body: 'Body',
+        link: 'https://www.tabnews.com.br/api/v1/sponsored_contents?query=param',
+        bid: 3,
+        budget: 200,
+      });
+
+      expect(response.status).toBe(201);
+
+      expect(responseBody).toStrictEqual({
+        id: responseBody.id,
+        owner_id: defaultUser.id,
+        slug: 'title',
+        title: 'Title',
+        body: 'Body',
+        link: 'https://www.tabnews.com.br/api/v1/sponsored_contents?query=param',
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+        activated_at: responseBody.activated_at,
+        deactivated_at: null,
+        owner_username: defaultUser.username,
+      });
+
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.activated_at)).not.toBe(NaN);
+    });
+
+    test('sponsored content with "title" containing custom slug special characters', async () => {
+      const sponsoredContentsRequestBuilder = new RequestBuilder('/api/v1/sponsored_contents');
+      const defaultUser = await sponsoredContentsRequestBuilder.buildUser();
+      await orchestrator.createBalance({
+        balanceType: 'user:tabcash',
+        recipientId: defaultUser.id,
+        amount: 550,
+      });
+
+      const { response, responseBody } = await sponsoredContentsRequestBuilder.post({
+        title: 'title_1.000% @me!+#ã',
+        body: 'Body',
+        bid: 7,
+        budget: 500,
+      });
+
+      expect(response.status).toBe(201);
+
+      expect(responseBody).toStrictEqual({
+        id: responseBody.id,
+        owner_id: defaultUser.id,
+        slug: 'title-1-000-por-cento-mea',
+        title: 'title_1.000% @me!+#ã',
+        body: 'Body',
+        link: null,
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+        activated_at: responseBody.activated_at,
+        deactivated_at: null,
+        owner_username: defaultUser.username,
+      });
+
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.activated_at)).not.toBe(NaN);
+    });
+
+    describe('TabCash', () => {
+      test('sponsored content without enough TabCash', async () => {
+        const sponsoredContentsRequestBuilder = new RequestBuilder('/api/v1/sponsored_contents');
+        const defaultUser = await sponsoredContentsRequestBuilder.buildUser();
+        await orchestrator.createBalance({
+          balanceType: 'user:tabcash',
+          recipientId: defaultUser.id,
+          amount: 100,
+        });
+
+        const { response, responseBody } = await sponsoredContentsRequestBuilder.post({
+          title: 'Not enough TabCash',
+          body: 'Body.',
+          bid: 10,
+          budget: 101,
+        });
+
+        expect(response.status).toBe(422);
+
+        expect(responseBody).toStrictEqual({
+          name: 'UnprocessableEntityError',
+          message: 'Não foi possível utilizar TabCash para criar esta publicação patrocinada.',
+          action: 'Informe um valor menor ou acumule mais TabCash.',
+          status_code: 422,
+          error_id: responseBody.error_id,
+          request_id: responseBody.request_id,
+          error_location_code: 'MODEL:BALANCE:SPONSOR_CONTENT:NOT_ENOUGH',
+        });
+        expect(uuidVersion(responseBody.error_id)).toBe(4);
+        expect(uuidVersion(responseBody.request_id)).toBe(4);
+      });
+
+      test('sponsored content updating user TabCash', async () => {
+        const sponsoredContentsRequestBuilder = new RequestBuilder('/api/v1/sponsored_contents');
+        const defaultUser = await sponsoredContentsRequestBuilder.buildUser();
+        await orchestrator.createBalance({
+          balanceType: 'user:tabcash',
+          recipientId: defaultUser.id,
+          amount: 250,
+        });
+
+        const initialTabcoins = 270;
+        await orchestrator.createBalance({
+          balanceType: 'user:tabcoin',
+          recipientId: defaultUser.id,
+          amount: initialTabcoins,
+        });
+
+        const { response, responseBody } = await sponsoredContentsRequestBuilder.post({
+          title: 'Check user TabCash',
+          body: 'Body',
+          bid: 15,
+          budget: 120,
+        });
+
+        expect(response.status).toBe(201);
+
+        expect(responseBody).toStrictEqual({
+          id: responseBody.id,
+          owner_id: defaultUser.id,
+          slug: 'check-user-tabcash',
+          title: 'Check user TabCash',
+          body: 'Body',
+          link: null,
+          created_at: responseBody.created_at,
+          updated_at: responseBody.updated_at,
+          activated_at: responseBody.activated_at,
+          deactivated_at: null,
+          owner_username: defaultUser.username,
+        });
+        expect(uuidVersion(responseBody.id)).toBe(4);
+        expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+        expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+        expect(Date.parse(responseBody.activated_at)).not.toBe(NaN);
+
+        const updatedUser = await user.findOneById(defaultUser.id, { withBalance: true });
+        expect(updatedUser.tabcoins).toBe(initialTabcoins);
+        expect(updatedUser.tabcash).toBe(130);
+      });
+    });
+
+    describe('Prestige', () => {
+      test('should be able to create a sponsored content with negative prestige by more than threshold', async () => {
+        const sponsoredContentsRequestBuilder = new RequestBuilder('/api/v1/sponsored_contents');
+        const defaultUser = await sponsoredContentsRequestBuilder.buildUser();
+        await orchestrator.createBalance({
+          balanceType: 'user:tabcash',
+          recipientId: defaultUser.id,
+          amount: 300,
+        });
+        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: -1, rootPrestigeDenominator: 2 });
+
+        const { response, responseBody } = await sponsoredContentsRequestBuilder.post({
+          title: 'With negative prestige',
+          body: 'Relevant relevant relevant; user with negative prestige.',
+          bid: 30,
+          budget: 300,
+        });
+
+        expect(response.status).toBe(201);
+
+        expect(responseBody).toStrictEqual({
+          id: responseBody.id,
+          owner_id: defaultUser.id,
+          slug: 'with-negative-prestige',
+          title: 'With negative prestige',
+          body: 'Relevant relevant relevant; user with negative prestige.',
+          link: null,
+          created_at: responseBody.created_at,
+          updated_at: responseBody.updated_at,
+          activated_at: responseBody.activated_at,
+          deactivated_at: null,
+          owner_username: defaultUser.username,
+        });
+
+        expect(uuidVersion(responseBody.id)).toBe(4);
+        expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+        expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+        expect(Date.parse(responseBody.activated_at)).not.toBe(NaN);
+
+        const updatedUser = await user.findOneById(defaultUser.id, { withBalance: true });
+        expect(updatedUser.tabcoins).toBe(0);
+        expect(updatedUser.tabcash).toBe(0);
+      });
+
+      test('should not earn TabCoins even if it has the minimum prestige in "root" content', async () => {
+        const sponsoredContentsRequestBuilder = new RequestBuilder('/api/v1/sponsored_contents');
+        const defaultUser = await sponsoredContentsRequestBuilder.buildUser();
+        await orchestrator.createBalance({
+          balanceType: 'user:tabcash',
+          recipientId: defaultUser.id,
+          amount: 185,
+        });
+        await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: 2, rootPrestigeDenominator: 10 });
+
+        const { response, responseBody } = await sponsoredContentsRequestBuilder.post({
+          title: 'No TabCoins earnings',
+          body: 'Sponsored content does not give TabCoins to the author, even if the content is relevant.',
+          bid: 10,
+          budget: 185,
+        });
+
+        expect(response.status).toBe(201);
+
+        expect(responseBody).toStrictEqual({
+          id: responseBody.id,
+          owner_id: defaultUser.id,
+          slug: 'no-tabcoins-earnings',
+          title: 'No TabCoins earnings',
+          body: 'Sponsored content does not give TabCoins to the author, even if the content is relevant.',
+          link: null,
+          created_at: responseBody.created_at,
+          updated_at: responseBody.updated_at,
+          activated_at: responseBody.activated_at,
+          deactivated_at: null,
+          owner_username: defaultUser.username,
+        });
+
+        expect(uuidVersion(responseBody.id)).toBe(4);
+        expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+        expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+
+        const updatedUser = await user.findOneById(defaultUser.id, { withBalance: true });
+        expect(updatedUser.tabcoins).toBe(0);
+        expect(updatedUser.tabcash).toBe(0);
+      });
+    });
+  });
+});

--- a/tests/integration/api/v1/users/[username]/patch.test.js
+++ b/tests/integration/api/v1/users/[username]/patch.test.js
@@ -699,6 +699,7 @@ describe('PATCH /api/v1/users/[username]', () => {
           'create:content:text_child',
           'update:content',
           'update:user',
+          'create:ads',
         ],
         notifications: defaultUser.notifications,
         tabcoins: 0,

--- a/tests/integration/models/event.test.js
+++ b/tests/integration/models/event.test.js
@@ -583,5 +583,38 @@ describe('models/event', () => {
       expect(uuidVersion(lastEvent.id)).toBe(4);
       expect(Date.parse(lastEvent.created_at)).not.toBe(NaN);
     });
+
+    test('Create "create:sponsored_content" event', async () => {
+      const sponsoredContentsRequestBuilder = new RequestBuilder('/api/v1/sponsored_contents');
+      const defaultUser = await sponsoredContentsRequestBuilder.buildUser();
+      await orchestrator.createBalance({
+        balanceType: 'user:tabcash',
+        recipientId: defaultUser.id,
+        amount: 30,
+      });
+
+      const { responseBody } = await sponsoredContentsRequestBuilder.post({
+        title: 'Sponsored content',
+        body: 'Body',
+        bid: 10,
+        budget: 30,
+      });
+
+      const lastEvent = await orchestrator.getLastEvent();
+
+      expect(lastEvent).toStrictEqual({
+        id: lastEvent.id,
+        type: 'create:sponsored_content',
+        originator_user_id: defaultUser.id,
+        originator_ip: '127.0.0.1',
+        created_at: lastEvent.created_at,
+        metadata: {
+          id: responseBody.id,
+        },
+      });
+
+      expect(uuidVersion(lastEvent.id)).toBe(4);
+      expect(Date.parse(lastEvent.created_at)).not.toBe(NaN);
+    });
   });
 });


### PR DESCRIPTION
## Mudanças realizadas

Esse PR é a primeira parte da implementação de backend, que foi demonstrada de forma completa em https://github.com/filipedeschamps/tabnews.com.br/pull/1719. Aqui se encontram os primeiros dois commits do outro PR, com algumas pequenas mudanças.

Neste momento, não foi necessária a criação das funções de cálculos de TabCoins e TabCash da publicação patrocinada. O `balance_type` em `sponsored_content_tabcoin_operations` será útil para reverter votos em caso de `nuke`.

A implementação utiliza o índice único `contents_owner_id_slug_deleted_at_unique_index` para garantir unicidade de nome do usuário + slug. Isso significa que um conteúdo patrocinado desativado ainda é considerado nessa "unicidade", visto que o `deleted_at` em `contents` não é atualizado quando a publicação já está desativada (`deactivate_at < NOW()`).

Houve uma mudança em um `error_location_code` do `models/content` que não sei se deve ser considerado breaking change. Se formos considerar, então irei alterar a descrição do commit para deixar explícito e também marcarei o PR.

A rota para criar uma publicação patrocinada é `POST /api/v1/sponsored_contents`.

Issue relacionado: #1491.

## Tipo de mudança

- [x] Nova funcionalidade

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
