### PR TITLE
Armazenar dados de TabCash dos anúncios

### DIFF
--- a/infra/migrations/1721243449839_create-table-ad-tabcash-operations.js
+++ b/infra/migrations/1721243449839_create-table-ad-tabcash-operations.js
@@ -1,0 +1,83 @@
+exports.up = (pgm) => {
+  pgm.createType('ad_balance_type_enum', ['budget', 'daily_debit']);
+
+  pgm.createType('originator_type_enum', ['event', 'user']);
+
+  pgm.createTable('ad_tabcash_operations', {
+    id: {
+      type: 'uuid',
+      default: pgm.func('gen_random_uuid()'),
+      notNull: true,
+      primaryKey: true,
+    },
+
+    sequence: {
+      type: 'serial',
+      notNull: true,
+    },
+
+    balance_type: {
+      type: 'ad_balance_type_enum',
+      notNull: true,
+    },
+
+    recipient_id: {
+      type: 'uuid',
+      notNull: true,
+    },
+
+    amount: {
+      type: 'integer',
+      notNull: true,
+    },
+
+    originator_type: {
+      type: 'originator_type_enum',
+      notNull: true,
+    },
+
+    originator_id: {
+      type: 'uuid',
+      notNull: true,
+    },
+
+    created_at: {
+      type: 'timestamp with time zone',
+      notNull: true,
+      default: pgm.func("(now() at time zone 'utc')"),
+    },
+  });
+
+  pgm.createFunction(
+    'get_ad_current_tabcash',
+    [
+      {
+        name: 'recipient_id_input',
+        mode: 'IN',
+        type: 'uuid',
+      },
+    ],
+    {
+      returns: 'integer',
+      language: 'plpgsql',
+      replace: true,
+    },
+    `
+    DECLARE
+    total_tabcash integer;
+    BEGIN
+      SELECT COALESCE(SUM(amount), 0)
+      INTO total_tabcash
+      FROM ad_tabcash_operations
+      WHERE
+        recipient_id = recipient_id_input;
+
+      RETURN total_tabcash;
+    END;
+  `,
+  );
+
+  pgm.createIndex('ad_tabcash_operations', ['recipient_id', 'balance_type']);
+};
+
+exports.down = false;

--- a/models/balance.js
+++ b/models/balance.js
@@ -4,18 +4,21 @@ import database from 'infra/database.js';
 const tableNameMap = {
   'user:tabcoin': 'user_tabcoin_operations',
   'user:tabcash': 'user_tabcash_operations',
+  'ad:budget': 'ad_tabcash_operations',
   default: 'content_tabcoin_operations',
 };
 
 const balanceTypeMap = {
   'content:tabcoin:credit': 'credit',
   'content:tabcoin:debit': 'debit',
-  default: 'initial',
+  'content:tabcoin:initial': 'initial',
+  'ad:budget': 'budget',
 };
 
 const sqlFunctionMap = {
   'user:tabcoin': 'get_user_current_tabcoins',
   'user:tabcash': 'get_user_current_tabcash',
+  'ad:budget': 'get_ad_current_tabcash',
   default: 'get_content_current_tabcoins',
 };
 
@@ -48,7 +51,7 @@ async function findAllByOriginatorId(originatorId, options) {
 
 async function create({ balanceType, recipientId, amount, originatorType, originatorId }, options = {}) {
   const tableName = tableNameMap[balanceType] || tableNameMap.default;
-  const hasBalanceTypeColum = balanceType.startsWith('content:tabcoin');
+  const hasBalanceTypeColum = !balanceType.startsWith('user:');
   const totalBalanceFunction = sqlFunctionMap[balanceType] || sqlFunctionMap.default;
 
   const returning = options.withBalance ? `*, ${totalBalanceFunction}($1) as total` : '*';
@@ -65,7 +68,7 @@ async function create({ balanceType, recipientId, amount, originatorType, origin
   };
 
   if (hasBalanceTypeColum) {
-    const parsedBalanceType = balanceTypeMap[balanceType] || balanceTypeMap.default;
+    const parsedBalanceType = balanceTypeMap[balanceType] || balanceType;
 
     query.values.push(parsedBalanceType);
   }

--- a/models/balance.js
+++ b/models/balance.js
@@ -132,7 +132,7 @@ async function rateContent({ contentId, contentOwnerId, fromUserId, transactionT
         INSERT INTO content_tabcoin_operations
           (balance_type, recipient_id, amount, originator_type, originator_id)
         VALUES
-          ($10, $4, $5, $8, $9)
+          ($10, $4, $5, 'user', $1)
         RETURNING
           *
       )

--- a/models/ban.js
+++ b/models/ban.js
@@ -40,6 +40,12 @@ async function nuke(userId, options = {}) {
       }
     }
 
+    const userBalanceOperations = await balance.findAllByOriginatorId(userId, options);
+
+    for (const userBalanceOperation of userBalanceOperations) {
+      await balance.undo(userBalanceOperation, options);
+    }
+
     async function getAllRatingEventsFromUser(userId, options = {}) {
       const query = {
         text: `

--- a/models/content.js
+++ b/models/content.js
@@ -592,8 +592,8 @@ async function creditOrDebitTabCoins(oldContent, newContent, options = {}) {
         balanceType: 'content:tabcoin:initial',
         recipientId: newContent.id,
         amount: contentEarnings,
-        originatorType: options.eventId ? 'event' : 'content',
-        originatorId: options.eventId ? options.eventId : newContent.id,
+        originatorType: 'user',
+        originatorId: newContent.owner_id,
       },
       {
         transaction: options.transaction,

--- a/models/validator.js
+++ b/models/validator.js
@@ -509,6 +509,7 @@ const schemas = {
       'tabcoins',
       'tabcoins_credit',
       'tabcoins_debit',
+      'tabcash',
     ]) {
       const keyValidationFunction = schemas[key];
       contentSchema = contentSchema.concat(keyValidationFunction());

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -2975,6 +2975,7 @@ describe('POST /api/v1/contents', () => {
           tabcoins: 0,
           tabcoins_credit: 0,
           tabcoins_debit: 0,
+          tabcash: defaultTabCashForAdCreation,
           owner_username: defaultUser.username,
         });
 
@@ -2994,7 +2995,7 @@ describe('POST /api/v1/contents', () => {
           amount: 1_000 + defaultTabCashForAdCreation,
         });
 
-        const { response: contentResponse } = await contentsRequestBuilder.post({
+        const { response: contentResponse, responseBody: contentResponseBody } = await contentsRequestBuilder.post({
           title: 'Ad title',
           body: 'Ad body',
           status: 'published',
@@ -3004,6 +3005,7 @@ describe('POST /api/v1/contents', () => {
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
         expect.soft(contentResponse.status).toBe(201);
+        expect(contentResponseBody.tabcash).toBe(defaultTabCashForAdCreation);
         expect(userResponseBody.tabcash).toBe(1_000);
       });
 


### PR DESCRIPTION
Implementa a parte 3f citada em https://github.com/filipedeschamps/tabnews.com.br/issues/1491#issuecomment-2226440549

## Mudanças realizadas

Cria a tabela `ad_tabcash_operations` seguindo praticamente a mesma lógica das outras tabelas `operations`, mas com uma pequena melhoria que facilita alguns tipos de consultas que hoje são complexas nas outras tabelas. Por exemplo buscar se um usuário já votou em um conteúdo, desfazer votos (seja no banimento ou arrependimento), buscar quais conteúdos um usuário interegiu, etc.

A utilização de ENUM não é a diferença relevante, mas sim usar `user` ao invés de `event` em `originator_type` e, consequentemente, o `id` do usuário em `originator_id`. Com essa pequena mudança nós não perdemos nada, mas facilitamos muito a criação de outras funcionalidades.

Apenas para demonstrar que não perdemos nada com essa mudança (só ganhamos), adicionei o segundo commit aplicando a mesma lógica na tabela `content_tabcoin_operations`. Todos os testes continuam passando, e só foi preciso adequar o trecho de código que desfaz as transações no momento de banimento. A mudança é para algo mais simples, sem precisar iterar em `userEvents` ao buscar as transações pelo id do usuário:

```js
    for (const userEvent of userEvents) {
      const eventBalanceOperations = await balance.findAllByOriginatorId(userEvent.id, options);
      for (const eventBalanceOperation of eventBalanceOperations) {
        await balance.undo(eventBalanceOperation, options);
      }
    }
```
vs
```js
    const userBalanceOperations = await balance.findAllByOriginatorId(userId, options);

    for (const userBalanceOperation of userBalanceOperations) {
      await balance.undo(userBalanceOperation, options);
    }
```

Obs. O trecho com o loop extra ainda é necessário para as tabelas `user_tabcoin_operations` e `user_tabcash_operations`, que ainda usam o `originatorType: 'event'`.



## Tipo de mudança

- [x] Nova funcionalidade

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
