### PR TITLE
Identifica publicações patrocinadas na lista de conteúdos

### DIFF
--- a/pages/interface/components/ContentList/index.js
+++ b/pages/interface/components/ContentList/index.js
@@ -108,12 +108,16 @@ export default function ContentList({ ad, contentList: list, pagination, paginat
                 whiteSpace: 'nowrap',
                 color: 'neutral.emphasis',
               }}>
-              <TabCoinBalanceTooltip
-                direction="ne"
-                credit={contentObject.tabcoins_credit}
-                debit={contentObject.tabcoins_debit}>
-                <TabCoinsText count={contentObject.tabcoins} />
-              </TabCoinBalanceTooltip>
+              {contentObject.type === 'ad' ? (
+                <Text sx={{ color: 'success.fg' }}>Patrocinado</Text>
+              ) : (
+                <TabCoinBalanceTooltip
+                  direction="ne"
+                  credit={contentObject.tabcoins_credit}
+                  debit={contentObject.tabcoins_debit}>
+                  <TabCoinsText count={contentObject.tabcoins} />
+                </TabCoinBalanceTooltip>
+              )}
               {' · '}
               <Text>
                 <ChildrenDeepCountText count={contentObject.children_deep_count} />


### PR DESCRIPTION
## Mudanças realizadas

As publicações patrocinadas são exibidas em listas nas páginas `/recentes/todos`, `/recentes/classificados` e `/[username]/classificados/1`. Nesses casos, podemos identificá-las como "Patrocinado", conforme já foi sugerido em #1491.

Acham que faz sentido adicionar um Tooltip com alguma informação? A princípio, não me pareceu necessário. Em https://github.com/filipedeschamps/tabnews.com.br/issues/1491#issuecomment-1987356263, foi levantada a possibilidade de exibir os TabCoins.

### Todos recentes (modo claro, desktop, 1070px de largura)

![Modo claro, escrito "Patrocinado" apenas nos conteúdos que são patrocinados, no lugar da quantidade de TabCoins.](https://github.com/user-attachments/assets/e6eca20e-0199-49a8-b21b-d85190a53a02)

### Classificados (modo escuro, mobile, 336px de largura)

![O mesmo que a imagem anterior, porém no modo escuro e uma lista que contém apenas publicações patrocinadas ("Classificados")](https://github.com/user-attachments/assets/5f3c9100-caed-4645-9180-681931ba8288)

## Tipo de mudança

- [x] Nova funcionalidade

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [ ] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
