### PR TITLE
fix(ad banner): limits overflow of Tooltip's mirrored invisible div

### DIFF
--- a/pages/interface/components/AdBanner/index.js
+++ b/pages/interface/components/AdBanner/index.js
@@ -32,7 +32,7 @@ export default function AdBanner({ ad, ...props }) {
         </Link>
       </Box>
 
-      <Text sx={{ whiteSpace: 'nowrap', fontSize: 0, color: 'neutral.emphasis' }}>
+      <Text sx={{ whiteSpace: 'nowrap', overflow: 'hidden', fontSize: 0, color: 'neutral.emphasis' }}>
         Contribuindo com{' '}
         <Tooltip
           aria-label={`Autor: ${ad.owner_username}`}


### PR DESCRIPTION
## Mudanças realizadas

Em conjunto com o PR #1753, corrige o espaço em branco na lateral da página de conteúdo causado pelo banner, apontado em https://github.com/filipedeschamps/tabnews.com.br/pull/1747#issuecomment-2234986931.

Dependendo do tamanho da tela e das personalizações de tamanho de fontes, o problema ainda poderia ocorrer, pois a `div` invisível do nosso Tooltip customizado não respeitava o `overflow: hidden` do `Link`, mas agora respeita o do `Text` superior.

## Tipo de mudança

- [x] Correção de bug
