### PR TITLE
Clarifica no FAQ o que acontece quando o orçamento do anúncio acaba

### DIFF
--- a/pages/faq/index.public.js
+++ b/pages/faq/index.public.js
@@ -56,9 +56,9 @@ Atualmente, o único espaço de anúncio disponível é o de [publicações patr
       question: 'Como funciona uma publicação patrocinada?',
       answer: `_Esse tipo de anúncio está em desenvolvimento, então está em constante evolução. Você pode acompanhar o que está sendo feito no [issue #1491 do GitHub](https://github.com/filipedeschamps/tabnews.com.br/issues/1491)._
 
-No topo das listas de conteúdos [Relevantes](/) e [Recentes](/recentes/pagina/1), e também nas páginas de publicações e comentários, após o conteúdo principal, uma publicação patrocinada escolhida de forma aleatória é exibida. Caso a publicação tenha um link de "**fonte**", o visitante que clicar no título da publicação será redirecionado para o link. Caso o link seja para um site externo, o domínio será identificado após o título, por exemplo: \`Título da publicação patrocinada (site-externo.com.br)\`.
+No topo das listas de conteúdos [Relevantes](/) e [Recentes](/recentes/pagina/1), e também nas páginas de publicações e comentários, após o conteúdo principal, uma publicação patrocinada escolhida de forma aleatória é exibida como um _banner_. Caso a publicação tenha um link de "**fonte**", o visitante que clicar no título da publicação será redirecionado para o link. Caso o link seja para um site externo, o domínio será identificado após o título, por exemplo: \`Título da publicação patrocinada (site-externo.com.br)\`.
 
-Para criar uma publicação patrocinada, você investirá **100 TabCash**. A cada dia que passar, **10 TabCash** serão consumidos da publicação patrocinada.
+Para criar uma publicação patrocinada, você investirá **100 TabCash** no orçamento dela. Ainda não está definido como o orçamento será consumido e ainda não é possível alterar o valor do orçamento.
 
 Recomendamos que o título tenha até 70 caracteres para que possa ser exibido sem reticências ao final.`,
     },


### PR DESCRIPTION
## Mudanças realizadas

Surgiu uma [dúvida no TabNews](https://www.tabnews.com.br/kht/65d8ac80-a237-4e55-bc45-118d51264b9e) sobre o que acontece quando o orçamento da publicação patrocinada acaba. Essa alteração no FAQ é para deixar isso mais claro.

Aproveitei para introduzir o termo _banner_ porque facilita a explicação de que, sem orçamento, o anúncio não aparecerá como um banner.

Caso tenham sugestões para melhorar essa parte de publicações patrocinadas no FAQ, sintam-se à vontade.

## Tipo de mudança

- [x] Atualização do FAQ

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [ ] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
