### PR TITLE
[C.I.] Remove o cache da pasta `/.next/cache` e atualiza as outras `actions`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Start containers
         run: npm run services:up
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: '18'
           cache: 'npm'
@@ -31,8 +31,8 @@ jobs:
     name: Lint Styles
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '18'
           cache: 'npm'
@@ -43,7 +43,7 @@ jobs:
     name: Lint Commits
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v4
+      - uses: wagoid/commitlint-github-action@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,6 @@ jobs:
       - name: Start containers
         run: npm run services:up
 
-      - uses: actions/cache@v2
-        with:
-          path: ${{ github.workspace }}/.next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
-          restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
-
       - uses: actions/setup-node@v2
         with:
           node-version: '18'


### PR DESCRIPTION
Remove a action `cache@v2` que armazenava um cache da pasta `/.next/cache` que não trazia nenhum ganho.

Aproveitei para atualizar as demais `actions`, menos a `wagoid/commitlint-github-action` que não deu para ir para a `v6` por causa da [breaking change com `commitlint.config.js`](https://github.com/wagoid/commitlint-github-action/blob/master/CHANGELOG.md#600-2024-03-28).