### PR TITLE
Não trocar o anúncio visível a cada revalidação da página

### DIFF
--- a/pages/interface/components/AdBanner/index.js
+++ b/pages/interface/components/AdBanner/index.js
@@ -1,12 +1,23 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
 import { Box, Link, Text, Tooltip } from '@/TabNewsUI';
 import { LinkExternalIcon } from '@/TabNewsUI/icons';
 import { getDomain, isExternalLink, isTrustedDomain } from 'pages/interface';
 
-export default function AdBanner({ ad, ...props }) {
+export default function AdBanner({ ad: newAd, ...props }) {
+  const [ad, setAd] = useState(newAd);
+  const router = useRouter();
+
   const link = ad.source_url || `/${ad.owner_username}/${ad.slug}`;
   const isAdToExternalLink = isExternalLink(link);
   const domain = isAdToExternalLink ? `(${getDomain(link)})` : '';
   const title = ad.title.length > 70 ? ad.title.substring(0, 67).trim().concat('...') : ad.title;
+
+  useEffect(() => {
+    setAd(newAd);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router.asPath]);
 
   return (
     <Box {...props} as="aside" sx={{ display: 'grid', ...props.sx }}>


### PR DESCRIPTION
Como os anúncios variam aleatoriamente a cada geração das páginas estáticas no lado do servidor, não é interessante trocar o anúncio visível no client apenas porque a página foi revalidada em segundo plano.

Por exemplo, os anúncios ficam se alternando quando o usuário alterna entre abas abertas ou quando a página é automaticamente revalidada instantes após o carregamento, quando o cache dela está obsoleto. Isso ficou mais claro agora que temos uma variedade maior de anúncios publicados.

## Mudanças realizadas

Agora, o anúncio visível só vai mudar quando ocorrer uma navegação entre diferentes páginas.

Uma melhoria futura pode ser permitir trocar o anúncio na página deixada aberta, mas somente após algum tempo.

## Tipo de mudança

- [x] Correção de bug
