### PR TITLE
Exibe publicação patrocinada (anúncio) no topo da lista de conteúdos

### DIFF
--- a/pages/index.public.js
+++ b/pages/index.public.js
@@ -2,16 +2,18 @@ import { getStaticPropsRevalidate } from 'next-swr';
 
 import { ContentList, DefaultLayout } from '@/TabNewsUI';
 import { FaTree } from '@/TabNewsUI/icons';
+import ad from 'models/advertisement';
 import authorization from 'models/authorization.js';
 import content from 'models/content.js';
 import user from 'models/user.js';
 import validator from 'models/validator.js';
 
-export default function Home({ contentListFound, pagination }) {
+export default function Home({ adFound, contentListFound, pagination }) {
   return (
     <>
       <DefaultLayout>
         <ContentList
+          ad={adFound}
           contentList={contentListFound}
           pagination={pagination}
           paginationBasePath="/pagina"
@@ -48,8 +50,12 @@ export const getStaticProps = getStaticPropsRevalidate(async () => {
 
   const secureContentValues = authorization.filterOutput(userTryingToGet, 'read:content:list', contentListFound);
 
+  const adsFound = await ad.getRandom(1);
+  const secureAdValues = authorization.filterOutput(userTryingToGet, 'read:ad:list', adsFound);
+
   return {
     props: {
+      adFound: secureAdValues[0] ?? null,
       contentListFound: secureContentValues,
       pagination: results.pagination,
     },

--- a/pages/interface/components/ContentList/index.js
+++ b/pages/interface/components/ContentList/index.js
@@ -1,7 +1,8 @@
 import { Box, EmptyState, Link, Pagination, PastTime, TabCoinBalanceTooltip, Text, Tooltip } from '@/TabNewsUI';
-import { CommentIcon } from '@/TabNewsUI/icons';
+import { CommentIcon, LinkExternalIcon } from '@/TabNewsUI/icons';
+import { getDomain, isExternalLink, isTrustedDomain } from 'pages/interface';
 
-export default function ContentList({ contentList: list, pagination, paginationBasePath, emptyStateProps }) {
+export default function ContentList({ ad, contentList: list, pagination, paginationBasePath, emptyStateProps }) {
   const listNumberStart = pagination.perPage * (pagination.currentPage - 1) + 1;
 
   return (
@@ -18,6 +19,7 @@ export default function ContentList({ contentList: list, pagination, paginationB
           }}
           key={`content-list-${listNumberStart}`}
           start={listNumberStart}>
+          <Ad ad={ad} />
           <RenderItems />
           <EndOfRelevant />
         </Box>
@@ -144,4 +146,55 @@ export default function ContentList({ contentList: list, pagination, paginationB
   function RenderEmptyMessage(props) {
     return <EmptyState title="Nenhum conteúdo encontrado" {...props} />;
   }
+}
+
+function Ad({ ad }) {
+  if (!ad) {
+    return;
+  }
+
+  const link = ad.source_url || `/${ad.owner_username}/${ad.slug}`;
+  const isAdToExternalLink = isExternalLink(link);
+  const domain = isAdToExternalLink ? `(${getDomain(link)})` : '';
+  const title = ad.title.length > 70 ? ad.title.substring(0, 67).trim().concat('...') : ad.title;
+
+  return (
+    <Box as="li" sx={{ display: 'grid', gridColumnStart: 2, '::marker': 'none' }}>
+      <Box>
+        <Link
+          sx={{
+            overflow: 'auto',
+            fontWeight: 'semibold',
+            wordWrap: 'break-word',
+            ':link': {
+              color: 'success.fg',
+            },
+            ':visited': {
+              color: 'success.fg',
+            },
+          }}
+          href={link}
+          rel={isTrustedDomain(link) ? undefined : 'nofollow'}>
+          <Text sx={{ wordBreak: 'break-word', marginRight: 1 }}>
+            {title} {domain}
+          </Text>
+          {isAdToExternalLink && <LinkExternalIcon verticalAlign="middle" />}
+        </Link>
+      </Box>
+
+      <Text sx={{ whiteSpace: 'nowrap', fontSize: 0, color: 'neutral.emphasis' }}>
+        Contribuindo com{' '}
+        <Tooltip
+          aria-label={`Autor: ${ad.owner_username}`}
+          direction="nw"
+          sx={{ position: 'absolute', display: 'grid' }}>
+          <Link
+            sx={{ overflow: 'hidden', textOverflow: 'ellipsis', color: 'neutral.emphasis', mr: 2 }}
+            href={`/${ad.owner_username}`}>
+            {ad.owner_username}
+          </Link>
+        </Tooltip>
+      </Text>
+    </Box>
+  );
 }

--- a/pages/interface/components/ContentList/index.js
+++ b/pages/interface/components/ContentList/index.js
@@ -103,13 +103,11 @@ export default function ContentList({ contentList: list, pagination, paginationB
               </Text>
               {' · '}
               <Tooltip aria-label={`Autor: ${contentObject.owner_username}`}>
-                <Box sx={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
-                  <Text as="address" sx={{ fontStyle: 'normal' }}>
-                    <Link sx={{ color: 'neutral.emphasis' }} href={`/${contentObject.owner_username}`}>
-                      {contentObject.owner_username}
-                    </Link>
-                  </Text>
-                </Box>
+                <Text as="address" sx={{ fontStyle: 'normal', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                  <Link sx={{ color: 'neutral.emphasis' }} href={`/${contentObject.owner_username}`}>
+                    {contentObject.owner_username}
+                  </Link>
+                </Text>
               </Tooltip>
               {' · '}
               <Text>

--- a/pages/interface/components/TabNewsUI/icons/index.js
+++ b/pages/interface/components/TabNewsUI/icons/index.js
@@ -15,6 +15,7 @@ export {
   GearIcon,
   HomeIcon,
   KebabHorizontalIcon,
+  LinkExternalIcon,
   LinkIcon,
   ListUnorderedIcon,
   MoonIcon,

--- a/pages/interface/index.js
+++ b/pages/interface/index.js
@@ -7,3 +7,4 @@ export { default as createErrorMessage } from './utils/error-message';
 export { default as isValidJsonString } from './utils/is-valid-json-string';
 export { default as processNdJsonStream } from './utils/nd-json-stream';
 export { default as isTrustedDomain } from './utils/trusted-domain';
+export { getDomain, isExternalLink } from './utils/url';

--- a/pages/interface/utils/url.js
+++ b/pages/interface/utils/url.js
@@ -1,0 +1,18 @@
+import webserver from 'infra/webserver';
+
+const webserverHostname = new URL(webserver.host).hostname;
+
+export function isExternalLink(link) {
+  const linkUrl = new URL(link, webserver.host);
+  return webserverHostname !== linkUrl.hostname;
+}
+
+export function getDomain(link) {
+  const linkUrl = new URL(link, webserver.host);
+  const domain = linkUrl.hostname;
+
+  if (domain.startsWith('www.')) {
+    return domain.substring(4);
+  }
+  return domain;
+}

--- a/pages/pagina/[page]/index.public.js
+++ b/pages/pagina/[page]/index.public.js
@@ -2,16 +2,17 @@ import { getStaticPropsRevalidate } from 'next-swr';
 
 import { ContentList, DefaultLayout } from '@/TabNewsUI';
 import webserver from 'infra/webserver';
+import ad from 'models/advertisement';
 import authorization from 'models/authorization.js';
 import content from 'models/content.js';
 import user from 'models/user.js';
 import validator from 'models/validator.js';
 
-export default function Home({ contentListFound, pagination }) {
+export default function Home({ adFound, contentListFound, pagination }) {
   return (
     <>
       <DefaultLayout metadata={{ title: `Página ${pagination.currentPage} · Relevantes` }}>
-        <ContentList contentList={contentListFound} pagination={pagination} paginationBasePath="/pagina" />
+        <ContentList ad={adFound} contentList={contentListFound} pagination={pagination} paginationBasePath="/pagina" />
       </DefaultLayout>
     </>
   );
@@ -66,8 +67,12 @@ export const getStaticProps = getStaticPropsRevalidate(async (context) => {
 
   const secureContentValues = authorization.filterOutput(userTryingToGet, 'read:content:list', contentListFound);
 
+  const adsFound = await ad.getRandom(1);
+  const secureAdValues = authorization.filterOutput(userTryingToGet, 'read:ad:list', adsFound);
+
   return {
     props: {
+      adFound: secureAdValues[0] ?? null,
       contentListFound: secureContentValues,
       pagination: results.pagination,
     },

--- a/pages/recentes/comentarios/[page]/index.public.js
+++ b/pages/recentes/comentarios/[page]/index.public.js
@@ -2,13 +2,14 @@ import { getStaticPropsRevalidate } from 'next-swr';
 
 import { ContentList, DefaultLayout, RecentTabNav } from '@/TabNewsUI';
 import webserver from 'infra/webserver';
+import ad from 'models/advertisement';
 import authorization from 'models/authorization.js';
 import content from 'models/content.js';
 import removeMarkdown from 'models/remove-markdown';
 import user from 'models/user.js';
 import validator from 'models/validator.js';
 
-export default function CommentsPage({ contentListFound, pagination }) {
+export default function CommentsPage({ adFound, contentListFound, pagination }) {
   return (
     <DefaultLayout
       metadata={{
@@ -16,7 +17,12 @@ export default function CommentsPage({ contentListFound, pagination }) {
         description: 'Comentários no TabNews ordenados pelos mais recentes.',
       }}>
       <RecentTabNav />
-      <ContentList contentList={contentListFound} pagination={pagination} paginationBasePath="/recentes/comentarios" />
+      <ContentList
+        ad={adFound}
+        contentList={contentListFound}
+        pagination={pagination}
+        paginationBasePath="/recentes/comentarios"
+      />
     </DefaultLayout>
   );
 }
@@ -67,8 +73,12 @@ export const getStaticProps = getStaticPropsRevalidate(async (context) => {
     content.body = removeMarkdown(content.body, { maxLength: 255 });
   }
 
+  const adsFound = await ad.getRandom(1);
+  const secureAdValues = authorization.filterOutput(userTryingToGet, 'read:ad:list', adsFound);
+
   return {
     props: {
+      adFound: secureAdValues[0] ?? null,
       contentListFound: secureContentListFound,
       pagination: results.pagination,
     },

--- a/pages/recentes/pagina/[page]/index.public.js
+++ b/pages/recentes/pagina/[page]/index.public.js
@@ -2,12 +2,13 @@ import { getStaticPropsRevalidate } from 'next-swr';
 
 import { ContentList, DefaultLayout, RecentTabNav } from '@/TabNewsUI';
 import webserver from 'infra/webserver';
+import ad from 'models/advertisement';
 import authorization from 'models/authorization.js';
 import content from 'models/content.js';
 import user from 'models/user.js';
 import validator from 'models/validator.js';
 
-export default function Home({ contentListFound, pagination }) {
+export default function Home({ adFound, contentListFound, pagination }) {
   return (
     <>
       <DefaultLayout
@@ -16,7 +17,12 @@ export default function Home({ contentListFound, pagination }) {
           description: 'Publicações no TabNews ordenadas pelas mais recentes.',
         }}>
         <RecentTabNav />
-        <ContentList contentList={contentListFound} pagination={pagination} paginationBasePath="/recentes/pagina" />
+        <ContentList
+          ad={adFound}
+          contentList={contentListFound}
+          pagination={pagination}
+          paginationBasePath="/recentes/pagina"
+        />
       </DefaultLayout>
     </>
   );
@@ -71,8 +77,12 @@ export const getStaticProps = getStaticPropsRevalidate(async (context) => {
 
   const secureContentValues = authorization.filterOutput(userTryingToGet, 'read:content:list', contentListFound);
 
+  const adsFound = await ad.getRandom(1);
+  const secureAdValues = authorization.filterOutput(userTryingToGet, 'read:ad:list', adsFound);
+
   return {
     props: {
+      adFound: secureAdValues[0] ?? null,
       contentListFound: secureContentValues,
       pagination: results.pagination,
     },

--- a/pages/recentes/todos/[page]/index.public.js
+++ b/pages/recentes/todos/[page]/index.public.js
@@ -2,13 +2,14 @@ import { getStaticPropsRevalidate } from 'next-swr';
 
 import { ContentList, DefaultLayout, RecentTabNav } from '@/TabNewsUI';
 import webserver from 'infra/webserver';
+import ad from 'models/advertisement';
 import authorization from 'models/authorization.js';
 import content from 'models/content.js';
 import removeMarkdown from 'models/remove-markdown';
 import user from 'models/user.js';
 import validator from 'models/validator.js';
 
-export default function ContentsPage({ contentListFound, pagination }) {
+export default function ContentsPage({ adFound, contentListFound, pagination }) {
   return (
     <DefaultLayout
       metadata={{
@@ -16,7 +17,12 @@ export default function ContentsPage({ contentListFound, pagination }) {
         description: 'Conteúdos no TabNews ordenados pelos mais recentes.',
       }}>
       <RecentTabNav />
-      <ContentList contentList={contentListFound} pagination={pagination} paginationBasePath="/recentes/todos" />
+      <ContentList
+        ad={adFound}
+        contentList={contentListFound}
+        pagination={pagination}
+        paginationBasePath="/recentes/todos"
+      />
     </DefaultLayout>
   );
 }
@@ -70,8 +76,12 @@ export const getStaticProps = getStaticPropsRevalidate(async (context) => {
     }
   }
 
+  const adsFound = await ad.getRandom(1);
+  const secureAdValues = authorization.filterOutput(userTryingToGet, 'read:ad:list', adsFound);
+
   return {
     props: {
+      adFound: secureAdValues[0] ?? null,
       contentListFound: secureContentListFound,
       pagination: results.pagination,
     },

--- a/tests/unit/interface/utils/url.test.js
+++ b/tests/unit/interface/utils/url.test.js
@@ -1,0 +1,30 @@
+import { getDomain, isExternalLink } from 'pages/interface';
+import orchestrator from 'tests/orchestrator';
+
+describe('getDomain', () => {
+  it('should return the domain for all protocols', () => {
+    expect(getDomain('http://github.com/web')).toBe('github.com');
+    expect(getDomain('https://tabnews.com.br/user?q=1')).toBe('tabnews.com.br');
+    expect(getDomain('//curso.dev')).toBe('curso.dev');
+  });
+
+  it('should return the domain and subdomain', () => {
+    expect(getDomain('https://secret.tabnews.com.br')).toBe('secret.tabnews.com.br');
+    expect(getDomain('https://my.custom.example.com')).toBe('my.custom.example.com');
+  });
+
+  it('should not return "www." in the beginning', () => {
+    expect(getDomain('https://www.google.com')).toBe('google.com');
+    expect(getDomain('https://www.example.com/fakewebsite.com')).toBe('example.com');
+    expect(getDomain('https://www.www-site.co')).toBe('www-site.co');
+  });
+});
+
+describe('isExternalLink', () => {
+  it('should check external link comparing to webserver URL', () => {
+    expect(isExternalLink('https://www.example.com')).toBe(true);
+    expect(isExternalLink('https://custom-tabnews.com.br')).toBe(true);
+
+    expect(isExternalLink(`${orchestrator.webserverUrl}/api/v1/contents`)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Mudanças realizadas

1. O primeiro commit corrige o _overflow_ no nome do autor nos itens da lista.
2. O segundo commit exibe um anúncio no topo da lista de conteúdos (relevantes e recentes).

Páginas alteradas:

* Relevantes (em todas páginas).
* Recentes (em todas as abas e todas as páginas).

A UI foi implementada conforme sugerido em https://github.com/filipedeschamps/tabnews.com.br/issues/1491#issuecomment-2225881693, mas com a cor verde `success.fg` do Primer, porque a cor verde do TabCash não passa no teste de acessibilidade no modo claro, conforme mencionado em https://github.com/filipedeschamps/tabnews.com.br/pull/1744.

Também precisei ver algumas possibilidades de cores no modo escuro, essas foram as opções que levantei:

| Opção | Link normal | Link visitado |
| --- | --- | --- |
| 1. Link `success.fg`, visitado `success.fg` | ![Link do anúncio no tom verde do `success.fg` do Primer](https://github.com/user-attachments/assets/6d2c164e-f298-46c9-a0e8-348224f6f309) | ![A mesma imagem](https://github.com/user-attachments/assets/6d2c164e-f298-46c9-a0e8-348224f6f309) |
| 2. Link `success.fg`, visitado `fg.subtle` | ![Link do anúncio no tom verde do `success.fg` do Primer](https://github.com/user-attachments/assets/6d2c164e-f298-46c9-a0e8-348224f6f309) | ![Link no tom cinza do `fg.subtle` do Primer](https://github.com/user-attachments/assets/e5098faf-515d-4d99-9549-c95a43370eb8) |
| 3. Link `success.fg`, visitado `#568062` | ![Link do anúncio no tom verde do `success.fg` do Primer](https://github.com/user-attachments/assets/6d2c164e-f298-46c9-a0e8-348224f6f309) | ![Um tom verde mais próximmo do cinza, lembrando um link normal visitado esverdeado](https://github.com/user-attachments/assets/030e2288-2b8d-459d-95de-24e99cb91113) |
| 3. (Modo escuro) Link `success.fg`, visitado `#59a263` | ![Modo escuro, link do anúncio no tom verde do `success.fg` do Primer](https://github.com/user-attachments/assets/eab9365a-ee4f-4467-86a3-16a7ee6ca628) | ![Modo escuro, um tom verde mais próximmo do cinza, lembrando um link normal visitado esverdeado](https://github.com/user-attachments/assets/97ed3896-d6f6-4911-9936-269a08b1e489) |

Achei o modo 3 mais adequado, por isso coloquei tanto o modo claro quanto o escuro. Como podem ver, a cor do link visitado é diferente para cada modo para passar no teste de acessibilidade. A cor do link visitado foi escolhida visando lembrar um link normal visitado do TabNews (cinza) ao mesmo tempo que demonstra que o link é um anúncio (verde), então são tons de verde acinzentado.

Dessa forma, as cores são:

| Link | Modo claro | Modo escuro |
| --- | --- | --- |
| Normal | `#1a7f37` | `#3fb950` |
| Visitado | `#568062` | `#59a263` |

Agora, uma imagem de um anúncio com link externo e com o maior título possível (página 2 de Recentes):

![Anúncio no topo da página de conteúdos, título longo ocupando três linhas, com o domínio do link externo explícito ao final do título (tabnews.com.br) e o ícone de link externo.](https://github.com/user-attachments/assets/851a6a8f-07ea-4066-a3d5-348fd34c7aff)

Na página Relevantes, mobile (375 pixels de largura):

![Anúncio no topo da página de conteúdos, título longo ocupando nove linhas, contando o domínio do link e o ícone de link externo.](https://github.com/user-attachments/assets/31ce39ef-d3b4-4a30-ad4c-531c6333b9dd)

O conteúdo aparece duas vezes porque a lista de conteúdos ainda retorna anúncios

Sobre a implementação do tema personalizado, o Primer [recomenda](https://primer.style/react/theming#customizing-the-theme) usar a biblioteca [`deepmerge`](https://www.npmjs.com/package/deepmerge), o que simplificaria o código, então se acharem mellhor, posso adicioná-la.

## Tipo de mudança

- [x] Nova funcionalidade

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [ ] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
