### PR TITLE
Não listar anúncios em relevantes, RSS e `/contents`

### DIFF
--- a/pages/api/v1/contents/[username]/[slug]/index.public.js
+++ b/pages/api/v1/contents/[username]/[slug]/index.public.js
@@ -93,7 +93,7 @@ async function patchHandler(request, response) {
     where: {
       owner_username: request.query.username,
       slug: request.query.slug,
-      $or: [{ status: 'draft' }, { status: 'published' }],
+      status: ['draft', 'published'],
     },
   });
 

--- a/pages/api/v1/contents/index.public.js
+++ b/pages/api/v1/contents/index.public.js
@@ -54,6 +54,7 @@ async function getHandler(request, response) {
     where: {
       parent_id: request.query.with_children ? undefined : null,
       status: 'published',
+      type: 'content',
       $not_null: request.query.with_root === false ? ['parent_id'] : undefined,
     },
     attributes: {

--- a/pages/api/v1/contents/rss/index.public.js
+++ b/pages/api/v1/contents/rss/index.public.js
@@ -25,6 +25,7 @@ async function handleRequest(request, response) {
     where: {
       parent_id: null,
       status: 'published',
+      type: 'content',
     },
     page: 1,
     per_page: 30,

--- a/queries/rankingQueries.js
+++ b/queries/rankingQueries.js
@@ -24,6 +24,7 @@ const rankedContent = `
             parent_id IS NULL
             AND status = 'published'
             AND published_at > NOW() - INTERVAL '7 days'
+            AND type != 'ad'
         UNION
         SELECT
             contents.id,
@@ -40,6 +41,7 @@ const rankedContent = `
         WHERE
             parent_id IS NULL
             AND status = 'published'
+            AND type != 'ad'
     ),
     ranked_published_root_contents AS (
         SELECT

--- a/tests/constants-for-tests.js
+++ b/tests/constants-for-tests.js
@@ -1,3 +1,4 @@
 export const defaultTabCashForAdCreation = 100;
 export const maxSlugLength = 160;
 export const maxTitleLength = 255;
+export const relevantBody = 'Body with relevant text needs to contain a good amount of words.';

--- a/tests/integration/api/v1/contents/rss/get.test.js
+++ b/tests/integration/api/v1/contents/rss/get.test.js
@@ -1,3 +1,4 @@
+import { defaultTabCashForAdCreation, relevantBody } from 'tests/constants-for-tests';
 import orchestrator from 'tests/orchestrator.js';
 
 describe('GET /recentes/rss', () => {
@@ -19,6 +20,49 @@ describe('GET /recentes/rss', () => {
     });
 
     test('With 0 contents', async () => {
+      const response = await fetch(`${orchestrator.webserverUrl}/recentes/rss`);
+      const responseBody = await response.text();
+
+      const lastBuildDateFromResponseBody = /<lastBuildDate>(.*?)<\/lastBuildDate>/.exec(responseBody)[1];
+
+      expect(response.status).toEqual(200);
+
+      expect(responseBody).toStrictEqual(`<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0">
+    <channel>
+        <title>TabNews</title>
+        <link>${orchestrator.webserverUrl}/recentes/rss</link>
+        <description>Conteúdos para quem trabalha com Programação e Tecnologia</description>
+        <lastBuildDate>${lastBuildDateFromResponseBody}</lastBuildDate>
+        <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
+        <generator>https://github.com/jpmonette/feed</generator>
+        <language>pt</language>
+        <image>
+            <title>TabNews</title>
+            <url>${orchestrator.webserverUrl}/favicon-mobile.png</url>
+            <link>${orchestrator.webserverUrl}/recentes/rss</link>
+        </image>
+    </channel>
+</rss>`);
+    });
+
+    test('With 1 "ad" content`', async () => {
+      const defaultUser = await orchestrator.createUser();
+
+      await orchestrator.createBalance({
+        balanceType: 'user:tabcash',
+        recipientId: defaultUser.id,
+        amount: defaultTabCashForAdCreation,
+      });
+
+      await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Ad Title',
+        body: relevantBody,
+        status: 'published',
+        type: 'ad',
+      });
+
       const response = await fetch(`${orchestrator.webserverUrl}/recentes/rss`);
       const responseBody = await response.text();
 


### PR DESCRIPTION
Parte da etapa 3c citada em https://github.com/filipedeschamps/tabnews.com.br/issues/1491#issuecomment-2226440549.

## Mudanças realizadas

Altera o validador e o model content para permitir passar um array como filtro para os campos `id`, `status` e `type`, eliminando assim a necessidade do filtro `$or`.

Já remove os anúncios das listas de relevantes, RSS e `/contents`, mas ainda mantém em `/username` e `/recentes` por ainda depender de alguns detalhes citados em #1749.

## Tipo de mudança

- [x] Nova funcionalidade

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
