### PR TITLE
Identifica uma publicação patrocinada na página dela (URL `/[username]/[slug]`)

### DIFF
--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -211,6 +211,11 @@ function ViewMode({ setComponentMode, contentObject, isPageRootOwner, viewFrame 
                   <Label>Autor</Label>
                 </Tooltip>
               )}
+              {contentObject.type === 'ad' && (
+                <Tooltip aria-label="Patrocinado com TabCash" direction="n" sx={{ position: 'absolute' }}>
+                  <Label variant="success">Patrocinado</Label>
+                </Tooltip>
+              )}
             </LabelGroup>
             {!contentObject.parent_id && (
               <>


### PR DESCRIPTION
## Mudanças realizadas

Conforme comentado em https://github.com/filipedeschamps/tabnews.com.br/issues/1491#issuecomment-2226440549 e discutido no issue em questão, adicionei um `Label` para identificar uma publicação patrocinada com a `variant="success"`. Eu havia experimentado usar a cor do TabCash, mas não passa no teste de acessibilidade no modo claro.

| Cenário | Resultado |
| --- | --- |
| Modo claro, cor do TabCash |  ![Label "Patrocinado", tooltip "Patrocinado com TabCash", na cor do TabCash, no modo claro](https://github.com/user-attachments/assets/a52aaa5a-5578-49e0-9391-e49160bd74a9) |
| Modo escuro, cor do TabCash | ![Mesma mensagem e cor utilizada no modo escuro](https://github.com/user-attachments/assets/22cf2762-bb9a-4615-bc0e-b88f9ceb04e5) |
| Modo claro, `variant="success"` | ![A variant "success" também é uma cor verde, porém mais escura](https://github.com/user-attachments/assets/7d9dba49-47f5-4faa-9a63-5212d8261734) |
| Modo escuro, `variant="success"` | ![Mesma mensagem e cor utilizada no modo escuro](https://github.com/user-attachments/assets/dd7dd367-9ce7-47dd-ae3f-5dc4bd6aa107) |

O teste de acessibilidade com a cor do TabCash:

| Modo claro | Modo escuro |
| --- | --- |
| ![Nota 3.22, não passa no AA](https://github.com/user-attachments/assets/cf75942a-f2e5-48be-865b-723cb7155aae) | ![Nota 5.89, passa no AA](https://github.com/user-attachments/assets/ee140510-be15-4c75-be37-5d4aff6342ca) |

[Teste no WebAIM](https://webaim.org/resources/contrastchecker/?fcolor=2DA44E&bcolor=FFFFFF)

Apenas para mencionar, o Primer utiliza cores diferentes para a borda e a cor do texto (duas cores diferentes no modo claro, mais duas cores diferentes no modo escuro).

## Tipo de mudança

- [x] Nova funcionalidade

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [ ] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
