### PR TITLE
Filtrar anúncios nas páginas de conteúdos

### DIFF
--- a/models/advertisement.js
+++ b/models/advertisement.js
@@ -1,9 +1,21 @@
 import database from 'infra/database';
 
-async function getRandom(limit) {
+async function getRandom(limit, options = {}) {
+  const { ignoreId, ownerId, tryOtherOwners } = options;
+
   const query = {
     values: [limit],
   };
+
+  let where = "type = 'ad' AND status = 'published'";
+
+  if (ownerId) {
+    where += ` AND c.owner_id = '${ownerId}'`;
+  }
+
+  if (ignoreId) {
+    where += ` AND c.id != '${ignoreId}'`;
+  }
 
   query.text = `
     SELECT
@@ -15,12 +27,16 @@ async function getRandom(limit) {
       'markdown' as ad_type
     FROM contents c
     INNER JOIN users u ON c.owner_id = u.id
-    WHERE type = 'ad' AND status = 'published'
+    WHERE ${where}
     ORDER BY RANDOM()
     LIMIT $1;
   `;
 
   const results = await database.query(query);
+
+  if (!results.rows.length && ownerId && tryOtherOwners) {
+    return getRandom(limit, { ignoreId });
+  }
 
   return results.rows;
 }

--- a/models/validator.js
+++ b/models/validator.js
@@ -393,6 +393,20 @@ const schemas = {
     });
   },
 
+  ignore_id: function () {
+    return Joi.object({
+      ignore_id: schemas.id().extract('id'),
+    });
+  },
+
+  flexible: function () {
+    return Joi.object({
+      flexible: Joi.boolean()
+        .default(false)
+        .when('$required.optional', { is: 'required', then: Joi.required(), otherwise: Joi.optional() }),
+    });
+  },
+
   where: function () {
     let whereSchema = Joi.object({}).optional().min(1);
 

--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -418,7 +418,11 @@ export const getStaticProps = getStaticPropsRevalidate(async (context) => {
     secureParentContentFound.body = removeMarkdown(secureParentContentFound.body, { maxLength: 50 });
   }
 
-  const adsFound = await ad.getRandom(1);
+  const adsFound = await ad.getRandom(1, {
+    ignoreId: secureContentFound.id,
+    ownerId: secureContentFound.owner_id,
+    tryOtherOwners: secureContentFound.type === 'content',
+  });
   const secureAdValues = authorization.filterOutput(userTryingToGet, 'read:ad:list', adsFound);
 
   return {

--- a/pages/api/v1/sponsored-beta/index.public.js
+++ b/pages/api/v1/sponsored-beta/index.public.js
@@ -19,6 +19,9 @@ export default nextConnect({
 function getValidationHandler(request, response, next) {
   const cleanValues = validator(request.query, {
     per_page: 'optional',
+    owner_id: 'optional',
+    ignore_id: 'optional',
+    flexible: 'optional',
   });
 
   request.query = cleanValues;
@@ -29,7 +32,11 @@ function getValidationHandler(request, response, next) {
 async function getHandler(request, response) {
   const userTryingToList = user.createAnonymous();
 
-  const ads = await ad.getRandom(request.query.per_page);
+  const ads = await ad.getRandom(request.query.per_page, {
+    ignoreId: request.query.ignore_id,
+    ownerId: request.query.owner_id,
+    tryOtherOwners: request.query.flexible,
+  });
 
   const secureOutputValues = authorization.filterOutput(userTryingToList, 'read:ad:list', ads);
 


### PR DESCRIPTION
## Mudanças realizadas

Adiciona filtros na função `getRandom` para permitir:

- Preferir mostrar anúncios do próprio usuário em seus conteúdos
- Não mostrar anúncios de outros usuários nas páginas de anúncios
- Nunca mostrar no banner o mesmo anúncio que está sendo visitado

Com isso atende ao sugerido em https://github.com/filipedeschamps/tabnews.com.br/pull/1747#issuecomment-2234325715 e resolve #1756 .

## Tipo de mudança

- [x] Correção de bug
- [x] Nova funcionalidade

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
