### PR TITLE
feat: add content type enum and column to contents table

### DIFF
--- a/infra/migrations/1720619007506_alter-table-contents-add-type.js
+++ b/infra/migrations/1720619007506_alter-table-contents-add-type.js
@@ -1,0 +1,13 @@
+exports.up = (pgm) => {
+  pgm.createType('content_types_enum', ['content', 'pitch', 'ad']);
+
+  pgm.addColumns('contents', {
+    type: {
+      type: 'content_types_enum',
+      notNull: true,
+      default: 'content',
+    },
+  });
+};
+
+exports.down = false;


### PR DESCRIPTION
Baseado em https://github.com/filipedeschamps/tabnews.com.br/issues/1491#issuecomment-2220490103

## Mudanças realizadas

Cria o `content_types_enum` que aceita os valores `content`, `pitch` e `ad`.

Adiciona a coluna `type` na tabela `contents` usando `content_types_enum` com o valor padrão `content`.

Obs. Vou deixar como draft porque a migration do PR #1638 já foi executada em homologação. Então vou criar uma versão simplificada daquele PR para poder rodar a migration em produção antes desse aqui.

## Tipo de mudança

- [x] Nova funcionalidade

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Os testes antigos estão passando localmente.
