### PR TITLE
feat(advertisement): adds `getRandom` function to retrieve random ads

### DIFF
--- a/models/advertisement.js
+++ b/models/advertisement.js
@@ -1,0 +1,30 @@
+import database from 'infra/database';
+
+async function getRandom(limit) {
+  const query = {
+    values: [limit],
+  };
+
+  query.text = `
+    SELECT
+      c.id,
+      c.slug,
+      c.title,
+      c.source_url,
+      u.username as owner_username,
+      'markdown' as ad_type
+    FROM contents c
+    INNER JOIN users u ON c.owner_id = u.id
+    WHERE type = 'ad' AND status = 'published'
+    ORDER BY RANDOM()
+    LIMIT $1;
+  `;
+
+  const results = await database.query(query);
+
+  return results.rows;
+}
+
+export default Object.freeze({
+  getRandom,
+});

--- a/models/authorization.js
+++ b/models/authorization.js
@@ -41,6 +41,9 @@ const availableFeatures = new Set([
   'update:user:others',
   'ban:user',
   'create:recovery_token:username',
+
+  // ADVERTISEMENT
+  'read:ad:list',
 ]);
 
 function can(user, feature, resource) {
@@ -288,6 +291,17 @@ function filterOutput(user, feature, output) {
       created_at: 'required',
       updated_at: 'required',
     });
+  }
+
+  if (feature === 'read:ad:list') {
+    filteredOutputValues = validator(
+      {
+        ad_list: output,
+      },
+      {
+        ad_list: 'required',
+      },
+    ).ad_list;
   }
 
   // Force the clean up of "undefined" values

--- a/models/validator.js
+++ b/models/validator.js
@@ -511,6 +511,54 @@ const schemas = {
     return contentSchema;
   },
 
+  ad: function () {
+    let contentSchema = Joi.object({
+      children: Joi.array().optional().items(Joi.link('#content')),
+    })
+      .required()
+      .min(1)
+      .id('ad');
+
+    for (const key of [
+      'id',
+      'owner_id',
+      'slug',
+      'title',
+      'body',
+      'status',
+      'ad_type',
+      'source_url',
+      'created_at',
+      'updated_at',
+      'published_at',
+      'deleted_at',
+      'owner_username',
+      'children_deep_count',
+      'tabcash',
+    ]) {
+      const keyValidationFunction = schemas[key];
+      contentSchema = contentSchema.concat(keyValidationFunction());
+    }
+
+    return contentSchema;
+  },
+
+  ad_list: function () {
+    return Joi.object({
+      ad_list: Joi.array().items(Joi.link('#ad')).required().shared(schemas.ad()),
+    });
+  },
+
+  ad_type: function () {
+    return Joi.object({
+      type: Joi.string()
+        .trim()
+        .valid('markdown')
+        .default('markdown')
+        .when('$required.ad_type', { is: 'required', then: Joi.required(), otherwise: Joi.optional() }),
+    });
+  },
+
   with_children: function () {
     return Joi.object({
       with_children: Joi.boolean().when('$required.with_children', {

--- a/pages/api/v1/sponsored-beta/index.public.js
+++ b/pages/api/v1/sponsored-beta/index.public.js
@@ -1,0 +1,37 @@
+import nextConnect from 'next-connect';
+
+import ad from 'models/advertisement';
+import authorization from 'models/authorization.js';
+import cacheControl from 'models/cache-control';
+import controller from 'models/controller.js';
+import user from 'models/user.js';
+import validator from 'models/validator.js';
+
+export default nextConnect({
+  attachParams: true,
+  onNoMatch: controller.onNoMatchHandler,
+  onError: controller.onErrorHandler,
+})
+  .use(controller.injectRequestMetadata)
+  .use(controller.logRequest)
+  .get(cacheControl.swrMaxAge(10), getValidationHandler, getHandler);
+
+function getValidationHandler(request, response, next) {
+  const cleanValues = validator(request.query, {
+    per_page: 'optional',
+  });
+
+  request.query = cleanValues;
+
+  next();
+}
+
+async function getHandler(request, response) {
+  const userTryingToList = user.createAnonymous();
+
+  const ads = await ad.getRandom(request.query.per_page);
+
+  const secureOutputValues = authorization.filterOutput(userTryingToList, 'read:ad:list', ads);
+
+  return response.status(200).json(secureOutputValues);
+}

--- a/tests/integration/api/v1/sponsored-beta/get.test.js
+++ b/tests/integration/api/v1/sponsored-beta/get.test.js
@@ -1,0 +1,111 @@
+import { defaultTabCashForAdCreation } from 'tests/constants-for-tests';
+import orchestrator from 'tests/orchestrator.js';
+import RequestBuilder from 'tests/request-builder';
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+});
+
+describe('GET /api/v1/sponsored-beta', () => {
+  describe('Anonymous user', () => {
+    const adsRequestBuilder = new RequestBuilder('/api/v1/sponsored-beta');
+    let owner;
+
+    beforeEach(async () => {
+      await orchestrator.dropAllTables();
+      await orchestrator.runPendingMigrations();
+      owner = await orchestrator.createUser();
+
+      orchestrator.createBalance({
+        balanceType: 'user:tabcash',
+        recipientId: owner.id,
+        amount: 100 * defaultTabCashForAdCreation,
+      });
+    });
+
+    it('should never get default content', async () => {
+      await orchestrator.createContent({
+        owner_id: owner.id,
+        title: 'Content',
+        status: 'published',
+        type: 'content',
+      });
+
+      const { response, responseBody } = await adsRequestBuilder.get();
+
+      expect.soft(response.status).toBe(200);
+      expect(responseBody).toEqual([]);
+    });
+
+    it('should never get unpublished ad', async () => {
+      await orchestrator.createContent({
+        owner_id: owner.id,
+        title: 'Draft Ad',
+        status: 'draft',
+        type: 'ad',
+      });
+
+      const deletedAd = await orchestrator.createContent({
+        owner_id: owner.id,
+        title: 'Deleted Ad',
+        status: 'published',
+        type: 'ad',
+      });
+
+      await orchestrator.updateContent(deletedAd.id, { status: 'deleted' });
+
+      const { response, responseBody } = await adsRequestBuilder.get();
+
+      expect(response.status).toBe(200);
+      expect(responseBody).toEqual([]);
+    });
+
+    it('should return ads', async () => {
+      const createdAds = await createAds(4, owner);
+
+      const { response, responseBody } = await adsRequestBuilder.get();
+
+      expect.soft(response.status).toBe(200);
+
+      expect(createdAds).toContainEqual(responseBody[0]);
+      expect(createdAds).toContainEqual(responseBody[1]);
+      expect(createdAds).toContainEqual(responseBody[2]);
+      expect(createdAds).toContainEqual(responseBody[3]);
+    });
+
+    it('should limit the number of ads returned', async () => {
+      const createdAds = await createAds(3, owner);
+
+      const { response, responseBody } = await adsRequestBuilder.get('?per_page=2');
+
+      expect.soft(response.status).toBe(200);
+      expect.soft(responseBody).toHaveLength(2);
+
+      expect(createdAds).toContainEqual(responseBody[0]);
+      expect(createdAds).toContainEqual(responseBody[1]);
+    });
+  });
+});
+
+async function createAds(count, owner) {
+  const ads = [];
+  for (let i = 0; i < count; i++) {
+    const ad = await orchestrator.createContent({
+      owner_id: owner.id,
+      title: `Ad #${i}`,
+      status: 'published',
+      type: 'ad',
+    });
+
+    ads.push({
+      id: ad.id,
+      title: ad.title,
+      slug: ad.slug,
+      owner_username: owner.username,
+      source_url: ad.source_url,
+      type: 'markdown',
+    });
+  }
+
+  return ads;
+}


### PR DESCRIPTION
Essa é uma parte da etapa 3a citada em https://github.com/filipedeschamps/tabnews.com.br/issues/1491#issuecomment-2226440549.

## Mudanças realizadas

Cria o model `advertisement` com uma função `getRandom` responsável por devolver uma quantidade escolhida de publicidades aleatórias.

Cada publicidade devolvida contém apenas as propriedades básicas necessárias para a UI: id, title, slug, owner_username, source_url e type. Sendo que `type` aqui é o `ad_type` e não o `content_type`, então por enquanto é só `markdown`.

Foi criado o `/sponsored-beta` provisoriamente para facilitar os testes do novo model.

Só não estamos testando realmente a aleatoriedade, que foi deixada como responsabilidade para `ORDER BY RANDOM()` do PostgreSQL.

## Tipo de mudança

- [x] Nova funcionalidade

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam **parcialmente** que o recurso funciona conforme esperado (menos a aleatoriedade).
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
