### PR TITLE
Valida `metadata` de todos tipos de evento e usa `snake_case`

### DIFF
--- a/models/event.js
+++ b/models/event.js
@@ -1,13 +1,15 @@
+import snakeize from 'snakeize';
+
 import database from 'infra/database.js';
 import validator from 'models/validator.js';
 
 async function create(object, options = {}) {
-  object = validateObject(object);
+  const cleanObject = validateObject(snakeize(object));
 
   const query = {
     text: `INSERT INTO events (type, originator_user_id, originator_ip, metadata)
                VALUES($1, $2, $3, $4) RETURNING *;`,
-    values: [object.type, object.originatorUserId, object.originatorIp, object.metadata],
+    values: [cleanObject.type, cleanObject.originator_user_id, cleanObject.originator_ip, cleanObject.metadata],
   };
 
   const results = await database.query(query, options);

--- a/models/validator.js
+++ b/models/validator.js
@@ -635,6 +635,26 @@ const schemas = {
           }),
         },
         {
+          is: 'update:user',
+          then: Joi.object({
+            id: Joi.string().required(),
+            updatedFields: Joi.array()
+              .items(Joi.string().valid('description', 'notifications', 'username'))
+              .required(),
+            username: Joi.object({
+              old: Joi.string().required(),
+              new: Joi.string().required(),
+            }),
+          }),
+        },
+        {
+          is: 'ban:user',
+          then: Joi.object({
+            ban_type: schemas.ban_type().extract('ban_type').required(),
+            user_id: schemas.id().extract('id').required(),
+          }),
+        },
+        {
           is: 'create:content:text_root',
           then: Joi.object({
             id: Joi.string().required(),
@@ -659,6 +679,16 @@ const schemas = {
           }),
         },
         {
+          is: 'update:content:tabcoins',
+          then: Joi.object({
+            transaction_type: schemas.transaction_type().extract('transaction_type').required(),
+            from_user_id: Joi.string().required(),
+            content_owner_id: Joi.string().required(),
+            content_id: Joi.string().required(),
+            amount: Joi.number().integer().min(1).required(),
+          }),
+        },
+        {
           is: 'firewall:block_users',
           then: Joi.object({
             from_rule: Joi.string().required(),
@@ -677,6 +707,13 @@ const schemas = {
           then: Joi.object({
             from_rule: Joi.string().required(),
             contents: Joi.array().required(),
+          }),
+        },
+        {
+          is: 'reward:user:tabcoins',
+          then: Joi.object({
+            reward_type: Joi.string().valid('daily').required(),
+            amount: Joi.number().integer().min(1).required(),
           }),
         },
       ]),

--- a/models/validator.js
+++ b/models/validator.js
@@ -620,8 +620,8 @@ const schemas = {
         .messages({
           'any.only': '{#label} não aceita o valor "{#value}".',
         }),
-      originatorUserId: Joi.string().guid({ version: 'uuidv4' }).optional(),
-      originatorIp: Joi.string()
+      originator_user_id: Joi.string().guid({ version: 'uuidv4' }).optional(),
+      originator_ip: Joi.string()
         .ip({
           version: ['ipv4', 'ipv6'],
         })
@@ -637,7 +637,7 @@ const schemas = {
           is: 'update:user',
           then: Joi.object({
             id: Joi.string().required(),
-            updatedFields: Joi.array()
+            updated_fields: Joi.array()
               .items(Joi.string().valid('description', 'notifications', 'username'))
               .required(),
             username: Joi.object({

--- a/models/validator.js
+++ b/models/validator.js
@@ -616,7 +616,6 @@ const schemas = {
           'firewall:block_contents:text_root',
           'firewall:block_contents:text_child',
           'reward:user:tabcoins',
-          'system:update:tabcoins',
         )
         .messages({
           'any.only': '{#label} não aceita o valor "{#value}".',

--- a/tests/integration/models/event.test.js
+++ b/tests/integration/models/event.test.js
@@ -59,7 +59,7 @@ describe('models/event', () => {
         created_at: lastEvent.created_at,
         metadata: {
           id: defaultUser.id,
-          updatedFields: ['description', 'notifications', 'username'],
+          updated_fields: ['description', 'notifications', 'username'],
           username: {
             old: defaultUser.username,
             new: responseBody.username,
@@ -348,7 +348,7 @@ describe('models/event', () => {
         created_at: lastEvent.created_at,
         metadata: {
           id: userToBeUpdated.id,
-          updatedFields: ['description'],
+          updated_fields: ['description'],
         },
       });
 


### PR DESCRIPTION
## Mudanças realizadas

O PR #1638 usa `snakeize` no `event.create()`, e ao realizar um `rebase`, alguns testes do `models/event` quebraram por terem um `metadata` chamado `updatedFields`, e não `updated_fields`. Também percebi que alguns `metadata`s não são validados no `validator`, então:

1. https://github.com/filipedeschamps/tabnews.com.br/commit/0fc32efa0a8882a79e7d45a5d79afbad9858303f: passa a validar o metadata de eventos que não eram validados antes.
2. https://github.com/filipedeschamps/tabnews.com.br/commit/9b3ca67330c28e23ee6302421efba885bf04a1c5: remove tipo de evento não usado: `system:update:tabcoins`.
3. https://github.com/filipedeschamps/tabnews.com.br/commit/228f64d8a8d27d82ed20cb2f0a96221903794c4f: uma sugestão para padronizarmos as propriedades do `metadata` na forma `snake_case`, onde a única que quebrava esse padrão era a `updatedFields`.

## Tipo de mudança

- [x] Correção de bug
- [x] Refatoração

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
