### PR TITLE
Corrige espaço em branco na lateral da página de conteúdo causado pelo banner de anúncio

### DIFF
--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -83,7 +83,7 @@ export default function Post({ adFound, contentFound, rootContentFound, parentCo
             />
           </Box>
 
-          {adFound && <AdBanner ad={adFound} sx={{ ml: 5, pl: 1, width: '100%' }} />}
+          {adFound && <AdBanner ad={adFound} sx={{ ml: 5, pl: 1 }} />}
 
           <RenderChildrenTree
             key={contentFound.id}


### PR DESCRIPTION
## Mudanças realizadas

Corrige o espaço em branco na lateral da página de conteúdo causado pelo banner, apontado em https://github.com/filipedeschamps/tabnews.com.br/pull/1747#issuecomment-2234986931.

O `width` deixou de ser necessário conforme foram feitas alterações no PR original, e esse problema não havia sido percebido. Fiz testes locais com textos de anúncio longos e curtos, e o `width` não pareceu mais necessário, então removê-lo resolveu o problema.

Como fica difícil mostrar que o scroll horizontal não existe por GIF ou vídeo, vou deixar prints com títulos longos e curtos para mostrar que eles continuam exibidos corretamente:

![Título longo em uma linha](https://github.com/user-attachments/assets/35e2277e-e916-4b22-8d40-6ab8c83c173b)

![Título longo em duas linhas](https://github.com/user-attachments/assets/3dd259ca-6ba7-4888-add8-d830d79b4e33)

![Título curto](https://github.com/user-attachments/assets/ecc8b3ce-358c-4525-b6b0-dc08c0793917)

![Com uma letra repetida várias vezes](https://github.com/user-attachments/assets/5a9930ee-0263-406e-b10e-5c8eb4186057)

![Com nome de usuário longo](https://github.com/user-attachments/assets/a782a6e6-5691-46f9-886a-1605b1251b5d)


## Tipo de mudança

- [x] Correção de bug

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [ ] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
