### PR TITLE
Adiciona testes que garantem que os anúncios não influenciam no prestígio dos usuários

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,6 +33,7 @@
         "vitest/no-conditional-in-test": "error",
         "vitest/no-disabled-tests": "warn",
         "vitest/no-focused-tests": "error",
+        "vitest/prefer-to-be": "error",
         "vitest/require-to-throw-message": "error"
       },
       "env": {

--- a/.eslintrc
+++ b/.eslintrc
@@ -33,6 +33,7 @@
         "vitest/no-conditional-in-test": "error",
         "vitest/no-disabled-tests": "warn",
         "vitest/no-focused-tests": "error",
+        "vitest/prefer-strict-equal": "error",
         "vitest/prefer-to-be": "error",
         "vitest/require-to-throw-message": "error"
       },

--- a/.eslintrc
+++ b/.eslintrc
@@ -29,6 +29,7 @@
         "plugin:vitest-globals/recommended"
       ],
       "rules": {
+        "require-await": "error",
         "vitest/no-conditional-in-test": "error",
         "vitest/no-disabled-tests": "warn",
         "vitest/no-focused-tests": "error",

--- a/tests/integration/api/v1/_use-cases/registration-flow.test.js
+++ b/tests/integration/api/v1/_use-cases/registration-flow.test.js
@@ -38,8 +38,8 @@ describe('Use case: Registration Flow (all successfully)', () => {
     expect(uuidVersion(postUserResponseBody.id)).toBe(4);
     expect(postUserResponseBody.username).toBe('RegularRegistrationFlow');
     expect(postUserResponseBody.features).toEqual(['read:activation_token']);
-    expect(Date.parse(postUserResponseBody.created_at)).not.toBe(NaN);
-    expect(Date.parse(postUserResponseBody.updated_at)).not.toBe(NaN);
+    expect(Date.parse(postUserResponseBody.created_at)).not.toBeNaN();
+    expect(Date.parse(postUserResponseBody.updated_at)).not.toBeNaN();
     expect(postUserResponseBody).not.toHaveProperty('email');
     expect(postUserResponseBody).not.toHaveProperty('password');
 
@@ -84,8 +84,8 @@ describe('Use case: Registration Flow (all successfully)', () => {
     expect(uuidVersion(activationApiResponseBody.id)).toBe(4);
     expect(activationApiResponseBody.id).toBe(tokenObjectInDatabase.id);
     expect(activationApiResponseBody.used).toBe(true);
-    expect(Date.parse(activationApiResponseBody.created_at)).not.toBe(NaN);
-    expect(Date.parse(activationApiResponseBody.updated_at)).not.toBe(NaN);
+    expect(Date.parse(activationApiResponseBody.created_at)).not.toBeNaN();
+    expect(Date.parse(activationApiResponseBody.updated_at)).not.toBeNaN();
     expect(activationApiResponseBody).not.toHaveProperty('password');
     expect(activationApiResponseBody).not.toHaveProperty('email');
     expect(activationApiResponseBody).not.toHaveProperty('user_id');
@@ -119,9 +119,9 @@ describe('Use case: Registration Flow (all successfully)', () => {
     expect(postSessionResponse.status).toBe(201);
     expect(postSessionResponseBody.token.length).toBe(96);
     expect(uuidVersion(postSessionResponseBody.id)).toBe(4);
-    expect(Date.parse(postSessionResponseBody.expires_at)).not.toBe(NaN);
-    expect(Date.parse(postSessionResponseBody.created_at)).not.toBe(NaN);
-    expect(Date.parse(postSessionResponseBody.updated_at)).not.toBe(NaN);
+    expect(Date.parse(postSessionResponseBody.expires_at)).not.toBeNaN();
+    expect(Date.parse(postSessionResponseBody.created_at)).not.toBeNaN();
+    expect(Date.parse(postSessionResponseBody.updated_at)).not.toBeNaN();
 
     const sessionObjectInDatabase = await session.findOneById(postSessionResponseBody.id);
     expect(sessionObjectInDatabase.user_id).toBe(postUserResponseBody.id);

--- a/tests/integration/api/v1/_use-cases/registration-flow.test.js
+++ b/tests/integration/api/v1/_use-cases/registration-flow.test.js
@@ -37,7 +37,7 @@ describe('Use case: Registration Flow (all successfully)', () => {
     expect(postUserResponse.status).toBe(201);
     expect(uuidVersion(postUserResponseBody.id)).toBe(4);
     expect(postUserResponseBody.username).toBe('RegularRegistrationFlow');
-    expect(postUserResponseBody.features).toEqual(['read:activation_token']);
+    expect(postUserResponseBody.features).toStrictEqual(['read:activation_token']);
     expect(Date.parse(postUserResponseBody.created_at)).not.toBeNaN();
     expect(Date.parse(postUserResponseBody.updated_at)).not.toBeNaN();
     expect(postUserResponseBody).not.toHaveProperty('email');
@@ -59,7 +59,7 @@ describe('Use case: Registration Flow (all successfully)', () => {
     const activationPageEndpoint = `${activation.getActivationPageEndpoint()}/${tokenObjectInDatabase.id}`;
 
     expect(activationEmail.sender).toBe('<contato@tabnews.com.br>');
-    expect(activationEmail.recipients).toEqual(['<regularregistrationflow@gmail.com>']);
+    expect(activationEmail.recipients).toStrictEqual(['<regularregistrationflow@gmail.com>']);
     expect(activationEmail.subject).toBe('Ative seu cadastro no TabNews');
     expect(activationEmail.text).toContain(postUserResponseBody.username);
     expect(activationEmail.html).toContain(postUserResponseBody.username);
@@ -91,7 +91,7 @@ describe('Use case: Registration Flow (all successfully)', () => {
     expect(activationApiResponseBody).not.toHaveProperty('user_id');
 
     const activatedUserInDatabase = await user.findOneByUsername('RegularRegistrationFlow');
-    expect(activatedUserInDatabase.features).toEqual([
+    expect(activatedUserInDatabase.features).toStrictEqual([
       'create:session',
       'read:session',
       'create:content',

--- a/tests/integration/api/v1/_use-cases/registration-flow.test.js
+++ b/tests/integration/api/v1/_use-cases/registration-flow.test.js
@@ -34,12 +34,12 @@ describe('Use case: Registration Flow (all successfully)', () => {
 
     postUserResponseBody = await postUserResponse.json();
 
-    expect(postUserResponse.status).toEqual(201);
-    expect(uuidVersion(postUserResponseBody.id)).toEqual(4);
-    expect(postUserResponseBody.username).toEqual('RegularRegistrationFlow');
+    expect(postUserResponse.status).toBe(201);
+    expect(uuidVersion(postUserResponseBody.id)).toBe(4);
+    expect(postUserResponseBody.username).toBe('RegularRegistrationFlow');
     expect(postUserResponseBody.features).toEqual(['read:activation_token']);
-    expect(Date.parse(postUserResponseBody.created_at)).not.toEqual(NaN);
-    expect(Date.parse(postUserResponseBody.updated_at)).not.toEqual(NaN);
+    expect(Date.parse(postUserResponseBody.created_at)).not.toBe(NaN);
+    expect(Date.parse(postUserResponseBody.updated_at)).not.toBe(NaN);
     expect(postUserResponseBody).not.toHaveProperty('email');
     expect(postUserResponseBody).not.toHaveProperty('password');
 
@@ -49,7 +49,7 @@ describe('Use case: Registration Flow (all successfully)', () => {
     expect(passwordsMatch).toBe(true);
 
     const userInDatabase = await user.findOneById(postUserResponseBody.id);
-    expect(userInDatabase.email).toEqual('regularregistrationflow@gmail.com');
+    expect(userInDatabase.email).toBe('regularregistrationflow@gmail.com');
   });
 
   test('Receive email (successfully)', async () => {
@@ -58,9 +58,9 @@ describe('Use case: Registration Flow (all successfully)', () => {
     tokenObjectInDatabase = await activation.findOneTokenByUserId(postUserResponseBody.id);
     const activationPageEndpoint = `${activation.getActivationPageEndpoint()}/${tokenObjectInDatabase.id}`;
 
-    expect(activationEmail.sender).toEqual('<contato@tabnews.com.br>');
+    expect(activationEmail.sender).toBe('<contato@tabnews.com.br>');
     expect(activationEmail.recipients).toEqual(['<regularregistrationflow@gmail.com>']);
-    expect(activationEmail.subject).toEqual('Ative seu cadastro no TabNews');
+    expect(activationEmail.subject).toBe('Ative seu cadastro no TabNews');
     expect(activationEmail.text).toContain(postUserResponseBody.username);
     expect(activationEmail.html).toContain(postUserResponseBody.username);
     expect(activationEmail.text).toContain(activationPageEndpoint);
@@ -80,12 +80,12 @@ describe('Use case: Registration Flow (all successfully)', () => {
     });
     const activationApiResponseBody = await activationApiResponse.json();
 
-    expect(activationApiResponse.status).toEqual(200);
-    expect(uuidVersion(activationApiResponseBody.id)).toEqual(4);
-    expect(activationApiResponseBody.id).toEqual(tokenObjectInDatabase.id);
-    expect(activationApiResponseBody.used).toEqual(true);
-    expect(Date.parse(activationApiResponseBody.created_at)).not.toEqual(NaN);
-    expect(Date.parse(activationApiResponseBody.updated_at)).not.toEqual(NaN);
+    expect(activationApiResponse.status).toBe(200);
+    expect(uuidVersion(activationApiResponseBody.id)).toBe(4);
+    expect(activationApiResponseBody.id).toBe(tokenObjectInDatabase.id);
+    expect(activationApiResponseBody.used).toBe(true);
+    expect(Date.parse(activationApiResponseBody.created_at)).not.toBe(NaN);
+    expect(Date.parse(activationApiResponseBody.updated_at)).not.toBe(NaN);
     expect(activationApiResponseBody).not.toHaveProperty('password');
     expect(activationApiResponseBody).not.toHaveProperty('email');
     expect(activationApiResponseBody).not.toHaveProperty('user_id');
@@ -116,22 +116,22 @@ describe('Use case: Registration Flow (all successfully)', () => {
 
     postSessionResponseBody = await postSessionResponse.json();
 
-    expect(postSessionResponse.status).toEqual(201);
-    expect(postSessionResponseBody.token.length).toEqual(96);
-    expect(uuidVersion(postSessionResponseBody.id)).toEqual(4);
-    expect(Date.parse(postSessionResponseBody.expires_at)).not.toEqual(NaN);
-    expect(Date.parse(postSessionResponseBody.created_at)).not.toEqual(NaN);
-    expect(Date.parse(postSessionResponseBody.updated_at)).not.toEqual(NaN);
+    expect(postSessionResponse.status).toBe(201);
+    expect(postSessionResponseBody.token.length).toBe(96);
+    expect(uuidVersion(postSessionResponseBody.id)).toBe(4);
+    expect(Date.parse(postSessionResponseBody.expires_at)).not.toBe(NaN);
+    expect(Date.parse(postSessionResponseBody.created_at)).not.toBe(NaN);
+    expect(Date.parse(postSessionResponseBody.updated_at)).not.toBe(NaN);
 
     const sessionObjectInDatabase = await session.findOneById(postSessionResponseBody.id);
-    expect(sessionObjectInDatabase.user_id).toEqual(postUserResponseBody.id);
+    expect(sessionObjectInDatabase.user_id).toBe(postUserResponseBody.id);
 
     parsedCookiesFromPost = orchestrator.parseSetCookies(postSessionResponse);
-    expect(parsedCookiesFromPost.session_id.name).toEqual('session_id');
-    expect(parsedCookiesFromPost.session_id.value).toEqual(postSessionResponseBody.token);
-    expect(parsedCookiesFromPost.session_id.maxAge).toEqual(60 * 60 * 24 * 30);
-    expect(parsedCookiesFromPost.session_id.path).toEqual('/');
-    expect(parsedCookiesFromPost.session_id.httpOnly).toEqual(true);
+    expect(parsedCookiesFromPost.session_id.name).toBe('session_id');
+    expect(parsedCookiesFromPost.session_id.value).toBe(postSessionResponseBody.token);
+    expect(parsedCookiesFromPost.session_id.maxAge).toBe(60 * 60 * 24 * 30);
+    expect(parsedCookiesFromPost.session_id.path).toBe('/');
+    expect(parsedCookiesFromPost.session_id.httpOnly).toBe(true);
   });
 
   test('Get user (successfully)', async () => {
@@ -144,7 +144,7 @@ describe('Use case: Registration Flow (all successfully)', () => {
 
     const getUserResponseBody = await getUserResponse.json();
 
-    expect(getUserResponse.status).toEqual(200);
+    expect(getUserResponse.status).toBe(200);
     expect(getUserResponseBody).toStrictEqual({
       id: postUserResponseBody.id,
       username: postUserResponseBody.username,

--- a/tests/integration/api/v1/activation/patch.test.js
+++ b/tests/integration/api/v1/activation/patch.test.js
@@ -18,15 +18,15 @@ describe('PATCH /api/v1/activation', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"body" enviado deve ser do tipo Object.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(responseBody.key).toEqual('object');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"body" enviado deve ser do tipo Object.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.key).toBe('object');
     });
 
     test('Activating using a null token', async () => {
@@ -43,15 +43,15 @@ describe('PATCH /api/v1/activation', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"token_id" deve ser do tipo String.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(responseBody.key).toEqual('token_id');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"token_id" deve ser do tipo String.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.key).toBe('token_id');
     });
 
     test('Activating using a malformatted number token', async () => {
@@ -68,15 +68,15 @@ describe('PATCH /api/v1/activation', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"token_id" deve ser do tipo String.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(responseBody.key).toEqual('token_id');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"token_id" deve ser do tipo String.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.key).toBe('token_id');
     });
 
     test('Activating using an empty string token', async () => {
@@ -93,15 +93,15 @@ describe('PATCH /api/v1/activation', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"token_id" não pode estar em branco.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(responseBody.key).toEqual('token_id');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"token_id" não pode estar em branco.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.key).toBe('token_id');
     });
 
     test('Activating using a malformatted string token', async () => {
@@ -118,27 +118,27 @@ describe('PATCH /api/v1/activation', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"token_id" deve possuir um token UUID na versão 4.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(responseBody.key).toEqual('token_id');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"token_id" deve possuir um token UUID na versão 4.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.key).toBe('token_id');
     });
 
     test('Activating using a fresh and valid token', async () => {
       const defaultUser = await orchestrator.createUser();
       const activationToken = await activation.create(defaultUser);
 
-      expect(uuidVersion(activationToken.id)).toEqual(4);
-      expect(activationToken.user_id).toEqual(defaultUser.id);
-      expect(activationToken.used).toEqual(false);
-      expect(Date.parse(activationToken.expires_at)).not.toEqual(NaN);
-      expect(Date.parse(activationToken.created_at)).not.toEqual(NaN);
-      expect(Date.parse(activationToken.updated_at)).not.toEqual(NaN);
+      expect(uuidVersion(activationToken.id)).toBe(4);
+      expect(activationToken.user_id).toBe(defaultUser.id);
+      expect(activationToken.used).toBe(false);
+      expect(Date.parse(activationToken.expires_at)).not.toBe(NaN);
+      expect(Date.parse(activationToken.created_at)).not.toBe(NaN);
+      expect(Date.parse(activationToken.updated_at)).not.toBe(NaN);
       expect(activationToken.expires_at - activationToken.created_at).toBe(900000); // 15 minutes
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/activation`, {
@@ -154,12 +154,12 @@ describe('PATCH /api/v1/activation', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(responseBody.used).toEqual(true);
-      expect(Date.parse(activationToken.expires_at)).not.toEqual(NaN);
-      expect(Date.parse(activationToken.created_at)).not.toEqual(NaN);
-      expect(Date.parse(activationToken.updated_at)).not.toEqual(NaN);
+      expect(response.status).toBe(200);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(responseBody.used).toBe(true);
+      expect(Date.parse(activationToken.expires_at)).not.toBe(NaN);
+      expect(Date.parse(activationToken.created_at)).not.toBe(NaN);
+      expect(Date.parse(activationToken.updated_at)).not.toBe(NaN);
       expect(responseBody.updated_at > responseBody.created_at).toBe(true);
     });
 
@@ -193,15 +193,15 @@ describe('PATCH /api/v1/activation', () => {
 
       const secondTryRespondeBody = await secondTryResponde.json();
 
-      expect(secondTryResponde.status).toEqual(200);
-      expect(uuidVersion(secondTryRespondeBody.id)).toEqual(4);
-      expect(secondTryRespondeBody.used).toEqual(true);
-      expect(Date.parse(activationToken.expires_at)).not.toEqual(NaN);
-      expect(Date.parse(activationToken.created_at)).not.toEqual(NaN);
-      expect(Date.parse(activationToken.updated_at)).not.toEqual(NaN);
+      expect(secondTryResponde.status).toBe(200);
+      expect(uuidVersion(secondTryRespondeBody.id)).toBe(4);
+      expect(secondTryRespondeBody.used).toBe(true);
+      expect(Date.parse(activationToken.expires_at)).not.toBe(NaN);
+      expect(Date.parse(activationToken.created_at)).not.toBe(NaN);
+      expect(Date.parse(activationToken.updated_at)).not.toBe(NaN);
       expect(secondTryRespondeBody.updated_at > secondTryRespondeBody.created_at).toBe(true);
 
-      expect(firstTryResponde.status).toEqual(secondTryResponde.status);
+      expect(firstTryResponde.status).toBe(secondTryResponde.status);
       expect(firstTryRespondeBody).toEqual(secondTryRespondeBody);
     });
 
@@ -225,15 +225,15 @@ describe('PATCH /api/v1/activation', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(404);
-      expect(responseBody.status_code).toEqual(404);
-      expect(responseBody.name).toEqual('NotFoundError');
-      expect(responseBody.message).toEqual('O token de ativação utilizado não foi encontrado no sistema ou expirou.');
-      expect(responseBody.action).toEqual('Faça login novamente para receber um novo token por email.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:ACTIVATION:FIND_ONE_VALID_TOKEN_BY_ID:NOT_FOUND');
-      expect(responseBody.key).toEqual('token_id');
+      expect(response.status).toBe(404);
+      expect(responseBody.status_code).toBe(404);
+      expect(responseBody.name).toBe('NotFoundError');
+      expect(responseBody.message).toBe('O token de ativação utilizado não foi encontrado no sistema ou expirou.');
+      expect(responseBody.action).toBe('Faça login novamente para receber um novo token por email.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:ACTIVATION:FIND_ONE_VALID_TOKEN_BY_ID:NOT_FOUND');
+      expect(responseBody.key).toBe('token_id');
     });
   });
 
@@ -256,16 +256,16 @@ describe('PATCH /api/v1/activation', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(403);
-      expect(responseBody.status_code).toEqual(403);
-      expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('Você não pode mais ler tokens de ativação.');
-      expect(responseBody.action).toEqual(
+      expect(response.status).toBe(403);
+      expect(responseBody.status_code).toBe(403);
+      expect(responseBody.name).toBe('ForbiddenError');
+      expect(responseBody.message).toBe('Você não pode mais ler tokens de ativação.');
+      expect(responseBody.action).toBe(
         'Verifique se você já está logado ou tentando ativar novamente o seu ou outro usuário que já está ativo.',
       );
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:ACTIVATION:ACTIVATE_USER_BY_USER_ID:FEATURE_NOT_FOUND');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:ACTIVATION:ACTIVATE_USER_BY_USER_ID:FEATURE_NOT_FOUND');
     });
 
     test('Already active, logged in and trying to activate with a valid token', async () => {
@@ -288,14 +288,14 @@ describe('PATCH /api/v1/activation', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(403);
-      expect(responseBody.status_code).toEqual(403);
-      expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('Usuário não pode executar esta operação.');
-      expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "read:activation_token".');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
+      expect(response.status).toBe(403);
+      expect(responseBody.status_code).toBe(403);
+      expect(responseBody.name).toBe('ForbiddenError');
+      expect(responseBody.message).toBe('Usuário não pode executar esta operação.');
+      expect(responseBody.action).toBe('Verifique se este usuário possui a feature "read:activation_token".');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
     });
   });
 });

--- a/tests/integration/api/v1/activation/patch.test.js
+++ b/tests/integration/api/v1/activation/patch.test.js
@@ -136,9 +136,9 @@ describe('PATCH /api/v1/activation', () => {
       expect(uuidVersion(activationToken.id)).toBe(4);
       expect(activationToken.user_id).toBe(defaultUser.id);
       expect(activationToken.used).toBe(false);
-      expect(Date.parse(activationToken.expires_at)).not.toBe(NaN);
-      expect(Date.parse(activationToken.created_at)).not.toBe(NaN);
-      expect(Date.parse(activationToken.updated_at)).not.toBe(NaN);
+      expect(Date.parse(activationToken.expires_at)).not.toBeNaN();
+      expect(Date.parse(activationToken.created_at)).not.toBeNaN();
+      expect(Date.parse(activationToken.updated_at)).not.toBeNaN();
       expect(activationToken.expires_at - activationToken.created_at).toBe(900000); // 15 minutes
 
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/activation`, {
@@ -157,9 +157,9 @@ describe('PATCH /api/v1/activation', () => {
       expect(response.status).toBe(200);
       expect(uuidVersion(responseBody.id)).toBe(4);
       expect(responseBody.used).toBe(true);
-      expect(Date.parse(activationToken.expires_at)).not.toBe(NaN);
-      expect(Date.parse(activationToken.created_at)).not.toBe(NaN);
-      expect(Date.parse(activationToken.updated_at)).not.toBe(NaN);
+      expect(Date.parse(activationToken.expires_at)).not.toBeNaN();
+      expect(Date.parse(activationToken.created_at)).not.toBeNaN();
+      expect(Date.parse(activationToken.updated_at)).not.toBeNaN();
       expect(responseBody.updated_at > responseBody.created_at).toBe(true);
     });
 
@@ -196,9 +196,9 @@ describe('PATCH /api/v1/activation', () => {
       expect(secondTryResponde.status).toBe(200);
       expect(uuidVersion(secondTryRespondeBody.id)).toBe(4);
       expect(secondTryRespondeBody.used).toBe(true);
-      expect(Date.parse(activationToken.expires_at)).not.toBe(NaN);
-      expect(Date.parse(activationToken.created_at)).not.toBe(NaN);
-      expect(Date.parse(activationToken.updated_at)).not.toBe(NaN);
+      expect(Date.parse(activationToken.expires_at)).not.toBeNaN();
+      expect(Date.parse(activationToken.created_at)).not.toBeNaN();
+      expect(Date.parse(activationToken.updated_at)).not.toBeNaN();
       expect(secondTryRespondeBody.updated_at > secondTryRespondeBody.created_at).toBe(true);
 
       expect(firstTryResponde.status).toBe(secondTryResponde.status);

--- a/tests/integration/api/v1/activation/patch.test.js
+++ b/tests/integration/api/v1/activation/patch.test.js
@@ -202,7 +202,7 @@ describe('PATCH /api/v1/activation', () => {
       expect(secondTryRespondeBody.updated_at > secondTryRespondeBody.created_at).toBe(true);
 
       expect(firstTryResponde.status).toBe(secondTryResponde.status);
-      expect(firstTryRespondeBody).toEqual(secondTryRespondeBody);
+      expect(firstTryRespondeBody).toStrictEqual(secondTryRespondeBody);
     });
 
     test('Activating using an expired token', async () => {

--- a/tests/integration/api/v1/contents/[username]/[slug]/children/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/children/get.test.js
@@ -23,14 +23,14 @@ describe('GET /api/v1/contents/[username]/[slug]/children', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(404);
-      expect(responseBody.status_code).toEqual(404);
-      expect(responseBody.name).toEqual('NotFoundError');
-      expect(responseBody.message).toEqual('O conteúdo informado não foi encontrado no sistema.');
-      expect(responseBody.action).toEqual('Verifique se o "slug" está digitado corretamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('CONTROLLER:CONTENT:CHILDREN:GET_HANDLER:SLUG_NOT_FOUND');
+      expect(response.status).toBe(404);
+      expect(responseBody.status_code).toBe(404);
+      expect(responseBody.name).toBe('NotFoundError');
+      expect(responseBody.message).toBe('O conteúdo informado não foi encontrado no sistema.');
+      expect(responseBody.action).toBe('Verifique se o "slug" está digitado corretamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('CONTROLLER:CONTENT:CHILDREN:GET_HANDLER:SLUG_NOT_FOUND');
     });
 
     test('From "root" content with "deleted" status', async () => {
@@ -48,14 +48,14 @@ describe('GET /api/v1/contents/[username]/[slug]/children', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(404);
-      expect(responseBody.status_code).toEqual(404);
-      expect(responseBody.name).toEqual('NotFoundError');
-      expect(responseBody.message).toEqual('O conteúdo informado não foi encontrado no sistema.');
-      expect(responseBody.action).toEqual('Verifique se o "slug" está digitado corretamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('CONTROLLER:CONTENT:CHILDREN:GET_HANDLER:SLUG_NOT_FOUND');
+      expect(response.status).toBe(404);
+      expect(responseBody.status_code).toBe(404);
+      expect(responseBody.name).toBe('NotFoundError');
+      expect(responseBody.message).toBe('O conteúdo informado não foi encontrado no sistema.');
+      expect(responseBody.action).toBe('Verifique se o "slug" está digitado corretamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('CONTROLLER:CONTENT:CHILDREN:GET_HANDLER:SLUG_NOT_FOUND');
     });
 
     test('From "root" content with "published" status with no children', async () => {
@@ -71,7 +71,7 @@ describe('GET /api/v1/contents/[username]/[slug]/children', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
       expect(responseBody).toEqual([]);
     });
 
@@ -140,8 +140,8 @@ describe('GET /api/v1/contents/[username]/[slug]/children', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
-      expect(responseBody.length).toEqual(2);
+      expect(response.status).toBe(200);
+      expect(responseBody.length).toBe(2);
       expect(responseBody).toStrictEqual([
         {
           id: childBranchBLevel1.id,
@@ -341,8 +341,8 @@ describe('GET /api/v1/contents/[username]/[slug]/children', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
-      expect(responseBody.length).toEqual(2);
+      expect(response.status).toBe(200);
+      expect(responseBody.length).toBe(2);
       expect(responseBody).toStrictEqual([
         {
           id: childBranchBLevel2Content2.id,
@@ -430,8 +430,8 @@ describe('GET /api/v1/contents/[username]/[slug]/children', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
-      expect(responseBody.length).toEqual(2);
+      expect(response.status).toBe(200);
+      expect(responseBody.length).toBe(2);
       expect(responseBody).toStrictEqual([
         {
           id: childBranchBLevel1.id,

--- a/tests/integration/api/v1/contents/[username]/[slug]/children/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/children/get.test.js
@@ -72,7 +72,7 @@ describe('GET /api/v1/contents/[username]/[slug]/children', () => {
       const responseBody = await response.json();
 
       expect(response.status).toBe(200);
-      expect(responseBody).toEqual([]);
+      expect(responseBody).toStrictEqual([]);
     });
 
     test('From "root" content with "published" status with 6 "published" and 1 "draft" children', async () => {

--- a/tests/integration/api/v1/contents/[username]/[slug]/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/get.test.js
@@ -1,5 +1,6 @@
 import { version as uuidVersion } from 'uuid';
 
+import { relevantBody } from 'tests/constants-for-tests';
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {
@@ -155,7 +156,7 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
       const rootContent = await orchestrator.createContent({
         owner_id: defaultUser.id,
         title: 'Conteúdo root',
-        body: 'Body with relevant texts needs to contain a good amount of words',
+        body: relevantBody,
         status: 'published',
       });
 
@@ -202,7 +203,7 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
         parent_id: null,
         slug: responseBody.slug,
         title: 'Conteúdo root',
-        body: 'Body with relevant texts needs to contain a good amount of words',
+        body: relevantBody,
         status: 'published',
         type: 'content',
         tabcoins: 1,

--- a/tests/integration/api/v1/contents/[username]/[slug]/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/get.test.js
@@ -15,14 +15,14 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents/ThisUserDoesNotExists/slug`);
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(404);
-      expect(responseBody.status_code).toEqual(404);
-      expect(responseBody.name).toEqual('NotFoundError');
-      expect(responseBody.message).toEqual('O "username" informado não foi encontrado no sistema.');
-      expect(responseBody.action).toEqual('Verifique se o "username" está digitado corretamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:USER:FIND_ONE_BY_USERNAME:NOT_FOUND');
+      expect(response.status).toBe(404);
+      expect(responseBody.status_code).toBe(404);
+      expect(responseBody.name).toBe('NotFoundError');
+      expect(responseBody.message).toBe('O "username" informado não foi encontrado no sistema.');
+      expect(responseBody.action).toBe('Verifique se o "username" está digitado corretamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:USER:FIND_ONE_BY_USERNAME:NOT_FOUND');
     });
 
     test('Content with "username" existent, but "slug" non-existent', async () => {
@@ -34,14 +34,14 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(404);
-      expect(responseBody.status_code).toEqual(404);
-      expect(responseBody.name).toEqual('NotFoundError');
-      expect(responseBody.message).toEqual('O conteúdo informado não foi encontrado no sistema.');
-      expect(responseBody.action).toEqual('Verifique se o "slug" está digitado corretamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('CONTROLLER:CONTENT:GET_HANDLER:SLUG_NOT_FOUND');
+      expect(response.status).toBe(404);
+      expect(responseBody.status_code).toBe(404);
+      expect(responseBody.name).toBe('NotFoundError');
+      expect(responseBody.message).toBe('O conteúdo informado não foi encontrado no sistema.');
+      expect(responseBody.action).toBe('Verifique se o "slug" está digitado corretamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('CONTROLLER:CONTENT:GET_HANDLER:SLUG_NOT_FOUND');
     });
 
     test('Content "root" with "status" set to "draft"', async () => {
@@ -60,14 +60,14 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(404);
-      expect(responseBody.status_code).toEqual(404);
-      expect(responseBody.name).toEqual('NotFoundError');
-      expect(responseBody.message).toEqual('O conteúdo informado não foi encontrado no sistema.');
-      expect(responseBody.action).toEqual('Verifique se o "slug" está digitado corretamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('CONTROLLER:CONTENT:GET_HANDLER:SLUG_NOT_FOUND');
+      expect(response.status).toBe(404);
+      expect(responseBody.status_code).toBe(404);
+      expect(responseBody.name).toBe('NotFoundError');
+      expect(responseBody.message).toBe('O conteúdo informado não foi encontrado no sistema.');
+      expect(responseBody.action).toBe('Verifique se o "slug" está digitado corretamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('CONTROLLER:CONTENT:GET_HANDLER:SLUG_NOT_FOUND');
     });
 
     test('Content "root" with "status" set to "published"', async () => {
@@ -87,7 +87,7 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: defaultUserContent.id,
@@ -110,8 +110,8 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
         children_deep_count: 0,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(uuidVersion(responseBody.owner_id)).toEqual(4);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(uuidVersion(responseBody.owner_id)).toBe(4);
     });
 
     test('Content "root" with "status" set to "deleted"', async () => {
@@ -132,7 +132,7 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(404);
+      expect(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -145,8 +145,8 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
         key: 'slug',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('Content "root" with with "children"', async () => {
@@ -195,7 +195,7 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: rootContent.id,
@@ -218,8 +218,8 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
         children_deep_count: 3,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(uuidVersion(responseBody.owner_id)).toEqual(4);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(uuidVersion(responseBody.owner_id)).toBe(4);
     });
 
     test('Content "child" with "status" set to "draft"', async () => {
@@ -245,14 +245,14 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(404);
-      expect(responseBody.status_code).toEqual(404);
-      expect(responseBody.name).toEqual('NotFoundError');
-      expect(responseBody.message).toEqual('O conteúdo informado não foi encontrado no sistema.');
-      expect(responseBody.action).toEqual('Verifique se o "slug" está digitado corretamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('CONTROLLER:CONTENT:GET_HANDLER:SLUG_NOT_FOUND');
+      expect(response.status).toBe(404);
+      expect(responseBody.status_code).toBe(404);
+      expect(responseBody.name).toBe('NotFoundError');
+      expect(responseBody.message).toBe('O conteúdo informado não foi encontrado no sistema.');
+      expect(responseBody.action).toBe('Verifique se o "slug" está digitado corretamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('CONTROLLER:CONTENT:GET_HANDLER:SLUG_NOT_FOUND');
     });
 
     test('Content "child" with "status" set to "published"', async () => {
@@ -278,7 +278,7 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: childContent.id,
@@ -349,7 +349,7 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: childContent.id,
@@ -372,9 +372,9 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
         children_deep_count: 2,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(uuidVersion(responseBody.owner_id)).toEqual(4);
-      expect(uuidVersion(responseBody.parent_id)).toEqual(4);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(uuidVersion(responseBody.owner_id)).toBe(4);
+      expect(uuidVersion(responseBody.parent_id)).toBe(4);
     });
 
     test('Content "child" with "status" set to "deleted"', async () => {
@@ -413,8 +413,8 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
         key: 'slug',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('Content "root" with TabCoins credits and debits', async () => {
@@ -436,7 +436,7 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: defaultUserContent.id,
@@ -459,8 +459,8 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
         children_deep_count: 0,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(uuidVersion(responseBody.owner_id)).toEqual(4);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(uuidVersion(responseBody.owner_id)).toBe(4);
     });
   });
 });

--- a/tests/integration/api/v1/contents/[username]/[slug]/parent/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/parent/get.test.js
@@ -24,7 +24,7 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(404);
+      expect(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -37,8 +37,8 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
         key: 'slug',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('From "root" content with "deleted" status', async () => {
@@ -56,7 +56,7 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(404);
+      expect(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -69,8 +69,8 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
         key: 'slug',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('From "root" content with "published" status', async () => {
@@ -86,7 +86,7 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(404);
+      expect(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -100,8 +100,8 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
         key: 'parent_id',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('From "child" content 1 level deep with "draft" status', async () => {
@@ -128,7 +128,7 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(404);
+      expect(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -141,8 +141,8 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
         key: 'slug',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('From "child" content 1 level deep with "deleted" status', async () => {
@@ -173,7 +173,7 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(404);
+      expect(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -186,8 +186,8 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
         key: 'slug',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('From "child" content 1 level deep with "published" status', async () => {
@@ -214,7 +214,7 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: rootContent.id,
@@ -278,7 +278,7 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: childContentLevel2.id,
@@ -346,7 +346,7 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: childContentLevel2.id,
@@ -415,7 +415,7 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: childContentLevel2.id,
@@ -466,7 +466,7 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: rootContent.id,

--- a/tests/integration/api/v1/contents/[username]/[slug]/parent/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/parent/get.test.js
@@ -1,5 +1,6 @@
 import { version as uuidVersion } from 'uuid';
 
+import { relevantBody } from 'tests/constants-for-tests';
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {
@@ -196,7 +197,7 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
       const rootContent = await orchestrator.createContent({
         owner_id: firstUser.id,
         title: 'Root content title',
-        body: 'Root - Body with relevant texts needs to contain a good amount of words',
+        body: relevantBody,
         status: 'published',
       });
 
@@ -221,7 +222,7 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
         owner_id: firstUser.id,
         slug: 'root-content-title',
         title: 'Root content title',
-        body: 'Root - Body with relevant texts needs to contain a good amount of words',
+        body: relevantBody,
         children_deep_count: 1,
         status: 'published',
         type: 'content',
@@ -445,7 +446,7 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
       const rootContent = await orchestrator.createContent({
         owner_id: firstUser.id,
         title: 'Root content title',
-        body: 'Root - Body with relevant texts needs to contain a good amount of words',
+        body: relevantBody,
         status: 'published',
       });
 
@@ -473,7 +474,7 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
         owner_id: firstUser.id,
         slug: 'root-content-title',
         title: 'Root content title',
-        body: 'Root - Body with relevant texts needs to contain a good amount of words',
+        body: relevantBody,
         children_deep_count: 1,
         status: 'published',
         type: 'content',

--- a/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
@@ -20,14 +20,14 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         body: 'Não deveria conseguir.',
       });
 
-      expect(response.status).toEqual(403);
-      expect(responseBody.status_code).toEqual(403);
-      expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('Usuário não pode executar esta operação.');
-      expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "update:content".');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
+      expect(response.status).toBe(403);
+      expect(responseBody.status_code).toBe(403);
+      expect(responseBody.name).toBe('ForbiddenError');
+      expect(responseBody.message).toBe('Usuário não pode executar esta operação.');
+      expect(responseBody.action).toBe('Verifique se este usuário possui a feature "update:content".');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
     });
   });
 
@@ -41,14 +41,14 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         body: 'Não deveria conseguir, pois não possui a feature "update:content".',
       });
 
-      expect(response.status).toEqual(403);
-      expect(responseBody.status_code).toEqual(403);
-      expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('Usuário não pode executar esta operação.');
-      expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "update:content".');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
+      expect(response.status).toBe(403);
+      expect(responseBody.status_code).toBe(403);
+      expect(responseBody.name).toBe('ForbiddenError');
+      expect(responseBody.message).toBe('Usuário não pode executar esta operação.');
+      expect(responseBody.action).toBe('Verifique se este usuário possui a feature "update:content".');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
     });
 
     test('"child" content with valid data', async () => {
@@ -76,14 +76,14 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         },
       );
 
-      expect(response.status).toEqual(403);
-      expect(responseBody.status_code).toEqual(403);
-      expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('Usuário não pode executar esta operação.');
-      expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "update:content".');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
+      expect(response.status).toBe(403);
+      expect(responseBody.status_code).toBe(403);
+      expect(responseBody.name).toBe('ForbiddenError');
+      expect(responseBody.message).toBe('Usuário não pode executar esta operação.');
+      expect(responseBody.action).toBe('Verifique se este usuário possui a feature "update:content".');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
     });
   });
 
@@ -106,14 +106,14 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         },
       );
 
-      expect(response.status).toEqual(403);
-      expect(responseBody.status_code).toEqual(403);
-      expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('Você não possui permissão para editar conteúdos na raiz do site.');
-      expect(responseBody.action).toEqual('Verifique se você possui a feature "create:content:text_root".');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual(
+      expect(response.status).toBe(403);
+      expect(responseBody.status_code).toBe(403);
+      expect(responseBody.name).toBe('ForbiddenError');
+      expect(responseBody.message).toBe('Você não possui permissão para editar conteúdos na raiz do site.');
+      expect(responseBody.action).toBe('Verifique se você possui a feature "create:content:text_root".');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe(
         'CONTROLLER:CONTENT:PATCH_HANDLER:CREATE:CONTENT:TEXT_ROOT:FEATURE_NOT_FOUND',
       );
     });
@@ -142,7 +142,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         },
       );
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -164,11 +164,11 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         owner_username: userWithoutFeature.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.published_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
-      expect(responseBody.updated_at > childContent.updated_at.toISOString()).toEqual(true);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.published_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(responseBody.updated_at > childContent.updated_at.toISOString()).toBe(true);
     });
   });
 
@@ -189,7 +189,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { source_url: 'http://www.tabnews.com.br/' },
       );
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -211,11 +211,11 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         owner_username: userWithoutFeature.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.published_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
-      expect(responseBody.updated_at > rootContent.updated_at.toISOString()).toEqual(true);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.published_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(responseBody.updated_at > rootContent.updated_at.toISOString()).toBe(true);
     });
 
     test('"child" content with valid data', async () => {
@@ -242,16 +242,14 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         },
       );
 
-      expect(response.status).toEqual(403);
-      expect(responseBody.status_code).toEqual(403);
-      expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual(
-        'Você não possui permissão para editar conteúdos dentro de outros conteúdos.',
-      );
-      expect(responseBody.action).toEqual('Verifique se você possui a feature "create:content:text_child".');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual(
+      expect(response.status).toBe(403);
+      expect(responseBody.status_code).toBe(403);
+      expect(responseBody.name).toBe('ForbiddenError');
+      expect(responseBody.message).toBe('Você não possui permissão para editar conteúdos dentro de outros conteúdos.');
+      expect(responseBody.action).toBe('Verifique se você possui a feature "create:content:text_child".');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe(
         'CONTROLLER:CONTENT:PATCH_HANDLER:CREATE:CONTENT:TEXT_CHILD:FEATURE_NOT_FOUND',
       );
     });
@@ -265,14 +263,14 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
 
       const { response, responseBody } = await contentsRequestBuilder.patch(`/${defaultUser.username}/slug`);
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"body" enviado deve ser do tipo Object.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"body" enviado deve ser do tipo Object.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with PATCH Body containing an invalid JSON string', async () => {
@@ -285,14 +283,14 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         'Texto corrido no lugar de um JSON',
       );
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"body" enviado deve ser do tipo Object.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"body" enviado deve ser do tipo Object.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with PATCH Body containing an empty Object', async () => {
@@ -301,14 +299,14 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
 
       const { response, responseBody } = await contentsRequestBuilder.patch(`/${defaultUser.username}/slug`, {});
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('Objeto enviado deve ter no mínimo uma chave.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('Objeto enviado deve ter no mínimo uma chave.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with invalid "username" in the URL', async () => {
@@ -317,14 +315,14 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
 
       const { response, responseBody } = await contentsRequestBuilder.patch(`/invalid-username/slug`, {});
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"username" deve conter apenas caracteres alfanuméricos.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"username" deve conter apenas caracteres alfanuméricos.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with invalid "slug" in the URL', async () => {
@@ -336,14 +334,14 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         {},
       );
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"slug" está no formato errado.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"slug" está no formato errado.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "username" non-existent', async () => {
@@ -355,14 +353,14 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         body: 'Não deveria conseguir',
       });
 
-      expect(response.status).toEqual(404);
-      expect(responseBody.status_code).toEqual(404);
-      expect(responseBody.name).toEqual('NotFoundError');
-      expect(responseBody.message).toEqual('O "username" informado não foi encontrado no sistema.');
-      expect(responseBody.action).toEqual('Verifique se o "username" está digitado corretamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:USER:FIND_ONE_BY_USERNAME:NOT_FOUND');
+      expect(response.status).toBe(404);
+      expect(responseBody.status_code).toBe(404);
+      expect(responseBody.name).toBe('NotFoundError');
+      expect(responseBody.message).toBe('O "username" informado não foi encontrado no sistema.');
+      expect(responseBody.action).toBe('Verifique se o "username" está digitado corretamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:USER:FIND_ONE_BY_USERNAME:NOT_FOUND');
     });
 
     test('Content with "username" existent, but "slug" non-existent', async () => {
@@ -383,14 +381,14 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         },
       );
 
-      expect(response.status).toEqual(404);
-      expect(responseBody.status_code).toEqual(404);
-      expect(responseBody.name).toEqual('NotFoundError');
-      expect(responseBody.message).toEqual('O conteúdo informado não foi encontrado no sistema.');
-      expect(responseBody.action).toEqual('Verifique se o "slug" está digitado corretamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('CONTROLLER:CONTENT:PATCH_HANDLER:SLUG_NOT_FOUND');
+      expect(response.status).toBe(404);
+      expect(responseBody.status_code).toBe(404);
+      expect(responseBody.name).toBe('NotFoundError');
+      expect(responseBody.message).toBe('O conteúdo informado não foi encontrado no sistema.');
+      expect(responseBody.action).toBe('Verifique se o "slug" está digitado corretamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('CONTROLLER:CONTENT:PATCH_HANDLER:SLUG_NOT_FOUND');
     });
 
     test('Content with "username" and "slug" pointing to content from another user', async () => {
@@ -412,14 +410,14 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         },
       );
 
-      expect(response.status).toEqual(403);
-      expect(responseBody.status_code).toEqual(403);
-      expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('Você não possui permissão para atualizar o conteúdo de outro usuário.');
-      expect(responseBody.action).toEqual('Verifique se você possui a feature "update:content:others".');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual(
+      expect(response.status).toBe(403);
+      expect(responseBody.status_code).toBe(403);
+      expect(responseBody.name).toBe('ForbiddenError');
+      expect(responseBody.message).toBe('Você não possui permissão para atualizar o conteúdo de outro usuário.');
+      expect(responseBody.action).toBe('Verifique se você possui a feature "update:content:others".');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe(
         'CONTROLLER:CONTENTS:PATCH:USER_CANT_UPDATE_CONTENT_FROM_OTHER_USER',
       );
     });
@@ -445,7 +443,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         },
       );
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: firstUserContent.id,
@@ -467,11 +465,11 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         owner_username: firstUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
-      expect(responseBody.published_at).toEqual(firstUserContent.published_at.toISOString());
-      expect(responseBody.updated_at > firstUserContent.updated_at.toISOString()).toEqual(true);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(responseBody.published_at).toBe(firstUserContent.published_at.toISOString());
+      expect(responseBody.updated_at > firstUserContent.updated_at.toISOString()).toBe(true);
     });
 
     test('Content with "body" declared solely', async () => {
@@ -489,7 +487,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { body: 'Body novo' },
       );
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -511,10 +509,10 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
-      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toEqual(true);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
     test('Content with TabCoins credits and debits', async () => {
@@ -535,7 +533,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { body: 'New body' },
       );
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -557,10 +555,10 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
-      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toEqual(true);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
     test('Content with "body" containing blank String', async () => {
@@ -578,14 +576,14 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { body: '' },
       );
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"body" não pode estar em branco.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"body" não pode estar em branco.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "body" containing empty Markdown', async () => {
@@ -606,14 +604,14 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         },
       );
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('Markdown deve conter algum texto.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('Markdown deve conter algum texto.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "title", "body" and "source_url" containing \\u0000 null characters', async () => {
@@ -636,7 +634,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         },
       );
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -658,9 +656,9 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
     });
 
     test('Content with "title" and "body" containing invalid characters', async () => {
@@ -681,14 +679,14 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         },
       );
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"body" deve começar com caracteres visíveis.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"body" deve começar com caracteres visíveis.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "body" containing more than 20.000 characters', async () => {
@@ -706,14 +704,14 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { body: 'A'.repeat(20001) },
       );
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"body" deve conter no máximo 20000 caracteres.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"body" deve conter no máximo 20000 caracteres.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "body" containing untrimmed values', async () => {
@@ -731,14 +729,14 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { body: ' Espaço no início e no fim ' },
       );
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"body" deve começar com caracteres visíveis.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"body" deve começar com caracteres visíveis.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "body" ending with untrimmed values', async () => {
@@ -756,7 +754,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { body: 'Espaço só no fim ' },
       );
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -778,10 +776,10 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
-      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toEqual(true);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
     test('Content with "body" containing Null value', async () => {
@@ -799,14 +797,14 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { body: null },
       );
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"body" deve ser do tipo String.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"body" deve ser do tipo String.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "slug" declared solely', async () => {
@@ -825,7 +823,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { slug: 'slug-novo' },
       );
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -847,10 +845,10 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
-      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toEqual(true);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
     test('Content with "slug" containing the same value of another content (same user, both "published" status)', async () => {
@@ -879,7 +877,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { slug: 'primeiro-conteudo' },
       );
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -891,8 +889,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         error_location_code: 'MODEL:CONTENT:CHECK_FOR_CONTENT_UNIQUENESS:ALREADY_EXISTS',
         key: 'slug',
       });
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('Content with "slug" containing the same value of another content (same user, one with "draft" and the other "published" status)', async () => {
@@ -921,7 +919,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { slug: 'primeiro-conteudo' },
       );
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -933,8 +931,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         error_location_code: 'MODEL:CONTENT:CHECK_FOR_CONTENT_UNIQUENESS:ALREADY_EXISTS',
         key: 'slug',
       });
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('Content with "slug" containing the same value of another content (same user, one with "published" and the other "deleted" status)', async () => {
@@ -966,7 +964,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { slug: 'primeiro-conteudo' },
       );
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -988,9 +986,9 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.published_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.published_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
     });
 
     test('Content with "slug" containing a blank String', async () => {
@@ -1008,14 +1006,14 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { slug: '' },
       );
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"slug" não pode estar em branco.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"slug" não pode estar em branco.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test(`Content with "slug" containing more than ${maxSlugLength} bytes`, async () => {
@@ -1038,7 +1036,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         },
       );
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1063,10 +1061,10 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
-      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toEqual(true);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
     test('Content with "slug" containing special characters', async () => {
@@ -1084,14 +1082,14 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { slug: 'slug-não-pode-ter-caracteres-especiais' },
       );
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"slug" está no formato errado.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"slug" está no formato errado.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "slug" containing Null value', async () => {
@@ -1109,14 +1107,14 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { slug: null },
       );
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"slug" deve ser do tipo String.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"slug" deve ser do tipo String.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "slug" with trailing hyphen', async () => {
@@ -1136,7 +1134,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         },
       );
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1158,10 +1156,10 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
-      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toEqual(true);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
     test('Content with "title" declared solely', async () => {
@@ -1179,7 +1177,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { title: 'Título novo' },
       );
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1201,10 +1199,10 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
-      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toEqual(true);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
     test('Content with "title" containing a blank String', async () => {
@@ -1222,14 +1220,14 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { title: '' },
       );
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"title" não pode estar em branco.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"title" não pode estar em branco.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "title", but current content is "deleted"', async () => {
@@ -1251,7 +1249,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { title: 'Título novo' },
       );
 
-      expect(response.status).toEqual(404);
+      expect(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -1263,8 +1261,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         error_location_code: 'CONTROLLER:CONTENT:PATCH_HANDLER:SLUG_NOT_FOUND',
         key: 'slug',
       });
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test(`Content with "title" containing more than ${maxTitleLength} characters`, async () => {
@@ -1284,14 +1282,14 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         },
       );
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual(`"title" deve conter no máximo ${maxTitleLength} caracteres.`);
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe(`"title" deve conter no máximo ${maxTitleLength} caracteres.`);
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "title" containing Null value in "root" content', async () => {
@@ -1309,14 +1307,14 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { title: null },
       );
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"title" é um campo obrigatório.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:CONTENT:CHECK_ROOT_CONTENT_TITLE:MISSING_TITLE');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"title" é um campo obrigatório.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:CONTENT:CHECK_ROOT_CONTENT_TITLE:MISSING_TITLE');
     });
 
     test('Content with "title" containing Null value in "child" content', async () => {
@@ -1341,7 +1339,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { title: null },
       );
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: childContent.id,
@@ -1363,10 +1361,10 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
-      expect(responseBody.updated_at > childContent.updated_at.toISOString()).toEqual(true);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(responseBody.updated_at > childContent.updated_at.toISOString()).toBe(true);
     });
 
     test('Content with "title" containing untrimmed values', async () => {
@@ -1384,7 +1382,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { title: ' Título válido, mas com espaços em branco no início e no fim ' },
       );
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1406,10 +1404,10 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
-      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toEqual(true);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
     test('Content with "title" containing unescaped characters', async () => {
@@ -1427,7 +1425,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { title: `Tab & News | Conteúdos com \n valor <strong>concreto</strong> e "massa"> participe! '\\o/'` },
       );
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1449,10 +1447,10 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
-      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toEqual(true);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
     test('Content with "status" "draft" set to "draft"', async () => {
@@ -1470,7 +1468,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { status: 'draft' },
       );
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1492,10 +1490,10 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
-      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toEqual(true);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
     test('Content with "status" "draft" set to "published"', async () => {
@@ -1514,7 +1512,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { status: 'published' },
       );
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1536,11 +1534,11 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.published_at)).not.toEqual(NaN);
-      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toEqual(true);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.published_at)).not.toBe(NaN);
+      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
     test('Content with "status" "published" set to "draft"', async () => {
@@ -1559,7 +1557,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { status: 'draft' },
       );
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -1571,8 +1569,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         error_location_code: 'MODEL:CONTENT:CHECK_STATUS_CHANGE:STATUS_ALREADY_PUBLISHED',
         key: 'status',
       });
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('Content with "status" "published" set to "deleted"', async () => {
@@ -1591,7 +1589,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { status: 'deleted' },
       );
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1613,14 +1611,14 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(uuidVersion(responseBody.owner_id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.published_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.deleted_at)).not.toEqual(NaN);
-      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toEqual(true);
-      expect(responseBody.deleted_at > defaultUserContent.published_at.toISOString()).toEqual(true);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(uuidVersion(responseBody.owner_id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.published_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.deleted_at)).not.toBe(NaN);
+      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
+      expect(responseBody.deleted_at > defaultUserContent.published_at.toISOString()).toBe(true);
     });
 
     test('Content with "status" "published" set to "deleted", than "published"', async () => {
@@ -1641,7 +1639,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       const { response: republishedResponse, responseBody: republishedResponseBody } =
         await contentsRequestBuilder.patch(`/${defaultUser.username}/${originalContent.slug}`, { status: 'published' });
 
-      expect(republishedResponse.status).toEqual(404);
+      expect(republishedResponse.status).toBe(404);
       expect(republishedResponseBody).toStrictEqual({
         name: 'NotFoundError',
         message: 'O conteúdo informado não foi encontrado no sistema.',
@@ -1652,8 +1650,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         error_location_code: 'CONTROLLER:CONTENT:PATCH_HANDLER:SLUG_NOT_FOUND',
         key: 'slug',
       });
-      expect(uuidVersion(republishedResponseBody.error_id)).toEqual(4);
-      expect(uuidVersion(republishedResponseBody.request_id)).toEqual(4);
+      expect(uuidVersion(republishedResponseBody.error_id)).toBe(4);
+      expect(uuidVersion(republishedResponseBody.request_id)).toBe(4);
     });
 
     test('Content with "status" set to "non_existent_status"', async () => {
@@ -1671,16 +1669,16 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { status: 'non_existent_status' },
       );
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual(
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe(
         '"status" deve possuir um dos seguintes valores: "draft", "published", "deleted", "firewall".',
       );
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "status" set to "firewall"', async () => {
@@ -1698,7 +1696,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { status: 'firewall' },
       );
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
       expect(responseBody).toStrictEqual({
         status_code: 400,
         name: 'ValidationError',
@@ -1710,8 +1708,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         key: 'status',
         type: 'any.only',
       });
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('Content with "status" set to Null', async () => {
@@ -1729,16 +1727,16 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { status: null },
       );
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual(
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe(
         '"status" deve possuir um dos seguintes valores: "draft", "published", "deleted", "firewall".',
       );
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "status" set a blank String', async () => {
@@ -1756,16 +1754,16 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { status: '' },
       );
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual(
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe(
         '"status" deve possuir um dos seguintes valores: "draft", "published", "deleted", "firewall".',
       );
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "source_url" containing a valid HTTP URL', async () => {
@@ -1783,7 +1781,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { source_url: 'http://www.tabnews.com.br/' },
       );
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1805,10 +1803,10 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
-      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toEqual(true);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
     test('Content with "source_url" containing a valid HTTPS URL', async () => {
@@ -1826,7 +1824,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { source_url: 'https://www.tabnews.com.br/museu' },
       );
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1848,10 +1846,10 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
-      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toEqual(true);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
     test('Content with "source_url" containing a valid long TLD', async () => {
@@ -1869,7 +1867,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { source_url: 'https://nic.xn--vermgensberatung-pwb/' },
       );
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1891,10 +1889,10 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
-      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toEqual(true);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
     test('Content with "source_url" containing a valid short URL', async () => {
@@ -1912,7 +1910,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { source_url: 'https://t.me' },
       );
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1934,10 +1932,10 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
-      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toEqual(true);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
     test('Content with "source_url" containing a invalid short TLD', async () => {
@@ -1955,16 +1953,16 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { source_url: 'http://invalidtl.d' },
       );
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual(
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe(
         '"source_url" deve possuir uma URL válida e utilizando os protocolos HTTP ou HTTPS.',
       );
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "source_url" containing a invalid long TLD', async () => {
@@ -1982,16 +1980,16 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { source_url: 'https://tl.dcomvinteecincocaracteres' },
       );
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual(
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe(
         '"source_url" deve possuir uma URL válida e utilizando os protocolos HTTP ou HTTPS.',
       );
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "source_url" containing a not accepted Protocol', async () => {
@@ -2009,16 +2007,16 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { source_url: 'ftp://www.tabnews.com.br' },
       );
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual(
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe(
         '"source_url" deve possuir uma URL válida e utilizando os protocolos HTTP ou HTTPS.',
       );
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "source_url" not containing a protocol', async () => {
@@ -2036,16 +2034,16 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { source_url: 'www.tabnews.com.br' },
       );
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual(
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe(
         '"source_url" deve possuir uma URL válida e utilizando os protocolos HTTP ou HTTPS.',
       );
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "source_url" containing an incomplete URL', async () => {
@@ -2063,16 +2061,16 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { source_url: 'https://lol.' },
       );
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual(
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe(
         '"source_url" deve possuir uma URL válida e utilizando os protocolos HTTP ou HTTPS.',
       );
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "source_url" containing query parameters', async () => {
@@ -2090,7 +2088,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { source_url: 'https://www.tabnews.com.br/api/v1/contents?strategy=old' },
       );
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -2112,11 +2110,11 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
-      expect(responseBody.published_at).toEqual(null);
-      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toEqual(true);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(responseBody.published_at).toBe(null);
+      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
     test('Content with "source_url" containing fragment component', async () => {
@@ -2134,7 +2132,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { source_url: 'https://www.tabnews.com.br/#:~:text=TabNews,-Status' },
       );
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -2156,11 +2154,11 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
-      expect(responseBody.published_at).toEqual(null);
-      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toEqual(true);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(responseBody.published_at).toBe(null);
+      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
     test('Content with "source_url" containing an empty String', async () => {
@@ -2178,14 +2176,14 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { source_url: '' },
       );
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"source_url" não pode estar em branco.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"source_url" não pode estar em branco.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "source_url" containing a Null value', async () => {
@@ -2204,7 +2202,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { source_url: null },
       );
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -2226,10 +2224,10 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
-      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toEqual(true);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
     test('Content with "parent_id" declared solely', async () => {
@@ -2253,16 +2251,16 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { parent_id: rootContent.id },
       );
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('Objeto enviado deve ter no mínimo uma chave.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('Objeto enviado deve ter no mínimo uma chave.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "title" and "parent_id" set to another "parent_id"', async () => {
@@ -2296,7 +2294,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         },
       );
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -2318,10 +2316,10 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
-      expect(responseBody.updated_at > childContent.updated_at.toISOString()).toEqual(true);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(responseBody.updated_at > childContent.updated_at.toISOString()).toBe(true);
     });
 
     test('Content from another user', async () => {
@@ -2341,14 +2339,14 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { title: 'Tentando atualizar o conteúdo.' },
       );
 
-      expect(response.status).toEqual(403);
-      expect(responseBody.status_code).toEqual(403);
-      expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('Você não possui permissão para atualizar o conteúdo de outro usuário.');
-      expect(responseBody.action).toEqual('Verifique se você possui a feature "update:content:others".');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual(
+      expect(response.status).toBe(403);
+      expect(responseBody.status_code).toBe(403);
+      expect(responseBody.name).toBe('ForbiddenError');
+      expect(responseBody.message).toBe('Você não possui permissão para atualizar o conteúdo de outro usuário.');
+      expect(responseBody.action).toBe('Verifique se você possui a feature "update:content:others".');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe(
         'CONTROLLER:CONTENTS:PATCH:USER_CANT_UPDATE_CONTENT_FROM_OTHER_USER',
       );
     });
@@ -2372,12 +2370,12 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
           { status: 'draft' },
         );
 
-        expect(responseBody.tabcoins).toEqual(0);
+        expect(responseBody.tabcoins).toBe(0);
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
-        expect(userResponseBody.tabcoins).toEqual(0);
-        expect(userResponseBody.tabcash).toEqual(0);
+        expect(userResponseBody.tabcoins).toBe(0);
+        expect(userResponseBody.tabcash).toBe(0);
       });
 
       test('"root" content updated from "draft" to "published" status', async () => {
@@ -2398,12 +2396,12 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
           { status: 'published' },
         );
 
-        expect(responseBody.tabcoins).toEqual(1);
+        expect(responseBody.tabcoins).toBe(1);
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
-        expect(userResponseBody.tabcoins).toEqual(2);
-        expect(userResponseBody.tabcash).toEqual(0);
+        expect(userResponseBody.tabcoins).toBe(2);
+        expect(userResponseBody.tabcash).toBe(0);
       });
 
       test('"root" content updated from "draft" to "deleted" status', async () => {
@@ -2424,12 +2422,12 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
           { status: 'deleted' },
         );
 
-        expect(responseBody.tabcoins).toEqual(0);
+        expect(responseBody.tabcoins).toBe(0);
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
-        expect(userResponseBody.tabcoins).toEqual(0);
-        expect(userResponseBody.tabcash).toEqual(0);
+        expect(userResponseBody.tabcoins).toBe(0);
+        expect(userResponseBody.tabcash).toBe(0);
       });
 
       test('"root" content updated from "published" to "deleted" status (with prestige)', async () => {
@@ -2447,8 +2445,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
 
         const { responseBody: userResponseBodyBefore } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
-        expect(userResponseBodyBefore.tabcoins).toEqual(8);
-        expect(userResponseBodyBefore.tabcash).toEqual(0);
+        expect(userResponseBodyBefore.tabcoins).toBe(8);
+        expect(userResponseBodyBefore.tabcash).toBe(0);
 
         await orchestrator.createBalance({
           balanceType: 'content:tabcoin:initial',
@@ -2463,12 +2461,12 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
           { status: 'deleted' },
         );
 
-        expect(responseBody.tabcoins).toEqual(1);
+        expect(responseBody.tabcoins).toBe(1);
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
-        expect(userResponseBody.tabcoins).toEqual(0);
-        expect(userResponseBody.tabcash).toEqual(0);
+        expect(userResponseBody.tabcoins).toBe(0);
+        expect(userResponseBody.tabcash).toBe(0);
       });
 
       test('"root" content updated from "published" to "deleted" status (without prestige)', async () => {
@@ -2485,8 +2483,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
 
         const { responseBody: userResponseBodyBefore } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
-        expect(userResponseBodyBefore.tabcoins).toEqual(0);
-        expect(userResponseBodyBefore.tabcash).toEqual(0);
+        expect(userResponseBodyBefore.tabcoins).toBe(0);
+        expect(userResponseBodyBefore.tabcash).toBe(0);
 
         await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: 1 });
 
@@ -2495,12 +2493,12 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
           { status: 'deleted' },
         );
 
-        expect(responseBody.tabcoins).toEqual(1);
+        expect(responseBody.tabcoins).toBe(1);
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
-        expect(userResponseBody.tabcoins).toEqual(0);
-        expect(userResponseBody.tabcash).toEqual(0);
+        expect(userResponseBody.tabcoins).toBe(0);
+        expect(userResponseBody.tabcash).toBe(0);
       });
 
       test('Deletion of "root" content that was first published without the minimum amount of relevant words', async () => {
@@ -2518,20 +2516,20 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
 
         const { responseBody: userResponseBodyBefore } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
-        expect(userResponseBodyBefore.tabcoins).toEqual(0);
-        expect(userResponseBodyBefore.tabcash).toEqual(0);
+        expect(userResponseBodyBefore.tabcoins).toBe(0);
+        expect(userResponseBodyBefore.tabcash).toBe(0);
 
         const { responseBody } = await contentsRequestBuilder.patch(
           `/${defaultUser.username}/${defaultUserContent.slug}`,
           { status: 'deleted' },
         );
 
-        expect(responseBody.tabcoins).toEqual(0);
+        expect(responseBody.tabcoins).toBe(0);
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
-        expect(userResponseBody.tabcoins).toEqual(0);
-        expect(userResponseBody.tabcash).toEqual(0);
+        expect(userResponseBody.tabcoins).toBe(0);
+        expect(userResponseBody.tabcash).toBe(0);
       });
 
       test('"root" content with positive tabcoins updated from "published" to "deleted" status (with prestige)', async () => {
@@ -2560,22 +2558,22 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const { responseBody: contentFirstGetResponseBody } = await contentsRequestBuilder.get(
           `/${defaultUser.username}/${defaultUserContent.slug}`,
         );
-        expect(contentFirstGetResponseBody.tabcoins).toEqual(11);
+        expect(contentFirstGetResponseBody.tabcoins).toBe(11);
 
         const { responseBody: userFirstGetResponseBody } = await usersRequestBuilder.get(`/${defaultUser.username}`);
-        expect(userFirstGetResponseBody.tabcoins).toEqual(12);
+        expect(userFirstGetResponseBody.tabcoins).toBe(12);
 
         const { responseBody: contentSecondResponseBody } = await contentsRequestBuilder.patch(
           `/${defaultUser.username}/${defaultUserContent.slug}`,
           { status: 'deleted' },
         );
 
-        expect(contentSecondResponseBody.tabcoins).toEqual(11);
+        expect(contentSecondResponseBody.tabcoins).toBe(11);
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
-        expect(userResponseBody.tabcoins).toEqual(0);
-        expect(userResponseBody.tabcash).toEqual(0);
+        expect(userResponseBody.tabcoins).toBe(0);
+        expect(userResponseBody.tabcash).toBe(0);
       });
 
       test('"root" content with positive tabcoins updated from "published" to "deleted" status (without prestige)', async () => {
@@ -2597,22 +2595,22 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const { responseBody: contentFirstGetResponseBody } = await contentsRequestBuilder.get(
           `/${defaultUser.username}/${defaultUserContent.slug}`,
         );
-        expect(contentFirstGetResponseBody.tabcoins).toEqual(11);
+        expect(contentFirstGetResponseBody.tabcoins).toBe(11);
 
         const { responseBody: userFirstGetResponseBody } = await usersRequestBuilder.get(`/${defaultUser.username}`);
-        expect(userFirstGetResponseBody.tabcoins).toEqual(10);
+        expect(userFirstGetResponseBody.tabcoins).toBe(10);
 
         const { responseBody: contentSecondResponseBody } = await contentsRequestBuilder.patch(
           `/${defaultUser.username}/${defaultUserContent.slug}`,
           { status: 'deleted' },
         );
 
-        expect(contentSecondResponseBody.tabcoins).toEqual(11);
+        expect(contentSecondResponseBody.tabcoins).toBe(11);
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
-        expect(userResponseBody.tabcoins).toEqual(0);
-        expect(userResponseBody.tabcash).toEqual(0);
+        expect(userResponseBody.tabcoins).toBe(0);
+        expect(userResponseBody.tabcash).toBe(0);
       });
 
       test('"root" content with negative tabcoins updated from "published" to "deleted" status (with prestige)', async () => {
@@ -2641,22 +2639,22 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const { responseBody: contentFirstGetResponseBody } = await contentsRequestBuilder.get(
           `/${defaultUser.username}/${defaultUserContent.slug}`,
         );
-        expect(contentFirstGetResponseBody.tabcoins).toEqual(-9);
+        expect(contentFirstGetResponseBody.tabcoins).toBe(-9);
 
         const { responseBody: userFirstGetResponseBody } = await usersRequestBuilder.get(`/${defaultUser.username}`);
-        expect(userFirstGetResponseBody.tabcoins).toEqual(-8);
+        expect(userFirstGetResponseBody.tabcoins).toBe(-8);
 
         const { responseBody: contentSecondResponseBody } = await contentsRequestBuilder.patch(
           `/${defaultUser.username}/${defaultUserContent.slug}`,
           { status: 'deleted' },
         );
 
-        expect(contentSecondResponseBody.tabcoins).toEqual(-9);
+        expect(contentSecondResponseBody.tabcoins).toBe(-9);
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
-        expect(userResponseBody.tabcoins).toEqual(-10);
-        expect(userResponseBody.tabcash).toEqual(0);
+        expect(userResponseBody.tabcoins).toBe(-10);
+        expect(userResponseBody.tabcash).toBe(0);
       });
 
       test('"root" content with negative tabcoins updated from "published" to "deleted" status (without prestige)', async () => {
@@ -2678,22 +2676,22 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const { responseBody: contentFirstGetResponseBody } = await contentsRequestBuilder.get(
           `/${defaultUser.username}/${defaultUserContent.slug}`,
         );
-        expect(contentFirstGetResponseBody.tabcoins).toEqual(-9);
+        expect(contentFirstGetResponseBody.tabcoins).toBe(-9);
 
         const { responseBody: userFirstGetResponseBody } = await usersRequestBuilder.get(`/${defaultUser.username}`);
-        expect(userFirstGetResponseBody.tabcoins).toEqual(-10);
+        expect(userFirstGetResponseBody.tabcoins).toBe(-10);
 
         const { responseBody: contentSecondResponseBody } = await contentsRequestBuilder.patch(
           `/${defaultUser.username}/${defaultUserContent.slug}`,
           { status: 'deleted' },
         );
 
-        expect(contentSecondResponseBody.tabcoins).toEqual(-9);
+        expect(contentSecondResponseBody.tabcoins).toBe(-9);
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
-        expect(userResponseBody.tabcoins).toEqual(-10);
-        expect(userResponseBody.tabcash).toEqual(0);
+        expect(userResponseBody.tabcoins).toBe(-10);
+        expect(userResponseBody.tabcash).toBe(0);
       });
 
       test('"child" content updated from "draft" to "draft" status', async () => {
@@ -2722,12 +2720,12 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
           { status: 'draft' },
         );
 
-        expect(responseBody.tabcoins).toEqual(0);
+        expect(responseBody.tabcoins).toBe(0);
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
-        expect(userResponseBody.tabcoins).toEqual(2);
-        expect(userResponseBody.tabcash).toEqual(0);
+        expect(userResponseBody.tabcoins).toBe(2);
+        expect(userResponseBody.tabcash).toBe(0);
       });
 
       test('"child" content updated from "draft" to "published" status (same user)', async () => {
@@ -2757,12 +2755,12 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
           { status: 'published' },
         );
 
-        expect(responseBody.tabcoins).toEqual(0);
+        expect(responseBody.tabcoins).toBe(0);
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
-        expect(userResponseBody.tabcoins).toEqual(2);
-        expect(userResponseBody.tabcash).toEqual(0);
+        expect(userResponseBody.tabcoins).toBe(2);
+        expect(userResponseBody.tabcash).toBe(0);
       });
 
       test('"child" content updated from "draft" to "published" status (different user)', async () => {
@@ -2790,20 +2788,20 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
 
         const { responseBody: userResponse1Body } = await usersRequestBuilder.get(`/${secondUser.username}`);
 
-        expect(userResponse1Body.tabcoins).toEqual(0);
-        expect(userResponse1Body.tabcash).toEqual(0);
+        expect(userResponse1Body.tabcoins).toBe(0);
+        expect(userResponse1Body.tabcash).toBe(0);
 
         const { responseBody: responseBody } = await contentsRequestBuilder.patch(
           `/${secondUser.username}/${childContent.slug}`,
           { status: 'published' },
         );
 
-        expect(responseBody.tabcoins).toEqual(1);
+        expect(responseBody.tabcoins).toBe(1);
 
         const { responseBody: userResponse2Body } = await usersRequestBuilder.get(`/${secondUser.username}`);
 
-        expect(userResponse2Body.tabcoins).toEqual(2);
-        expect(userResponse2Body.tabcash).toEqual(0);
+        expect(userResponse2Body.tabcoins).toBe(2);
+        expect(userResponse2Body.tabcash).toBe(0);
       });
 
       test('"child" content updated from "draft" to "deleted" status (same user)', async () => {
@@ -2830,20 +2828,20 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
 
         const { responseBody: userResponse1Body } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
-        expect(userResponse1Body.tabcoins).toEqual(2);
-        expect(userResponse1Body.tabcash).toEqual(0);
+        expect(userResponse1Body.tabcoins).toBe(2);
+        expect(userResponse1Body.tabcash).toBe(0);
 
         const { responseBody: responseBody } = await contentsRequestBuilder.patch(
           `/${defaultUser.username}/${childContent.slug}`,
           { status: 'deleted' },
         );
 
-        expect(responseBody.tabcoins).toEqual(0);
+        expect(responseBody.tabcoins).toBe(0);
 
         const { responseBody: userResponse2Body } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
-        expect(userResponse2Body.tabcoins).toEqual(2);
-        expect(userResponse2Body.tabcash).toEqual(0);
+        expect(userResponse2Body.tabcoins).toBe(2);
+        expect(userResponse2Body.tabcash).toBe(0);
       });
 
       test('"child" content updated from "draft" to "deleted" status (different user)', async () => {
@@ -2871,20 +2869,20 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
 
         const { responseBody: userResponse1Body } = await usersRequestBuilder.get(`/${secondUser.username}`);
 
-        expect(userResponse1Body.tabcoins).toEqual(0);
-        expect(userResponse1Body.tabcash).toEqual(0);
+        expect(userResponse1Body.tabcoins).toBe(0);
+        expect(userResponse1Body.tabcash).toBe(0);
 
         const { responseBody: responseBody } = await contentsRequestBuilder.patch(
           `/${secondUser.username}/${childContent.slug}`,
           { status: 'deleted' },
         );
 
-        expect(responseBody.tabcoins).toEqual(0);
+        expect(responseBody.tabcoins).toBe(0);
 
         const { responseBody: userResponse2Body } = await usersRequestBuilder.get(`/${secondUser.username}`);
 
-        expect(userResponse2Body.tabcoins).toEqual(0);
-        expect(userResponse2Body.tabcash).toEqual(0);
+        expect(userResponse2Body.tabcoins).toBe(0);
+        expect(userResponse2Body.tabcash).toBe(0);
       });
 
       test('"child" content updated from "published" to "deleted" status (same user - with prestige)', async () => {
@@ -2911,20 +2909,20 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
 
         const { responseBody: userResponse1Body } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
-        expect(userResponse1Body.tabcoins).toEqual(2);
-        expect(userResponse1Body.tabcash).toEqual(0);
+        expect(userResponse1Body.tabcoins).toBe(2);
+        expect(userResponse1Body.tabcash).toBe(0);
 
         const { responseBody: responseBody } = await contentsRequestBuilder.patch(
           `/${defaultUser.username}/${childContent.slug}`,
           { status: 'deleted' },
         );
 
-        expect(responseBody.tabcoins).toEqual(0);
+        expect(responseBody.tabcoins).toBe(0);
 
         const { responseBody: userResponse2Body } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
-        expect(userResponse2Body.tabcoins).toEqual(2);
-        expect(userResponse2Body.tabcash).toEqual(0);
+        expect(userResponse2Body.tabcoins).toBe(2);
+        expect(userResponse2Body.tabcash).toBe(0);
       });
 
       test('"child" content updated from "published" to "deleted" status (same user - without prestige)', async () => {
@@ -2950,20 +2948,20 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
 
         const { responseBody: userResponse1Body } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
-        expect(userResponse1Body.tabcoins).toEqual(0);
-        expect(userResponse1Body.tabcash).toEqual(0);
+        expect(userResponse1Body.tabcoins).toBe(0);
+        expect(userResponse1Body.tabcash).toBe(0);
 
         const { responseBody: responseBody } = await contentsRequestBuilder.patch(
           `/${defaultUser.username}/${childContent.slug}`,
           { status: 'deleted' },
         );
 
-        expect(responseBody.tabcoins).toEqual(0);
+        expect(responseBody.tabcoins).toBe(0);
 
         const { responseBody: userResponse2Body } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
-        expect(userResponse2Body.tabcoins).toEqual(0);
-        expect(userResponse2Body.tabcash).toEqual(0);
+        expect(userResponse2Body.tabcoins).toBe(0);
+        expect(userResponse2Body.tabcash).toBe(0);
       });
 
       test('"child" content updated from "published" to "deleted" status (different user - with prestige)', async () => {
@@ -2990,20 +2988,20 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
 
         const { responseBody: secondUserResponse1Body } = await usersRequestBuilder.get(`/${secondUser.username}`);
 
-        expect(secondUserResponse1Body.tabcoins).toEqual(2);
-        expect(secondUserResponse1Body.tabcash).toEqual(0);
+        expect(secondUserResponse1Body.tabcoins).toBe(2);
+        expect(secondUserResponse1Body.tabcash).toBe(0);
 
         const { responseBody: responseBody } = await contentsRequestBuilder.patch(
           `/${secondUser.username}/${childContent.slug}`,
           { status: 'deleted' },
         );
 
-        expect(responseBody.tabcoins).toEqual(1);
+        expect(responseBody.tabcoins).toBe(1);
 
         const { responseBody: secondUserResponse2Body } = await usersRequestBuilder.get(`/${secondUser.username}`);
 
-        expect(secondUserResponse2Body.tabcoins).toEqual(0);
-        expect(secondUserResponse2Body.tabcash).toEqual(0);
+        expect(secondUserResponse2Body.tabcoins).toBe(0);
+        expect(secondUserResponse2Body.tabcash).toBe(0);
       });
 
       test('"child" content updated from "published" to "deleted" status (different user - without prestige)', async () => {
@@ -3029,20 +3027,20 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
 
         const { responseBody: secondUserResponse1Body } = await usersRequestBuilder.get(`/${secondUser.username}`);
 
-        expect(secondUserResponse1Body.tabcoins).toEqual(0);
-        expect(secondUserResponse1Body.tabcash).toEqual(0);
+        expect(secondUserResponse1Body.tabcoins).toBe(0);
+        expect(secondUserResponse1Body.tabcash).toBe(0);
 
         const { responseBody: responseBody } = await contentsRequestBuilder.patch(
           `/${secondUser.username}/${childContent.slug}`,
           { status: 'deleted' },
         );
 
-        expect(responseBody.tabcoins).toEqual(1);
+        expect(responseBody.tabcoins).toBe(1);
 
         const { responseBody: secondUserResponse2Body } = await usersRequestBuilder.get(`/${secondUser.username}`);
 
-        expect(secondUserResponse2Body.tabcoins).toEqual(0);
-        expect(secondUserResponse2Body.tabcash).toEqual(0);
+        expect(secondUserResponse2Body.tabcoins).toBe(0);
+        expect(secondUserResponse2Body.tabcash).toBe(0);
       });
 
       test('Deletion of "child" content that was first published without the minimum amount of relevant words (without votes)', async () => {
@@ -3069,20 +3067,20 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
 
         const { responseBody: userResponse1Body } = await usersRequestBuilder.get(`/${secondUser.username}`);
 
-        expect(userResponse1Body.tabcoins).toEqual(0);
-        expect(userResponse1Body.tabcash).toEqual(0);
+        expect(userResponse1Body.tabcoins).toBe(0);
+        expect(userResponse1Body.tabcash).toBe(0);
 
         const { responseBody: responseBody } = await contentsRequestBuilder.patch(
           `/${secondUser.username}/${childContent.slug}`,
           { status: 'deleted' },
         );
 
-        expect(responseBody.tabcoins).toEqual(0);
+        expect(responseBody.tabcoins).toBe(0);
 
         const { responseBody: userResponse2Body } = await usersRequestBuilder.get(`/${secondUser.username}`);
 
-        expect(userResponse2Body.tabcoins).toEqual(0);
-        expect(userResponse2Body.tabcash).toEqual(0);
+        expect(userResponse2Body.tabcoins).toBe(0);
+        expect(userResponse2Body.tabcash).toBe(0);
       });
 
       test('Deletion of "child" content that was first published without the minimum amount of relevant words (with positive votes)', async () => {
@@ -3111,20 +3109,20 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
 
         const { responseBody: userResponse1Body } = await usersRequestBuilder.get(`/${secondUser.username}`);
 
-        expect(userResponse1Body.tabcoins).toEqual(10);
-        expect(userResponse1Body.tabcash).toEqual(0);
+        expect(userResponse1Body.tabcoins).toBe(10);
+        expect(userResponse1Body.tabcash).toBe(0);
 
         const { responseBody: responseBody } = await contentsRequestBuilder.patch(
           `/${secondUser.username}/${childContent.slug}`,
           { status: 'deleted' },
         );
 
-        expect(responseBody.tabcoins).toEqual(10);
+        expect(responseBody.tabcoins).toBe(10);
 
         const { responseBody: userResponse2Body } = await usersRequestBuilder.get(`/${secondUser.username}`);
 
-        expect(userResponse2Body.tabcoins).toEqual(0);
-        expect(userResponse2Body.tabcash).toEqual(0);
+        expect(userResponse2Body.tabcoins).toBe(0);
+        expect(userResponse2Body.tabcash).toBe(0);
       });
 
       test('Deletion of "child" content that was first published without the minimum amount of relevant words (with negative votes)', async () => {
@@ -3153,20 +3151,20 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
 
         const { responseBody: userResponse1Body } = await usersRequestBuilder.get(`/${secondUser.username}`);
 
-        expect(userResponse1Body.tabcoins).toEqual(-10);
-        expect(userResponse1Body.tabcash).toEqual(0);
+        expect(userResponse1Body.tabcoins).toBe(-10);
+        expect(userResponse1Body.tabcash).toBe(0);
 
         const { responseBody: responseBody } = await contentsRequestBuilder.patch(
           `/${secondUser.username}/${childContent.slug}`,
           { status: 'deleted' },
         );
 
-        expect(responseBody.tabcoins).toEqual(-10);
+        expect(responseBody.tabcoins).toBe(-10);
 
         const { responseBody: userResponse2Body } = await usersRequestBuilder.get(`/${secondUser.username}`);
 
-        expect(userResponse2Body.tabcoins).toEqual(-10);
-        expect(userResponse2Body.tabcash).toEqual(0);
+        expect(userResponse2Body.tabcoins).toBe(-10);
+        expect(userResponse2Body.tabcash).toBe(0);
       });
     });
   });
@@ -3192,7 +3190,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         },
       );
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: secondUserContent.id,
@@ -3214,12 +3212,12 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         owner_username: secondUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.published_at)).not.toEqual(NaN);
-      expect(responseBody.published_at).toEqual(secondUserContent.published_at.toISOString());
-      expect(responseBody.updated_at > secondUserContent.updated_at.toISOString()).toEqual(true);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.published_at)).not.toBe(NaN);
+      expect(responseBody.published_at).toBe(secondUserContent.published_at.toISOString());
+      expect(responseBody.updated_at > secondUserContent.updated_at.toISOString()).toBe(true);
     });
   });
 });

--- a/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
@@ -165,9 +165,9 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.published_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.published_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
       expect(responseBody.updated_at > childContent.updated_at.toISOString()).toBe(true);
     });
   });
@@ -212,9 +212,9 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.published_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.published_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
       expect(responseBody.updated_at > rootContent.updated_at.toISOString()).toBe(true);
     });
 
@@ -466,8 +466,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
       expect(responseBody.published_at).toBe(firstUserContent.published_at.toISOString());
       expect(responseBody.updated_at > firstUserContent.updated_at.toISOString()).toBe(true);
     });
@@ -510,8 +510,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
       expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
@@ -556,8 +556,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
       expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
@@ -657,8 +657,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
     });
 
     test('Content with "title" and "body" containing invalid characters', async () => {
@@ -777,8 +777,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
       expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
@@ -846,8 +846,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
       expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
@@ -986,9 +986,9 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.published_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.published_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
     });
 
     test('Content with "slug" containing a blank String', async () => {
@@ -1062,8 +1062,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
       expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
@@ -1157,8 +1157,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
       expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
@@ -1200,8 +1200,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
       expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
@@ -1362,8 +1362,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
       expect(responseBody.updated_at > childContent.updated_at.toISOString()).toBe(true);
     });
 
@@ -1405,8 +1405,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
       expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
@@ -1448,8 +1448,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
       expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
@@ -1491,8 +1491,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
       expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
@@ -1535,9 +1535,9 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.published_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.published_at)).not.toBeNaN();
       expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
@@ -1613,10 +1613,10 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
 
       expect(uuidVersion(responseBody.id)).toBe(4);
       expect(uuidVersion(responseBody.owner_id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.published_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.deleted_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.published_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.deleted_at)).not.toBeNaN();
       expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
       expect(responseBody.deleted_at > defaultUserContent.published_at.toISOString()).toBe(true);
     });
@@ -1804,8 +1804,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
       expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
@@ -1847,8 +1847,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
       expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
@@ -1890,8 +1890,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
       expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
@@ -1933,8 +1933,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
       expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
@@ -2111,9 +2111,9 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
-      expect(responseBody.published_at).toBe(null);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+      expect(responseBody.published_at).toBeNull();
       expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
@@ -2155,9 +2155,9 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
-      expect(responseBody.published_at).toBe(null);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+      expect(responseBody.published_at).toBeNull();
       expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
@@ -2225,8 +2225,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
       expect(responseBody.updated_at > defaultUserContent.updated_at.toISOString()).toBe(true);
     });
 
@@ -2317,8 +2317,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
       expect(responseBody.updated_at > childContent.updated_at.toISOString()).toBe(true);
     });
 
@@ -3213,9 +3213,9 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.published_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.published_at)).not.toBeNaN();
       expect(responseBody.published_at).toBe(secondUserContent.published_at.toISOString());
       expect(responseBody.updated_at > secondUserContent.updated_at.toISOString()).toBe(true);
     });

--- a/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
@@ -1,6 +1,6 @@
 import { version as uuidVersion } from 'uuid';
 
-import { maxSlugLength, maxTitleLength } from 'tests/constants-for-tests';
+import { maxSlugLength, maxTitleLength, relevantBody } from 'tests/constants-for-tests';
 import orchestrator from 'tests/orchestrator.js';
 import RequestBuilder from 'tests/request-builder';
 
@@ -1505,7 +1505,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       const defaultUserContent = await orchestrator.createContent({
         owner_id: defaultUser.id,
         title: 'Título velho',
-        body: 'Body with relevant texts needs to contain a good amount of words',
+        body: relevantBody,
         status: 'draft',
       });
 
@@ -1522,7 +1522,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         parent_id: null,
         slug: 'titulo-velho',
         title: 'Título velho',
-        body: 'Body with relevant texts needs to contain a good amount of words',
+        body: relevantBody,
         status: 'published',
         type: 'content',
         source_url: null,
@@ -1582,7 +1582,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       const defaultUserContent = await orchestrator.createContent({
         owner_id: defaultUser.id,
         title: 'Title',
-        body: 'Body with relevant texts needs to contain a good amount of words',
+        body: relevantBody,
         status: 'published',
       });
 
@@ -1599,7 +1599,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         parent_id: null,
         slug: 'title',
         title: 'Title',
-        body: 'Body with relevant texts needs to contain a good amount of words',
+        body: relevantBody,
         status: 'deleted',
         type: 'content',
         tabcoins: 1,
@@ -2389,7 +2389,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const defaultUserContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
           title: 'Title',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'draft',
         });
 
@@ -2441,7 +2441,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const defaultUserContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
           title: 'Title',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'published',
         });
 
@@ -2479,7 +2479,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const defaultUserContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
           title: 'Title',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'published',
         });
 
@@ -2543,7 +2543,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const defaultUserContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
           title: 'Title',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'published',
         });
 
@@ -2586,7 +2586,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const defaultUserContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
           title: 'Title',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'published',
         });
 
@@ -2624,7 +2624,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const defaultUserContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
           title: 'Title',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'published',
         });
 
@@ -2667,7 +2667,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const defaultUserContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
           title: 'Title',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'published',
         });
 
@@ -2706,7 +2706,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const rootContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
           title: 'Root',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'published',
         });
 
@@ -2714,7 +2714,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
           owner_id: defaultUser.id,
           parent_id: rootContent.id,
           title: 'Child',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
         });
 
         const { responseBody: responseBody } = await contentsRequestBuilder.patch(
@@ -2740,7 +2740,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const rootContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
           title: 'Root',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'published',
         });
 
@@ -2748,7 +2748,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
           owner_id: defaultUser.id,
           parent_id: rootContent.id,
           title: 'Child',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'draft',
         });
 
@@ -2776,7 +2776,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const rootContent = await orchestrator.createContent({
           owner_id: firstUser.id,
           title: 'Root',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'published',
         });
 
@@ -2784,7 +2784,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
           owner_id: secondUser.id,
           parent_id: rootContent.id,
           title: 'Child',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'draft',
         });
 
@@ -2816,7 +2816,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const rootContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
           title: 'Root',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'published',
         });
 
@@ -2824,7 +2824,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
           owner_id: defaultUser.id,
           parent_id: rootContent.id,
           title: 'Child',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'draft',
         });
 
@@ -2857,7 +2857,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const rootContent = await orchestrator.createContent({
           owner_id: firstUser.id,
           title: 'Root',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'published',
         });
 
@@ -2865,7 +2865,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
           owner_id: secondUser.id,
           parent_id: rootContent.id,
           title: 'Child',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'draft',
         });
 
@@ -2897,7 +2897,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const rootContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
           title: 'Root',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'published',
         });
 
@@ -2905,7 +2905,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
           owner_id: defaultUser.id,
           parent_id: rootContent.id,
           title: 'Child',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'published',
         });
 
@@ -2936,7 +2936,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const rootContent = await orchestrator.createContent({
           owner_id: defaultUser.id,
           title: 'Root',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'published',
         });
 
@@ -2944,7 +2944,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
           owner_id: defaultUser.id,
           parent_id: rootContent.id,
           title: 'Child',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'published',
         });
 
@@ -2976,7 +2976,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const rootContent = await orchestrator.createContent({
           owner_id: firstUser.id,
           title: 'Root',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'published',
         });
 
@@ -2984,7 +2984,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
           owner_id: secondUser.id,
           parent_id: rootContent.id,
           title: 'Child',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'published',
         });
 
@@ -3015,7 +3015,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const rootContent = await orchestrator.createContent({
           owner_id: firstUser.id,
           title: 'Root',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'published',
         });
 
@@ -3023,7 +3023,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
           owner_id: secondUser.id,
           parent_id: rootContent.id,
           title: 'Child',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'published',
         });
 
@@ -3055,7 +3055,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const rootContent = await orchestrator.createContent({
           owner_id: firstUser.id,
           title: 'Root',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'published',
         });
 
@@ -3095,7 +3095,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const rootContent = await orchestrator.createContent({
           owner_id: firstUser.id,
           title: 'Root',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'published',
         });
 
@@ -3137,7 +3137,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         const rootContent = await orchestrator.createContent({
           owner_id: firstUser.id,
           title: 'Root',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'published',
         });
 
@@ -3180,7 +3180,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       const secondUserContent = await orchestrator.createContent({
         owner_id: secondUser.id,
         title: 'Conteúdo do Segundo Usuário antes do patch!',
-        body: 'Body antes do patch! - Body with relevant texts needs to contain a good amount of words',
+        body: relevantBody,
         status: 'published',
       });
 

--- a/tests/integration/api/v1/contents/[username]/[slug]/root/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/root/get.test.js
@@ -1,5 +1,6 @@
 import { version as uuidVersion } from 'uuid';
 
+import { relevantBody } from 'tests/constants-for-tests';
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {
@@ -196,7 +197,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
       const rootContent = await orchestrator.createContent({
         owner_id: firstUser.id,
         title: 'Root content title',
-        body: 'Body with relevant texts needs to contain a good amount of words',
+        body: relevantBody,
         status: 'published',
       });
 
@@ -221,7 +222,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
         owner_id: firstUser.id,
         slug: 'root-content-title',
         title: 'Root content title',
-        body: 'Body with relevant texts needs to contain a good amount of words',
+        body: relevantBody,
         children_deep_count: 1,
         status: 'published',
         type: 'content',
@@ -244,7 +245,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
       const rootContent = await orchestrator.createContent({
         owner_id: firstUser.id,
         title: 'Root content title',
-        body: 'Body with relevant texts needs to contain a good amount of words',
+        body: relevantBody,
         status: 'published',
       });
 
@@ -285,7 +286,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
         owner_id: firstUser.id,
         slug: 'root-content-title',
         title: 'Root content title',
-        body: 'Body with relevant texts needs to contain a good amount of words',
+        body: relevantBody,
         children_deep_count: 3,
         status: 'published',
         type: 'content',
@@ -308,7 +309,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
       const rootContent = await orchestrator.createContent({
         owner_id: firstUser.id,
         title: 'Root content title',
-        body: 'Body with relevant texts needs to contain a good amount of words',
+        body: relevantBody,
         status: 'published',
       });
 
@@ -354,7 +355,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
         owner_id: firstUser.id,
         slug: 'root-content-title',
         title: 'Root content title',
-        body: 'Body with relevant texts needs to contain a good amount of words',
+        body: relevantBody,
         children_deep_count: 2,
         status: 'published',
         type: 'content',
@@ -446,7 +447,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
       const rootContent = await orchestrator.createContent({
         owner_id: firstUser.id,
         title: 'Root content title',
-        body: 'Root - Body with relevant texts needs to contain a good amount of words',
+        body: relevantBody,
         status: 'published',
         source_url: 'https://www.tabnews.com.br/',
       });
@@ -516,7 +517,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
       const rootContent = await orchestrator.createContent({
         owner_id: firstUser.id,
         title: 'Root content title',
-        body: 'Body with relevant texts needs to contain a good amount of words',
+        body: relevantBody,
         status: 'published',
       });
 
@@ -552,7 +553,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
         owner_id: firstUser.id,
         slug: 'root-content-title',
         title: 'Root content title',
-        body: 'Body with relevant texts needs to contain a good amount of words',
+        body: relevantBody,
         children_deep_count: 2,
         status: 'published',
         type: 'content',

--- a/tests/integration/api/v1/contents/[username]/[slug]/root/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/root/get.test.js
@@ -24,7 +24,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(404);
+      expect(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -37,8 +37,8 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
         key: 'slug',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('From "root" content with "deleted" status', async () => {
@@ -56,7 +56,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(404);
+      expect(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -69,8 +69,8 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
         key: 'slug',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('From "root" content with "published" status', async () => {
@@ -86,7 +86,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(404);
+      expect(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -100,8 +100,8 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
         key: 'parent_id',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('From "child" content 1 level deep with "draft" status', async () => {
@@ -128,7 +128,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(404);
+      expect(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -141,8 +141,8 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
         key: 'slug',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('From "child" content 1 level deep with "deleted" status', async () => {
@@ -173,7 +173,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(404);
+      expect(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -186,8 +186,8 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
         key: 'slug',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('From "child" content 1 level deep with "published" status', async () => {
@@ -214,7 +214,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: rootContent.id,
@@ -278,7 +278,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: rootContent.id,
@@ -347,7 +347,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: rootContent.id,
@@ -416,7 +416,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: rootContent.id,
@@ -486,7 +486,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: rootContent.id,
@@ -545,7 +545,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: rootContent.id,

--- a/tests/integration/api/v1/contents/[username]/[slug]/tabcoins/post.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/tabcoins/post.test.js
@@ -1,3 +1,4 @@
+import { relevantBody } from 'tests/constants-for-tests';
 import orchestrator from 'tests/orchestrator.js';
 import RequestBuilder from 'tests/request-builder';
 
@@ -110,7 +111,7 @@ describe('POST /api/v1/contents/tabcoins', () => {
       const firstUserContent = await orchestrator.createContent({
         owner_id: firstUser.id,
         title: 'Root',
-        body: 'Body with relevant texts needs to contain a good amount of words',
+        body: relevantBody,
         status: 'published',
       });
 
@@ -155,7 +156,7 @@ describe('POST /api/v1/contents/tabcoins', () => {
       const firstUserContent = await orchestrator.createContent({
         owner_id: firstUser.id,
         title: 'Root',
-        body: 'Body with relevant texts needs to contain a good amount of words',
+        body: relevantBody,
         status: 'published',
       });
 
@@ -338,7 +339,7 @@ describe('POST /api/v1/contents/tabcoins', () => {
       const firstUserContent = await orchestrator.createContent({
         owner_id: firstUser.id,
         title: 'Root',
-        body: 'Body with relevant texts needs to contain a good amount of words',
+        body: relevantBody,
         status: 'published',
       });
 

--- a/tests/integration/api/v1/contents/[username]/[slug]/tabcoins/post.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/tabcoins/post.test.js
@@ -142,13 +142,13 @@ describe('POST /api/v1/contents/tabcoins', () => {
       const usersRequestBuilder = new RequestBuilder('/api/v1/users');
       const { responseBody: firstUserResponseBody } = await usersRequestBuilder.get(`/${firstUser.username}`);
 
-      expect(firstUserResponseBody.tabcoins).toStrictEqual(1);
-      expect(firstUserResponseBody.tabcash).toStrictEqual(0);
+      expect(firstUserResponseBody.tabcoins).toBe(1);
+      expect(firstUserResponseBody.tabcash).toBe(0);
 
       const { responseBody: secondUserResponseBody } = await usersRequestBuilder.get(`/${secondUser.username}`);
 
-      expect(secondUserResponseBody.tabcoins).toStrictEqual(0);
-      expect(secondUserResponseBody.tabcash).toStrictEqual(1);
+      expect(secondUserResponseBody.tabcoins).toBe(0);
+      expect(secondUserResponseBody.tabcash).toBe(1);
     });
 
     test('With "transaction_type" set to "debit"', async () => {
@@ -187,13 +187,13 @@ describe('POST /api/v1/contents/tabcoins', () => {
       const usersRequestBuilder = new RequestBuilder('/api/v1/users');
       const { responseBody: firstUserResponseBody } = await usersRequestBuilder.get(`/${firstUser.username}`);
 
-      expect(firstUserResponseBody.tabcoins).toStrictEqual(-1);
-      expect(firstUserResponseBody.tabcash).toStrictEqual(0);
+      expect(firstUserResponseBody.tabcoins).toBe(-1);
+      expect(firstUserResponseBody.tabcash).toBe(0);
 
       const { responseBody: secondUserResponseBody } = await usersRequestBuilder.get(`/${secondUser.username}`);
 
-      expect(secondUserResponseBody.tabcoins).toStrictEqual(0);
-      expect(secondUserResponseBody.tabcash).toStrictEqual(1);
+      expect(secondUserResponseBody.tabcoins).toBe(0);
+      expect(secondUserResponseBody.tabcash).toBe(1);
     });
 
     test('With "transaction_type" set to "credit" four times (should be blocked)', async () => {
@@ -256,13 +256,13 @@ describe('POST /api/v1/contents/tabcoins', () => {
       const usersRequestBuilder = new RequestBuilder('/api/v1/users');
       const { responseBody: firstUserResponseBody } = await usersRequestBuilder.get(`/${firstUser.username}`);
 
-      expect(firstUserResponseBody.tabcoins).toStrictEqual(3);
-      expect(firstUserResponseBody.tabcash).toStrictEqual(0);
+      expect(firstUserResponseBody.tabcoins).toBe(3);
+      expect(firstUserResponseBody.tabcash).toBe(0);
 
       const { responseBody: secondUserResponseBody } = await usersRequestBuilder.get(`/${secondUser.username}`);
 
-      expect(secondUserResponseBody.tabcoins).toStrictEqual(2);
-      expect(secondUserResponseBody.tabcash).toStrictEqual(3);
+      expect(secondUserResponseBody.tabcoins).toBe(2);
+      expect(secondUserResponseBody.tabcash).toBe(3);
     });
 
     test('With "transaction_type" set to "debit" four times (should be blocked)', async () => {
@@ -325,13 +325,13 @@ describe('POST /api/v1/contents/tabcoins', () => {
       const usersRequestBuilder = new RequestBuilder('/api/v1/users');
       const { responseBody: firstUserResponseBody } = await usersRequestBuilder.get(`/${firstUser.username}`);
 
-      expect(firstUserResponseBody.tabcoins).toStrictEqual(-3);
-      expect(firstUserResponseBody.tabcash).toStrictEqual(0);
+      expect(firstUserResponseBody.tabcoins).toBe(-3);
+      expect(firstUserResponseBody.tabcash).toBe(0);
 
       const { responseBody: secondUserResponseBody } = await usersRequestBuilder.get(`/${secondUser.username}`);
 
-      expect(secondUserResponseBody.tabcoins).toStrictEqual(2);
-      expect(secondUserResponseBody.tabcash).toStrictEqual(3);
+      expect(secondUserResponseBody.tabcoins).toBe(2);
+      expect(secondUserResponseBody.tabcash).toBe(3);
     });
 
     test('With "transaction_type" set to "debit" twice to make content "tabcoins" negative', async () => {
@@ -371,13 +371,13 @@ describe('POST /api/v1/contents/tabcoins', () => {
       const usersRequestBuilder = new RequestBuilder('/api/v1/users');
       const { responseBody: firstUserResponse1Body } = await usersRequestBuilder.get(`/${firstUser.username}`);
 
-      expect(firstUserResponse1Body.tabcoins).toStrictEqual(-1);
-      expect(firstUserResponse1Body.tabcash).toStrictEqual(0);
+      expect(firstUserResponse1Body.tabcoins).toBe(-1);
+      expect(firstUserResponse1Body.tabcash).toBe(0);
 
       const { responseBody: secondUserResponse1Body } = await usersRequestBuilder.get(`/${secondUser.username}`);
 
-      expect(secondUserResponse1Body.tabcoins).toStrictEqual(2);
-      expect(secondUserResponse1Body.tabcash).toStrictEqual(1);
+      expect(secondUserResponse1Body.tabcoins).toBe(2);
+      expect(secondUserResponse1Body.tabcash).toBe(1);
 
       // ROUND 2 OF DEBIT
       const { response: postTabCoinsResponse2, responseBody: postTabCoinsResponse2Body } =
@@ -395,13 +395,13 @@ describe('POST /api/v1/contents/tabcoins', () => {
 
       const { responseBody: firstUserResponse2Body } = await usersRequestBuilder.get(`/${firstUser.username}`);
 
-      expect(firstUserResponse2Body.tabcoins).toStrictEqual(-2);
-      expect(firstUserResponse2Body.tabcash).toStrictEqual(0);
+      expect(firstUserResponse2Body.tabcoins).toBe(-2);
+      expect(firstUserResponse2Body.tabcash).toBe(0);
 
       const { responseBody: secondUserResponse2Body } = await usersRequestBuilder.get(`/${secondUser.username}`);
 
-      expect(secondUserResponse2Body.tabcoins).toStrictEqual(0);
-      expect(secondUserResponse2Body.tabcash).toStrictEqual(2);
+      expect(secondUserResponse2Body.tabcoins).toBe(0);
+      expect(secondUserResponse2Body.tabcash).toBe(2);
     });
 
     test('With 20 simultaneous posts, but enough TabCoins for 1', async () => {
@@ -438,9 +438,9 @@ describe('POST /api/v1/contents/tabcoins', () => {
       const successPostIndex1 = postTabCoinsResponsesStatus.indexOf(201);
       const successPostIndex2 = postTabCoinsResponsesStatus.indexOf(201, successPostIndex1 + 1);
 
-      expect(successPostIndex1).not.toEqual(-1);
-      expect(successPostIndex2).toEqual(-1);
-      expect(postTabCoinsResponsesStatus[successPostIndex1]).toEqual(201);
+      expect(successPostIndex1).not.toBe(-1);
+      expect(successPostIndex2).toBe(-1);
+      expect(postTabCoinsResponsesStatus[successPostIndex1]).toBe(201);
 
       expect(postTabCoinsResponsesBody[successPostIndex1]).toStrictEqual({
         tabcoins: 1,
@@ -451,7 +451,7 @@ describe('POST /api/v1/contents/tabcoins', () => {
       postTabCoinsResponsesStatus.splice(successPostIndex1, 1);
       postTabCoinsResponsesBody.splice(successPostIndex1, 1);
 
-      postTabCoinsResponsesStatus.forEach((status) => expect(status).toEqual(422));
+      postTabCoinsResponsesStatus.forEach((status) => expect(status).toBe(422));
 
       expect(postTabCoinsResponsesBody).toContainEqual({
         name: 'UnprocessableEntityError',
@@ -466,13 +466,13 @@ describe('POST /api/v1/contents/tabcoins', () => {
       const usersRequestBuilder = new RequestBuilder('/api/v1/users');
       const { responseBody: firstUserResponseBody } = await usersRequestBuilder.get(`/${firstUser.username}`);
 
-      expect(firstUserResponseBody.tabcoins).toStrictEqual(1);
-      expect(firstUserResponseBody.tabcash).toStrictEqual(0);
+      expect(firstUserResponseBody.tabcoins).toBe(1);
+      expect(firstUserResponseBody.tabcash).toBe(0);
 
       const { responseBody: secondUserResponseBody } = await usersRequestBuilder.get(`/${secondUser.username}`);
 
-      expect(secondUserResponseBody.tabcoins).toStrictEqual(0);
-      expect(secondUserResponseBody.tabcash).toStrictEqual(1);
+      expect(secondUserResponseBody.tabcoins).toBe(0);
+      expect(secondUserResponseBody.tabcash).toBe(1);
     });
 
     // This tests are being temporarily skipped because of the new feature of not allowing
@@ -517,14 +517,14 @@ describe('POST /api/v1/contents/tabcoins', () => {
 
       for (let i = 0; i < timesSuccessfully; i++) {
         successPostIndexes.push(postTabCoinsResponsesStatus.indexOf(201, successPostIndexes[i] + 1));
-        expect(successPostIndexes[i]).not.toEqual(-1);
-        expect(postTabCoinsResponsesStatus[successPostIndexes[i]]).toEqual(201);
+        expect(successPostIndexes[i]).not.toBe(-1);
+        expect(postTabCoinsResponsesStatus[successPostIndexes[i]]).toBe(201);
         expect(postTabCoinsResponsesBody).toContainEqual({
           tabcoins: 2 + i,
         });
       }
 
-      expect(successPostIndexes[timesSuccessfully]).toEqual(-1);
+      expect(successPostIndexes[timesSuccessfully]).toBe(-1);
 
       successPostIndexes.splice(-1, 1);
       successPostIndexes.reverse();
@@ -534,7 +534,7 @@ describe('POST /api/v1/contents/tabcoins', () => {
         postTabCoinsResponsesBody.splice(idx, 1);
       });
 
-      postTabCoinsResponsesStatus.forEach((status) => expect(status).toEqual(422));
+      postTabCoinsResponsesStatus.forEach((status) => expect(status).toBe(422));
 
       postTabCoinsResponsesBody.forEach((responseBody) =>
         expect(responseBody).toStrictEqual({
@@ -551,13 +551,13 @@ describe('POST /api/v1/contents/tabcoins', () => {
       const usersRequestBuilder = new RequestBuilder('/api/v1/users');
       const { responseBody: firstUserResponseBody } = await usersRequestBuilder.get(`/${firstUser.username}`);
 
-      expect(firstUserResponseBody.tabcoins).toStrictEqual(2 + timesSuccessfully);
-      expect(firstUserResponseBody.tabcash).toStrictEqual(0);
+      expect(firstUserResponseBody.tabcoins).toBe(2 + timesSuccessfully);
+      expect(firstUserResponseBody.tabcash).toBe(0);
 
       const { responseBody: secondUserResponseBody } = await usersRequestBuilder.get(`/${secondUser.username}`);
 
-      expect(secondUserResponseBody.tabcoins).toStrictEqual(0);
-      expect(secondUserResponseBody.tabcash).toStrictEqual(timesSuccessfully);
+      expect(secondUserResponseBody.tabcoins).toBe(0);
+      expect(secondUserResponseBody.tabcash).toBe(timesSuccessfully);
     });
 
     // eslint-disable-next-line vitest/no-disabled-tests
@@ -600,7 +600,7 @@ describe('POST /api/v1/contents/tabcoins', () => {
 
       const postTabCoinsResponsesBody = await Promise.all(postTabCoinsResponsesBodyPromises);
 
-      expect([201, 422]).toEqual(expect.arrayContaining(postTabCoinsResponsesStatus));
+      expect([201, 422]).toBe(expect.arrayContaining(postTabCoinsResponsesStatus));
 
       expect(postTabCoinsResponsesBody).toContainEqual(
         expect.objectContaining({

--- a/tests/integration/api/v1/contents/[username]/[slug]/thumbnail/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/thumbnail/get.test.js
@@ -25,7 +25,7 @@ describe('GET /api/v1/contents/[username]/[slug]/thumbnail', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(404);
+      expect(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -39,8 +39,8 @@ describe('GET /api/v1/contents/[username]/[slug]/thumbnail', () => {
         key: 'slug',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('"root" content with "deleted" status', async () => {
@@ -58,7 +58,7 @@ describe('GET /api/v1/contents/[username]/[slug]/thumbnail', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(404);
+      expect(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -72,8 +72,8 @@ describe('GET /api/v1/contents/[username]/[slug]/thumbnail', () => {
         key: 'slug',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('"root" content with short "title", short "username" and 0 "children"', async () => {
@@ -114,8 +114,8 @@ describe('GET /api/v1/contents/[username]/[slug]/thumbnail', () => {
         ),
       );
 
-      expect(response.status).toEqual(200);
-      expect(Buffer.compare(benchmarkFile, responseBody)).toEqual(0); // has the same bytes
+      expect(response.status).toBe(200);
+      expect(Buffer.compare(benchmarkFile, responseBody)).toBe(0); // has the same bytes
     });
 
     test('"root" content with long "title", long "username" and 0 "children"', async () => {
@@ -157,8 +157,8 @@ describe('GET /api/v1/contents/[username]/[slug]/thumbnail', () => {
         ),
       );
 
-      expect(response.status).toEqual(200);
-      expect(Buffer.compare(benchmarkFile, responseBody)).toEqual(0); // has the same bytes
+      expect(response.status).toBe(200);
+      expect(Buffer.compare(benchmarkFile, responseBody)).toBe(0); // has the same bytes
     });
 
     test('"root" content with long "title", long "username" and 2 "children"', async () => {
@@ -214,8 +214,8 @@ describe('GET /api/v1/contents/[username]/[slug]/thumbnail', () => {
         ),
       );
 
-      expect(response.status).toEqual(200);
-      expect(Buffer.compare(benchmarkFile, responseBody)).toEqual(0); // has the same bytes
+      expect(response.status).toBe(200);
+      expect(Buffer.compare(benchmarkFile, responseBody)).toBe(0); // has the same bytes
     });
 
     test('"child" content with short "parent_title", short "body" and 0 "children"', async () => {
@@ -263,8 +263,8 @@ describe('GET /api/v1/contents/[username]/[slug]/thumbnail', () => {
         ),
       );
 
-      expect(response.status).toEqual(200);
-      expect(Buffer.compare(benchmarkFile, responseBody)).toEqual(0); // has the same bytes
+      expect(response.status).toBe(200);
+      expect(Buffer.compare(benchmarkFile, responseBody)).toBe(0); // has the same bytes
     });
 
     test('"child" content with long "parent_title", long "body" and 0 "children"', async () => {
@@ -313,8 +313,8 @@ describe('GET /api/v1/contents/[username]/[slug]/thumbnail', () => {
         ),
       );
 
-      expect(response.status).toEqual(200);
-      expect(Buffer.compare(benchmarkFile, responseBody)).toEqual(0); // has the same bytes
+      expect(response.status).toBe(200);
+      expect(Buffer.compare(benchmarkFile, responseBody)).toBe(0); // has the same bytes
     });
 
     test('"child" of a "child" content with "parent_title"', async () => {
@@ -369,8 +369,8 @@ describe('GET /api/v1/contents/[username]/[slug]/thumbnail', () => {
         ),
       );
 
-      expect(response.status).toEqual(200);
-      expect(Buffer.compare(benchmarkFile, responseBody)).toEqual(0); // has the same bytes
+      expect(response.status).toBe(200);
+      expect(Buffer.compare(benchmarkFile, responseBody)).toBe(0); // has the same bytes
     });
 
     test('"child" of a "child" content without "parent_title"', async () => {
@@ -425,8 +425,8 @@ describe('GET /api/v1/contents/[username]/[slug]/thumbnail', () => {
         ),
       );
 
-      expect(response.status).toEqual(200);
-      expect(Buffer.compare(benchmarkFile, responseBody)).toEqual(0); // has the same bytes
+      expect(response.status).toBe(200);
+      expect(Buffer.compare(benchmarkFile, responseBody)).toBe(0); // has the same bytes
     });
   });
 });

--- a/tests/integration/api/v1/contents/[username]/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/get.test.js
@@ -16,14 +16,14 @@ describe('GET /api/v1/contents/[username]', () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents/ThisUserDoesNotExists`);
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(404);
-      expect(responseBody.status_code).toEqual(404);
-      expect(responseBody.name).toEqual('NotFoundError');
-      expect(responseBody.message).toEqual('O "username" informado não foi encontrado no sistema.');
-      expect(responseBody.action).toEqual('Verifique se o "username" está digitado corretamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:USER:FIND_ONE_BY_USERNAME:NOT_FOUND');
+      expect(response.status).toBe(404);
+      expect(responseBody.status_code).toBe(404);
+      expect(responseBody.name).toBe('NotFoundError');
+      expect(responseBody.message).toBe('O "username" informado não foi encontrado no sistema.');
+      expect(responseBody.action).toBe('Verifique se o "username" está digitado corretamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:USER:FIND_ONE_BY_USERNAME:NOT_FOUND');
     });
 
     test('"username" existent, but with no content at all', async () => {
@@ -40,7 +40,7 @@ describe('GET /api/v1/contents/[username]', () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}`);
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
       expect(responseBody).toEqual([]);
     });
 
@@ -66,7 +66,7 @@ describe('GET /api/v1/contents/[username]', () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}`);
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
       expect(responseBody).toEqual([]);
     });
 
@@ -106,7 +106,7 @@ describe('GET /api/v1/contents/[username]', () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents/${firstUser.username}`);
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
       expect(responseBody).toEqual([
         {
           id: childContent.id,
@@ -166,7 +166,7 @@ describe('GET /api/v1/contents/[username]', () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents/${firstUser.username}`);
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
       expect(responseBody).toEqual([
         {
           id: childContent.id,
@@ -234,7 +234,7 @@ describe('GET /api/v1/contents/[username]', () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents/${firstUser.username}?strategy=new`);
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual([
         {
@@ -297,11 +297,11 @@ describe('GET /api/v1/contents/[username]', () => {
         },
       ]);
 
-      expect(uuidVersion(responseBody[0].id)).toEqual(4);
-      expect(uuidVersion(responseBody[1].id)).toEqual(4);
-      expect(uuidVersion(responseBody[0].owner_id)).toEqual(4);
-      expect(uuidVersion(responseBody[1].owner_id)).toEqual(4);
-      expect(responseBody[0].published_at > responseBody[1].published_at).toEqual(true);
+      expect(uuidVersion(responseBody[0].id)).toBe(4);
+      expect(uuidVersion(responseBody[1].id)).toBe(4);
+      expect(uuidVersion(responseBody[0].owner_id)).toBe(4);
+      expect(uuidVersion(responseBody[1].owner_id)).toBe(4);
+      expect(responseBody[0].published_at > responseBody[1].published_at).toBe(true);
     });
 
     test('"username" existent with 4 contents, but only 2 "root" "published"', async () => {
@@ -348,7 +348,7 @@ describe('GET /api/v1/contents/[username]', () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents/${firstUser.username}?strategy=new`);
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual([
         {
@@ -411,11 +411,11 @@ describe('GET /api/v1/contents/[username]', () => {
         },
       ]);
 
-      expect(uuidVersion(responseBody[0].id)).toEqual(4);
-      expect(uuidVersion(responseBody[1].id)).toEqual(4);
-      expect(uuidVersion(responseBody[0].owner_id)).toEqual(4);
-      expect(uuidVersion(responseBody[1].owner_id)).toEqual(4);
-      expect(responseBody[0].published_at > responseBody[1].published_at).toEqual(true);
+      expect(uuidVersion(responseBody[0].id)).toBe(4);
+      expect(uuidVersion(responseBody[1].id)).toBe(4);
+      expect(uuidVersion(responseBody[0].owner_id)).toBe(4);
+      expect(uuidVersion(responseBody[1].owner_id)).toBe(4);
+      expect(responseBody[0].published_at > responseBody[1].published_at).toBe(true);
     });
 
     test('"username" existent with "root" and "child" content with TabCoins credits and debits', async () => {
@@ -444,7 +444,7 @@ describe('GET /api/v1/contents/[username]', () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents/${firstUser.username}?strategy=new`);
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual([
         {
@@ -488,11 +488,11 @@ describe('GET /api/v1/contents/[username]', () => {
         },
       ]);
 
-      expect(uuidVersion(responseBody[0].id)).toEqual(4);
-      expect(uuidVersion(responseBody[1].id)).toEqual(4);
-      expect(uuidVersion(responseBody[0].owner_id)).toEqual(4);
-      expect(uuidVersion(responseBody[1].owner_id)).toEqual(4);
-      expect(responseBody[0].published_at > responseBody[1].published_at).toEqual(true);
+      expect(uuidVersion(responseBody[0].id)).toBe(4);
+      expect(uuidVersion(responseBody[1].id)).toBe(4);
+      expect(uuidVersion(responseBody[0].owner_id)).toBe(4);
+      expect(uuidVersion(responseBody[1].owner_id)).toBe(4);
+      expect(responseBody[0].published_at > responseBody[1].published_at).toBe(true);
     });
 
     test('"username" existent with 60 contents, default pagination and strategy "new"', async () => {
@@ -560,8 +560,8 @@ describe('GET /api/v1/contents/[username]', () => {
       const responseLinkHeader = parseLinkHeader(response.headers.get('Link'));
       const responseTotalRowsHeader = response.headers.get('X-Pagination-Total-Rows');
 
-      expect(response.status).toEqual(200);
-      expect(responseTotalRowsHeader).toEqual('60');
+      expect(response.status).toBe(200);
+      expect(responseTotalRowsHeader).toBe('60');
       expect(responseLinkHeader).toStrictEqual({
         first: {
           page: '1',
@@ -586,14 +586,14 @@ describe('GET /api/v1/contents/[username]', () => {
         },
       });
 
-      expect(responseBody.length).toEqual(30);
-      expect(responseBody[0].title).toEqual('Conteúdo #60');
-      expect(responseBody[1].title).toEqual('Conteúdo #59');
-      expect(responseBody[2].title).toEqual('Conteúdo #58');
-      expect(responseBody[15].title).toEqual('Conteúdo #45');
-      expect(responseBody[27].title).toEqual('Conteúdo #33');
-      expect(responseBody[28].title).toEqual('Conteúdo #32');
-      expect(responseBody[29].title).toEqual('Conteúdo #31');
+      expect(responseBody.length).toBe(30);
+      expect(responseBody[0].title).toBe('Conteúdo #60');
+      expect(responseBody[1].title).toBe('Conteúdo #59');
+      expect(responseBody[2].title).toBe('Conteúdo #58');
+      expect(responseBody[15].title).toBe('Conteúdo #45');
+      expect(responseBody[27].title).toBe('Conteúdo #33');
+      expect(responseBody[28].title).toBe('Conteúdo #32');
+      expect(responseBody[29].title).toBe('Conteúdo #31');
 
       const page2Response = await fetch(responseLinkHeader.next.url);
       const page2ResponseBody = await page2Response.json();
@@ -601,8 +601,8 @@ describe('GET /api/v1/contents/[username]', () => {
       const page2ResponseLinkHeader = parseLinkHeader(page2Response.headers.get('Link'));
       const page2ResponseTotalRowsHeader = page2Response.headers.get('X-Pagination-Total-Rows');
 
-      expect(page2Response.status).toEqual(200);
-      expect(page2ResponseTotalRowsHeader).toEqual('60');
+      expect(page2Response.status).toBe(200);
+      expect(page2ResponseTotalRowsHeader).toBe('60');
       expect(page2ResponseLinkHeader).toStrictEqual({
         first: {
           page: '1',
@@ -627,12 +627,12 @@ describe('GET /api/v1/contents/[username]', () => {
         },
       });
 
-      expect(page2ResponseBody.length).toEqual(30);
-      expect(page2ResponseBody[0].title).toEqual('Conteúdo #30');
-      expect(page2ResponseBody[1].title).toEqual('Conteúdo #29');
-      expect(page2ResponseBody[27].title).toEqual('Conteúdo #3');
-      expect(page2ResponseBody[28].title).toEqual('Conteúdo #2');
-      expect(page2ResponseBody[29].title).toEqual('Conteúdo #1');
+      expect(page2ResponseBody.length).toBe(30);
+      expect(page2ResponseBody[0].title).toBe('Conteúdo #30');
+      expect(page2ResponseBody[1].title).toBe('Conteúdo #29');
+      expect(page2ResponseBody[27].title).toBe('Conteúdo #3');
+      expect(page2ResponseBody[28].title).toBe('Conteúdo #2');
+      expect(page2ResponseBody[29].title).toBe('Conteúdo #1');
     });
 
     test('"username" existent with 60 contents, default pagination and strategy "relevant"', async () => {
@@ -702,8 +702,8 @@ describe('GET /api/v1/contents/[username]', () => {
       const responseLinkHeader = parseLinkHeader(response.headers.get('Link'));
       const responseTotalRowsHeader = response.headers.get('X-Pagination-Total-Rows');
 
-      expect(response.status).toEqual(200);
-      expect(responseTotalRowsHeader).toEqual('60');
+      expect(response.status).toBe(200);
+      expect(responseTotalRowsHeader).toBe('60');
       expect(responseLinkHeader).toStrictEqual({
         first: {
           page: '1',
@@ -728,16 +728,16 @@ describe('GET /api/v1/contents/[username]', () => {
         },
       });
 
-      expect(responseBody.length).toEqual(30);
-      expect(responseBody[0].title).toEqual('Conteúdo #31');
-      expect(responseBody[1].title).toEqual('Conteúdo #36');
-      expect(responseBody[2].title).toEqual('Conteúdo #59');
-      expect(responseBody[3].title).toEqual('Conteúdo #58');
-      expect(responseBody[6].title).toEqual('Conteúdo #55');
-      expect(responseBody[26].title).toEqual('Conteúdo #32');
-      expect(responseBody[27].title).toEqual('Conteúdo #60');
-      expect(responseBody[28].title).toEqual('Conteúdo #50');
-      expect(responseBody[29].title).toEqual('Conteúdo #51');
+      expect(responseBody.length).toBe(30);
+      expect(responseBody[0].title).toBe('Conteúdo #31');
+      expect(responseBody[1].title).toBe('Conteúdo #36');
+      expect(responseBody[2].title).toBe('Conteúdo #59');
+      expect(responseBody[3].title).toBe('Conteúdo #58');
+      expect(responseBody[6].title).toBe('Conteúdo #55');
+      expect(responseBody[26].title).toBe('Conteúdo #32');
+      expect(responseBody[27].title).toBe('Conteúdo #60');
+      expect(responseBody[28].title).toBe('Conteúdo #50');
+      expect(responseBody[29].title).toBe('Conteúdo #51');
 
       const page2Response = await fetch(responseLinkHeader.next.url);
       const page2ResponseBody = await page2Response.json();
@@ -745,8 +745,8 @@ describe('GET /api/v1/contents/[username]', () => {
       const page2ResponseLinkHeader = parseLinkHeader(page2Response.headers.get('Link'));
       const page2ResponseTotalRowsHeader = page2Response.headers.get('X-Pagination-Total-Rows');
 
-      expect(page2Response.status).toEqual(200);
-      expect(page2ResponseTotalRowsHeader).toEqual('60');
+      expect(page2Response.status).toBe(200);
+      expect(page2ResponseTotalRowsHeader).toBe('60');
       expect(page2ResponseLinkHeader).toStrictEqual({
         first: {
           page: '1',
@@ -771,12 +771,12 @@ describe('GET /api/v1/contents/[username]', () => {
         },
       });
 
-      expect(page2ResponseBody.length).toEqual(30);
-      expect(page2ResponseBody[0].title).toEqual('Conteúdo #30');
-      expect(page2ResponseBody[1].title).toEqual('Conteúdo #29');
-      expect(page2ResponseBody[27].title).toEqual('Conteúdo #3');
-      expect(page2ResponseBody[28].title).toEqual('Conteúdo #2');
-      expect(page2ResponseBody[29].title).toEqual('Conteúdo #1');
+      expect(page2ResponseBody.length).toBe(30);
+      expect(page2ResponseBody[0].title).toBe('Conteúdo #30');
+      expect(page2ResponseBody[1].title).toBe('Conteúdo #29');
+      expect(page2ResponseBody[27].title).toBe('Conteúdo #3');
+      expect(page2ResponseBody[28].title).toBe('Conteúdo #2');
+      expect(page2ResponseBody[29].title).toBe('Conteúdo #1');
     });
 
     test('"username" existent with 4 contents, but only 2 "root" "published" and with_children "false"', async () => {
@@ -824,7 +824,7 @@ describe('GET /api/v1/contents/[username]', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual([
         {
@@ -867,11 +867,11 @@ describe('GET /api/v1/contents/[username]', () => {
         },
       ]);
 
-      expect(uuidVersion(responseBody[0].id)).toEqual(4);
-      expect(uuidVersion(responseBody[1].id)).toEqual(4);
-      expect(uuidVersion(responseBody[0].owner_id)).toEqual(4);
-      expect(uuidVersion(responseBody[1].owner_id)).toEqual(4);
-      expect(responseBody[0].published_at > responseBody[1].published_at).toEqual(true);
+      expect(uuidVersion(responseBody[0].id)).toBe(4);
+      expect(uuidVersion(responseBody[1].id)).toBe(4);
+      expect(uuidVersion(responseBody[0].owner_id)).toBe(4);
+      expect(uuidVersion(responseBody[1].owner_id)).toBe(4);
+      expect(responseBody[0].published_at > responseBody[1].published_at).toBe(true);
 
       const responseLinkHeader = parseLinkHeader(response.headers.get('Link'));
       expect(responseLinkHeader.first.url).toBe(
@@ -938,7 +938,7 @@ describe('GET /api/v1/contents/[username]', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual([
         {
@@ -983,11 +983,11 @@ describe('GET /api/v1/contents/[username]', () => {
         },
       ]);
 
-      expect(uuidVersion(responseBody[0].id)).toEqual(4);
-      expect(uuidVersion(responseBody[1].id)).toEqual(4);
-      expect(uuidVersion(responseBody[0].owner_id)).toEqual(4);
-      expect(uuidVersion(responseBody[1].owner_id)).toEqual(4);
-      expect(responseBody[0].published_at > responseBody[1].published_at).toEqual(true);
+      expect(uuidVersion(responseBody[0].id)).toBe(4);
+      expect(uuidVersion(responseBody[1].id)).toBe(4);
+      expect(uuidVersion(responseBody[0].owner_id)).toBe(4);
+      expect(uuidVersion(responseBody[1].owner_id)).toBe(4);
+      expect(responseBody[0].published_at > responseBody[1].published_at).toBe(true);
 
       const responseLinkHeader = parseLinkHeader(response.headers.get('Link'));
       expect(responseLinkHeader.first.url).toBe(

--- a/tests/integration/api/v1/contents/[username]/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/get.test.js
@@ -41,7 +41,7 @@ describe('GET /api/v1/contents/[username]', () => {
       const responseBody = await response.json();
 
       expect(response.status).toBe(200);
-      expect(responseBody).toEqual([]);
+      expect(responseBody).toStrictEqual([]);
     });
 
     test('"username" existent, but with no "published" "root" content', async () => {
@@ -67,7 +67,7 @@ describe('GET /api/v1/contents/[username]', () => {
       const responseBody = await response.json();
 
       expect(response.status).toBe(200);
-      expect(responseBody).toEqual([]);
+      expect(responseBody).toStrictEqual([]);
     });
 
     test('"username" existent and only with "published" "child" content (short body)', async () => {
@@ -107,7 +107,7 @@ describe('GET /api/v1/contents/[username]', () => {
       const responseBody = await response.json();
 
       expect(response.status).toBe(200);
-      expect(responseBody).toEqual([
+      expect(responseBody).toStrictEqual([
         {
           id: childContent.id,
           owner_id: firstUser.id,
@@ -167,7 +167,7 @@ describe('GET /api/v1/contents/[username]', () => {
       const responseBody = await response.json();
 
       expect(response.status).toBe(200);
-      expect(responseBody).toEqual([
+      expect(responseBody).toStrictEqual([
         {
           id: childContent.id,
           owner_id: firstUser.id,

--- a/tests/integration/api/v1/contents/[username]/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/get.test.js
@@ -136,7 +136,7 @@ describe('GET /api/v1/contents/[username]', () => {
       const secondUser = await orchestrator.createUser();
 
       // secondUserRootContent
-      orchestrator.createContent({
+      await orchestrator.createContent({
         owner_id: secondUser.id,
         title: 'Conteúdo de outro usuário',
         status: 'published',
@@ -208,7 +208,7 @@ describe('GET /api/v1/contents/[username]', () => {
       });
 
       // thirdRootContent
-      orchestrator.createContent({
+      await orchestrator.createContent({
         owner_id: firstUser.id,
         title: 'Terceiro conteúdo criado',
         body: `Este conteúdo não deverá aparecer na lista retornada pelo /contents/[username],

--- a/tests/integration/api/v1/contents/firewall.post.test.js
+++ b/tests/integration/api/v1/contents/firewall.post.test.js
@@ -66,15 +66,15 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
           },
         });
 
-        expect(content1.status).toEqual('firewall');
+        expect(content1.status).toBe('firewall');
         expect(content1.deleted_at).toBeNull();
-        expect(Date.parse(content1.updated_at)).not.toEqual(NaN);
-        expect(content1.updated_at.toISOString()).toEqual(response1Body.updated_at);
+        expect(Date.parse(content1.updated_at)).not.toBe(NaN);
+        expect(content1.updated_at.toISOString()).toBe(response1Body.updated_at);
 
-        expect(content2.status).toEqual('firewall');
+        expect(content2.status).toBe('firewall');
         expect(content2.deleted_at).toBeNull();
-        expect(Date.parse(content2.updated_at)).not.toEqual(NaN);
-        expect(content2.updated_at.toISOString()).toEqual(response2Body.updated_at);
+        expect(Date.parse(content2.updated_at)).not.toBe(NaN);
+        expect(content2.updated_at.toISOString()).toBe(response2Body.updated_at);
 
         expect(content3).toBeUndefined();
 
@@ -91,8 +91,8 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
           },
           created_at: lastEvent.created_at,
         });
-        expect(uuidVersion(lastEvent.id)).toEqual(4);
-        expect(Date.parse(lastEvent.created_at)).not.toEqual(NaN);
+        expect(uuidVersion(lastEvent.id)).toBe(4);
+        expect(Date.parse(lastEvent.created_at)).not.toBe(NaN);
 
         const allEmails = await orchestrator.getEmails();
         expect(allEmails).toHaveLength(0);
@@ -146,8 +146,8 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
           },
         });
 
-        expect(content1.status).toEqual('firewall');
-        expect(content2.status).toEqual('firewall');
+        expect(content1.status).toBe('firewall');
+        expect(content2.status).toBe('firewall');
         expect(content1.deleted_at).toBeNull();
         expect(content2.deleted_at).toEqual(content2BeforeFirewall.deleted_at);
         expect(content2.deleted_at).not.toBeNull();
@@ -166,8 +166,8 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
           },
           created_at: lastEvent.created_at,
         });
-        expect(uuidVersion(lastEvent.id)).toEqual(4);
-        expect(Date.parse(lastEvent.created_at)).not.toEqual(NaN);
+        expect(uuidVersion(lastEvent.id)).toBe(4);
+        expect(Date.parse(lastEvent.created_at)).not.toBe(NaN);
 
         const allEmails = await orchestrator.getEmails();
         expect(allEmails).toHaveLength(0);
@@ -218,8 +218,8 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
           },
         });
 
-        expect(content1.status).toEqual('firewall');
-        expect(content2.status).toEqual('firewall');
+        expect(content1.status).toBe('firewall');
+        expect(content2.status).toBe('firewall');
         expect(content3).toBeUndefined();
 
         const lastEvent = await orchestrator.getLastEvent();
@@ -281,15 +281,15 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
           },
         });
 
-        expect(content1.status).toEqual('firewall');
+        expect(content1.status).toBe('firewall');
         expect(content1.deleted_at).toBeNull();
-        expect(Date.parse(content1.updated_at)).not.toEqual(NaN);
-        expect(content1.updated_at.toISOString()).toEqual(response1Body.updated_at);
+        expect(Date.parse(content1.updated_at)).not.toBe(NaN);
+        expect(content1.updated_at.toISOString()).toBe(response1Body.updated_at);
 
-        expect(content2.status).toEqual('firewall');
+        expect(content2.status).toBe('firewall');
         expect(content2.deleted_at).toBeNull();
-        expect(Date.parse(content2.updated_at)).not.toEqual(NaN);
-        expect(content2.updated_at.toISOString()).toEqual(response2Body.updated_at);
+        expect(Date.parse(content2.updated_at)).not.toBe(NaN);
+        expect(content2.updated_at.toISOString()).toBe(response2Body.updated_at);
 
         expect(content3).toBeUndefined();
 
@@ -306,8 +306,8 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
           },
           created_at: lastEvent.created_at,
         });
-        expect(uuidVersion(lastEvent.id)).toEqual(4);
-        expect(Date.parse(lastEvent.created_at)).not.toEqual(NaN);
+        expect(uuidVersion(lastEvent.id)).toBe(4);
+        expect(Date.parse(lastEvent.created_at)).not.toBe(NaN);
 
         const allEmails = await orchestrator.getEmails();
         expect(allEmails).toHaveLength(0);
@@ -368,8 +368,8 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
           },
         });
 
-        expect(content1.status).toEqual('firewall');
-        expect(content2.status).toEqual('firewall');
+        expect(content1.status).toBe('firewall');
+        expect(content2.status).toBe('firewall');
         expect(content1.deleted_at).toBeNull();
         expect(content2.deleted_at).toEqual(content2BeforeFirewall.deleted_at);
         expect(content2.deleted_at).not.toBeNull();
@@ -388,8 +388,8 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
           },
           created_at: lastEvent.created_at,
         });
-        expect(uuidVersion(lastEvent.id)).toEqual(4);
-        expect(Date.parse(lastEvent.created_at)).not.toEqual(NaN);
+        expect(uuidVersion(lastEvent.id)).toBe(4);
+        expect(Date.parse(lastEvent.created_at)).not.toBe(NaN);
 
         const allEmails = await orchestrator.getEmails();
         expect(allEmails).toHaveLength(0);

--- a/tests/integration/api/v1/contents/firewall.post.test.js
+++ b/tests/integration/api/v1/contents/firewall.post.test.js
@@ -68,12 +68,12 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
 
         expect(content1.status).toBe('firewall');
         expect(content1.deleted_at).toBeNull();
-        expect(Date.parse(content1.updated_at)).not.toBe(NaN);
+        expect(Date.parse(content1.updated_at)).not.toBeNaN();
         expect(content1.updated_at.toISOString()).toBe(response1Body.updated_at);
 
         expect(content2.status).toBe('firewall');
         expect(content2.deleted_at).toBeNull();
-        expect(Date.parse(content2.updated_at)).not.toBe(NaN);
+        expect(Date.parse(content2.updated_at)).not.toBeNaN();
         expect(content2.updated_at.toISOString()).toBe(response2Body.updated_at);
 
         expect(content3).toBeUndefined();
@@ -92,7 +92,7 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
           created_at: lastEvent.created_at,
         });
         expect(uuidVersion(lastEvent.id)).toBe(4);
-        expect(Date.parse(lastEvent.created_at)).not.toBe(NaN);
+        expect(Date.parse(lastEvent.created_at)).not.toBeNaN();
 
         const allEmails = await orchestrator.getEmails();
         expect(allEmails).toHaveLength(0);
@@ -167,7 +167,7 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
           created_at: lastEvent.created_at,
         });
         expect(uuidVersion(lastEvent.id)).toBe(4);
-        expect(Date.parse(lastEvent.created_at)).not.toBe(NaN);
+        expect(Date.parse(lastEvent.created_at)).not.toBeNaN();
 
         const allEmails = await orchestrator.getEmails();
         expect(allEmails).toHaveLength(0);
@@ -283,12 +283,12 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
 
         expect(content1.status).toBe('firewall');
         expect(content1.deleted_at).toBeNull();
-        expect(Date.parse(content1.updated_at)).not.toBe(NaN);
+        expect(Date.parse(content1.updated_at)).not.toBeNaN();
         expect(content1.updated_at.toISOString()).toBe(response1Body.updated_at);
 
         expect(content2.status).toBe('firewall');
         expect(content2.deleted_at).toBeNull();
-        expect(Date.parse(content2.updated_at)).not.toBe(NaN);
+        expect(Date.parse(content2.updated_at)).not.toBeNaN();
         expect(content2.updated_at.toISOString()).toBe(response2Body.updated_at);
 
         expect(content3).toBeUndefined();
@@ -307,7 +307,7 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
           created_at: lastEvent.created_at,
         });
         expect(uuidVersion(lastEvent.id)).toBe(4);
-        expect(Date.parse(lastEvent.created_at)).not.toBe(NaN);
+        expect(Date.parse(lastEvent.created_at)).not.toBeNaN();
 
         const allEmails = await orchestrator.getEmails();
         expect(allEmails).toHaveLength(0);
@@ -389,7 +389,7 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
           created_at: lastEvent.created_at,
         });
         expect(uuidVersion(lastEvent.id)).toBe(4);
-        expect(Date.parse(lastEvent.created_at)).not.toBe(NaN);
+        expect(Date.parse(lastEvent.created_at)).not.toBeNaN();
 
         const allEmails = await orchestrator.getEmails();
         expect(allEmails).toHaveLength(0);

--- a/tests/integration/api/v1/contents/firewall.post.test.js
+++ b/tests/integration/api/v1/contents/firewall.post.test.js
@@ -149,7 +149,7 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
         expect(content1.status).toBe('firewall');
         expect(content2.status).toBe('firewall');
         expect(content1.deleted_at).toBeNull();
-        expect(content2.deleted_at).toEqual(content2BeforeFirewall.deleted_at);
+        expect(content2.deleted_at).toStrictEqual(content2BeforeFirewall.deleted_at);
         expect(content2.deleted_at).not.toBeNull();
         expect(content3).toBeUndefined();
 
@@ -371,7 +371,7 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
         expect(content1.status).toBe('firewall');
         expect(content2.status).toBe('firewall');
         expect(content1.deleted_at).toBeNull();
-        expect(content2.deleted_at).toEqual(content2BeforeFirewall.deleted_at);
+        expect(content2.deleted_at).toStrictEqual(content2BeforeFirewall.deleted_at);
         expect(content2.deleted_at).not.toBeNull();
         expect(content3).toBeUndefined();
 

--- a/tests/integration/api/v1/contents/firewall.post.test.js
+++ b/tests/integration/api/v1/contents/firewall.post.test.js
@@ -14,7 +14,7 @@ beforeEach(async () => {
 
 describe('POST /api/v1/contents [FIREWALL]', () => {
   async function createContentViaApi(contentsRequestBuilder, body) {
-    return contentsRequestBuilder.post({
+    return await contentsRequestBuilder.post({
       title: body?.title ?? `New content - ${new Date().getTime()}`,
       body: 'body',
       status: 'published',

--- a/tests/integration/api/v1/contents/get.test.js
+++ b/tests/integration/api/v1/contents/get.test.js
@@ -65,14 +65,14 @@ describe('GET /api/v1/contents', () => {
     test('With no content', async () => {
       const { response, responseBody } = await contentsRequestBuilder.get();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
       expect(responseBody).toEqual([]);
     });
 
     test('With invalid strategy', async () => {
       const { response, responseBody } = await contentsRequestBuilder.get(`?strategy=invalid`);
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -86,8 +86,8 @@ describe('GET /api/v1/contents', () => {
         type: 'any.only',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('With 2 "published" entries and strategy "new"', async () => {
@@ -138,7 +138,7 @@ describe('GET /api/v1/contents', () => {
 
       const { response, responseBody } = await contentsRequestBuilder.get(`?strategy=new`);
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual([
         {
@@ -181,11 +181,11 @@ describe('GET /api/v1/contents', () => {
         },
       ]);
 
-      expect(uuidVersion(responseBody[0].id)).toEqual(4);
-      expect(uuidVersion(responseBody[1].id)).toEqual(4);
-      expect(uuidVersion(responseBody[0].owner_id)).toEqual(4);
-      expect(uuidVersion(responseBody[1].owner_id)).toEqual(4);
-      expect(responseBody[0].published_at > responseBody[1].published_at).toEqual(true);
+      expect(uuidVersion(responseBody[0].id)).toBe(4);
+      expect(uuidVersion(responseBody[1].id)).toBe(4);
+      expect(uuidVersion(responseBody[0].owner_id)).toBe(4);
+      expect(uuidVersion(responseBody[1].owner_id)).toBe(4);
+      expect(responseBody[0].published_at > responseBody[1].published_at).toBe(true);
     });
 
     test('With 2 "published" entries and strategy "old"', async () => {
@@ -236,7 +236,7 @@ describe('GET /api/v1/contents', () => {
 
       const { response, responseBody } = await contentsRequestBuilder.get(`?strategy=old`);
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual([
         {
@@ -279,11 +279,11 @@ describe('GET /api/v1/contents', () => {
         },
       ]);
 
-      expect(uuidVersion(responseBody[0].id)).toEqual(4);
-      expect(uuidVersion(responseBody[1].id)).toEqual(4);
-      expect(uuidVersion(responseBody[0].owner_id)).toEqual(4);
-      expect(uuidVersion(responseBody[1].owner_id)).toEqual(4);
-      expect(responseBody[1].published_at > responseBody[0].published_at).toEqual(true);
+      expect(uuidVersion(responseBody[0].id)).toBe(4);
+      expect(uuidVersion(responseBody[1].id)).toBe(4);
+      expect(uuidVersion(responseBody[0].owner_id)).toBe(4);
+      expect(uuidVersion(responseBody[1].owner_id)).toBe(4);
+      expect(responseBody[1].published_at > responseBody[0].published_at).toBe(true);
     });
 
     test('With 3 children 3 level deep and default strategy', async () => {
@@ -327,7 +327,7 @@ describe('GET /api/v1/contents', () => {
 
       const { response, responseBody } = await contentsRequestBuilder.get();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual([
         {
@@ -369,8 +369,8 @@ describe('GET /api/v1/contents', () => {
       const responseLinkHeader = parseLinkHeader(response.headers.get('Link'));
       const responseTotalRowsHeader = response.headers.get('X-Pagination-Total-Rows');
 
-      expect(response.status).toEqual(200);
-      expect(responseTotalRowsHeader).toEqual('60');
+      expect(response.status).toBe(200);
+      expect(responseTotalRowsHeader).toBe('60');
       expect(responseLinkHeader).toStrictEqual({
         first: {
           page: '1',
@@ -395,9 +395,9 @@ describe('GET /api/v1/contents', () => {
         },
       });
 
-      expect(responseBody.length).toEqual(30);
-      expect(responseBody[0].title).toEqual('Conteúdo #60');
-      expect(responseBody[29].title).toEqual('Conteúdo #31');
+      expect(responseBody.length).toBe(30);
+      expect(responseBody[0].title).toBe('Conteúdo #60');
+      expect(responseBody[29].title).toBe('Conteúdo #31');
     });
 
     test('With 60 entries, default "page", "per_page" and strategy "relevant" (default)', async () => {
@@ -729,8 +729,8 @@ describe('GET /api/v1/contents', () => {
       const responseLinkHeader = parseLinkHeader(response.headers.get('Link'));
       const responseTotalRowsHeader = response.headers.get('X-Pagination-Total-Rows');
 
-      expect(response.status).toEqual(200);
-      expect(responseTotalRowsHeader).toEqual('56');
+      expect(response.status).toBe(200);
+      expect(responseTotalRowsHeader).toBe('56');
       expect(responseLinkHeader).toStrictEqual({
         first: {
           page: '1',
@@ -755,43 +755,43 @@ describe('GET /api/v1/contents', () => {
         },
       });
 
-      expect(responseBody.length).toEqual(30);
+      expect(responseBody.length).toBe(30);
 
       // group_1 -> score > 16 and less than 36 hours ago
-      expect(responseBody[0].title).toEqual('Conteúdo #31');
+      expect(responseBody[0].title).toBe('Conteúdo #31');
 
       // group_2 -> score > 8 and less than 24 hours ago
-      expect(responseBody[1].title).toEqual('Conteúdo #36');
+      expect(responseBody[1].title).toBe('Conteúdo #36');
 
       // group_3 -> max one new content by user with less than 12 hours
-      expect(responseBody[2].title).toEqual('Conteúdo #60');
-      expect(responseBody[3].title).toEqual('Conteúdo #59');
-      expect(responseBody[4].title).toEqual('Conteúdo #58');
+      expect(responseBody[2].title).toBe('Conteúdo #60');
+      expect(responseBody[3].title).toBe('Conteúdo #59');
+      expect(responseBody[4].title).toBe('Conteúdo #58');
 
       // group_4 -> score > 11 and less than 36 hours ago
-      expect(responseBody[5].title).toEqual('Conteúdo #6');
+      expect(responseBody[5].title).toBe('Conteúdo #6');
 
       // group_5 -> score > 8 and less than 3 days ago
-      expect(responseBody[6].title).toEqual('Conteúdo #8');
-      expect(responseBody[7].title).toEqual('Conteúdo #7');
-      expect(responseBody[8].title).toEqual('Conteúdo #9');
+      expect(responseBody[6].title).toBe('Conteúdo #8');
+      expect(responseBody[7].title).toBe('Conteúdo #7');
+      expect(responseBody[8].title).toBe('Conteúdo #9');
 
       // group_6 -> tabcoins > 0 and less than 7 days ago
       // or commented less than 24 hours
-      expect(responseBody[9].title).toEqual('Conteúdo #2');
-      expect(responseBody[10].title).toEqual('Conteúdo #3');
-      expect(responseBody[11].title).toEqual('Conteúdo #5');
-      expect(responseBody[12].title).toEqual('Conteúdo #48');
-      expect(responseBody[13].title).toEqual('Conteúdo #45');
-      expect(responseBody[14].title).toEqual('Conteúdo #53');
-      expect(responseBody[15].title).toEqual('Conteúdo #52');
-      expect(responseBody[16].title).toEqual('Conteúdo #57');
-      expect(responseBody[19].title).toEqual('Conteúdo #54');
-      expect(responseBody[20].title).toEqual('Conteúdo #49');
-      expect(responseBody[21].title).toEqual('Conteúdo #47');
-      expect(responseBody[22].title).toEqual('Conteúdo #46');
-      expect(responseBody[23].title).toEqual('Conteúdo #44');
-      expect(responseBody[29].title).toEqual('Conteúdo #38');
+      expect(responseBody[9].title).toBe('Conteúdo #2');
+      expect(responseBody[10].title).toBe('Conteúdo #3');
+      expect(responseBody[11].title).toBe('Conteúdo #5');
+      expect(responseBody[12].title).toBe('Conteúdo #48');
+      expect(responseBody[13].title).toBe('Conteúdo #45');
+      expect(responseBody[14].title).toBe('Conteúdo #53');
+      expect(responseBody[15].title).toBe('Conteúdo #52');
+      expect(responseBody[16].title).toBe('Conteúdo #57');
+      expect(responseBody[19].title).toBe('Conteúdo #54');
+      expect(responseBody[20].title).toBe('Conteúdo #49');
+      expect(responseBody[21].title).toBe('Conteúdo #47');
+      expect(responseBody[22].title).toBe('Conteúdo #46');
+      expect(responseBody[23].title).toBe('Conteúdo #44');
+      expect(responseBody[29].title).toBe('Conteúdo #38');
 
       const page2RequestBuilder = new RequestBuilder(responseLinkHeader.next.url);
       const { response: page2Response, responseBody: page2ResponseBody } = await page2RequestBuilder.get();
@@ -799,8 +799,8 @@ describe('GET /api/v1/contents', () => {
       const page2ResponseLinkHeader = parseLinkHeader(page2Response.headers.get('Link'));
       const page2ResponseTotalRowsHeader = page2Response.headers.get('X-Pagination-Total-Rows');
 
-      expect(page2Response.status).toEqual(200);
-      expect(page2ResponseTotalRowsHeader).toEqual('56');
+      expect(page2Response.status).toBe(200);
+      expect(page2ResponseTotalRowsHeader).toBe('56');
       expect(page2ResponseLinkHeader).toStrictEqual({
         first: {
           page: '1',
@@ -825,13 +825,13 @@ describe('GET /api/v1/contents', () => {
         },
       });
 
-      expect(page2ResponseBody.length).toEqual(26);
-      expect(page2ResponseBody[0].title).toEqual('Conteúdo #37');
-      expect(page2ResponseBody[1].title).toEqual('Conteúdo #35');
-      expect(page2ResponseBody[2].title).toEqual('Conteúdo #34');
-      expect(page2ResponseBody[3].title).toEqual('Conteúdo #33');
-      expect(page2ResponseBody[24].title).toEqual('Conteúdo #11');
-      expect(page2ResponseBody[25].title).toEqual('Conteúdo #10');
+      expect(page2ResponseBody.length).toBe(26);
+      expect(page2ResponseBody[0].title).toBe('Conteúdo #37');
+      expect(page2ResponseBody[1].title).toBe('Conteúdo #35');
+      expect(page2ResponseBody[2].title).toBe('Conteúdo #34');
+      expect(page2ResponseBody[3].title).toBe('Conteúdo #33');
+      expect(page2ResponseBody[24].title).toBe('Conteúdo #11');
+      expect(page2ResponseBody[25].title).toBe('Conteúdo #10');
     });
 
     test('With 9 entries, custom "page", "per_page" and strategy "new" (navigating using Link Header)', async () => {
@@ -854,8 +854,8 @@ describe('GET /api/v1/contents', () => {
       const page1LinkHeader = parseLinkHeader(page1.headers.get('Link'));
       const page1TotalRowsHeader = page1.headers.get('X-Pagination-Total-Rows');
 
-      expect(page1.status).toEqual(200);
-      expect(page1TotalRowsHeader).toEqual('9');
+      expect(page1.status).toBe(200);
+      expect(page1TotalRowsHeader).toBe('9');
       expect(page1LinkHeader).toStrictEqual({
         first: {
           page: '1',
@@ -880,10 +880,10 @@ describe('GET /api/v1/contents', () => {
         },
       });
 
-      expect(page1Body.length).toEqual(3);
-      expect(page1Body[0].title).toEqual('Conteúdo #9');
-      expect(page1Body[1].title).toEqual('Conteúdo #8');
-      expect(page1Body[2].title).toEqual('Conteúdo #7');
+      expect(page1Body.length).toBe(3);
+      expect(page1Body[0].title).toBe('Conteúdo #9');
+      expect(page1Body[1].title).toBe('Conteúdo #8');
+      expect(page1Body[2].title).toBe('Conteúdo #7');
 
       const page2RequestBuilder = new RequestBuilder(page1LinkHeader.next.url);
       const { response: page2, responseBody: page2Body } = await page2RequestBuilder.get();
@@ -891,8 +891,8 @@ describe('GET /api/v1/contents', () => {
       const page2LinkHeader = parseLinkHeader(page2.headers.get('Link'));
       const page2TotalRowsHeader = page2.headers.get('X-Pagination-Total-Rows');
 
-      expect(page2.status).toEqual(200);
-      expect(page2TotalRowsHeader).toEqual('9');
+      expect(page2.status).toBe(200);
+      expect(page2TotalRowsHeader).toBe('9');
       expect(page2LinkHeader).toStrictEqual({
         first: {
           page: '1',
@@ -924,10 +924,10 @@ describe('GET /api/v1/contents', () => {
         },
       });
 
-      expect(page2Body.length).toEqual(3);
-      expect(page2Body[0].title).toEqual('Conteúdo #6');
-      expect(page2Body[1].title).toEqual('Conteúdo #5');
-      expect(page2Body[2].title).toEqual('Conteúdo #4');
+      expect(page2Body.length).toBe(3);
+      expect(page2Body[0].title).toBe('Conteúdo #6');
+      expect(page2Body[1].title).toBe('Conteúdo #5');
+      expect(page2Body[2].title).toBe('Conteúdo #4');
 
       const page3RequestBuilder = new RequestBuilder(page2LinkHeader.next.url);
       const { response: page3, responseBody: page3Body } = await page3RequestBuilder.get();
@@ -935,8 +935,8 @@ describe('GET /api/v1/contents', () => {
       const page3LinkHeader = parseLinkHeader(page3.headers.get('Link'));
       const page3TotalRowsHeader = page3.headers.get('X-Pagination-Total-Rows');
 
-      expect(page3.status).toEqual(200);
-      expect(page3TotalRowsHeader).toEqual('9');
+      expect(page3.status).toBe(200);
+      expect(page3TotalRowsHeader).toBe('9');
       expect(page3LinkHeader).toStrictEqual({
         first: {
           page: '1',
@@ -961,10 +961,10 @@ describe('GET /api/v1/contents', () => {
         },
       });
 
-      expect(page3Body.length).toEqual(3);
-      expect(page3Body[0].title).toEqual('Conteúdo #3');
-      expect(page3Body[1].title).toEqual('Conteúdo #2');
-      expect(page3Body[2].title).toEqual('Conteúdo #1');
+      expect(page3Body.length).toBe(3);
+      expect(page3Body[0].title).toBe('Conteúdo #3');
+      expect(page3Body[1].title).toBe('Conteúdo #2');
+      expect(page3Body[2].title).toBe('Conteúdo #1');
 
       // FIRST AND LAST PAGE USING "PAGE 1" LINK HEADER
       const firstPageRequestBuilder = new RequestBuilder(page1LinkHeader.first.url);
@@ -972,8 +972,8 @@ describe('GET /api/v1/contents', () => {
       const firstPageLinkHeader = parseLinkHeader(firstPage.headers.get('Link'));
       const firstPageTotalRowsHeader = firstPage.headers.get('X-Pagination-Total-Rows');
 
-      expect(firstPage.status).toEqual(200);
-      expect(firstPageTotalRowsHeader).toEqual(page1TotalRowsHeader);
+      expect(firstPage.status).toBe(200);
+      expect(firstPageTotalRowsHeader).toBe(page1TotalRowsHeader);
       expect(firstPageLinkHeader).toStrictEqual(page1LinkHeader);
       expect(firstPageBody).toEqual(page1Body);
 
@@ -982,8 +982,8 @@ describe('GET /api/v1/contents', () => {
       const lastPageLinkHeader = parseLinkHeader(lastPage.headers.get('Link'));
       const lastPageTotalRowsHeader = lastPage.headers.get('X-Pagination-Total-Rows');
 
-      expect(lastPage.status).toEqual(200);
-      expect(lastPageTotalRowsHeader).toEqual(page3TotalRowsHeader);
+      expect(lastPage.status).toBe(200);
+      expect(lastPageTotalRowsHeader).toBe(page3TotalRowsHeader);
       expect(lastPageLinkHeader).toStrictEqual(page3LinkHeader);
       expect(lastPageBody).toEqual(page3Body);
     });
@@ -1008,8 +1008,8 @@ describe('GET /api/v1/contents', () => {
       const page4LinkHeader = parseLinkHeader(page4.headers.get('Link'));
       const page4TotalRowsHeader = page4.headers.get('X-Pagination-Total-Rows');
 
-      expect(page4.status).toEqual(200);
-      expect(page4TotalRowsHeader).toEqual('9');
+      expect(page4.status).toBe(200);
+      expect(page4TotalRowsHeader).toBe('9');
       expect(page4LinkHeader).toStrictEqual({
         first: {
           page: '1',
@@ -1034,13 +1034,13 @@ describe('GET /api/v1/contents', () => {
         },
       });
 
-      expect(page4Body.length).toEqual(0);
+      expect(page4Body.length).toBe(0);
     });
 
     test('With "page" with a String', async () => {
       const { response, responseBody } = await contentsRequestBuilder.get('?page=CINCO');
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -1054,14 +1054,14 @@ describe('GET /api/v1/contents', () => {
         type: 'number.base',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('With "page" with an invalid minimum Number', async () => {
       const { response, responseBody } = await contentsRequestBuilder.get('?page=0');
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -1075,14 +1075,14 @@ describe('GET /api/v1/contents', () => {
         type: 'number.min',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('With "page" with an invalid maximum Number', async () => {
       const { response, responseBody } = await contentsRequestBuilder.get('?page=9007199254740991');
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -1096,14 +1096,14 @@ describe('GET /api/v1/contents', () => {
         type: 'number.max',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('With "page" with an unsafe Number', async () => {
       const { response, responseBody } = await contentsRequestBuilder.get('?page=9007199254740992');
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -1117,14 +1117,14 @@ describe('GET /api/v1/contents', () => {
         type: 'number.unsafe',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('With "page" with a Float Number', async () => {
       const { response, responseBody } = await contentsRequestBuilder.get('?page=1.5');
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -1138,14 +1138,14 @@ describe('GET /api/v1/contents', () => {
         type: 'number.integer',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('With "per_page" with a String', async () => {
       const { response, responseBody } = await contentsRequestBuilder.get('?per_page=SEIS');
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -1159,14 +1159,14 @@ describe('GET /api/v1/contents', () => {
         type: 'number.base',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('With "per_page" with an invalid minimum Number', async () => {
       const { response, responseBody } = await contentsRequestBuilder.get('?per_page=0');
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -1180,14 +1180,14 @@ describe('GET /api/v1/contents', () => {
         type: 'number.min',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('With "per_page" with an invalid maximum Number', async () => {
       const { response, responseBody } = await contentsRequestBuilder.get('?per_page=9007199254740991');
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -1201,14 +1201,14 @@ describe('GET /api/v1/contents', () => {
         type: 'number.max',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('With "per_page" with an unsafe Number', async () => {
       const { response, responseBody } = await contentsRequestBuilder.get('?per_page=9007199254740992');
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -1222,14 +1222,14 @@ describe('GET /api/v1/contents', () => {
         type: 'number.unsafe',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('With "per_page" with a Float Number', async () => {
       const { response, responseBody } = await contentsRequestBuilder.get('?per_page=1.5');
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -1243,8 +1243,8 @@ describe('GET /api/v1/contents', () => {
         type: 'number.integer',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
   });
 
@@ -1418,7 +1418,7 @@ describe('GET /api/v1/contents', () => {
       ])('get $content with params: $params', async ({ params, responseLinkParams, getExpected }) => {
         const { response, responseBody } = await contentsRequestBuilder.get(`?${params.join('&')}`);
 
-        expect(response.status).toEqual(200);
+        expect(response.status).toBe(200);
         expect(responseBody).toStrictEqual(getExpected());
 
         const linkParamsString = responseLinkParams.join('&');

--- a/tests/integration/api/v1/contents/get.test.js
+++ b/tests/integration/api/v1/contents/get.test.js
@@ -1261,10 +1261,11 @@ describe('GET /api/v1/contents', () => {
         await orchestrator.dropAllTables();
         await orchestrator.runPendingMigrations();
 
-        const createUser = async () => orchestrator.createUser();
-        const createContent = async (user, options) => orchestrator.createContent({ owner_id: user.id, ...options });
+        const createUser = async () => await orchestrator.createUser();
+        const createContent = async (user, options) =>
+          await orchestrator.createContent({ owner_id: user.id, ...options });
         const createComment = async (user, parent, body) =>
-          createContent(user, { body, status: 'published', parent_id: parent.id });
+          await createContent(user, { body, status: 'published', parent_id: parent.id });
 
         const [firstUser, secondUser, thirdUser] = await Promise.all(Array.from({ length: 3 }, () => createUser()));
 

--- a/tests/integration/api/v1/contents/get.test.js
+++ b/tests/integration/api/v1/contents/get.test.js
@@ -66,7 +66,7 @@ describe('GET /api/v1/contents', () => {
       const { response, responseBody } = await contentsRequestBuilder.get();
 
       expect(response.status).toBe(200);
-      expect(responseBody).toEqual([]);
+      expect(responseBody).toStrictEqual([]);
     });
 
     test('With invalid strategy', async () => {
@@ -975,7 +975,7 @@ describe('GET /api/v1/contents', () => {
       expect(firstPage.status).toBe(200);
       expect(firstPageTotalRowsHeader).toBe(page1TotalRowsHeader);
       expect(firstPageLinkHeader).toStrictEqual(page1LinkHeader);
-      expect(firstPageBody).toEqual(page1Body);
+      expect(firstPageBody).toStrictEqual(page1Body);
 
       const lastPageRequestBuilder = new RequestBuilder(page1LinkHeader.last.url);
       const { response: lastPage, responseBody: lastPageBody } = await lastPageRequestBuilder.get();
@@ -985,7 +985,7 @@ describe('GET /api/v1/contents', () => {
       expect(lastPage.status).toBe(200);
       expect(lastPageTotalRowsHeader).toBe(page3TotalRowsHeader);
       expect(lastPageLinkHeader).toStrictEqual(page3LinkHeader);
-      expect(lastPageBody).toEqual(page3Body);
+      expect(lastPageBody).toStrictEqual(page3Body);
     });
 
     test('With 9 entries but "page" out of bounds and strategy "new"', async () => {
@@ -1470,7 +1470,7 @@ describe('GET /api/v1/contents', () => {
           const { response, responseBody } = await contentsRequestBuilder.get(params);
 
           expect(response.status).toBe(200);
-          expect(responseBody).toEqual([]);
+          expect(responseBody).toStrictEqual([]);
         },
       );
     });

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -2244,7 +2244,7 @@ describe('POST /api/v1/contents', () => {
 
         const { responseBody } = await contentsRequestBuilder.post({
           title: 'Title',
-          body: 'Body with relevant text needs to contain a good amount of words.',
+          body: relevantBody,
         });
 
         expect(responseBody.tabcoins).toEqual(0);
@@ -2264,7 +2264,7 @@ describe('POST /api/v1/contents', () => {
 
         const { responseBody } = await contentsRequestBuilder.post({
           title: 'Title',
-          body: 'Body with relevant text needs to contain a good amount of words.',
+          body: relevantBody,
           status: 'published',
         });
 
@@ -2283,14 +2283,14 @@ describe('POST /api/v1/contents', () => {
 
         const { responseBody: rootContent } = await contentsRequestBuilder.post({
           title: 'Root',
-          body: 'Root - Body with relevant text needs to contain a good amount of words.',
+          body: relevantBody,
           status: 'published',
         });
 
         const secondUser = await contentsRequestBuilder.buildUser();
 
         const { responseBody } = await contentsRequestBuilder.post({
-          body: 'Child - Body with relevant text needs to contain a good amount of words.',
+          body: relevantBody,
           parent_id: rootContent.id,
           status: 'draft',
         });
@@ -2313,14 +2313,14 @@ describe('POST /api/v1/contents', () => {
         // User will receive tabcoins for publishing a root content.
         const { responseBody: rootContent } = await contentsRequestBuilder.post({
           title: 'Root',
-          body: 'Root - Body with relevant text needs to contain a good amount of words.',
+          body: relevantBody,
           status: 'published',
         });
 
         // But user will not receive additional tabcoins for
         // publishing a child content to itself.
         const { responseBody } = await contentsRequestBuilder.post({
-          body: 'Child - Body with relevant text needs to contain a good amount of words.',
+          body: relevantBody,
           parent_id: rootContent.id,
           status: 'published',
         });
@@ -2340,7 +2340,7 @@ describe('POST /api/v1/contents', () => {
 
         const { responseBody: rootContent } = await contentsRequestBuilder.post({
           title: 'Root',
-          body: 'Root - Body with relevant text needs to contain a good amount of words.',
+          body: relevantBody,
           status: 'published',
         });
 
@@ -2348,7 +2348,7 @@ describe('POST /api/v1/contents', () => {
         await orchestrator.createPrestige(secondUser.id);
 
         const { responseBody } = await contentsRequestBuilder.post({
-          body: 'Child - Body with relevant text needs to contain a good amount of words.',
+          body: relevantBody,
           parent_id: rootContent.id,
           status: 'published',
         });
@@ -2370,7 +2370,7 @@ describe('POST /api/v1/contents', () => {
 
         const { response, responseBody } = await contentsRequestBuilder.post({
           title: 'Title',
-          body: 'Body with relevant text needs to contain a good amount of words.',
+          body: relevantBody,
           status: 'published',
         });
 
@@ -2433,7 +2433,7 @@ describe('POST /api/v1/contents', () => {
 
         const { response, responseBody } = await contentsRequestBuilder.post({
           title: 'Title',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'published',
         });
 
@@ -2445,7 +2445,7 @@ describe('POST /api/v1/contents', () => {
           parent_id: null,
           slug: 'title',
           title: 'Title',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'published',
           type: 'content',
           source_url: null,
@@ -2529,7 +2529,7 @@ describe('POST /api/v1/contents', () => {
 
         const { response, responseBody } = await contentsRequestBuilder.post({
           title: 'Title',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'published',
         });
 
@@ -2541,7 +2541,7 @@ describe('POST /api/v1/contents', () => {
           parent_id: null,
           slug: 'title',
           title: 'Title',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'published',
           type: 'content',
           source_url: null,
@@ -2625,7 +2625,7 @@ describe('POST /api/v1/contents', () => {
 
         const { response, responseBody } = await contentsRequestBuilder.post({
           title: 'Title',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'published',
         });
 
@@ -2637,7 +2637,7 @@ describe('POST /api/v1/contents', () => {
           parent_id: null,
           slug: 'title',
           title: 'Title',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'published',
           type: 'content',
           source_url: null,
@@ -2676,7 +2676,7 @@ describe('POST /api/v1/contents', () => {
         await orchestrator.createPrestige(secondUser.id, { childPrestigeNumerator: 0, childPrestigeDenominator: 6 });
 
         const { response, responseBody } = await contentsRequestBuilder.post({
-          body: 'Deve conseguir publicar e ganhar TabCoins com esse texto.',
+          body: relevantBody,
           parent_id: rootContent.id,
           status: 'published',
         });
@@ -2689,7 +2689,7 @@ describe('POST /api/v1/contents', () => {
           parent_id: rootContent.id,
           slug: responseBody.slug,
           title: null,
-          body: 'Deve conseguir publicar e ganhar TabCoins com esse texto.',
+          body: relevantBody,
           status: 'published',
           type: 'content',
           source_url: null,
@@ -2967,7 +2967,7 @@ describe('POST /api/v1/contents', () => {
 
         const { response, responseBody } = await contentsRequestBuilder.post({
           title: 'Title',
-          body: 'Relevant text needs to contain a good amount of words',
+          body: relevantBody,
           status: 'published',
         });
 
@@ -2979,7 +2979,7 @@ describe('POST /api/v1/contents', () => {
           parent_id: null,
           slug: 'title',
           title: 'Title',
-          body: 'Relevant text needs to contain a good amount of words',
+          body: relevantBody,
           status: 'published',
           type: 'content',
           source_url: null,
@@ -3018,7 +3018,7 @@ describe('POST /api/v1/contents', () => {
         await orchestrator.createPrestige(secondUser.id, { childPrestigeNumerator: 0, childPrestigeDenominator: 6 });
 
         const { response, responseBody } = await contentsRequestBuilder.post({
-          body: 'Relevant text needs to contain a good amount of words',
+          body: relevantBody,
           parent_id: rootContent.id,
           status: 'published',
         });
@@ -3031,7 +3031,7 @@ describe('POST /api/v1/contents', () => {
           parent_id: rootContent.id,
           slug: responseBody.slug,
           title: null,
-          body: 'Relevant text needs to contain a good amount of words',
+          body: relevantBody,
           status: 'published',
           type: 'content',
           source_url: null,
@@ -3228,7 +3228,7 @@ describe('POST /api/v1/contents', () => {
 
         const { response: contentResponse, responseBody: contentResponseBody } = await contentsRequestBuilder.post({
           title: 'Title',
-          body: 'Relevant text needs to contain a good amount of words',
+          body: relevantBody,
           status: 'published',
           type: 'ad',
         });

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -162,8 +162,8 @@ describe('POST /api/v1/contents', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
     });
 
     test('Content with "body" not declared', async () => {
@@ -310,8 +310,8 @@ describe('POST /api/v1/contents', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
     });
 
     test('Content with "title" and "body" containing invalid characters', async () => {
@@ -403,8 +403,8 @@ describe('POST /api/v1/contents', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
     });
 
     test('Content with "body" containing Null value', async () => {
@@ -459,8 +459,8 @@ describe('POST /api/v1/contents', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
     });
 
     test('Content with "slug" containing a blank String', async () => {
@@ -522,8 +522,8 @@ describe('POST /api/v1/contents', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
     });
 
     test('Content with "slug" containing special characters', async () => {
@@ -678,9 +678,9 @@ describe('POST /api/v1/contents', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.published_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.published_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
     });
 
     test('Content with "slug" with trailing hyphen', async () => {
@@ -716,8 +716,8 @@ describe('POST /api/v1/contents', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
     });
 
     test('Content with "title" containing a blank String', async () => {
@@ -801,8 +801,8 @@ describe('POST /api/v1/contents', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
     });
 
     test('Content with "title" containing Braille Pattern Blank Unicode Character', async () => {
@@ -837,8 +837,8 @@ describe('POST /api/v1/contents', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
     });
 
     test(`Content with "title" containing special characters occupying more than ${maxTitleLength} bytes`, async () => {
@@ -873,8 +873,8 @@ describe('POST /api/v1/contents', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
     });
 
     test('Content with "title" containing untrimmed values', async () => {
@@ -909,8 +909,8 @@ describe('POST /api/v1/contents', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
     });
 
     test('Content with "title" containing unescaped characters', async () => {
@@ -945,8 +945,8 @@ describe('POST /api/v1/contents', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
     });
 
     test('Content with "status" set to "draft"', async () => {
@@ -982,8 +982,8 @@ describe('POST /api/v1/contents', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
     });
 
     test('Content with "status" set to "published"', async () => {
@@ -1019,9 +1019,9 @@ describe('POST /api/v1/contents', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.published_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.published_at)).not.toBeNaN();
     });
 
     test('Content with "status" set to "deleted"', async () => {
@@ -1171,8 +1171,8 @@ describe('POST /api/v1/contents', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
     });
 
     test('Content with "source_url" containing a valid HTTPS URL', async () => {
@@ -1208,8 +1208,8 @@ describe('POST /api/v1/contents', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
     });
 
     test('Content with "source_url" containing a valid long TLD', async () => {
@@ -1245,8 +1245,8 @@ describe('POST /api/v1/contents', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
     });
 
     test('Content with "source_url" containing a valid short URL', async () => {
@@ -1282,8 +1282,8 @@ describe('POST /api/v1/contents', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
     });
 
     test('Content with "source_url" containing a invalid short TLD', async () => {
@@ -1429,8 +1429,8 @@ describe('POST /api/v1/contents', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
     });
 
     test('Content with "source_url" containing fragment component', async () => {
@@ -1466,8 +1466,8 @@ describe('POST /api/v1/contents', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
     });
 
     test('Content with "source_url" containing an empty String', async () => {
@@ -1523,8 +1523,8 @@ describe('POST /api/v1/contents', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
     });
 
     test('"root" content with minimum valid data', async () => {
@@ -1561,8 +1561,8 @@ describe('POST /api/v1/contents', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
 
       const contentInDatabase = await database.query({
         text: 'SELECT * FROM contents WHERE id = $1',
@@ -1604,8 +1604,8 @@ describe('POST /api/v1/contents', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
     });
 
     test('"root" content with "title" not declared', async () => {
@@ -1684,8 +1684,8 @@ describe('POST /api/v1/contents', () => {
 
       expect(uuidVersion(responseBody.id)).toBe(4);
       expect(uuidVersion(responseBody.slug)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
 
       const contentInDatabase = await database.query({
         text: 'SELECT * FROM contents WHERE id = $1',
@@ -1736,9 +1736,9 @@ describe('POST /api/v1/contents', () => {
 
       expect(uuidVersion(responseBody.id)).toBe(4);
       expect(uuidVersion(responseBody.slug)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.published_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.published_at)).not.toBeNaN();
     });
 
     test('"child" content with "title"', async () => {
@@ -1781,9 +1781,9 @@ describe('POST /api/v1/contents', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.published_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.published_at)).not.toBeNaN();
     });
 
     test('"child" content with "parent_id" containing a Number', async () => {
@@ -1883,7 +1883,7 @@ describe('POST /api/v1/contents', () => {
         const getLastEmail = await orchestrator.getLastEmail();
 
         expect(response.status).toBe(201);
-        expect(getLastEmail).toBe(null);
+        expect(getLastEmail).toBeNull();
       });
 
       test('My "root" content replied by myself', async () => {
@@ -1909,7 +1909,7 @@ describe('POST /api/v1/contents', () => {
 
         expect(response.status).toBe(201);
         expect(responseBody.parent_id).toBe(rootContent.id);
-        expect(getLastEmail).toBe(null);
+        expect(getLastEmail).toBeNull();
       });
 
       test('My "root" content with short "title" replied by other user', async () => {
@@ -2139,7 +2139,7 @@ describe('POST /api/v1/contents', () => {
 
         // 5) CHECK IF FIRST USER RECEIVED ANY EMAIL
         const getLastEmail1 = await orchestrator.getLastEmail();
-        expect(getLastEmail1).toBe(null);
+        expect(getLastEmail1).toBeNull();
 
         // 6) ENABLE NOTIFICATIONS FOR FIRST USER
         const { response: userPatchResponse2 } = await usersRequestBuilder.patch(`/${firstUser.username}`, {
@@ -2454,8 +2454,8 @@ describe('POST /api/v1/contents', () => {
         });
 
         expect(uuidVersion(responseBody.id)).toBe(4);
-        expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-        expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+        expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+        expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
@@ -2506,8 +2506,8 @@ describe('POST /api/v1/contents', () => {
         });
 
         expect(uuidVersion(responseBody.id)).toBe(4);
-        expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-        expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+        expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+        expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${secondUser.username}`);
 
@@ -2550,8 +2550,8 @@ describe('POST /api/v1/contents', () => {
         });
 
         expect(uuidVersion(responseBody.id)).toBe(4);
-        expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-        expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+        expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+        expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
@@ -2602,8 +2602,8 @@ describe('POST /api/v1/contents', () => {
         });
 
         expect(uuidVersion(responseBody.id)).toBe(4);
-        expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-        expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+        expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+        expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${secondUser.username}`);
 
@@ -2646,8 +2646,8 @@ describe('POST /api/v1/contents', () => {
         });
 
         expect(uuidVersion(responseBody.id)).toBe(4);
-        expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-        expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+        expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+        expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
@@ -2698,8 +2698,8 @@ describe('POST /api/v1/contents', () => {
         });
 
         expect(uuidVersion(responseBody.id)).toBe(4);
-        expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-        expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+        expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+        expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${secondUser.username}`);
 
@@ -2888,8 +2888,8 @@ describe('POST /api/v1/contents', () => {
         });
 
         expect(uuidVersion(responseBody.id)).toBe(4);
-        expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-        expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+        expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+        expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
@@ -2940,8 +2940,8 @@ describe('POST /api/v1/contents', () => {
         });
 
         expect(uuidVersion(responseBody.id)).toBe(4);
-        expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-        expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+        expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+        expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${secondUser.username}`);
 
@@ -2986,8 +2986,8 @@ describe('POST /api/v1/contents', () => {
         });
 
         expect(uuidVersion(responseBody.id)).toBe(4);
-        expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-        expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+        expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+        expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
@@ -3038,8 +3038,8 @@ describe('POST /api/v1/contents', () => {
         });
 
         expect(uuidVersion(responseBody.id)).toBe(4);
-        expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-        expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+        expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+        expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${secondUser.username}`);
 

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -2716,7 +2716,7 @@ describe('POST /api/v1/contents', () => {
           now: new Date(Date.now() - 1000 * 60 * 60 * 24 * 3), // 3 days ago
         });
 
-        orchestrator.createBalance({
+        await orchestrator.createBalance({
           balanceType: 'user:tabcash',
           recipientId: defaultUser.id,
           amount: defaultTabCashForAdCreation,
@@ -2775,7 +2775,7 @@ describe('POST /api/v1/contents', () => {
           now: new Date(Date.now() - 1000 * 60 * 60 * 24 * 3), // 3 days ago
         });
 
-        orchestrator.createBalance({
+        await orchestrator.createBalance({
           balanceType: 'user:tabcash',
           recipientId: defaultUser.id,
           amount: defaultTabCashForAdCreation,
@@ -3053,7 +3053,7 @@ describe('POST /api/v1/contents', () => {
         const contentsRequestBuilder = new RequestBuilder('/api/v1/contents');
         const defaultUser = await contentsRequestBuilder.buildUser();
 
-        orchestrator.createBalance({
+        await orchestrator.createBalance({
           balanceType: 'user:tabcash',
           recipientId: defaultUser.id,
           amount: defaultTabCashForAdCreation,
@@ -3100,7 +3100,7 @@ describe('POST /api/v1/contents', () => {
         const usersRequestBuilder = new RequestBuilder('/api/v1/users');
         const defaultUser = await contentsRequestBuilder.buildUser();
 
-        orchestrator.createBalance({
+        await orchestrator.createBalance({
           balanceType: 'user:tabcash',
           recipientId: defaultUser.id,
           amount: 1_000 + defaultTabCashForAdCreation,
@@ -3125,7 +3125,7 @@ describe('POST /api/v1/contents', () => {
         const usersRequestBuilder = new RequestBuilder('/api/v1/users');
         const defaultUser = await contentsRequestBuilder.buildUser();
 
-        orchestrator.createBalance({
+        await orchestrator.createBalance({
           balanceType: 'user:tabcash',
           recipientId: defaultUser.id,
           amount: defaultTabCashForAdCreation - 1,
@@ -3165,7 +3165,7 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        orchestrator.createBalance({
+        await orchestrator.createBalance({
           balanceType: 'user:tabcash',
           recipientId: defaultUser.id,
           amount: defaultTabCashForAdCreation,
@@ -3212,7 +3212,7 @@ describe('POST /api/v1/contents', () => {
         const defaultUser = await contentsRequestBuilder.buildUser();
         await orchestrator.createPrestige(defaultUser.id, { rootPrestigeNumerator: 2, rootPrestigeDenominator: 10 });
 
-        orchestrator.createBalance({
+        await orchestrator.createBalance({
           balanceType: 'user:tabcash',
           recipientId: defaultUser.id,
           amount: defaultTabCashForAdCreation,
@@ -3240,7 +3240,7 @@ describe('POST /api/v1/contents', () => {
         const contentsRequestBuilder = new RequestBuilder('/api/v1/contents');
         const defaultUser = await contentsRequestBuilder.buildUser();
 
-        orchestrator.createBalance({
+        await orchestrator.createBalance({
           balanceType: 'user:tabcash',
           recipientId: defaultUser.id,
           amount: defaultTabCashForAdCreation,

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -21,14 +21,14 @@ describe('POST /api/v1/contents', () => {
         body: 'Não deveria conseguir.',
       });
 
-      expect(response.status).toEqual(403);
-      expect(responseBody.status_code).toEqual(403);
-      expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('Usuário não pode executar esta operação.');
-      expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "create:content".');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
+      expect(response.status).toBe(403);
+      expect(responseBody.status_code).toBe(403);
+      expect(responseBody.name).toBe('ForbiddenError');
+      expect(responseBody.message).toBe('Usuário não pode executar esta operação.');
+      expect(responseBody.action).toBe('Verifique se este usuário possui a feature "create:content".');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
     });
   });
 
@@ -42,14 +42,14 @@ describe('POST /api/v1/contents', () => {
         body: 'Não deveria conseguir, pois não possui a feature "create:content:text_root".',
       });
 
-      expect(response.status).toEqual(403);
-      expect(responseBody.status_code).toEqual(403);
-      expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('Você não possui permissão para criar conteúdos na raiz do site.');
-      expect(responseBody.action).toEqual('Verifique se você possui a feature "create:content:text_root".');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual(
+      expect(response.status).toBe(403);
+      expect(responseBody.status_code).toBe(403);
+      expect(responseBody.name).toBe('ForbiddenError');
+      expect(responseBody.message).toBe('Você não possui permissão para criar conteúdos na raiz do site.');
+      expect(responseBody.action).toBe('Verifique se você possui a feature "create:content:text_root".');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe(
         'CONTROLLER:CONTENT:POST_HANDLER:CREATE:CONTENT:TEXT_ROOT:FEATURE_NOT_FOUND',
       );
     });
@@ -75,16 +75,14 @@ describe('POST /api/v1/contents', () => {
         status: 'published',
       });
 
-      expect(response.status).toEqual(403);
-      expect(responseBody.status_code).toEqual(403);
-      expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual(
-        'Você não possui permissão para criar conteúdos dentro de outros conteúdos.',
-      );
-      expect(responseBody.action).toEqual('Verifique se você possui a feature "create:content:text_child".');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual(
+      expect(response.status).toBe(403);
+      expect(responseBody.status_code).toBe(403);
+      expect(responseBody.name).toBe('ForbiddenError');
+      expect(responseBody.message).toBe('Você não possui permissão para criar conteúdos dentro de outros conteúdos.');
+      expect(responseBody.action).toBe('Verifique se você possui a feature "create:content:text_child".');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe(
         'CONTROLLER:CONTENT:POST_HANDLER:CREATE:CONTENT:TEXT_CHILD:FEATURE_NOT_FOUND',
       );
     });
@@ -98,14 +96,14 @@ describe('POST /api/v1/contents', () => {
 
       const { response, responseBody } = await contentsRequestBuilder.post();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"body" enviado deve ser do tipo Object.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"body" enviado deve ser do tipo Object.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with POST Body containing an invalid JSON string', async () => {
@@ -118,14 +116,14 @@ describe('POST /api/v1/contents', () => {
         'Texto corrido no lugar de um JSON',
       );
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"body" enviado deve ser do tipo Object.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"body" enviado deve ser do tipo Object.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "owner_id" pointing to another user', async () => {
@@ -141,7 +139,7 @@ describe('POST /api/v1/contents', () => {
         owner_id: secondUser.id,
       });
 
-      expect(response.status).toEqual(201);
+      expect(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -163,9 +161,9 @@ describe('POST /api/v1/contents', () => {
         owner_username: firstUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
     });
 
     test('Content with "body" not declared', async () => {
@@ -176,14 +174,14 @@ describe('POST /api/v1/contents', () => {
         title: 'Não deveria conseguir, falta o "body".',
       });
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"body" é um campo obrigatório.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"body" é um campo obrigatório.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "body" containing blank String', async () => {
@@ -195,14 +193,14 @@ describe('POST /api/v1/contents', () => {
         body: '',
       });
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"body" não pode estar em branco.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"body" não pode estar em branco.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "body" containing empty Markdown', async () => {
@@ -269,14 +267,14 @@ describe('POST /api/v1/contents', () => {
           `,
       });
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('Markdown deve conter algum texto.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('Markdown deve conter algum texto.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "title", "body" and "source_url" containing \\u0000 null characters', async () => {
@@ -289,7 +287,7 @@ describe('POST /api/v1/contents', () => {
         source_url: 'https://teste-\u0000caractere.invalido/\u0000',
       });
 
-      expect(response.status).toEqual(201);
+      expect(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -311,9 +309,9 @@ describe('POST /api/v1/contents', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
     });
 
     test('Content with "title" and "body" containing invalid characters', async () => {
@@ -325,14 +323,14 @@ describe('POST /api/v1/contents', () => {
         body: '\u200fTexto começando e terminando com caracteres inválidos.\u200e',
       });
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"body" deve começar com caracteres visíveis.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"body" deve começar com caracteres visíveis.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "body" containing more than 20.000 characters', async () => {
@@ -344,14 +342,14 @@ describe('POST /api/v1/contents', () => {
         body: 'A'.repeat(20001),
       });
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"body" deve conter no máximo 20000 caracteres.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"body" deve conter no máximo 20000 caracteres.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "body" containing untrimmed values', async () => {
@@ -363,14 +361,14 @@ describe('POST /api/v1/contents', () => {
         body: ' Espaço no início e no fim ',
       });
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"body" deve começar com caracteres visíveis.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"body" deve começar com caracteres visíveis.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "body" ending with untrimmed values', async () => {
@@ -382,7 +380,7 @@ describe('POST /api/v1/contents', () => {
         body: 'Espaço só no fim ',
       });
 
-      expect(response.status).toEqual(201);
+      expect(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -404,9 +402,9 @@ describe('POST /api/v1/contents', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
     });
 
     test('Content with "body" containing Null value', async () => {
@@ -418,14 +416,14 @@ describe('POST /api/v1/contents', () => {
         body: null,
       });
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"body" deve ser do tipo String.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"body" deve ser do tipo String.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "slug" containing a custom valid value', async () => {
@@ -438,7 +436,7 @@ describe('POST /api/v1/contents', () => {
         slug: 'nodejs',
       });
 
-      expect(response.status).toEqual(201);
+      expect(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -460,9 +458,9 @@ describe('POST /api/v1/contents', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
     });
 
     test('Content with "slug" containing a blank String', async () => {
@@ -475,14 +473,14 @@ describe('POST /api/v1/contents', () => {
         slug: '',
       });
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"slug" não pode estar em branco.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"slug" não pode estar em branco.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test(`Content with "slug" containing more than ${maxSlugLength} bytes`, async () => {
@@ -498,7 +496,7 @@ describe('POST /api/v1/contents', () => {
         ),
       });
 
-      expect(response.status).toEqual(201);
+      expect(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -523,9 +521,9 @@ describe('POST /api/v1/contents', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
     });
 
     test('Content with "slug" containing special characters', async () => {
@@ -538,14 +536,14 @@ describe('POST /api/v1/contents', () => {
         slug: 'slug-não-pode-ter-caracteres-especiais',
       });
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"slug" está no formato errado.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"slug" está no formato errado.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "slug" containing Null value', async () => {
@@ -558,14 +556,14 @@ describe('POST /api/v1/contents', () => {
         slug: null,
       });
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"slug" deve ser do tipo String.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"slug" deve ser do tipo String.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "slug" containing the same value of another content (same user, both "published" status)', async () => {
@@ -586,7 +584,7 @@ describe('POST /api/v1/contents', () => {
         status: 'published',
       });
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -598,8 +596,8 @@ describe('POST /api/v1/contents', () => {
         error_location_code: 'MODEL:CONTENT:CHECK_FOR_CONTENT_UNIQUENESS:ALREADY_EXISTS',
         key: 'slug',
       });
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('Content with "slug" containing the same value of another content (same user, one with "draft" and the other "published" status)', async () => {
@@ -620,7 +618,7 @@ describe('POST /api/v1/contents', () => {
         status: 'published',
       });
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -632,8 +630,8 @@ describe('POST /api/v1/contents', () => {
         error_location_code: 'MODEL:CONTENT:CHECK_FOR_CONTENT_UNIQUENESS:ALREADY_EXISTS',
         key: 'slug',
       });
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('Content with "slug" containing the same value of another content (same user, one with "published" and the other "deleted" status)', async () => {
@@ -658,7 +656,7 @@ describe('POST /api/v1/contents', () => {
         status: 'published',
       });
 
-      expect(response.status).toEqual(201);
+      expect(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -680,9 +678,9 @@ describe('POST /api/v1/contents', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.published_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.published_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
     });
 
     test('Content with "slug" with trailing hyphen', async () => {
@@ -695,7 +693,7 @@ describe('POST /api/v1/contents', () => {
         slug: 'slug-with-trailing-hyphen---',
       });
 
-      expect(response.status).toEqual(201);
+      expect(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -717,9 +715,9 @@ describe('POST /api/v1/contents', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
     });
 
     test('Content with "title" containing a blank String', async () => {
@@ -731,14 +729,14 @@ describe('POST /api/v1/contents', () => {
         body: 'Qualquer coisa.',
       });
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"title" não pode estar em branco.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"title" não pode estar em branco.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test(`Content with "title" containing more than ${maxTitleLength} characters`, async () => {
@@ -750,14 +748,14 @@ describe('POST /api/v1/contents', () => {
         body: 'Qualquer coisa.',
       });
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual(`"title" deve conter no máximo ${maxTitleLength} caracteres.`);
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe(`"title" deve conter no máximo ${maxTitleLength} caracteres.`);
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test(`Content with "title" containing ${maxTitleLength} characters but more than ${maxTitleLength} bytes`, async () => {
@@ -773,7 +771,7 @@ describe('POST /api/v1/contents', () => {
         body: 'Instale o Node.js',
       });
 
-      expect(response.status).toEqual(201);
+      expect(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -802,9 +800,9 @@ describe('POST /api/v1/contents', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
     });
 
     test('Content with "title" containing Braille Pattern Blank Unicode Character', async () => {
@@ -816,7 +814,7 @@ describe('POST /api/v1/contents', () => {
         body: 'Instale o Node.js',
       });
 
-      expect(response.status).toEqual(201);
+      expect(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -838,9 +836,9 @@ describe('POST /api/v1/contents', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
     });
 
     test(`Content with "title" containing special characters occupying more than ${maxTitleLength} bytes`, async () => {
@@ -852,7 +850,7 @@ describe('POST /api/v1/contents', () => {
         body: `The title is ${maxTitleLength} characters but 765 bytes and the slug should only be ${maxSlugLength} bytes`,
       });
 
-      expect(response.status).toEqual(201);
+      expect(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -874,9 +872,9 @@ describe('POST /api/v1/contents', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
     });
 
     test('Content with "title" containing untrimmed values', async () => {
@@ -888,7 +886,7 @@ describe('POST /api/v1/contents', () => {
         body: 'Qualquer coisa.',
       });
 
-      expect(response.status).toEqual(201);
+      expect(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -910,9 +908,9 @@ describe('POST /api/v1/contents', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
     });
 
     test('Content with "title" containing unescaped characters', async () => {
@@ -924,7 +922,7 @@ describe('POST /api/v1/contents', () => {
         body: 'Qualquer coisa.',
       });
 
-      expect(response.status).toEqual(201);
+      expect(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -946,9 +944,9 @@ describe('POST /api/v1/contents', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
     });
 
     test('Content with "status" set to "draft"', async () => {
@@ -961,7 +959,7 @@ describe('POST /api/v1/contents', () => {
         status: 'draft',
       });
 
-      expect(response.status).toEqual(201);
+      expect(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -983,9 +981,9 @@ describe('POST /api/v1/contents', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
     });
 
     test('Content with "status" set to "published"', async () => {
@@ -998,7 +996,7 @@ describe('POST /api/v1/contents', () => {
         status: 'published',
       });
 
-      expect(response.status).toEqual(201);
+      expect(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1020,10 +1018,10 @@ describe('POST /api/v1/contents', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.published_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.published_at)).not.toBe(NaN);
     });
 
     test('Content with "status" set to "deleted"', async () => {
@@ -1036,7 +1034,7 @@ describe('POST /api/v1/contents', () => {
         status: 'deleted',
       });
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
         message: 'Não é possível criar um novo conteúdo diretamente com status "deleted".',
@@ -1060,7 +1058,7 @@ describe('POST /api/v1/contents', () => {
         status: 'firewall',
       });
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
         message: 'Não é possível criar um novo conteúdo diretamente com status "firewall".',
@@ -1084,16 +1082,16 @@ describe('POST /api/v1/contents', () => {
         status: 'inexisting_status',
       });
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual(
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe(
         '"status" deve possuir um dos seguintes valores: "draft", "published", "deleted", "firewall".',
       );
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "status" set to Null', async () => {
@@ -1106,16 +1104,16 @@ describe('POST /api/v1/contents', () => {
         status: null,
       });
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual(
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe(
         '"status" deve possuir um dos seguintes valores: "draft", "published", "deleted", "firewall".',
       );
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "status" set a blank String', async () => {
@@ -1128,16 +1126,16 @@ describe('POST /api/v1/contents', () => {
         status: '',
       });
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual(
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe(
         '"status" deve possuir um dos seguintes valores: "draft", "published", "deleted", "firewall".',
       );
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "source_url" containing a valid HTTP URL', async () => {
@@ -1150,7 +1148,7 @@ describe('POST /api/v1/contents', () => {
         source_url: 'http://www.tabnews.com.br/',
       });
 
-      expect(response.status).toEqual(201);
+      expect(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1172,9 +1170,9 @@ describe('POST /api/v1/contents', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
     });
 
     test('Content with "source_url" containing a valid HTTPS URL', async () => {
@@ -1187,7 +1185,7 @@ describe('POST /api/v1/contents', () => {
         source_url: 'https://www.tabnews.com.br/museu',
       });
 
-      expect(response.status).toEqual(201);
+      expect(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1209,9 +1207,9 @@ describe('POST /api/v1/contents', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
     });
 
     test('Content with "source_url" containing a valid long TLD', async () => {
@@ -1224,7 +1222,7 @@ describe('POST /api/v1/contents', () => {
         source_url: 'http://nic.xn--vermgensberatung-pwb/',
       });
 
-      expect(response.status).toEqual(201);
+      expect(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1246,9 +1244,9 @@ describe('POST /api/v1/contents', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
     });
 
     test('Content with "source_url" containing a valid short URL', async () => {
@@ -1261,7 +1259,7 @@ describe('POST /api/v1/contents', () => {
         source_url: 'https://t.me',
       });
 
-      expect(response.status).toEqual(201);
+      expect(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1283,9 +1281,9 @@ describe('POST /api/v1/contents', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
     });
 
     test('Content with "source_url" containing a invalid short TLD', async () => {
@@ -1298,16 +1296,16 @@ describe('POST /api/v1/contents', () => {
         source_url: 'https://invalidtl.d',
       });
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual(
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe(
         '"source_url" deve possuir uma URL válida e utilizando os protocolos HTTP ou HTTPS.',
       );
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "source_url" containing a invalid long TLD', async () => {
@@ -1320,16 +1318,16 @@ describe('POST /api/v1/contents', () => {
         source_url: 'http://tl.dcomvinteecincocaracteres',
       });
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual(
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe(
         '"source_url" deve possuir uma URL válida e utilizando os protocolos HTTP ou HTTPS.',
       );
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "source_url" containing a not accepted Protocol', async () => {
@@ -1342,16 +1340,16 @@ describe('POST /api/v1/contents', () => {
         source_url: 'ftp://www.tabnews.com.br',
       });
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual(
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe(
         '"source_url" deve possuir uma URL válida e utilizando os protocolos HTTP ou HTTPS.',
       );
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "source_url" not containing a protocol', async () => {
@@ -1364,16 +1362,16 @@ describe('POST /api/v1/contents', () => {
         source_url: 'www.tabnews.com.br',
       });
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual(
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe(
         '"source_url" deve possuir uma URL válida e utilizando os protocolos HTTP ou HTTPS.',
       );
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "source_url" containing an incomplete URL', async () => {
@@ -1386,16 +1384,16 @@ describe('POST /api/v1/contents', () => {
         source_url: 'https://lol.',
       });
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual(
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe(
         '"source_url" deve possuir uma URL válida e utilizando os protocolos HTTP ou HTTPS.',
       );
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "source_url" containing query parameters', async () => {
@@ -1408,7 +1406,7 @@ describe('POST /api/v1/contents', () => {
         source_url: 'https://www.tabnews.com.br/api/v1/contents?strategy=old',
       });
 
-      expect(response.status).toEqual(201);
+      expect(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1430,9 +1428,9 @@ describe('POST /api/v1/contents', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
     });
 
     test('Content with "source_url" containing fragment component', async () => {
@@ -1445,7 +1443,7 @@ describe('POST /api/v1/contents', () => {
         source_url: 'http://www.tabnews.com.br/#:~:text=TabNews,-Status',
       });
 
-      expect(response.status).toEqual(201);
+      expect(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1467,9 +1465,9 @@ describe('POST /api/v1/contents', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
     });
 
     test('Content with "source_url" containing an empty String', async () => {
@@ -1482,14 +1480,14 @@ describe('POST /api/v1/contents', () => {
         source_url: '',
       });
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"source_url" não pode estar em branco.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"source_url" não pode estar em branco.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Content with "source_url" containing a Null value', async () => {
@@ -1502,7 +1500,7 @@ describe('POST /api/v1/contents', () => {
         source_url: null,
       });
 
-      expect(response.status).toEqual(201);
+      expect(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1524,9 +1522,9 @@ describe('POST /api/v1/contents', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
     });
 
     test('"root" content with minimum valid data', async () => {
@@ -1539,7 +1537,7 @@ describe('POST /api/v1/contents', () => {
         body: 'Deveria conseguir, pois atualmente todos os usuários recebem todas as features relacionadas a "content".',
       });
 
-      expect(response.status).toEqual(201);
+      expect(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1562,9 +1560,9 @@ describe('POST /api/v1/contents', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
 
       const contentInDatabase = await database.query({
         text: 'SELECT * FROM contents WHERE id = $1',
@@ -1583,7 +1581,7 @@ describe('POST /api/v1/contents', () => {
         body: 'Body',
       });
 
-      expect(response.status).toEqual(201);
+      expect(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1605,9 +1603,9 @@ describe('POST /api/v1/contents', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
     });
 
     test('"root" content with "title" not declared', async () => {
@@ -1618,14 +1616,14 @@ describe('POST /api/v1/contents', () => {
         body: 'Não deveria conseguir, falta o "title".',
       });
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"title" é um campo obrigatório.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:CONTENT:CHECK_ROOT_CONTENT_TITLE:MISSING_TITLE');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"title" é um campo obrigatório.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:CONTENT:CHECK_ROOT_CONTENT_TITLE:MISSING_TITLE');
     });
 
     test('"root" content with "title" containing Null value', async () => {
@@ -1637,14 +1635,14 @@ describe('POST /api/v1/contents', () => {
         body: 'Não deveria conseguir, falta o "title".',
       });
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"title" é um campo obrigatório.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:CONTENT:CHECK_ROOT_CONTENT_TITLE:MISSING_TITLE');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"title" é um campo obrigatório.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:CONTENT:CHECK_ROOT_CONTENT_TITLE:MISSING_TITLE');
     });
 
     test('"child" content with minimum valid data', async () => {
@@ -1662,7 +1660,7 @@ describe('POST /api/v1/contents', () => {
         parent_id: rootContent.id,
       });
 
-      expect(response.status).toEqual(201);
+      expect(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1684,10 +1682,10 @@ describe('POST /api/v1/contents', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(uuidVersion(responseBody.slug)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(uuidVersion(responseBody.slug)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
 
       const contentInDatabase = await database.query({
         text: 'SELECT * FROM contents WHERE id = $1',
@@ -1714,7 +1712,7 @@ describe('POST /api/v1/contents', () => {
         status: 'published',
       });
 
-      expect(response.status).toEqual(201);
+      expect(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1736,11 +1734,11 @@ describe('POST /api/v1/contents', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(uuidVersion(responseBody.slug)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.published_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(uuidVersion(responseBody.slug)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.published_at)).not.toBe(NaN);
     });
 
     test('"child" content with "title"', async () => {
@@ -1760,7 +1758,7 @@ describe('POST /api/v1/contents', () => {
         status: 'published',
       });
 
-      expect(response.status).toEqual(201);
+      expect(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1782,10 +1780,10 @@ describe('POST /api/v1/contents', () => {
         owner_username: defaultUser.username,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.published_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.published_at)).not.toBe(NaN);
     });
 
     test('"child" content with "parent_id" containing a Number', async () => {
@@ -1797,14 +1795,14 @@ describe('POST /api/v1/contents', () => {
         parent_id: 123456,
       });
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"parent_id" deve ser do tipo String.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"parent_id" deve ser do tipo String.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('"child" content with "parent_id" containing a blank string', async () => {
@@ -1816,14 +1814,14 @@ describe('POST /api/v1/contents', () => {
         parent_id: '',
       });
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"parent_id" não pode estar em branco.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"parent_id" não pode estar em branco.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('"child" content with "parent_id" containing a malformatted UUIDV4', async () => {
@@ -1835,14 +1833,14 @@ describe('POST /api/v1/contents', () => {
         parent_id: 'isso não é um UUID válido',
       });
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"parent_id" deve possuir um token UUID na versão 4.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"parent_id" deve possuir um token UUID na versão 4.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('"child" content with "parent_id" that does not exists', async () => {
@@ -1854,7 +1852,7 @@ describe('POST /api/v1/contents', () => {
         parent_id: 'fe2e20f5-9296-45ea-9a0f-401866819b9e',
       });
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
       expect(responseBody).toStrictEqual({
         status_code: 400,
         name: 'ValidationError',
@@ -1865,8 +1863,8 @@ describe('POST /api/v1/contents', () => {
         error_id: responseBody.error_id,
         request_id: responseBody.request_id,
       });
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     describe('Notifications', () => {
@@ -2247,12 +2245,12 @@ describe('POST /api/v1/contents', () => {
           body: relevantBody,
         });
 
-        expect(responseBody.tabcoins).toEqual(0);
+        expect(responseBody.tabcoins).toBe(0);
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
-        expect(userResponseBody.tabcoins).toEqual(0);
-        expect(userResponseBody.tabcash).toEqual(0);
+        expect(userResponseBody.tabcoins).toBe(0);
+        expect(userResponseBody.tabcash).toBe(0);
       });
 
       test('"root" content with "published" status', async () => {
@@ -2268,12 +2266,12 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        expect(responseBody.tabcoins).toEqual(1);
+        expect(responseBody.tabcoins).toBe(1);
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
-        expect(userResponseBody.tabcoins).toEqual(2);
-        expect(userResponseBody.tabcash).toEqual(0);
+        expect(userResponseBody.tabcoins).toBe(2);
+        expect(userResponseBody.tabcash).toBe(0);
       });
 
       test('"child" content with "draft" status', async () => {
@@ -2295,12 +2293,12 @@ describe('POST /api/v1/contents', () => {
           status: 'draft',
         });
 
-        expect(responseBody.tabcoins).toEqual(0);
+        expect(responseBody.tabcoins).toBe(0);
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${secondUser.username}`);
 
-        expect(userResponseBody.tabcoins).toEqual(0);
-        expect(userResponseBody.tabcash).toEqual(0);
+        expect(userResponseBody.tabcoins).toBe(0);
+        expect(userResponseBody.tabcash).toBe(0);
       });
 
       test('"child" content with "published" status (same user)', async () => {
@@ -2325,12 +2323,12 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        expect(responseBody.tabcoins).toEqual(0);
+        expect(responseBody.tabcoins).toBe(0);
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
-        expect(userResponseBody.tabcoins).toEqual(2);
-        expect(userResponseBody.tabcash).toEqual(0);
+        expect(userResponseBody.tabcoins).toBe(2);
+        expect(userResponseBody.tabcash).toBe(0);
       });
 
       test('"child" content with "published" status (different user)', async () => {
@@ -2353,12 +2351,12 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        expect(responseBody.tabcoins).toEqual(1);
+        expect(responseBody.tabcoins).toBe(1);
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${secondUser.username}`);
 
-        expect(userResponseBody.tabcoins).toEqual(2);
-        expect(userResponseBody.tabcash).toEqual(0);
+        expect(userResponseBody.tabcoins).toBe(2);
+        expect(userResponseBody.tabcash).toBe(0);
       });
     });
 
@@ -2374,20 +2372,18 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        expect(response.status).toEqual(403);
-        expect(responseBody.status_code).toEqual(403);
-        expect(responseBody.name).toEqual('ForbiddenError');
-        expect(responseBody.message).toEqual(
+        expect(response.status).toBe(403);
+        expect(responseBody.status_code).toBe(403);
+        expect(responseBody.name).toBe('ForbiddenError');
+        expect(responseBody.message).toBe(
           'Não é possível publicar porque há outras publicações mal avaliadas que ainda não foram excluídas.',
         );
-        expect(responseBody.action).toEqual(
+        expect(responseBody.action).toBe(
           'Exclua seus conteúdos mais recentes que estiverem classificados como não relevantes.',
         );
-        expect(uuidVersion(responseBody.error_id)).toEqual(4);
-        expect(uuidVersion(responseBody.request_id)).toEqual(4);
-        expect(responseBody.error_location_code).toEqual(
-          'MODEL:CONTENT:CREDIT_OR_DEBIT_TABCOINS:NEGATIVE_USER_EARNINGS',
-        );
+        expect(uuidVersion(responseBody.error_id)).toBe(4);
+        expect(uuidVersion(responseBody.request_id)).toBe(4);
+        expect(responseBody.error_location_code).toBe('MODEL:CONTENT:CREDIT_OR_DEBIT_TABCOINS:NEGATIVE_USER_EARNINGS');
       });
 
       test('should not be able to create "child" content with negative prestige by more than threshold', async () => {
@@ -2409,20 +2405,18 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        expect(response.status).toEqual(403);
-        expect(responseBody.status_code).toEqual(403);
-        expect(responseBody.name).toEqual('ForbiddenError');
-        expect(responseBody.message).toEqual(
+        expect(response.status).toBe(403);
+        expect(responseBody.status_code).toBe(403);
+        expect(responseBody.name).toBe('ForbiddenError');
+        expect(responseBody.message).toBe(
           'Não é possível publicar porque há outras publicações mal avaliadas que ainda não foram excluídas.',
         );
-        expect(responseBody.action).toEqual(
+        expect(responseBody.action).toBe(
           'Exclua seus conteúdos mais recentes que estiverem classificados como não relevantes.',
         );
-        expect(uuidVersion(responseBody.error_id)).toEqual(4);
-        expect(uuidVersion(responseBody.request_id)).toEqual(4);
-        expect(responseBody.error_location_code).toEqual(
-          'MODEL:CONTENT:CREDIT_OR_DEBIT_TABCOINS:NEGATIVE_USER_EARNINGS',
-        );
+        expect(uuidVersion(responseBody.error_id)).toBe(4);
+        expect(uuidVersion(responseBody.request_id)).toBe(4);
+        expect(responseBody.error_location_code).toBe('MODEL:CONTENT:CREDIT_OR_DEBIT_TABCOINS:NEGATIVE_USER_EARNINGS');
       });
 
       test('Should be able to create "root" content with negative prestige at the threshold', async () => {
@@ -2437,7 +2431,7 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        expect(response.status).toEqual(201);
+        expect(response.status).toBe(201);
 
         expect(responseBody).toStrictEqual({
           id: responseBody.id,
@@ -2459,14 +2453,14 @@ describe('POST /api/v1/contents', () => {
           owner_username: defaultUser.username,
         });
 
-        expect(uuidVersion(responseBody.id)).toEqual(4);
-        expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-        expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+        expect(uuidVersion(responseBody.id)).toBe(4);
+        expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+        expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
-        expect(userResponseBody.tabcoins).toEqual(0);
-        expect(userResponseBody.tabcash).toEqual(0);
+        expect(userResponseBody.tabcoins).toBe(0);
+        expect(userResponseBody.tabcash).toBe(0);
       });
 
       test('Should be able to create "child" content with negative prestige at the threshold', async () => {
@@ -2489,7 +2483,7 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        expect(response.status).toEqual(201);
+        expect(response.status).toBe(201);
 
         expect(responseBody).toStrictEqual({
           id: responseBody.id,
@@ -2511,14 +2505,14 @@ describe('POST /api/v1/contents', () => {
           owner_username: secondUser.username,
         });
 
-        expect(uuidVersion(responseBody.id)).toEqual(4);
-        expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-        expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+        expect(uuidVersion(responseBody.id)).toBe(4);
+        expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+        expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${secondUser.username}`);
 
-        expect(userResponseBody.tabcoins).toEqual(0);
-        expect(userResponseBody.tabcash).toEqual(0);
+        expect(userResponseBody.tabcoins).toBe(0);
+        expect(userResponseBody.tabcash).toBe(0);
       });
 
       test('Should not be able to earn tabcoins if it has less than threshold prestige in "root" content', async () => {
@@ -2533,7 +2527,7 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        expect(response.status).toEqual(201);
+        expect(response.status).toBe(201);
 
         expect(responseBody).toStrictEqual({
           id: responseBody.id,
@@ -2555,14 +2549,14 @@ describe('POST /api/v1/contents', () => {
           owner_username: defaultUser.username,
         });
 
-        expect(uuidVersion(responseBody.id)).toEqual(4);
-        expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-        expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+        expect(uuidVersion(responseBody.id)).toBe(4);
+        expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+        expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
-        expect(userResponseBody.tabcoins).toEqual(0);
-        expect(userResponseBody.tabcash).toEqual(0);
+        expect(userResponseBody.tabcoins).toBe(0);
+        expect(userResponseBody.tabcash).toBe(0);
       });
 
       test('Should not be able to earn tabcoins if it has less than threshold prestige in "child" content', async () => {
@@ -2585,7 +2579,7 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        expect(response.status).toEqual(201);
+        expect(response.status).toBe(201);
 
         expect(responseBody).toStrictEqual({
           id: responseBody.id,
@@ -2607,14 +2601,14 @@ describe('POST /api/v1/contents', () => {
           owner_username: secondUser.username,
         });
 
-        expect(uuidVersion(responseBody.id)).toEqual(4);
-        expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-        expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+        expect(uuidVersion(responseBody.id)).toBe(4);
+        expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+        expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${secondUser.username}`);
 
-        expect(userResponseBody.tabcoins).toEqual(0);
-        expect(userResponseBody.tabcash).toEqual(0);
+        expect(userResponseBody.tabcoins).toBe(0);
+        expect(userResponseBody.tabcash).toBe(0);
       });
 
       test('Should be able to earn tabcoins if it has minimum prestige in "root" content', async () => {
@@ -2629,7 +2623,7 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        expect(response.status).toEqual(201);
+        expect(response.status).toBe(201);
 
         expect(responseBody).toStrictEqual({
           id: responseBody.id,
@@ -2651,14 +2645,14 @@ describe('POST /api/v1/contents', () => {
           owner_username: defaultUser.username,
         });
 
-        expect(uuidVersion(responseBody.id)).toEqual(4);
-        expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-        expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+        expect(uuidVersion(responseBody.id)).toBe(4);
+        expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+        expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
-        expect(userResponseBody.tabcoins).toEqual(1);
-        expect(userResponseBody.tabcash).toEqual(0);
+        expect(userResponseBody.tabcoins).toBe(1);
+        expect(userResponseBody.tabcash).toBe(0);
       });
 
       test('Should be able to earn tabcoins if it has minimum prestige in "child" content', async () => {
@@ -2681,7 +2675,7 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        expect(response.status).toEqual(201);
+        expect(response.status).toBe(201);
 
         expect(responseBody).toStrictEqual({
           id: responseBody.id,
@@ -2703,14 +2697,14 @@ describe('POST /api/v1/contents', () => {
           owner_username: secondUser.username,
         });
 
-        expect(uuidVersion(responseBody.id)).toEqual(4);
-        expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-        expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+        expect(uuidVersion(responseBody.id)).toBe(4);
+        expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+        expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${secondUser.username}`);
 
-        expect(userResponseBody.tabcoins).toEqual(1);
-        expect(userResponseBody.tabcash).toEqual(0);
+        expect(userResponseBody.tabcoins).toBe(1);
+        expect(userResponseBody.tabcash).toBe(0);
       });
 
       test('Should be able to publish even with a negative ad balance', async () => {
@@ -2845,20 +2839,18 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        expect(response.status).toEqual(403);
-        expect(responseBody.status_code).toEqual(403);
-        expect(responseBody.name).toEqual('ForbiddenError');
-        expect(responseBody.message).toEqual(
+        expect(response.status).toBe(403);
+        expect(responseBody.status_code).toBe(403);
+        expect(responseBody.name).toBe('ForbiddenError');
+        expect(responseBody.message).toBe(
           'Não é possível publicar porque há outras publicações mal avaliadas que ainda não foram excluídas.',
         );
-        expect(responseBody.action).toEqual(
+        expect(responseBody.action).toBe(
           'Exclua seus conteúdos mais recentes que estiverem classificados como não relevantes.',
         );
-        expect(uuidVersion(responseBody.error_id)).toEqual(4);
-        expect(uuidVersion(responseBody.request_id)).toEqual(4);
-        expect(responseBody.error_location_code).toEqual(
-          'MODEL:CONTENT:CREDIT_OR_DEBIT_TABCOINS:NEGATIVE_USER_EARNINGS',
-        );
+        expect(uuidVersion(responseBody.error_id)).toBe(4);
+        expect(uuidVersion(responseBody.request_id)).toBe(4);
+        expect(responseBody.error_location_code).toBe('MODEL:CONTENT:CREDIT_OR_DEBIT_TABCOINS:NEGATIVE_USER_EARNINGS');
       });
 
       test('Should not be able to earn tabcoins in "root" content', async () => {
@@ -2873,7 +2865,7 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        expect(response.status).toEqual(201);
+        expect(response.status).toBe(201);
 
         expect(responseBody).toStrictEqual({
           id: responseBody.id,
@@ -2895,14 +2887,14 @@ describe('POST /api/v1/contents', () => {
           owner_username: defaultUser.username,
         });
 
-        expect(uuidVersion(responseBody.id)).toEqual(4);
-        expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-        expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+        expect(uuidVersion(responseBody.id)).toBe(4);
+        expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+        expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
-        expect(userResponseBody.tabcoins).toEqual(0);
-        expect(userResponseBody.tabcash).toEqual(0);
+        expect(userResponseBody.tabcoins).toBe(0);
+        expect(userResponseBody.tabcash).toBe(0);
       });
 
       test('Should not be able to earn tabcoins in "child" content', async () => {
@@ -2925,7 +2917,7 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        expect(response.status).toEqual(201);
+        expect(response.status).toBe(201);
 
         expect(responseBody).toStrictEqual({
           id: responseBody.id,
@@ -2947,14 +2939,14 @@ describe('POST /api/v1/contents', () => {
           owner_username: secondUser.username,
         });
 
-        expect(uuidVersion(responseBody.id)).toEqual(4);
-        expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-        expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+        expect(uuidVersion(responseBody.id)).toBe(4);
+        expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+        expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${secondUser.username}`);
 
-        expect(userResponseBody.tabcoins).toEqual(0);
-        expect(userResponseBody.tabcash).toEqual(0);
+        expect(userResponseBody.tabcoins).toBe(0);
+        expect(userResponseBody.tabcash).toBe(0);
       });
     });
 
@@ -2971,7 +2963,7 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        expect(response.status).toEqual(201);
+        expect(response.status).toBe(201);
 
         expect(responseBody).toStrictEqual({
           id: responseBody.id,
@@ -2993,14 +2985,14 @@ describe('POST /api/v1/contents', () => {
           owner_username: defaultUser.username,
         });
 
-        expect(uuidVersion(responseBody.id)).toEqual(4);
-        expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-        expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+        expect(uuidVersion(responseBody.id)).toBe(4);
+        expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+        expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${defaultUser.username}`);
 
-        expect(userResponseBody.tabcoins).toEqual(1);
-        expect(userResponseBody.tabcash).toEqual(0);
+        expect(userResponseBody.tabcoins).toBe(1);
+        expect(userResponseBody.tabcash).toBe(0);
       });
 
       test('Should be able to earn tabcoins in "child" content', async () => {
@@ -3023,7 +3015,7 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        expect(response.status).toEqual(201);
+        expect(response.status).toBe(201);
 
         expect(responseBody).toStrictEqual({
           id: responseBody.id,
@@ -3045,14 +3037,14 @@ describe('POST /api/v1/contents', () => {
           owner_username: secondUser.username,
         });
 
-        expect(uuidVersion(responseBody.id)).toEqual(4);
-        expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-        expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+        expect(uuidVersion(responseBody.id)).toBe(4);
+        expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+        expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
 
         const { responseBody: userResponseBody } = await usersRequestBuilder.get(`/${secondUser.username}`);
 
-        expect(userResponseBody.tabcoins).toEqual(1);
-        expect(userResponseBody.tabcash).toEqual(0);
+        expect(userResponseBody.tabcoins).toBe(1);
+        expect(userResponseBody.tabcash).toBe(0);
       });
     });
 

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -1569,7 +1569,7 @@ describe('POST /api/v1/contents', () => {
         values: [responseBody.id],
       });
 
-      expect(contentInDatabase.rows[0].path).toEqual([]);
+      expect(contentInDatabase.rows[0].path).toStrictEqual([]);
     });
 
     test('"root" content with "title" containing custom slug special characters', async () => {
@@ -1692,7 +1692,7 @@ describe('POST /api/v1/contents', () => {
         values: [responseBody.id],
       });
 
-      expect(contentInDatabase.rows[0].path).toEqual([rootContent.id]);
+      expect(contentInDatabase.rows[0].path).toStrictEqual([rootContent.id]);
     });
 
     test('"child" content with "title" containing Null value', async () => {

--- a/tests/integration/api/v1/contents/rss/get.test.js
+++ b/tests/integration/api/v1/contents/rss/get.test.js
@@ -11,12 +11,12 @@ describe('GET /recentes/rss', () => {
   describe('Anonymous user', () => {
     test('With `/rss` alias`', async () => {
       const response = await fetch(`${orchestrator.webserverUrl}/rss`);
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
     });
 
     test('With `/rss.xml` alias`', async () => {
       const response = await fetch(`${orchestrator.webserverUrl}/rss.xml`);
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
     });
 
     test('With 0 contents', async () => {
@@ -25,9 +25,9 @@ describe('GET /recentes/rss', () => {
 
       const lastBuildDateFromResponseBody = /<lastBuildDate>(.*?)<\/lastBuildDate>/.exec(responseBody)[1];
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
-      expect(responseBody).toStrictEqual(`<?xml version="1.0" encoding="utf-8"?>
+      expect(responseBody).toBe(`<?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0">
     <channel>
         <title>TabNews</title>
@@ -68,9 +68,9 @@ describe('GET /recentes/rss', () => {
 
       const lastBuildDateFromResponseBody = /<lastBuildDate>(.*?)<\/lastBuildDate>/.exec(responseBody)[1];
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
-      expect(responseBody).toStrictEqual(`<?xml version="1.0" encoding="utf-8"?>
+      expect(responseBody).toBe(`<?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0">
     <channel>
         <title>TabNews</title>
@@ -121,8 +121,8 @@ describe('GET /recentes/rss', () => {
       const response = await fetch(`${orchestrator.webserverUrl}/rss`);
       const responseBody = await response.text();
 
-      expect(response.status).toEqual(200);
-      expect(responseBody).toStrictEqual(`<?xml version="1.0" encoding="utf-8"?>
+      expect(response.status).toBe(200);
+      expect(responseBody).toBe(`<?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/">
     <channel>
         <title>TabNews</title>

--- a/tests/integration/api/v1/email-confirmation/patch.test.js
+++ b/tests/integration/api/v1/email-confirmation/patch.test.js
@@ -20,7 +20,7 @@ describe('PATCH /api/v1/email-confirmation', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -49,7 +49,7 @@ describe('PATCH /api/v1/email-confirmation', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -78,7 +78,7 @@ describe('PATCH /api/v1/email-confirmation', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -107,7 +107,7 @@ describe('PATCH /api/v1/email-confirmation', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -136,7 +136,7 @@ describe('PATCH /api/v1/email-confirmation', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -171,13 +171,13 @@ describe('PATCH /api/v1/email-confirmation', () => {
         }),
       });
 
-      expect(updateUserResponse.status).toEqual(200);
+      expect(updateUserResponse.status).toBe(200);
 
       // Attention: it should not update the email in the database
       // before the user clicks on the confirmation link sent to the new email.
       // See `/tests/integration/email-confirmation` for more details.
       const userInDatabaseCheck1 = await user.findOneById(defaultUser.id);
-      expect(userInDatabaseCheck1.email).toEqual('fresh.valid.token@email.com');
+      expect(userInDatabaseCheck1.email).toBe('fresh.valid.token@email.com');
 
       // 2) RECEIVE CONFIRMATION EMAIL
       const confirmationEmail = await orchestrator.getLastEmail();
@@ -187,9 +187,9 @@ describe('PATCH /api/v1/email-confirmation', () => {
         tokenObjectInDatabase.id,
       );
 
-      expect(confirmationEmail.sender).toEqual('<contato@tabnews.com.br>');
+      expect(confirmationEmail.sender).toBe('<contato@tabnews.com.br>');
       expect(confirmationEmail.recipients).toEqual(['<new@email.com>']);
-      expect(confirmationEmail.subject).toEqual('Confirme seu novo email');
+      expect(confirmationEmail.subject).toBe('Confirme seu novo email');
       expect(confirmationEmail.text).toContain(defaultUser.username);
       expect(confirmationEmail.html).toContain(defaultUser.username);
       expect(confirmationEmail.text).toContain('Uma alteração de email foi solicitada.');
@@ -211,7 +211,7 @@ describe('PATCH /api/v1/email-confirmation', () => {
 
       const emailConfirmationResponseBody = await emailConfirmationResponse.json();
 
-      expect(emailConfirmationResponse.status).toEqual(200);
+      expect(emailConfirmationResponse.status).toBe(200);
 
       expect(emailConfirmationResponseBody).toStrictEqual({
         id: emailConfirmationResponseBody.id,
@@ -221,12 +221,12 @@ describe('PATCH /api/v1/email-confirmation', () => {
         updated_at: emailConfirmationResponseBody.updated_at,
       });
 
-      expect(uuidVersion(emailConfirmationResponseBody.id)).toEqual(4);
+      expect(uuidVersion(emailConfirmationResponseBody.id)).toBe(4);
       expect(emailConfirmationResponseBody.updated_at > tokenObjectInDatabase.updated_at.toISOString()).toBe(true);
 
       // 4) CHECK IF EMAIL WAS UPDATED
       const userInDatabaseCheck2 = await user.findOneById(defaultUser.id);
-      expect(userInDatabaseCheck2.email).toEqual('new@email.com');
+      expect(userInDatabaseCheck2.email).toBe('new@email.com');
     });
 
     test('With an already used, but valid token', async () => {
@@ -248,7 +248,7 @@ describe('PATCH /api/v1/email-confirmation', () => {
       });
 
       const userInDatabase = await user.findOneById(defaultUser.id);
-      expect(userInDatabase.email).toEqual('idempotent@patch.com');
+      expect(userInDatabase.email).toBe('idempotent@patch.com');
 
       const firstTryResponseBody = await firstTryResponse.json();
 
@@ -265,7 +265,7 @@ describe('PATCH /api/v1/email-confirmation', () => {
 
       const secondTryResponseBody = await secondTryResponse.json();
 
-      expect(secondTryResponse.status).toEqual(200);
+      expect(secondTryResponse.status).toBe(200);
 
       expect(secondTryResponseBody).toStrictEqual({
         id: emailConfirmationToken.id,
@@ -355,7 +355,7 @@ describe('PATCH /api/v1/email-confirmation', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -369,7 +369,7 @@ describe('PATCH /api/v1/email-confirmation', () => {
       });
 
       const userInDatabaseCheck1 = await user.findOneById(firstUser.id);
-      expect(userInDatabaseCheck1.email).toEqual('validation.error@after.com');
+      expect(userInDatabaseCheck1.email).toBe('validation.error@after.com');
     });
 
     test('With an expired token', async () => {
@@ -399,7 +399,7 @@ describe('PATCH /api/v1/email-confirmation', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(404);
+      expect(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -413,7 +413,7 @@ describe('PATCH /api/v1/email-confirmation', () => {
       });
 
       const userInDatabaseCheck1 = await user.findOneById(defaultUser.id);
-      expect(userInDatabaseCheck1.email).toEqual('expired.token@email.com');
+      expect(userInDatabaseCheck1.email).toBe('expired.token@email.com');
     });
   });
 });

--- a/tests/integration/api/v1/email-confirmation/patch.test.js
+++ b/tests/integration/api/v1/email-confirmation/patch.test.js
@@ -188,7 +188,7 @@ describe('PATCH /api/v1/email-confirmation', () => {
       );
 
       expect(confirmationEmail.sender).toBe('<contato@tabnews.com.br>');
-      expect(confirmationEmail.recipients).toEqual(['<new@email.com>']);
+      expect(confirmationEmail.recipients).toStrictEqual(['<new@email.com>']);
       expect(confirmationEmail.subject).toBe('Confirme seu novo email');
       expect(confirmationEmail.text).toContain(defaultUser.username);
       expect(confirmationEmail.html).toContain(defaultUser.username);
@@ -277,8 +277,8 @@ describe('PATCH /api/v1/email-confirmation', () => {
 
       expect(secondTryResponseBody.updated_at > emailConfirmationToken.updated_at.toISOString()).toBe(true);
 
-      expect(firstTryResponse.status).toEqual(secondTryResponse.status);
-      expect(firstTryResponseBody).toEqual(secondTryResponseBody);
+      expect(firstTryResponse.status).toStrictEqual(secondTryResponse.status);
+      expect(firstTryResponseBody).toStrictEqual(secondTryResponseBody);
     });
 
     test('With an already used email (before creating the token)', async () => {

--- a/tests/integration/api/v1/migrations/get.test.js
+++ b/tests/integration/api/v1/migrations/get.test.js
@@ -15,14 +15,14 @@ describe('GET /api/v1/migrations', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(403);
-      expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('Usuário não pode executar esta operação.');
-      expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "read:migration".');
-      expect(responseBody.status_code).toEqual(403);
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
+      expect(response.status).toBe(403);
+      expect(responseBody.name).toBe('ForbiddenError');
+      expect(responseBody.message).toBe('Usuário não pode executar esta operação.');
+      expect(responseBody.action).toBe('Verifique se este usuário possui a feature "read:migration".');
+      expect(responseBody.status_code).toBe(403);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
     });
   });
 
@@ -42,14 +42,14 @@ describe('GET /api/v1/migrations', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(403);
-      expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('Usuário não pode executar esta operação.');
-      expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "read:migration".');
-      expect(responseBody.status_code).toEqual(403);
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
+      expect(response.status).toBe(403);
+      expect(responseBody.name).toBe('ForbiddenError');
+      expect(responseBody.message).toBe('Usuário não pode executar esta operação.');
+      expect(responseBody.action).toBe('Verifique se este usuário possui a feature "read:migration".');
+      expect(responseBody.status_code).toBe(403);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
     });
   });
 
@@ -75,8 +75,8 @@ describe('GET /api/v1/migrations', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
-      expect(Array.isArray(responseBody)).toEqual(true);
+      expect(response.status).toBe(200);
+      expect(Array.isArray(responseBody)).toBe(true);
     });
 
     describe('Same user after losing "read:migration" feature', () => {
@@ -93,14 +93,14 @@ describe('GET /api/v1/migrations', () => {
 
         const responseBody = await responseAfter.json();
 
-        expect(responseAfter.status).toEqual(403);
-        expect(responseBody.name).toEqual('ForbiddenError');
-        expect(responseBody.message).toEqual('Usuário não pode executar esta operação.');
-        expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "read:migration".');
-        expect(responseBody.status_code).toEqual(403);
-        expect(uuidVersion(responseBody.error_id)).toEqual(4);
-        expect(uuidVersion(responseBody.request_id)).toEqual(4);
-        expect(responseBody.error_location_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
+        expect(responseAfter.status).toBe(403);
+        expect(responseBody.name).toBe('ForbiddenError');
+        expect(responseBody.message).toBe('Usuário não pode executar esta operação.');
+        expect(responseBody.action).toBe('Verifique se este usuário possui a feature "read:migration".');
+        expect(responseBody.status_code).toBe(403);
+        expect(uuidVersion(responseBody.error_id)).toBe(4);
+        expect(uuidVersion(responseBody.request_id)).toBe(4);
+        expect(responseBody.error_location_code).toBe('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
       });
     });
   });

--- a/tests/integration/api/v1/migrations/post.test.js
+++ b/tests/integration/api/v1/migrations/post.test.js
@@ -20,14 +20,14 @@ describe('POST /api/v1/migrations', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(403);
-      expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('Usuário não pode executar esta operação.');
-      expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "create:migration".');
-      expect(responseBody.status_code).toEqual(403);
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
+      expect(response.status).toBe(403);
+      expect(responseBody.name).toBe('ForbiddenError');
+      expect(responseBody.message).toBe('Usuário não pode executar esta operação.');
+      expect(responseBody.action).toBe('Verifique se este usuário possui a feature "create:migration".');
+      expect(responseBody.status_code).toBe(403);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
     });
   });
 
@@ -47,14 +47,14 @@ describe('POST /api/v1/migrations', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(403);
-      expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('Usuário não pode executar esta operação.');
-      expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "create:migration".');
-      expect(responseBody.status_code).toEqual(403);
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
+      expect(response.status).toBe(403);
+      expect(responseBody.name).toBe('ForbiddenError');
+      expect(responseBody.message).toBe('Usuário não pode executar esta operação.');
+      expect(responseBody.action).toBe('Verifique se este usuário possui a feature "create:migration".');
+      expect(responseBody.status_code).toBe(403);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
     });
   });
 
@@ -76,8 +76,8 @@ describe('POST /api/v1/migrations', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
-      expect(Array.isArray(responseBody)).toEqual(true);
+      expect(response.status).toBe(200);
+      expect(Array.isArray(responseBody)).toBe(true);
     });
   });
 });

--- a/tests/integration/api/v1/recovery/patch.test.js
+++ b/tests/integration/api/v1/recovery/patch.test.js
@@ -34,7 +34,7 @@ describe('PATCH /api/v1/recovery', () => {
       const updatedTokenInDatabase = await recovery.findOneTokenById(recoveryToken.id);
       const updatedUserInDatabase = await user.findOneById(defaultUser.id);
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         used: true,
@@ -43,13 +43,13 @@ describe('PATCH /api/v1/recovery', () => {
         updated_at: updatedTokenInDatabase.updated_at.toISOString(),
       });
 
-      expect(Date.parse(responseBody.expires_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.expires_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
       expect(responseBody.expires_at > responseBody.created_at).toBe(true);
       expect(responseBody.updated_at > recoveryToken.updated_at.toISOString()).toBe(true);
 
-      expect(defaultUser.password).not.toEqual(updatedUserInDatabase.password);
+      expect(defaultUser.password).not.toBe(updatedUserInDatabase.password);
     });
 
     test('With valid information and multiple active sessions', async () => {
@@ -96,7 +96,7 @@ describe('PATCH /api/v1/recovery', () => {
         }),
       });
 
-      expect(recoveryResponse.status).toEqual(200);
+      expect(recoveryResponse.status).toBe(200);
 
       // Third: test if both sessions are invalid
       const invalidSession1Response = await fetch(`${orchestrator.webserverUrl}/api/v1/user`, {
@@ -138,7 +138,7 @@ describe('PATCH /api/v1/recovery', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(404);
+      expect(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -151,8 +151,8 @@ describe('PATCH /api/v1/recovery', () => {
         key: 'token_id',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('With valid information, but expired token', async () => {
@@ -176,7 +176,7 @@ describe('PATCH /api/v1/recovery', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(404);
+      expect(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -189,8 +189,8 @@ describe('PATCH /api/v1/recovery', () => {
         key: 'token_id',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('With valid information, but non-existent token', async () => {
@@ -208,7 +208,7 @@ describe('PATCH /api/v1/recovery', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(404);
+      expect(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -221,8 +221,8 @@ describe('PATCH /api/v1/recovery', () => {
         key: 'token_id',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('With "token_id" missing', async () => {
@@ -239,7 +239,7 @@ describe('PATCH /api/v1/recovery', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -253,8 +253,8 @@ describe('PATCH /api/v1/recovery', () => {
         type: 'any.required',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('With "token_id" as a Number', async () => {
@@ -271,7 +271,7 @@ describe('PATCH /api/v1/recovery', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -300,7 +300,7 @@ describe('PATCH /api/v1/recovery', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -314,8 +314,8 @@ describe('PATCH /api/v1/recovery', () => {
         type: 'string.guid',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('With "password" missing', async () => {
@@ -332,7 +332,7 @@ describe('PATCH /api/v1/recovery', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -346,8 +346,8 @@ describe('PATCH /api/v1/recovery', () => {
         type: 'any.required',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     // -------
@@ -359,7 +359,7 @@ describe('PATCH /api/v1/recovery', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -373,8 +373,8 @@ describe('PATCH /api/v1/recovery', () => {
         type: 'object.base',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('With blank Object', async () => {
@@ -389,7 +389,7 @@ describe('PATCH /api/v1/recovery', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -403,8 +403,8 @@ describe('PATCH /api/v1/recovery', () => {
         type: 'any.required',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
   });
 });

--- a/tests/integration/api/v1/recovery/patch.test.js
+++ b/tests/integration/api/v1/recovery/patch.test.js
@@ -43,9 +43,9 @@ describe('PATCH /api/v1/recovery', () => {
         updated_at: updatedTokenInDatabase.updated_at.toISOString(),
       });
 
-      expect(Date.parse(responseBody.expires_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.expires_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
       expect(responseBody.expires_at > responseBody.created_at).toBe(true);
       expect(responseBody.updated_at > recoveryToken.updated_at.toISOString()).toBe(true);
 

--- a/tests/integration/api/v1/recovery/post.test.js
+++ b/tests/integration/api/v1/recovery/post.test.js
@@ -101,9 +101,9 @@ describe('POST /api/v1/recovery', () => {
         updated_at: tokenInDatabase.updated_at.toISOString(),
       });
 
-      expect(Date.parse(responseBody.expires_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.expires_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
       expect(responseBody.expires_at > responseBody.created_at).toBe(true);
 
       const lastEmail = await orchestrator.getLastEmail();
@@ -301,9 +301,9 @@ describe('POST /api/v1/recovery', () => {
         updated_at: tokenInDatabase.updated_at.toISOString(),
       });
 
-      expect(Date.parse(responseBody.expires_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.expires_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
       expect(responseBody.expires_at > responseBody.created_at).toBe(true);
 
       const lastEmail = await orchestrator.getLastEmail();

--- a/tests/integration/api/v1/recovery/post.test.js
+++ b/tests/integration/api/v1/recovery/post.test.js
@@ -26,7 +26,7 @@ describe('POST /api/v1/recovery', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(403);
+      expect(response.status).toBe(403);
 
       expect(responseBody).toStrictEqual({
         name: 'ForbiddenError',
@@ -38,8 +38,8 @@ describe('POST /api/v1/recovery', () => {
         error_location_code: 'CONTROLLER:RECOVERY:POST_HANDLER:CAN_NOT_CREATE_RECOVERY_TOKEN_USERNAME',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('With "username" malformatted', async () => {
@@ -56,7 +56,7 @@ describe('POST /api/v1/recovery', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -70,8 +70,8 @@ describe('POST /api/v1/recovery', () => {
         type: 'string.alphanum',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('With "email" valid and "user" found', async () => {
@@ -92,7 +92,7 @@ describe('POST /api/v1/recovery', () => {
 
       const tokenInDatabase = await recovery.findOneTokenByUserId(defaultUser.id);
 
-      expect(response.status).toEqual(201);
+      expect(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         used: false,
@@ -101,14 +101,14 @@ describe('POST /api/v1/recovery', () => {
         updated_at: tokenInDatabase.updated_at.toISOString(),
       });
 
-      expect(Date.parse(responseBody.expires_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.expires_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
       expect(responseBody.expires_at > responseBody.created_at).toBe(true);
 
       const lastEmail = await orchestrator.getLastEmail();
       expect(lastEmail.recipients[0].includes(defaultUser.email)).toBe(true);
-      expect(lastEmail.subject).toEqual('Recuperação de Senha');
+      expect(lastEmail.subject).toBe('Recuperação de Senha');
       expect(lastEmail.text).toContain(defaultUser.username);
       expect(lastEmail.html).toContain(defaultUser.username);
       expect(lastEmail.text).toContain(recovery.getRecoverPageEndpoint(tokenInDatabase.id));
@@ -162,7 +162,7 @@ describe('POST /api/v1/recovery', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -176,8 +176,8 @@ describe('POST /api/v1/recovery', () => {
         type: 'string.email',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('With key other than "username" or "email"', async () => {
@@ -194,7 +194,7 @@ describe('POST /api/v1/recovery', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -208,8 +208,8 @@ describe('POST /api/v1/recovery', () => {
         type: 'object.min',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('With blank Body', async () => {
@@ -219,7 +219,7 @@ describe('POST /api/v1/recovery', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -233,8 +233,8 @@ describe('POST /api/v1/recovery', () => {
         type: 'object.base',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('With blank Object', async () => {
@@ -249,7 +249,7 @@ describe('POST /api/v1/recovery', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -263,8 +263,8 @@ describe('POST /api/v1/recovery', () => {
         type: 'object.min',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
   });
 
@@ -292,7 +292,7 @@ describe('POST /api/v1/recovery', () => {
 
       const tokenInDatabase = await recovery.findOneTokenByUserId(defaultUser.id);
 
-      expect(response.status).toEqual(201);
+      expect(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         used: false,
@@ -301,14 +301,14 @@ describe('POST /api/v1/recovery', () => {
         updated_at: tokenInDatabase.updated_at.toISOString(),
       });
 
-      expect(Date.parse(responseBody.expires_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(Date.parse(responseBody.expires_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
       expect(responseBody.expires_at > responseBody.created_at).toBe(true);
 
       const lastEmail = await orchestrator.getLastEmail();
       expect(lastEmail.recipients[0].includes(defaultUser.email)).toBe(true);
-      expect(lastEmail.subject).toEqual('Recuperação de Senha');
+      expect(lastEmail.subject).toBe('Recuperação de Senha');
       expect(lastEmail.text).toContain(defaultUser.username);
       expect(lastEmail.html).toContain(defaultUser.username);
       expect(lastEmail.text).toContain(recovery.getRecoverPageEndpoint(tokenInDatabase.id));
@@ -334,7 +334,7 @@ describe('POST /api/v1/recovery', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -347,8 +347,8 @@ describe('POST /api/v1/recovery', () => {
         key: 'username',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
   });
 });

--- a/tests/integration/api/v1/sessions/delete.test.js
+++ b/tests/integration/api/v1/sessions/delete.test.js
@@ -17,7 +17,7 @@ describe('DELETE /api/v1/sessions', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(403);
+      expect(response.status).toBe(403);
 
       expect(responseBody).toStrictEqual({
         name: 'ForbiddenError',
@@ -29,8 +29,8 @@ describe('DELETE /api/v1/sessions', () => {
         error_location_code: 'MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('With malformatted "session_id" cookie', async () => {
@@ -43,7 +43,7 @@ describe('DELETE /api/v1/sessions', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -57,8 +57,8 @@ describe('DELETE /api/v1/sessions', () => {
         type: 'string.length',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
   });
 
@@ -99,10 +99,10 @@ describe('DELETE /api/v1/sessions', () => {
         updated_at: responseBody.updated_at,
       });
 
-      expect(responseBody.created_at).toEqual(sessionObject.created_at.toISOString());
-      expect(responseBody.expires_at < sessionObject.expires_at.toISOString()).toEqual(true);
-      expect(responseBody.expires_at < sessionObject.created_at.toISOString()).toEqual(true);
-      expect(responseBody.updated_at > sessionObject.updated_at.toISOString()).toEqual(true);
+      expect(responseBody.created_at).toBe(sessionObject.created_at.toISOString());
+      expect(responseBody.expires_at < sessionObject.expires_at.toISOString()).toBe(true);
+      expect(responseBody.expires_at < sessionObject.created_at.toISOString()).toBe(true);
+      expect(responseBody.updated_at > sessionObject.updated_at.toISOString()).toBe(true);
 
       // Third: test if the session is not working anymore
       const invalidSessionResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/user`, {
@@ -144,8 +144,8 @@ describe('DELETE /api/v1/sessions', () => {
         error_location_code: 'MODEL:AUTHENTICATION:INJECT_AUTHENTICATED_USER:USER_CANT_READ_SESSION',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
   });
 });

--- a/tests/integration/api/v1/sessions/get.test.js
+++ b/tests/integration/api/v1/sessions/get.test.js
@@ -15,7 +15,7 @@ describe('GET /api/v1/sessions', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(405);
+      expect(response.status).toBe(405);
 
       expect(responseBody).toStrictEqual({
         name: 'MethodNotAllowedError',
@@ -26,8 +26,8 @@ describe('GET /api/v1/sessions', () => {
         request_id: responseBody.request_id,
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
   });
 });

--- a/tests/integration/api/v1/sessions/post.test.js
+++ b/tests/integration/api/v1/sessions/post.test.js
@@ -35,9 +35,9 @@ describe('POST /api/v1/sessions', () => {
       expect(response.status).toBe(201);
       expect(responseBody.token.length).toBe(96);
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.expires_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.expires_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
 
       const sessionObjectInDatabase = await session.findOneById(responseBody.id);
       expect(sessionObjectInDatabase.user_id).toBe(defaultUser.id);

--- a/tests/integration/api/v1/sessions/post.test.js
+++ b/tests/integration/api/v1/sessions/post.test.js
@@ -33,21 +33,21 @@ describe('POST /api/v1/sessions', () => {
       const responseBody = await response.json();
 
       expect(response.status).toBe(201);
-      expect(responseBody.token.length).toEqual(96);
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.expires_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(responseBody.token.length).toBe(96);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.expires_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
 
       const sessionObjectInDatabase = await session.findOneById(responseBody.id);
-      expect(sessionObjectInDatabase.user_id).toEqual(defaultUser.id);
+      expect(sessionObjectInDatabase.user_id).toBe(defaultUser.id);
 
       const parsedCookiesFromResponse = orchestrator.parseSetCookies(response);
-      expect(parsedCookiesFromResponse.session_id.name).toEqual('session_id');
-      expect(parsedCookiesFromResponse.session_id.value).toEqual(responseBody.token);
-      expect(parsedCookiesFromResponse.session_id.maxAge).toEqual(60 * 60 * 24 * 30);
-      expect(parsedCookiesFromResponse.session_id.path).toEqual('/');
-      expect(parsedCookiesFromResponse.session_id.httpOnly).toEqual(true);
+      expect(parsedCookiesFromResponse.session_id.name).toBe('session_id');
+      expect(parsedCookiesFromResponse.session_id.value).toBe(responseBody.token);
+      expect(parsedCookiesFromResponse.session_id.maxAge).toBe(60 * 60 * 24 * 30);
+      expect(parsedCookiesFromResponse.session_id.path).toBe('/');
+      expect(parsedCookiesFromResponse.session_id.httpOnly).toBe(true);
     });
 
     test('Using a valid email and password, but user lost the feature "create:session"', async () => {
@@ -73,13 +73,13 @@ describe('POST /api/v1/sessions', () => {
       const responseBody = await response.json();
 
       expect(response.status).toBe(403);
-      expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('Você não possui permissão para fazer login.');
-      expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "create:session".');
-      expect(responseBody.status_code).toEqual(403);
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('CONTROLLER:SESSIONS:POST_HANDLER:CAN_NOT_CREATE_SESSION');
+      expect(responseBody.name).toBe('ForbiddenError');
+      expect(responseBody.message).toBe('Você não possui permissão para fazer login.');
+      expect(responseBody.action).toBe('Verifique se este usuário possui a feature "create:session".');
+      expect(responseBody.status_code).toBe(403);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('CONTROLLER:SESSIONS:POST_HANDLER:CAN_NOT_CREATE_SESSION');
     });
 
     test('Using a valid email and password, but not activated user', async () => {
@@ -102,13 +102,13 @@ describe('POST /api/v1/sessions', () => {
       const responseBody = await response.json();
 
       expect(response.status).toBe(403);
-      expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('O seu usuário ainda não está ativado.');
-      expect(responseBody.action).toEqual('Verifique seu email, pois acabamos de enviar um novo convite de ativação.');
-      expect(responseBody.status_code).toEqual(403);
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('CONTROLLER:SESSIONS:POST_HANDLER:USER_NOT_ACTIVATED');
+      expect(responseBody.name).toBe('ForbiddenError');
+      expect(responseBody.message).toBe('O seu usuário ainda não está ativado.');
+      expect(responseBody.action).toBe('Verifique seu email, pois acabamos de enviar um novo convite de ativação.');
+      expect(responseBody.status_code).toBe(403);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('CONTROLLER:SESSIONS:POST_HANDLER:USER_NOT_ACTIVATED');
     });
 
     test('Using a valid email and password, but wrong password', async () => {
@@ -133,13 +133,13 @@ describe('POST /api/v1/sessions', () => {
       const responseBody = await response.json();
 
       expect(response.status).toBe(401);
-      expect(responseBody.name).toEqual('UnauthorizedError');
-      expect(responseBody.message).toEqual('Dados não conferem.');
-      expect(responseBody.action).toEqual('Verifique se os dados enviados estão corretos.');
-      expect(responseBody.status_code).toEqual(401);
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('CONTROLLER:SESSIONS:POST_HANDLER:DATA_MISMATCH');
+      expect(responseBody.name).toBe('UnauthorizedError');
+      expect(responseBody.message).toBe('Dados não conferem.');
+      expect(responseBody.action).toBe('Verifique se os dados enviados estão corretos.');
+      expect(responseBody.status_code).toBe(401);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('CONTROLLER:SESSIONS:POST_HANDLER:DATA_MISMATCH');
     });
 
     test('Using a valid email and password, but wrong email', async () => {
@@ -164,13 +164,13 @@ describe('POST /api/v1/sessions', () => {
       const responseBody = await response.json();
 
       expect(response.status).toBe(401);
-      expect(responseBody.name).toEqual('UnauthorizedError');
-      expect(responseBody.message).toEqual('Dados não conferem.');
-      expect(responseBody.action).toEqual('Verifique se os dados enviados estão corretos.');
-      expect(responseBody.status_code).toEqual(401);
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('CONTROLLER:SESSIONS:POST_HANDLER:DATA_MISMATCH');
+      expect(responseBody.name).toBe('UnauthorizedError');
+      expect(responseBody.message).toBe('Dados não conferem.');
+      expect(responseBody.action).toBe('Verifique se os dados enviados estão corretos.');
+      expect(responseBody.status_code).toBe(401);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('CONTROLLER:SESSIONS:POST_HANDLER:DATA_MISMATCH');
     });
 
     test('Using a valid password, but without email', async () => {
@@ -186,13 +186,13 @@ describe('POST /api/v1/sessions', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"email" é um campo obrigatório.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"email" é um campo obrigatório.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
       expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
       expect(responseBody.key).toBe('email');
     });
@@ -211,13 +211,13 @@ describe('POST /api/v1/sessions', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"email" não pode estar em branco.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"email" não pode estar em branco.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
       expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
       expect(responseBody.key).toBe('email');
     });
@@ -236,13 +236,13 @@ describe('POST /api/v1/sessions', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"email" deve ser do tipo String.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"email" deve ser do tipo String.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
       expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
       expect(responseBody.key).toBe('email');
     });
@@ -261,13 +261,13 @@ describe('POST /api/v1/sessions', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"email" deve conter um email válido.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"email" deve conter um email válido.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
       expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
       expect(responseBody.key).toBe('email');
     });
@@ -285,13 +285,13 @@ describe('POST /api/v1/sessions', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"password" é um campo obrigatório.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"password" é um campo obrigatório.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
       expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
       expect(responseBody.key).toBe('password');
     });
@@ -310,13 +310,13 @@ describe('POST /api/v1/sessions', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"password" não pode estar em branco.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"password" não pode estar em branco.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
       expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
       expect(responseBody.key).toBe('password');
     });
@@ -335,13 +335,13 @@ describe('POST /api/v1/sessions', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"password" deve conter no mínimo 8 caracteres.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"password" deve conter no mínimo 8 caracteres.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
       expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
       expect(responseBody.key).toBe('password');
     });
@@ -360,13 +360,13 @@ describe('POST /api/v1/sessions', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"password" deve conter no máximo 72 caracteres.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"password" deve conter no máximo 72 caracteres.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
       expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
       expect(responseBody.key).toBe('password');
     });
@@ -385,13 +385,13 @@ describe('POST /api/v1/sessions', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"password" deve ser do tipo String.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"password" deve ser do tipo String.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
       expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
       expect(responseBody.key).toBe('password');
     });
@@ -403,13 +403,13 @@ describe('POST /api/v1/sessions', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"body" enviado deve ser do tipo Object.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"body" enviado deve ser do tipo Object.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
       expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
       expect(responseBody.key).toBe('object');
     });

--- a/tests/integration/api/v1/sponsored-beta/get.test.js
+++ b/tests/integration/api/v1/sponsored-beta/get.test.js
@@ -16,7 +16,7 @@ describe('GET /api/v1/sponsored-beta', () => {
       await orchestrator.runPendingMigrations();
       owner = await orchestrator.createUser();
 
-      orchestrator.createBalance({
+      await orchestrator.createBalance({
         balanceType: 'user:tabcash',
         recipientId: owner.id,
         amount: 100 * defaultTabCashForAdCreation,
@@ -97,7 +97,7 @@ describe('GET /api/v1/sponsored-beta', () => {
     it('should get from specific owner', async () => {
       const specificOwner = await orchestrator.createUser();
 
-      orchestrator.createBalance({
+      await orchestrator.createBalance({
         balanceType: 'user:tabcash',
         recipientId: specificOwner.id,
         amount: defaultTabCashForAdCreation,

--- a/tests/integration/api/v1/sponsored-beta/get.test.js
+++ b/tests/integration/api/v1/sponsored-beta/get.test.js
@@ -34,7 +34,7 @@ describe('GET /api/v1/sponsored-beta', () => {
       const { response, responseBody } = await adsRequestBuilder.get();
 
       expect.soft(response.status).toBe(200);
-      expect(responseBody).toEqual([]);
+      expect(responseBody).toStrictEqual([]);
     });
 
     it('should never get unpublished ad', async () => {
@@ -57,7 +57,7 @@ describe('GET /api/v1/sponsored-beta', () => {
       const { response, responseBody } = await adsRequestBuilder.get();
 
       expect(response.status).toBe(200);
-      expect(responseBody).toEqual([]);
+      expect(responseBody).toStrictEqual([]);
     });
 
     it('should return ads', async () => {
@@ -91,7 +91,7 @@ describe('GET /api/v1/sponsored-beta', () => {
       const { response, responseBody } = await adsRequestBuilder.get(`?ignore_id=${createdAds[0].id}`);
 
       expect.soft(response.status).toBe(200);
-      expect(responseBody).toEqual([]);
+      expect(responseBody).toStrictEqual([]);
     });
 
     it('should get from specific owner', async () => {

--- a/tests/integration/api/v1/status/get.test.js
+++ b/tests/integration/api/v1/status/get.test.js
@@ -11,18 +11,18 @@ describe('GET /status', () => {
       const serverStatusResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/status`);
       const serverStatusBody = await serverStatusResponse.json();
 
-      expect(serverStatusResponse.status).toEqual(200);
+      expect(serverStatusResponse.status).toBe(200);
       expect(serverStatusBody.updated_at).toBeDefined();
-      expect(serverStatusBody.dependencies.database.status).toEqual('healthy');
+      expect(serverStatusBody.dependencies.database.status).toBe('healthy');
       expect(serverStatusBody.dependencies.database.opened_connections).toBeGreaterThan(0);
       expect(serverStatusBody.dependencies.database.latency.first_query).toBeGreaterThan(0);
       expect(serverStatusBody.dependencies.database.latency.second_query).toBeGreaterThan(0);
       expect(serverStatusBody.dependencies.database.latency.third_query).toBeGreaterThan(0);
       expect(typeof serverStatusBody.dependencies.database.version).toBe('string');
 
-      expect(serverStatusBody.dependencies.webserver.status).toEqual('healthy');
-      expect(serverStatusBody.dependencies.webserver.provider).toEqual('local');
-      expect(serverStatusBody.dependencies.webserver.environment).toEqual('local');
+      expect(serverStatusBody.dependencies.webserver.status).toBe('healthy');
+      expect(serverStatusBody.dependencies.webserver.provider).toBe('local');
+      expect(serverStatusBody.dependencies.webserver.environment).toBe('local');
       expect(typeof serverStatusBody.dependencies.webserver.version).toBe('string');
     });
   });

--- a/tests/integration/api/v1/status/votes/get.test.js
+++ b/tests/integration/api/v1/status/votes/get.test.js
@@ -77,7 +77,7 @@ describe('GET /api/v1/status/votes', () => {
       const responseBody = await response.json();
 
       expect(response.status).toBe(200);
-      expect(responseBody).toEqual({ updated_at: expect.any(String), votesGraph: { edges: [], nodes: [] } });
+      expect(responseBody).toStrictEqual({ updated_at: expect.any(String), votesGraph: { edges: [], nodes: [] } });
     });
 
     test('Should retrieve voting data', async () => {

--- a/tests/integration/api/v1/status/votes/get.test.js
+++ b/tests/integration/api/v1/status/votes/get.test.js
@@ -16,14 +16,14 @@ describe('GET /api/v1/status/votes', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(403);
-      expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('Usuário não pode executar esta operação.');
-      expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "read:votes:others".');
-      expect(responseBody.status_code).toEqual(403);
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
+      expect(response.status).toBe(403);
+      expect(responseBody.name).toBe('ForbiddenError');
+      expect(responseBody.message).toBe('Usuário não pode executar esta operação.');
+      expect(responseBody.action).toBe('Verifique se este usuário possui a feature "read:votes:others".');
+      expect(responseBody.status_code).toBe(403);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
     });
   });
 
@@ -43,14 +43,14 @@ describe('GET /api/v1/status/votes', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(403);
-      expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('Usuário não pode executar esta operação.');
-      expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "read:votes:others".');
-      expect(responseBody.status_code).toEqual(403);
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
+      expect(response.status).toBe(403);
+      expect(responseBody.name).toBe('ForbiddenError');
+      expect(responseBody.message).toBe('Usuário não pode executar esta operação.');
+      expect(responseBody.action).toBe('Verifique se este usuário possui a feature "read:votes:others".');
+      expect(responseBody.status_code).toBe(403);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
     });
   });
 
@@ -76,7 +76,7 @@ describe('GET /api/v1/status/votes', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
       expect(responseBody).toEqual({ updated_at: expect.any(String), votesGraph: { edges: [], nodes: [] } });
     });
 
@@ -94,18 +94,18 @@ describe('GET /api/v1/status/votes', () => {
       const responseBody = await response.json();
       const votesData = responseBody.votesGraph;
 
-      expect(response.status).toEqual(200);
-      expect(votesData.edges.length).toEqual(1);
-      expect(votesData.edges[0].type).toEqual('credit');
-      expect(votesData.edges[0].value).toEqual(1);
-      expect(votesData.nodes.length).toEqual(2);
-      expect(votesData.nodes[0].group).toEqual('users');
-      expect(votesData.nodes[1].group).toEqual('users');
-      expect(votesData.nodes[0].votes).toEqual(1);
-      expect(votesData.nodes[1].votes).toEqual(1);
-      expect(votesData.edges[0].from).toEqual(votesData.nodes[0].id);
-      expect(votesData.edges[0].to).toEqual(votesData.nodes[1].id);
-      expect(votesData.edges[0].id).toEqual(`credit-${votesData.nodes[0].id}-${votesData.nodes[1].id}`);
+      expect(response.status).toBe(200);
+      expect(votesData.edges.length).toBe(1);
+      expect(votesData.edges[0].type).toBe('credit');
+      expect(votesData.edges[0].value).toBe(1);
+      expect(votesData.nodes.length).toBe(2);
+      expect(votesData.nodes[0].group).toBe('users');
+      expect(votesData.nodes[1].group).toBe('users');
+      expect(votesData.nodes[0].votes).toBe(1);
+      expect(votesData.nodes[1].votes).toBe(1);
+      expect(votesData.edges[0].from).toBe(votesData.nodes[0].id);
+      expect(votesData.edges[0].to).toBe(votesData.nodes[1].id);
+      expect(votesData.edges[0].id).toBe(`credit-${votesData.nodes[0].id}-${votesData.nodes[1].id}`);
     });
 
     describe('Same user after losing "read:votes:others" feature', () => {
@@ -122,14 +122,14 @@ describe('GET /api/v1/status/votes', () => {
 
         const responseBody = await responseAfter.json();
 
-        expect(responseAfter.status).toEqual(403);
-        expect(responseBody.name).toEqual('ForbiddenError');
-        expect(responseBody.message).toEqual('Usuário não pode executar esta operação.');
-        expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "read:votes:others".');
-        expect(responseBody.status_code).toEqual(403);
-        expect(uuidVersion(responseBody.error_id)).toEqual(4);
-        expect(uuidVersion(responseBody.request_id)).toEqual(4);
-        expect(responseBody.error_location_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
+        expect(responseAfter.status).toBe(403);
+        expect(responseBody.name).toBe('ForbiddenError');
+        expect(responseBody.message).toBe('Usuário não pode executar esta operação.');
+        expect(responseBody.action).toBe('Verifique se este usuário possui a feature "read:votes:others".');
+        expect(responseBody.status_code).toBe(403);
+        expect(uuidVersion(responseBody.error_id)).toBe(4);
+        expect(uuidVersion(responseBody.request_id)).toBe(4);
+        expect(responseBody.error_location_code).toBe('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
       });
     });
   });

--- a/tests/integration/api/v1/swr/get.test.js
+++ b/tests/integration/api/v1/swr/get.test.js
@@ -7,7 +7,7 @@ describe('GET /swr', () => {
     const serverTimeBody = await serverTimeResponse.json();
     const serverTime = serverTimeBody.timestamp;
 
-    expect(serverTimeResponse.status).toEqual(200);
+    expect(serverTimeResponse.status).toBe(200);
     expect(serverTime).toBeGreaterThanOrEqual(startTime);
     expect(serverTime).toBeLessThanOrEqual(Date.now());
   });

--- a/tests/integration/api/v1/user/get.test.js
+++ b/tests/integration/api/v1/user/get.test.js
@@ -17,14 +17,14 @@ describe('GET /api/v1/user', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(403);
-      expect(responseBody.status_code).toEqual(403);
-      expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('Usuário não pode executar esta operação.');
-      expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "read:session".');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
+      expect(response.status).toBe(403);
+      expect(responseBody.status_code).toBe(403);
+      expect(responseBody.name).toBe('ForbiddenError');
+      expect(responseBody.message).toBe('Usuário não pode executar esta operação.');
+      expect(responseBody.action).toBe('Verifique se este usuário possui a feature "read:session".');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
 
       const parsedCookiesFromGet = orchestrator.parseSetCookies(response);
       expect(parsedCookiesFromGet).toStrictEqual({});
@@ -40,15 +40,15 @@ describe('GET /api/v1/user', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"session_id" deve possuir 96 caracteres.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(responseBody.key).toEqual('session_id');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"session_id" deve possuir 96 caracteres.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.key).toBe('session_id');
 
       const parsedCookiesFromGet = orchestrator.parseSetCookies(response);
       expect(parsedCookiesFromGet).toStrictEqual({});
@@ -64,15 +64,15 @@ describe('GET /api/v1/user', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"session_id" deve possuir 96 caracteres.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(responseBody.key).toEqual('session_id');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"session_id" deve possuir 96 caracteres.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.key).toBe('session_id');
 
       const parsedCookiesFromGet = orchestrator.parseSetCookies(response);
       expect(parsedCookiesFromGet).toStrictEqual({});
@@ -88,15 +88,15 @@ describe('GET /api/v1/user', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"session_id" deve conter apenas caracteres alfanuméricos.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(responseBody.key).toEqual('session_id');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"session_id" deve conter apenas caracteres alfanuméricos.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.key).toBe('session_id');
 
       const parsedCookiesFromGet = orchestrator.parseSetCookies(response);
       expect(parsedCookiesFromGet).toStrictEqual({});
@@ -155,15 +155,15 @@ describe('GET /api/v1/user', () => {
       const responseBody = await response.json();
 
       expect(response.status).toBe(403);
-      expect(responseBody.status_code).toEqual(403);
-      expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('Você não possui permissão para executar esta ação.');
-      expect(responseBody.action).toEqual(
+      expect(responseBody.status_code).toBe(403);
+      expect(responseBody.name).toBe('ForbiddenError');
+      expect(responseBody.message).toBe('Você não possui permissão para executar esta ação.');
+      expect(responseBody.action).toBe(
         'Verifique se este usuário já ativou a sua conta e recebeu a feature "read:session".',
       );
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual(
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe(
         'MODEL:AUTHENTICATION:INJECT_AUTHENTICATED_USER:USER_CANT_READ_SESSION',
       );
 
@@ -191,20 +191,20 @@ describe('GET /api/v1/user', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(401);
-      expect(responseBody.status_code).toEqual(401);
-      expect(responseBody.name).toEqual('UnauthorizedError');
-      expect(responseBody.message).toEqual('Usuário não possui sessão ativa.');
-      expect(responseBody.action).toEqual('Verifique se este usuário está logado.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(response.status).toBe(401);
+      expect(responseBody.status_code).toBe(401);
+      expect(responseBody.name).toBe('UnauthorizedError');
+      expect(responseBody.message).toBe('Usuário não possui sessão ativa.');
+      expect(responseBody.action).toBe('Verifique se este usuário está logado.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
 
       const parsedCookiesFromGet = orchestrator.parseSetCookies(response);
-      expect(parsedCookiesFromGet.session_id.name).toEqual('session_id');
-      expect(parsedCookiesFromGet.session_id.value).toEqual('invalid');
-      expect(parsedCookiesFromGet.session_id.maxAge).toEqual(-1);
-      expect(parsedCookiesFromGet.session_id.path).toEqual('/');
-      expect(parsedCookiesFromGet.session_id.httpOnly).toEqual(true);
+      expect(parsedCookiesFromGet.session_id.name).toBe('session_id');
+      expect(parsedCookiesFromGet.session_id.value).toBe('invalid');
+      expect(parsedCookiesFromGet.session_id.maxAge).toBe(-1);
+      expect(parsedCookiesFromGet.session_id.path).toBe('/');
+      expect(parsedCookiesFromGet.session_id.httpOnly).toBe(true);
 
       const sessionObject = await orchestrator.findSessionByToken(defaultUserSession.token);
       expect(sessionObject).toBeUndefined();
@@ -249,18 +249,18 @@ describe('GET /api/v1/user', () => {
         });
 
         const parsedCookiesFromGet = orchestrator.parseSetCookies(response);
-        expect(parsedCookiesFromGet.session_id.name).toEqual('session_id');
-        expect(parsedCookiesFromGet.session_id.value).toEqual(sessionObjectBeforeRenew.token);
-        expect(parsedCookiesFromGet.session_id.maxAge).toEqual(60 * 60 * 24 * 30);
-        expect(parsedCookiesFromGet.session_id.path).toEqual('/');
-        expect(parsedCookiesFromGet.session_id.httpOnly).toEqual(true);
+        expect(parsedCookiesFromGet.session_id.name).toBe('session_id');
+        expect(parsedCookiesFromGet.session_id.value).toBe(sessionObjectBeforeRenew.token);
+        expect(parsedCookiesFromGet.session_id.maxAge).toBe(60 * 60 * 24 * 30);
+        expect(parsedCookiesFromGet.session_id.path).toBe('/');
+        expect(parsedCookiesFromGet.session_id.httpOnly).toBe(true);
 
         const sessionObjectAfterRenew = await orchestrator.findSessionByToken(defaultUserSession.token);
         expect(sessionObjectBeforeRenew).toStrictEqual(defaultUserSession);
-        expect(sessionObjectAfterRenew.id).toEqual(sessionObjectBeforeRenew.id);
+        expect(sessionObjectAfterRenew.id).toBe(sessionObjectBeforeRenew.id);
         expect(sessionObjectAfterRenew.created_at).toEqual(sessionObjectBeforeRenew.created_at);
-        expect(sessionObjectAfterRenew.expires_at > sessionObjectBeforeRenew.expires_at).toEqual(true);
-        expect(sessionObjectAfterRenew.updated_at > sessionObjectBeforeRenew.updated_at).toEqual(true);
+        expect(sessionObjectAfterRenew.expires_at > sessionObjectBeforeRenew.expires_at).toBe(true);
+        expect(sessionObjectAfterRenew.updated_at > sessionObjectBeforeRenew.updated_at).toBe(true);
       });
 
       test('Should be able to renew with 9 day token', async () => {
@@ -302,17 +302,17 @@ describe('GET /api/v1/user', () => {
         });
 
         const parsedCookiesFromGet = orchestrator.parseSetCookies(response);
-        expect(parsedCookiesFromGet.session_id.name).toEqual('session_id');
-        expect(parsedCookiesFromGet.session_id.value).toEqual(sessionObjectBeforeRenew.token);
-        expect(parsedCookiesFromGet.session_id.maxAge).toEqual(60 * 60 * 24 * 30);
-        expect(parsedCookiesFromGet.session_id.path).toEqual('/');
-        expect(parsedCookiesFromGet.session_id.httpOnly).toEqual(true);
+        expect(parsedCookiesFromGet.session_id.name).toBe('session_id');
+        expect(parsedCookiesFromGet.session_id.value).toBe(sessionObjectBeforeRenew.token);
+        expect(parsedCookiesFromGet.session_id.maxAge).toBe(60 * 60 * 24 * 30);
+        expect(parsedCookiesFromGet.session_id.path).toBe('/');
+        expect(parsedCookiesFromGet.session_id.httpOnly).toBe(true);
 
         const sessionObjectAfterRenew = await orchestrator.findSessionByToken(defaultUserSession.token);
-        expect(sessionObjectAfterRenew.id).toEqual(sessionObjectBeforeRenew.id);
+        expect(sessionObjectAfterRenew.id).toBe(sessionObjectBeforeRenew.id);
         expect(sessionObjectAfterRenew.created_at).toEqual(sessionObjectBeforeRenew.created_at);
-        expect(sessionObjectAfterRenew.expires_at > sessionObjectBeforeRenew.expires_at).toEqual(true);
-        expect(sessionObjectAfterRenew.updated_at > sessionObjectBeforeRenew.updated_at).toEqual(true);
+        expect(sessionObjectAfterRenew.expires_at > sessionObjectBeforeRenew.expires_at).toBe(true);
+        expect(sessionObjectAfterRenew.updated_at > sessionObjectBeforeRenew.updated_at).toBe(true);
       });
 
       test('Should not be able to renew with less than 9 days token', async () => {
@@ -380,9 +380,9 @@ describe('GET /api/v1/user', () => {
         const preRewardUser = await preRewardUserResponse.json();
 
         expect(preRewardUserResponse.status).toBe(200);
-        expect(preRewardUser.tabcoins).toStrictEqual(0);
-        expect(preRewardUser.tabcash).toStrictEqual(0);
-        expect(preRewardUser.updated_at).toStrictEqual(defaultUser.updated_at.toISOString());
+        expect(preRewardUser.tabcoins).toBe(0);
+        expect(preRewardUser.tabcash).toBe(0);
+        expect(preRewardUser.updated_at).toBe(defaultUser.updated_at.toISOString());
 
         await orchestrator.updateRewardedAt(
           defaultUser.id,
@@ -399,9 +399,9 @@ describe('GET /api/v1/user', () => {
         const rewardUser = await rewardUserResponse.json();
 
         expect(rewardUserResponse.status).toBe(200);
-        expect(rewardUser.tabcoins).toStrictEqual(defaultTestRewardValue);
-        expect(rewardUser.tabcash).toStrictEqual(0);
-        expect(rewardUser.updated_at).toStrictEqual(defaultUser.updated_at.toISOString());
+        expect(rewardUser.tabcoins).toBe(defaultTestRewardValue);
+        expect(rewardUser.tabcash).toBe(0);
+        expect(rewardUser.updated_at).toBe(defaultUser.updated_at.toISOString());
 
         const postRewardUserResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/user`, {
           method: 'GET',
@@ -413,9 +413,9 @@ describe('GET /api/v1/user', () => {
         const postRewardUser = await postRewardUserResponse.json();
 
         expect(postRewardUserResponse.status).toBe(200);
-        expect(postRewardUser.tabcoins).toStrictEqual(defaultTestRewardValue);
-        expect(postRewardUser.tabcash).toStrictEqual(0);
-        expect(postRewardUser.updated_at).toStrictEqual(defaultUser.updated_at.toISOString());
+        expect(postRewardUser.tabcoins).toBe(defaultTestRewardValue);
+        expect(postRewardUser.tabcash).toBe(0);
+        expect(postRewardUser.updated_at).toBe(defaultUser.updated_at.toISOString());
       });
 
       test('Should deduplicate simultaneous rewards', async () => {
@@ -436,9 +436,9 @@ describe('GET /api/v1/user', () => {
         const preRewardUser = await preRewardUserResponse.json();
 
         expect(preRewardUserResponse.status).toBe(200);
-        expect(preRewardUser.tabcoins).toStrictEqual(0);
-        expect(preRewardUser.tabcash).toStrictEqual(0);
-        expect(preRewardUser.updated_at).toStrictEqual(defaultUser.updated_at.toISOString());
+        expect(preRewardUser.tabcoins).toBe(0);
+        expect(preRewardUser.tabcash).toBe(0);
+        expect(preRewardUser.updated_at).toBe(defaultUser.updated_at.toISOString());
 
         await orchestrator.updateRewardedAt(
           defaultUser.id,
@@ -462,9 +462,9 @@ describe('GET /api/v1/user', () => {
         const postRewardUser = await postRewardUserResponse.json();
 
         expect(postRewardUserResponse.status).toBe(200);
-        expect(postRewardUser.tabcoins).toStrictEqual(defaultTestRewardValue);
-        expect(postRewardUser.tabcash).toStrictEqual(0);
-        expect(postRewardUser.updated_at).toStrictEqual(defaultUser.updated_at.toISOString());
+        expect(postRewardUser.tabcoins).toBe(defaultTestRewardValue);
+        expect(postRewardUser.tabcash).toBe(0);
+        expect(postRewardUser.updated_at).toBe(defaultUser.updated_at.toISOString());
       });
 
       test('Should not reward if user has no prestige', async () => {
@@ -484,9 +484,9 @@ describe('GET /api/v1/user', () => {
         const preRewardUser = await preRewardUserResponse.json();
 
         expect(preRewardUserResponse.status).toBe(200);
-        expect(preRewardUser.tabcoins).toStrictEqual(0);
-        expect(preRewardUser.tabcash).toStrictEqual(0);
-        expect(preRewardUser.updated_at).toStrictEqual(defaultUser.updated_at.toISOString());
+        expect(preRewardUser.tabcoins).toBe(0);
+        expect(preRewardUser.tabcash).toBe(0);
+        expect(preRewardUser.updated_at).toBe(defaultUser.updated_at.toISOString());
 
         await orchestrator.updateRewardedAt(
           defaultUser.id,
@@ -506,9 +506,9 @@ describe('GET /api/v1/user', () => {
         const postRewardUser = await postRewardUserResponse.json();
 
         expect(postRewardUserResponse.status).toBe(200);
-        expect(postRewardUser.tabcoins).toStrictEqual(0);
-        expect(postRewardUser.tabcash).toStrictEqual(0);
-        expect(postRewardUser.updated_at).toStrictEqual(defaultUser.updated_at.toISOString());
+        expect(postRewardUser.tabcoins).toBe(0);
+        expect(postRewardUser.tabcash).toBe(0);
+        expect(postRewardUser.updated_at).toBe(defaultUser.updated_at.toISOString());
       });
 
       test('Should not reward if user has negative prestige', async () => {
@@ -529,9 +529,9 @@ describe('GET /api/v1/user', () => {
         const preRewardUser = await preRewardUserResponse.json();
 
         expect(preRewardUserResponse.status).toBe(200);
-        expect(preRewardUser.tabcoins).toStrictEqual(0);
-        expect(preRewardUser.tabcash).toStrictEqual(0);
-        expect(preRewardUser.updated_at).toStrictEqual(defaultUser.updated_at.toISOString());
+        expect(preRewardUser.tabcoins).toBe(0);
+        expect(preRewardUser.tabcash).toBe(0);
+        expect(preRewardUser.updated_at).toBe(defaultUser.updated_at.toISOString());
 
         await orchestrator.updateRewardedAt(
           defaultUser.id,
@@ -551,9 +551,9 @@ describe('GET /api/v1/user', () => {
         const postRewardUser = await postRewardUserResponse.json();
 
         expect(postRewardUserResponse.status).toBe(200);
-        expect(postRewardUser.tabcoins).toStrictEqual(0);
-        expect(postRewardUser.tabcash).toStrictEqual(0);
-        expect(postRewardUser.updated_at).toStrictEqual(defaultUser.updated_at.toISOString());
+        expect(postRewardUser.tabcoins).toBe(0);
+        expect(postRewardUser.tabcash).toBe(0);
+        expect(postRewardUser.updated_at).toBe(defaultUser.updated_at.toISOString());
       });
 
       test('Should not reward if user has too many tabcoins', async () => {
@@ -580,9 +580,9 @@ describe('GET /api/v1/user', () => {
         const preRewardUser = await preRewardUserResponse.json();
 
         expect(preRewardUserResponse.status).toBe(200);
-        expect(preRewardUser.tabcoins).toStrictEqual(1000);
-        expect(preRewardUser.tabcash).toStrictEqual(0);
-        expect(preRewardUser.updated_at).toStrictEqual(defaultUser.updated_at.toISOString());
+        expect(preRewardUser.tabcoins).toBe(1000);
+        expect(preRewardUser.tabcash).toBe(0);
+        expect(preRewardUser.updated_at).toBe(defaultUser.updated_at.toISOString());
 
         await orchestrator.updateRewardedAt(
           defaultUser.id,
@@ -602,9 +602,9 @@ describe('GET /api/v1/user', () => {
         const postRewardUser = await postRewardUserResponse.json();
 
         expect(postRewardUserResponse.status).toBe(200);
-        expect(postRewardUser.tabcoins).toStrictEqual(1000);
-        expect(postRewardUser.tabcash).toStrictEqual(0);
-        expect(postRewardUser.updated_at).toStrictEqual(defaultUser.updated_at.toISOString());
+        expect(postRewardUser.tabcoins).toBe(1000);
+        expect(postRewardUser.tabcash).toBe(0);
+        expect(postRewardUser.updated_at).toBe(defaultUser.updated_at.toISOString());
       });
 
       test('Should be able to reward even with negative ad balance', async () => {

--- a/tests/integration/api/v1/user/get.test.js
+++ b/tests/integration/api/v1/user/get.test.js
@@ -225,7 +225,7 @@ describe('GET /api/v1/user', () => {
         const sessionObjectAfterRenew = await orchestrator.findSessionByToken(userRequestBuilder.sessionObject.token);
         expect(sessionObjectBeforeRenew).toStrictEqual(userRequestBuilder.sessionObject);
         expect(sessionObjectAfterRenew.id).toBe(sessionObjectBeforeRenew.id);
-        expect(sessionObjectAfterRenew.created_at).toEqual(sessionObjectBeforeRenew.created_at);
+        expect(sessionObjectAfterRenew.created_at).toStrictEqual(sessionObjectBeforeRenew.created_at);
         expect(sessionObjectAfterRenew.expires_at > sessionObjectBeforeRenew.expires_at).toBe(true);
         expect(sessionObjectAfterRenew.updated_at > sessionObjectBeforeRenew.updated_at).toBe(true);
       });
@@ -269,7 +269,7 @@ describe('GET /api/v1/user', () => {
 
         const sessionObjectAfterRenew = await orchestrator.findSessionByToken(userRequestBuilder.sessionObject.token);
         expect(sessionObjectAfterRenew.id).toBe(sessionObjectBeforeRenew.id);
-        expect(sessionObjectAfterRenew.created_at).toEqual(sessionObjectBeforeRenew.created_at);
+        expect(sessionObjectAfterRenew.created_at).toStrictEqual(sessionObjectBeforeRenew.created_at);
         expect(sessionObjectAfterRenew.expires_at > sessionObjectBeforeRenew.expires_at).toBe(true);
         expect(sessionObjectAfterRenew.updated_at > sessionObjectBeforeRenew.updated_at).toBe(true);
       });

--- a/tests/integration/api/v1/user/get.test.js
+++ b/tests/integration/api/v1/user/get.test.js
@@ -366,12 +366,10 @@ describe('GET /api/v1/user', () => {
 
         const simultaneousResults = await Promise.all([userRequestBuilder.get(), userRequestBuilder.get()]);
 
-        const tabcoins = await Promise.all(
-          simultaneousResults.map(async (result) => {
-            expect(result.response.status).toBe(200);
-            return result.responseBody.tabcoins;
-          }),
-        );
+        const tabcoins = simultaneousResults.map((result) => {
+          expect(result.response.status).toBe(200);
+          return result.responseBody.tabcoins;
+        });
 
         expect(tabcoins).toContain(defaultTestRewardValue);
 
@@ -401,7 +399,7 @@ describe('GET /api/v1/user', () => {
 
         const simultaneousResults = await Promise.all([userRequestBuilder.get(), userRequestBuilder.get()]);
 
-        simultaneousResults.forEach(async (result) => {
+        simultaneousResults.forEach((result) => {
           expect(result.response.status).toBe(200);
           expect(result.responseBody.tabcoins).toBe(0);
         });
@@ -433,7 +431,7 @@ describe('GET /api/v1/user', () => {
 
         const simultaneousResults = await Promise.all([userRequestBuilder.get(), userRequestBuilder.get()]);
 
-        simultaneousResults.forEach(async (result) => {
+        simultaneousResults.forEach((result) => {
           expect(result.response.status).toBe(200);
           expect(result.responseBody.tabcoins).toBe(0);
         });
@@ -471,7 +469,7 @@ describe('GET /api/v1/user', () => {
 
         const simultaneousResults = await Promise.all([userRequestBuilder.get(), userRequestBuilder.get()]);
 
-        simultaneousResults.forEach(async (result) => {
+        simultaneousResults.forEach((result) => {
           expect(result.response.status).toBe(200);
           expect(result.responseBody.tabcoins).toBe(1000);
         });
@@ -492,7 +490,7 @@ describe('GET /api/v1/user', () => {
           now: new Date(Date.now() - 1000 * 60 * 60 * 24 * 3), // 3 days ago
         });
 
-        orchestrator.createBalance({
+        await orchestrator.createBalance({
           balanceType: 'user:tabcash',
           recipientId: defaultUser.id,
           amount: defaultTabCashForAdCreation,
@@ -538,7 +536,7 @@ describe('GET /api/v1/user', () => {
           now: new Date(Date.now() - 1000 * 60 * 60 * 24 * 3), // 3 days ago
         });
 
-        orchestrator.createBalance({
+        await orchestrator.createBalance({
           balanceType: 'user:tabcash',
           recipientId: defaultUser.id,
           amount: defaultTabCashForAdCreation,

--- a/tests/integration/api/v1/user/post.test.js
+++ b/tests/integration/api/v1/user/post.test.js
@@ -17,7 +17,7 @@ describe('POST /api/v1/user', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(405);
+      expect(response.status).toBe(405);
 
       expect(responseBody).toStrictEqual({
         name: 'MethodNotAllowedError',
@@ -28,8 +28,8 @@ describe('POST /api/v1/user', () => {
         request_id: responseBody.request_id,
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
   });
 });

--- a/tests/integration/api/v1/users/[username]/delete.test.js
+++ b/tests/integration/api/v1/users/[username]/delete.test.js
@@ -1,5 +1,6 @@
 import { version as uuidVersion } from 'uuid';
 
+import { relevantBody } from 'tests/constants-for-tests';
 import orchestrator from 'tests/orchestrator.js';
 
 beforeAll(async () => {
@@ -183,7 +184,7 @@ describe('DELETE /api/v1/users/[username]', () => {
         },
         body: JSON.stringify({
           title: 'firstUserRootContent',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'published',
         }),
       });
@@ -198,7 +199,7 @@ describe('DELETE /api/v1/users/[username]', () => {
         },
         body: JSON.stringify({
           parent_id: firstUserRootContentBody.id,
-          body: 'firstUserChildContent - Body with relevant texts needs to contain a good amount of words',
+          body: 'firstUserChildContent' + relevantBody,
           status: 'published',
         }),
       });
@@ -214,7 +215,7 @@ describe('DELETE /api/v1/users/[username]', () => {
         },
         body: JSON.stringify({
           title: 'secondUserRootContent',
-          body: 'Body with relevant texts needs to contain a good amount of words',
+          body: relevantBody,
           status: 'published',
         }),
       });
@@ -229,7 +230,7 @@ describe('DELETE /api/v1/users/[username]', () => {
         },
         body: JSON.stringify({
           parent_id: firstUserRootContentBody.id,
-          body: 'secondUserChildContent #1 - Body with relevant texts needs to contain a good amount of words',
+          body: 'secondUserChildContent #1' + relevantBody,
           status: 'published',
         }),
       });
@@ -244,7 +245,7 @@ describe('DELETE /api/v1/users/[username]', () => {
         },
         body: JSON.stringify({
           parent_id: firstUserRootContentBody.id,
-          body: 'secondUserChildContent #2 - Body with relevant texts needs to contain a good amount of words',
+          body: 'secondUserChildContent #2' + relevantBody,
           status: 'published',
         }),
       });
@@ -259,7 +260,7 @@ describe('DELETE /api/v1/users/[username]', () => {
         },
         body: JSON.stringify({
           title: 'Draft Content',
-          body: 'Draft Content - Body with relevant texts needs to contain a good amount of words',
+          body: 'Draft Content' + relevantBody,
           status: 'draft',
         }),
       });
@@ -272,7 +273,7 @@ describe('DELETE /api/v1/users/[username]', () => {
         },
         body: JSON.stringify({
           title: 'Deleted Content',
-          body: 'Deleted Content - Body with relevant texts needs to contain a good amount of words',
+          body: 'Deleted Content' + relevantBody,
           status: 'published',
         }),
       });

--- a/tests/integration/api/v1/users/[username]/delete.test.js
+++ b/tests/integration/api/v1/users/[username]/delete.test.js
@@ -27,7 +27,7 @@ describe('DELETE /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toStrictEqual(403);
+      expect(response.status).toBe(403);
 
       expect(responseBody).toStrictEqual({
         name: 'ForbiddenError',
@@ -39,8 +39,8 @@ describe('DELETE /api/v1/users/[username]', () => {
         error_location_code: 'MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toStrictEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toStrictEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
   });
 
@@ -66,7 +66,7 @@ describe('DELETE /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toStrictEqual(403);
+      expect(response.status).toBe(403);
 
       expect(responseBody).toStrictEqual({
         name: 'ForbiddenError',
@@ -78,8 +78,8 @@ describe('DELETE /api/v1/users/[username]', () => {
         error_location_code: 'MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toStrictEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toStrictEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
   });
 
@@ -104,7 +104,7 @@ describe('DELETE /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toStrictEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -118,8 +118,8 @@ describe('DELETE /api/v1/users/[username]', () => {
         type: 'any.required',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toStrictEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toStrictEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('With "ban_type" with an invalid value', async () => {
@@ -144,7 +144,7 @@ describe('DELETE /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toStrictEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -158,8 +158,8 @@ describe('DELETE /api/v1/users/[username]', () => {
         type: 'any.only',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toStrictEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toStrictEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('With "ban_type" with "nuke" value', async () => {
@@ -338,8 +338,8 @@ describe('DELETE /api/v1/users/[username]', () => {
       //  +1 TabCoin from the credit of the secondUser to the root content.
       //  -1 TabCoin from the debit of the secondUser to the child content.
       const firstUserCheck1Body = await firstUserCheck1.json();
-      expect(firstUserCheck1Body.tabcoins).toStrictEqual(2);
-      expect(firstUserCheck1Body.tabcash).toStrictEqual(0);
+      expect(firstUserCheck1Body.tabcoins).toBe(2);
+      expect(firstUserCheck1Body.tabcash).toBe(0);
       expect(firstUserCheck1Body.features).toContain('ban:user');
 
       // 7) CHECK SECOND USER (PRE-BAN)
@@ -357,8 +357,8 @@ describe('DELETE /api/v1/users/[username]', () => {
       //  -2 TabCoins / +1 TabCash from credit to the firstUser root content
       //  -2 TabCoins / +1 TabCash from debit to the firstUser child content
       const secondUserCheck1Body = await secondUserCheck1.json();
-      expect(secondUserCheck1Body.tabcoins).toStrictEqual(2);
-      expect(secondUserCheck1Body.tabcash).toStrictEqual(2);
+      expect(secondUserCheck1Body.tabcoins).toBe(2);
+      expect(secondUserCheck1Body.tabcash).toBe(2);
 
       // 8) CHECK FIRST USER ROOT CONTENT (PRE-BAN)
       const firstUserRootContentCheck1 = await fetch(
@@ -366,10 +366,10 @@ describe('DELETE /api/v1/users/[username]', () => {
       );
       const firstUserRootContentCheck1Body = await firstUserRootContentCheck1.json();
 
-      expect(firstUserRootContentCheck1.status).toStrictEqual(200);
-      expect(firstUserRootContentCheck1Body.status).toStrictEqual('published');
-      expect(firstUserRootContentCheck1Body.tabcoins).toStrictEqual(2);
-      expect(firstUserRootContentCheck1Body.children_deep_count).toStrictEqual(3);
+      expect(firstUserRootContentCheck1.status).toBe(200);
+      expect(firstUserRootContentCheck1Body.status).toBe('published');
+      expect(firstUserRootContentCheck1Body.tabcoins).toBe(2);
+      expect(firstUserRootContentCheck1Body.children_deep_count).toBe(3);
 
       // 9) CHECK FIRST USER CHILD CONTENT (PRE-BAN)
       const firstUserChildCheck1 = await fetch(
@@ -377,10 +377,10 @@ describe('DELETE /api/v1/users/[username]', () => {
       );
       const firstUserChildCheck1Body = await firstUserChildCheck1.json();
 
-      expect(firstUserChildCheck1.status).toStrictEqual(200);
-      expect(firstUserRootContentCheck1Body.status).toStrictEqual('published');
-      expect(firstUserChildCheck1Body.tabcoins).toStrictEqual(-1);
-      expect(firstUserChildCheck1Body.children_deep_count).toStrictEqual(0);
+      expect(firstUserChildCheck1.status).toBe(200);
+      expect(firstUserRootContentCheck1Body.status).toBe('published');
+      expect(firstUserChildCheck1Body.tabcoins).toBe(-1);
+      expect(firstUserChildCheck1Body.children_deep_count).toBe(0);
 
       // 10) CHECK SECOND USER CONTENTS (PRE-BAN)
       const secondUserRootContentCheck1 = await fetch(
@@ -397,12 +397,12 @@ describe('DELETE /api/v1/users/[username]', () => {
       const secondUserChildContent1Check1Body = await secondUserChildContent1Check1.json();
       const secondUserChildContent2Check1Body = await secondUserChildContent2Check1.json();
 
-      expect(secondUserRootContentCheck1.status).toStrictEqual(200);
-      expect(secondUserRootContentCheck1Body.status).toStrictEqual('published');
-      expect(secondUserChildContent1Check1.status).toStrictEqual(200);
-      expect(secondUserChildContent1Check1Body.status).toStrictEqual('published');
-      expect(secondUserChildContent2Check1.status).toStrictEqual(200);
-      expect(secondUserChildContent2Check1Body.status).toStrictEqual('published');
+      expect(secondUserRootContentCheck1.status).toBe(200);
+      expect(secondUserRootContentCheck1Body.status).toBe('published');
+      expect(secondUserChildContent1Check1.status).toBe(200);
+      expect(secondUserChildContent1Check1Body.status).toBe('published');
+      expect(secondUserChildContent2Check1.status).toBe(200);
+      expect(secondUserChildContent2Check1Body.status).toBe('published');
 
       // 11) NUKE THE SECOND USER
       const nukeResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${secondUser.username}`, {
@@ -419,7 +419,7 @@ describe('DELETE /api/v1/users/[username]', () => {
 
       const nukeResponseBody = await nukeResponse.json();
 
-      expect(nukeResponse.status).toStrictEqual(200);
+      expect(nukeResponse.status).toBe(200);
 
       expect(nukeResponseBody).toStrictEqual({
         id: secondUser.id,
@@ -439,8 +439,8 @@ describe('DELETE /api/v1/users/[username]', () => {
       });
 
       const firstUserCheck2Body = await firstUserCheck2.json();
-      expect(firstUserCheck2Body.tabcoins).toStrictEqual(2);
-      expect(firstUserCheck2Body.tabcash).toStrictEqual(0);
+      expect(firstUserCheck2Body.tabcoins).toBe(2);
+      expect(firstUserCheck2Body.tabcash).toBe(0);
 
       // 13) CHECK SECOND USER (POST-BAN)
       const secondUserCheck2 = await fetch(`${orchestrator.webserverUrl}/api/v1/users/${secondUser.username}`, {
@@ -452,16 +452,16 @@ describe('DELETE /api/v1/users/[username]', () => {
 
       const secondUserCheck2Body = await secondUserCheck2.json();
 
-      expect(secondUserCheck2.status).toEqual(404);
-      expect(secondUserCheck2Body.status_code).toEqual(404);
-      expect(secondUserCheck2Body.name).toEqual('NotFoundError');
-      expect(secondUserCheck2Body.message).toEqual('O "username" informado não foi encontrado no sistema.');
-      expect(secondUserCheck2Body.action).toEqual('Verifique se o "username" está digitado corretamente.');
-      expect(secondUserCheck2Body.status_code).toEqual(404);
-      expect(secondUserCheck2Body.error_location_code).toEqual('MODEL:USER:FIND_ONE_BY_USERNAME:NOT_FOUND');
-      expect(uuidVersion(secondUserCheck2Body.error_id)).toEqual(4);
-      expect(uuidVersion(secondUserCheck2Body.request_id)).toEqual(4);
-      expect(secondUserCheck2Body.key).toEqual('username');
+      expect(secondUserCheck2.status).toBe(404);
+      expect(secondUserCheck2Body.status_code).toBe(404);
+      expect(secondUserCheck2Body.name).toBe('NotFoundError');
+      expect(secondUserCheck2Body.message).toBe('O "username" informado não foi encontrado no sistema.');
+      expect(secondUserCheck2Body.action).toBe('Verifique se o "username" está digitado corretamente.');
+      expect(secondUserCheck2Body.status_code).toBe(404);
+      expect(secondUserCheck2Body.error_location_code).toBe('MODEL:USER:FIND_ONE_BY_USERNAME:NOT_FOUND');
+      expect(uuidVersion(secondUserCheck2Body.error_id)).toBe(4);
+      expect(uuidVersion(secondUserCheck2Body.request_id)).toBe(4);
+      expect(secondUserCheck2Body.key).toBe('username');
 
       // 14) CHECK FIRST USER ROOT CONTENT (POST-BAN)
       const firstUserRootContentCheck2 = await fetch(
@@ -469,10 +469,10 @@ describe('DELETE /api/v1/users/[username]', () => {
       );
       const firstUserRootContentCheck2Body = await firstUserRootContentCheck2.json();
 
-      expect(firstUserRootContentCheck2.status).toStrictEqual(200);
-      expect(firstUserRootContentCheck2Body.status).toStrictEqual('published');
-      expect(firstUserRootContentCheck2Body.tabcoins).toStrictEqual(1);
-      expect(firstUserRootContentCheck2Body.children_deep_count).toStrictEqual(1);
+      expect(firstUserRootContentCheck2.status).toBe(200);
+      expect(firstUserRootContentCheck2Body.status).toBe('published');
+      expect(firstUserRootContentCheck2Body.tabcoins).toBe(1);
+      expect(firstUserRootContentCheck2Body.children_deep_count).toBe(1);
 
       // 15) CHECK FIRST USER CHILD CONTENT (POST-BAN)
       const firstUserChildCheck2 = await fetch(
@@ -480,10 +480,10 @@ describe('DELETE /api/v1/users/[username]', () => {
       );
       const firstUserChildCheck2Body = await firstUserChildCheck2.json();
 
-      expect(firstUserChildCheck2.status).toStrictEqual(200);
-      expect(firstUserRootContentCheck2Body.status).toStrictEqual('published');
-      expect(firstUserChildCheck2Body.tabcoins).toStrictEqual(0);
-      expect(firstUserChildCheck2Body.children_deep_count).toStrictEqual(0);
+      expect(firstUserChildCheck2.status).toBe(200);
+      expect(firstUserRootContentCheck2Body.status).toBe('published');
+      expect(firstUserChildCheck2Body.tabcoins).toBe(0);
+      expect(firstUserChildCheck2Body.children_deep_count).toBe(0);
 
       // 16) CHECK SECOND USER CONTENTS (POST-BAN)
       const secondUserRootContentCheck2 = await fetch(
@@ -496,9 +496,9 @@ describe('DELETE /api/v1/users/[username]', () => {
         `${orchestrator.webserverUrl}/api/v1/contents/${secondUser.username}/${secondUserChildContent2Body.slug}`,
       );
 
-      expect(secondUserRootContentCheck2.status).toStrictEqual(404);
-      expect(secondUserChildContent1Check2.status).toStrictEqual(404);
-      expect(secondUserChildContent2Check2.status).toStrictEqual(404);
+      expect(secondUserRootContentCheck2.status).toBe(404);
+      expect(secondUserChildContent1Check2.status).toBe(404);
+      expect(secondUserChildContent2Check2.status).toBe(404);
 
       // 17) TRY TO CREATE NEW CONTENT AS THE SECOND USER
       const secondUserRootContent2 = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
@@ -516,7 +516,7 @@ describe('DELETE /api/v1/users/[username]', () => {
 
       const secondUserRootContent2Body = await secondUserRootContent2.json();
 
-      expect(secondUserRootContent2.status).toStrictEqual(401);
+      expect(secondUserRootContent2.status).toBe(401);
 
       expect(secondUserRootContent2Body).toStrictEqual({
         name: 'UnauthorizedError',
@@ -548,16 +548,16 @@ describe('DELETE /api/v1/users/[username]', () => {
 
       const nukeResponseBody = await nukeResponse.json();
 
-      expect(nukeResponse.status).toEqual(404);
-      expect(nukeResponseBody.status_code).toEqual(404);
-      expect(nukeResponseBody.name).toEqual('NotFoundError');
-      expect(nukeResponseBody.message).toEqual('O "username" informado não foi encontrado no sistema.');
-      expect(nukeResponseBody.action).toEqual('Verifique se o "username" está digitado corretamente.');
-      expect(nukeResponseBody.status_code).toEqual(404);
-      expect(nukeResponseBody.error_location_code).toEqual('MODEL:USER:FIND_ONE_BY_USERNAME:NOT_FOUND');
-      expect(uuidVersion(nukeResponseBody.error_id)).toEqual(4);
-      expect(uuidVersion(nukeResponseBody.request_id)).toEqual(4);
-      expect(nukeResponseBody.key).toEqual('username');
+      expect(nukeResponse.status).toBe(404);
+      expect(nukeResponseBody.status_code).toBe(404);
+      expect(nukeResponseBody.name).toBe('NotFoundError');
+      expect(nukeResponseBody.message).toBe('O "username" informado não foi encontrado no sistema.');
+      expect(nukeResponseBody.action).toBe('Verifique se o "username" está digitado corretamente.');
+      expect(nukeResponseBody.status_code).toBe(404);
+      expect(nukeResponseBody.error_location_code).toBe('MODEL:USER:FIND_ONE_BY_USERNAME:NOT_FOUND');
+      expect(uuidVersion(nukeResponseBody.error_id)).toBe(4);
+      expect(uuidVersion(nukeResponseBody.request_id)).toBe(4);
+      expect(nukeResponseBody.key).toBe('username');
     });
 
     test('With "ban_type" on an user with "nuked" feature', async () => {
@@ -584,7 +584,7 @@ describe('DELETE /api/v1/users/[username]', () => {
 
       const nuke1ResponseBody = await nuke1Response.json();
 
-      expect(nuke1Response.status).toStrictEqual(200);
+      expect(nuke1Response.status).toBe(200);
 
       expect(nuke1ResponseBody).toStrictEqual({
         id: secondUser.id,
@@ -609,16 +609,16 @@ describe('DELETE /api/v1/users/[username]', () => {
 
       const nuke2ResponseBody = await nuke2Response.json();
 
-      expect(nuke2Response.status).toEqual(404);
-      expect(nuke2ResponseBody.status_code).toEqual(404);
-      expect(nuke2ResponseBody.name).toEqual('NotFoundError');
-      expect(nuke2ResponseBody.message).toEqual('O "username" informado não foi encontrado no sistema.');
-      expect(nuke2ResponseBody.action).toEqual('Verifique se o "username" está digitado corretamente.');
-      expect(nuke2ResponseBody.status_code).toEqual(404);
-      expect(nuke2ResponseBody.error_location_code).toEqual('MODEL:USER:FIND_ONE_BY_USERNAME:NOT_FOUND');
-      expect(uuidVersion(nuke2ResponseBody.error_id)).toEqual(4);
-      expect(uuidVersion(nuke2ResponseBody.request_id)).toEqual(4);
-      expect(nuke2ResponseBody.key).toEqual('username');
+      expect(nuke2Response.status).toBe(404);
+      expect(nuke2ResponseBody.status_code).toBe(404);
+      expect(nuke2ResponseBody.name).toBe('NotFoundError');
+      expect(nuke2ResponseBody.message).toBe('O "username" informado não foi encontrado no sistema.');
+      expect(nuke2ResponseBody.action).toBe('Verifique se o "username" está digitado corretamente.');
+      expect(nuke2ResponseBody.status_code).toBe(404);
+      expect(nuke2ResponseBody.error_location_code).toBe('MODEL:USER:FIND_ONE_BY_USERNAME:NOT_FOUND');
+      expect(uuidVersion(nuke2ResponseBody.error_id)).toBe(4);
+      expect(uuidVersion(nuke2ResponseBody.request_id)).toBe(4);
+      expect(nuke2ResponseBody.key).toBe('username');
     });
   });
 });

--- a/tests/integration/api/v1/users/[username]/get.test.js
+++ b/tests/integration/api/v1/users/[username]/get.test.js
@@ -15,16 +15,16 @@ describe('GET /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(404);
-      expect(responseBody.status_code).toEqual(404);
-      expect(responseBody.name).toEqual('NotFoundError');
-      expect(responseBody.message).toEqual('O "username" informado não foi encontrado no sistema.');
-      expect(responseBody.action).toEqual('Verifique se o "username" está digitado corretamente.');
-      expect(responseBody.status_code).toEqual(404);
-      expect(responseBody.error_location_code).toEqual('MODEL:USER:FIND_ONE_BY_USERNAME:NOT_FOUND');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.key).toEqual('username');
+      expect(response.status).toBe(404);
+      expect(responseBody.status_code).toBe(404);
+      expect(responseBody.name).toBe('NotFoundError');
+      expect(responseBody.message).toBe('O "username" informado não foi encontrado no sistema.');
+      expect(responseBody.action).toBe('Verifique se o "username" está digitado corretamente.');
+      expect(responseBody.status_code).toBe(404);
+      expect(responseBody.error_location_code).toBe('MODEL:USER:FIND_ONE_BY_USERNAME:NOT_FOUND');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.key).toBe('username');
     });
 
     test('Retrieving too short user', async () => {
@@ -32,15 +32,15 @@ describe('GET /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"username" deve conter no mínimo 3 caracteres.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.key).toEqual('username');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"username" deve conter no mínimo 3 caracteres.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.key).toBe('username');
     });
 
     test('Retrieving too long user', async () => {
@@ -48,15 +48,15 @@ describe('GET /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"username" deve conter no máximo 30 caracteres.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.key).toEqual('username');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"username" deve conter no máximo 30 caracteres.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.key).toBe('username');
     });
 
     test('Retrieving user with invalid characters', async () => {
@@ -64,15 +64,15 @@ describe('GET /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"username" deve conter apenas caracteres alfanuméricos.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.key).toEqual('username');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"username" deve conter apenas caracteres alfanuméricos.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.key).toBe('username');
     });
 
     test('Retrieving existing user using same capital letters', async () => {
@@ -84,7 +84,7 @@ describe('GET /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: userCreated.id,
@@ -97,9 +97,9 @@ describe('GET /api/v1/users/[username]', () => {
         updated_at: userCreated.updated_at.toISOString(),
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
       expect(responseBody).not.toHaveProperty('password');
       expect(responseBody).not.toHaveProperty('email');
     });
@@ -113,7 +113,7 @@ describe('GET /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: userCreated.id,
@@ -126,9 +126,9 @@ describe('GET /api/v1/users/[username]', () => {
         updated_at: userCreated.updated_at.toISOString(),
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
       expect(responseBody).not.toHaveProperty('password');
       expect(responseBody).not.toHaveProperty('email');
     });
@@ -142,16 +142,16 @@ describe('GET /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(404);
-      expect(responseBody.status_code).toEqual(404);
-      expect(responseBody.name).toEqual('NotFoundError');
-      expect(responseBody.message).toEqual('O "username" informado não foi encontrado no sistema.');
-      expect(responseBody.action).toEqual('Verifique se o "username" está digitado corretamente.');
-      expect(responseBody.status_code).toEqual(404);
-      expect(responseBody.error_location_code).toEqual('MODEL:USER:FIND_ONE_BY_USERNAME:NOT_FOUND');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.key).toEqual('username');
+      expect(response.status).toBe(404);
+      expect(responseBody.status_code).toBe(404);
+      expect(responseBody.name).toBe('NotFoundError');
+      expect(responseBody.message).toBe('O "username" informado não foi encontrado no sistema.');
+      expect(responseBody.action).toBe('Verifique se o "username" está digitado corretamente.');
+      expect(responseBody.status_code).toBe(404);
+      expect(responseBody.error_location_code).toBe('MODEL:USER:FIND_ONE_BY_USERNAME:NOT_FOUND');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.key).toBe('username');
     });
   });
 });

--- a/tests/integration/api/v1/users/[username]/get.test.js
+++ b/tests/integration/api/v1/users/[username]/get.test.js
@@ -98,8 +98,8 @@ describe('GET /api/v1/users/[username]', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
       expect(responseBody).not.toHaveProperty('password');
       expect(responseBody).not.toHaveProperty('email');
     });
@@ -127,8 +127,8 @@ describe('GET /api/v1/users/[username]', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
       expect(responseBody).not.toHaveProperty('password');
       expect(responseBody).not.toHaveProperty('email');
     });

--- a/tests/integration/api/v1/users/[username]/patch.test.js
+++ b/tests/integration/api/v1/users/[username]/patch.test.js
@@ -30,14 +30,14 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(403);
-      expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('Usuário não pode executar esta operação.');
-      expect(responseBody.action).toEqual('Verifique se este usuário possui a feature "update:user".');
-      expect(responseBody.status_code).toEqual(403);
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
+      expect(response.status).toBe(403);
+      expect(responseBody.name).toBe('ForbiddenError');
+      expect(responseBody.message).toBe('Usuário não pode executar esta operação.');
+      expect(responseBody.action).toBe('Verifique se este usuário possui a feature "update:user".');
+      expect(responseBody.status_code).toBe(403);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
     });
   });
 
@@ -62,14 +62,14 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(403);
-      expect(responseBody.name).toEqual('ForbiddenError');
-      expect(responseBody.message).toEqual('Você não possui permissão para atualizar outro usuário.');
-      expect(responseBody.action).toEqual('Verifique se você possui a feature "update:user:others".');
-      expect(responseBody.status_code).toEqual(403);
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('CONTROLLER:USERS:USERNAME:PATCH:USER_CANT_UPDATE_OTHER_USER');
+      expect(response.status).toBe(403);
+      expect(responseBody.name).toBe('ForbiddenError');
+      expect(responseBody.message).toBe('Você não possui permissão para atualizar outro usuário.');
+      expect(responseBody.action).toBe('Verifique se você possui a feature "update:user:others".');
+      expect(responseBody.status_code).toBe(403);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('CONTROLLER:USERS:USERNAME:PATCH:USER_CANT_UPDATE_OTHER_USER');
     });
 
     test('With expired session', async () => {
@@ -97,20 +97,20 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(401);
-      expect(responseBody.status_code).toEqual(401);
-      expect(responseBody.name).toEqual('UnauthorizedError');
-      expect(responseBody.message).toEqual('Usuário não possui sessão ativa.');
-      expect(responseBody.action).toEqual('Verifique se este usuário está logado.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(response.status).toBe(401);
+      expect(responseBody.status_code).toBe(401);
+      expect(responseBody.name).toBe('UnauthorizedError');
+      expect(responseBody.message).toBe('Usuário não possui sessão ativa.');
+      expect(responseBody.action).toBe('Verifique se este usuário está logado.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
 
       const parsedCookiesFromGet = orchestrator.parseSetCookies(response);
-      expect(parsedCookiesFromGet.session_id.name).toEqual('session_id');
-      expect(parsedCookiesFromGet.session_id.value).toEqual('invalid');
-      expect(parsedCookiesFromGet.session_id.maxAge).toEqual(-1);
-      expect(parsedCookiesFromGet.session_id.path).toEqual('/');
-      expect(parsedCookiesFromGet.session_id.httpOnly).toEqual(true);
+      expect(parsedCookiesFromGet.session_id.name).toBe('session_id');
+      expect(parsedCookiesFromGet.session_id.value).toBe('invalid');
+      expect(parsedCookiesFromGet.session_id.maxAge).toBe(-1);
+      expect(parsedCookiesFromGet.session_id.path).toBe('/');
+      expect(parsedCookiesFromGet.session_id.httpOnly).toBe(true);
 
       const sessionObject = await orchestrator.findSessionByToken(defaultUserSession.token);
       expect(sessionObject).toBeUndefined();
@@ -135,7 +135,7 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: defaultUser.id,
@@ -150,13 +150,13 @@ describe('PATCH /api/v1/users/[username]', () => {
         updated_at: responseBody.updated_at,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
+      expect(uuidVersion(responseBody.id)).toBe(4);
       expect(responseBody.updated_at > defaultUser.created_at.toISOString()).toBe(true);
 
       const defaultUserInDatabase = await user.findOneById(responseBody.id);
       const passwordsMatch = await password.compare('password', defaultUserInDatabase.password);
       expect(passwordsMatch).toBe(true);
-      expect(defaultUserInDatabase.email).toEqual(defaultUser.email);
+      expect(defaultUserInDatabase.email).toBe(defaultUser.email);
     });
 
     test('Patching itself with a valid and same username but with different case letters', async () => {
@@ -180,7 +180,7 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: defaultUser.id,
@@ -195,13 +195,13 @@ describe('PATCH /api/v1/users/[username]', () => {
         updated_at: responseBody.updated_at,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
+      expect(uuidVersion(responseBody.id)).toBe(4);
       expect(responseBody.updated_at > defaultUser.created_at.toISOString()).toBe(true);
 
       const defaultUserInDatabase = await user.findOneById(responseBody.id);
       const passwordsMatch = await password.compare('password', defaultUserInDatabase.password);
       expect(passwordsMatch).toBe(true);
-      expect(defaultUserInDatabase.email).toEqual(defaultUser.email);
+      expect(defaultUserInDatabase.email).toBe(defaultUser.email);
     });
 
     test('Patching itself with a valid, unique but "untrimmed" username', async () => {
@@ -223,7 +223,7 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: defaultUser.id,
@@ -238,7 +238,7 @@ describe('PATCH /api/v1/users/[username]', () => {
         updated_at: responseBody.updated_at,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
+      expect(uuidVersion(responseBody.id)).toBe(4);
       expect(responseBody.updated_at > defaultUser.created_at.toISOString()).toBe(true);
     });
 
@@ -264,15 +264,15 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('O "username" informado já está sendo usado.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(responseBody.error_location_code).toEqual('MODEL:USER:VALIDATE_UNIQUE_USERNAME:ALREADY_EXISTS');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.key).toEqual('username');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('O "username" informado já está sendo usado.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(responseBody.error_location_code).toBe('MODEL:USER:VALIDATE_UNIQUE_USERNAME:ALREADY_EXISTS');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.key).toBe('username');
     });
 
     test('Patching itself with "username" duplicated (different uppercase letters)', async () => {
@@ -297,15 +297,15 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('O "username" informado já está sendo usado.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(responseBody.error_location_code).toEqual('MODEL:USER:VALIDATE_UNIQUE_USERNAME:ALREADY_EXISTS');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.key).toEqual('username');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('O "username" informado já está sendo usado.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(responseBody.error_location_code).toBe('MODEL:USER:VALIDATE_UNIQUE_USERNAME:ALREADY_EXISTS');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.key).toBe('username');
     });
 
     test('Patching itself with "username" set to a null value', async () => {
@@ -327,15 +327,15 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"username" deve ser do tipo String.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.key).toEqual('username');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"username" deve ser do tipo String.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.key).toBe('username');
     });
 
     test('Patching itself with "username" with an empty string', async () => {
@@ -357,15 +357,15 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"username" não pode estar em branco.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.key).toEqual('username');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"username" não pode estar em branco.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.key).toBe('username');
     });
 
     test('Patching itself with "username" that\'s not a String', async () => {
@@ -387,15 +387,15 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"username" deve ser do tipo String.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.key).toEqual('username');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"username" deve ser do tipo String.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.key).toBe('username');
     });
 
     test('Patching itself with "username" containing non alphanumeric characters', async () => {
@@ -417,15 +417,15 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"username" deve conter apenas caracteres alfanuméricos.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.key).toEqual('username');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"username" deve conter apenas caracteres alfanuméricos.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.key).toBe('username');
     });
 
     test('Patching itself with "username" too short', async () => {
@@ -447,15 +447,15 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"username" deve conter no mínimo 3 caracteres.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.key).toEqual('username');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"username" deve conter no mínimo 3 caracteres.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.key).toBe('username');
     });
 
     test('Patching itself with "username" too long', async () => {
@@ -477,15 +477,15 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"username" deve conter no máximo 30 caracteres.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.key).toEqual('username');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"username" deve conter no máximo 30 caracteres.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.key).toBe('username');
     });
 
     test('Patching itself with "username" in blocked list', async () => {
@@ -507,15 +507,15 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('Este nome de usuário não está disponível para uso.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(responseBody.key).toEqual('username');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('Este nome de usuário não está disponível para uso.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.key).toBe('username');
     });
 
     test('Patching itself with "body" totally blank', async () => {
@@ -532,15 +532,15 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"body" enviado deve ser do tipo Object.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.key).toEqual('object');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"body" enviado deve ser do tipo Object.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.key).toBe('object');
     });
 
     test('Patching itself with "body" containing a String', async () => {
@@ -558,15 +558,15 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"body" enviado deve ser do tipo Object.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.key).toEqual('object');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"body" enviado deve ser do tipo Object.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.key).toBe('object');
     });
 
     test('Patching itself with "body" containing a blank Object', async () => {
@@ -586,15 +586,15 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('Objeto enviado deve ter no mínimo uma chave.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.key).toEqual('object');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('Objeto enviado deve ter no mínimo uma chave.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.key).toBe('object');
     });
 
     test('Patching itself with "email" duplicated exactly', async () => {
@@ -651,13 +651,13 @@ describe('PATCH /api/v1/users/[username]', () => {
         }),
       });
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       // Attention: it should not update the email in the database
       // before the user clicks on the confirmation link sent to the new email.
       // See `/tests/integration/email-confirmation` for more details.
       const userInDatabase = await user.findOneById(defaultUser.id);
-      expect(userInDatabase.email).toEqual('original@email.com');
+      expect(userInDatabase.email).toBe('original@email.com');
 
       // RECEIVING CONFIRMATION EMAIL
       const confirmationEmail = await orchestrator.getLastEmail();
@@ -667,9 +667,9 @@ describe('PATCH /api/v1/users/[username]', () => {
         tokenObjectInDatabase.id,
       );
 
-      expect(confirmationEmail.sender).toEqual('<contato@tabnews.com.br>');
+      expect(confirmationEmail.sender).toBe('<contato@tabnews.com.br>');
       expect(confirmationEmail.recipients).toEqual(['<different@email.com>']);
-      expect(confirmationEmail.subject).toEqual('Confirme seu novo email');
+      expect(confirmationEmail.subject).toBe('Confirme seu novo email');
       expect(confirmationEmail.text).toContain(defaultUser.username);
       expect(confirmationEmail.html).toContain(defaultUser.username);
       expect(confirmationEmail.text).toContain('Uma alteração de email foi solicitada.');
@@ -697,7 +697,7 @@ describe('PATCH /api/v1/users/[username]', () => {
         }),
       });
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       const userInDatabase = await user.findOneById(defaultUser.id);
       expect(userInDatabase.notifications).toBe(false);
@@ -721,7 +721,7 @@ describe('PATCH /api/v1/users/[username]', () => {
       });
 
       const responseBody = await response.json();
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
       expect(responseBody).toStrictEqual({
         id: defaultUser.id,
         username: defaultUser.username,
@@ -762,15 +762,15 @@ describe('PATCH /api/v1/users/[username]', () => {
       });
 
       const responseBody = await response.json();
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"description" deve conter no máximo 5000 caracteres.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(responseBody.type).toEqual('string.max');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"description" deve conter no máximo 5000 caracteres.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(responseBody.type).toBe('string.max');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     test('Patching itself with a "description" containing value null', async () => {
@@ -791,15 +791,15 @@ describe('PATCH /api/v1/users/[username]', () => {
       });
 
       const responseBody = await response.json();
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"description" deve ser do tipo String.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(responseBody.type).toEqual('string.base');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"description" deve ser do tipo String.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(responseBody.type).toBe('string.base');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
     describe('TEMPORARY BEHAVIOR', () => {
@@ -822,7 +822,7 @@ describe('PATCH /api/v1/users/[username]', () => {
           }),
         });
 
-        expect(response.status).toEqual(400);
+        expect(response.status).toBe(400);
 
         const defaultUserInDatabase = await user.findOneById(defaultUser.id);
         const passwordsMatch = await password.compare('thisPasswordWillNotChange', defaultUserInDatabase.password);
@@ -860,15 +860,15 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('Objeto enviado deve ter no mínimo uma chave.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.key).toEqual('object');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('Objeto enviado deve ter no mínimo uma chave.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.key).toBe('object');
     });
 
     test('Patching other user with all fields', async () => {
@@ -900,7 +900,7 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
       expect(responseBody).toStrictEqual({
         id: secondUser.id,
         username: secondUser.username,

--- a/tests/integration/api/v1/users/[username]/patch.test.js
+++ b/tests/integration/api/v1/users/[username]/patch.test.js
@@ -668,7 +668,7 @@ describe('PATCH /api/v1/users/[username]', () => {
       );
 
       expect(confirmationEmail.sender).toBe('<contato@tabnews.com.br>');
-      expect(confirmationEmail.recipients).toEqual(['<different@email.com>']);
+      expect(confirmationEmail.recipients).toStrictEqual(['<different@email.com>']);
       expect(confirmationEmail.subject).toBe('Confirme seu novo email');
       expect(confirmationEmail.text).toContain(defaultUser.username);
       expect(confirmationEmail.html).toContain(defaultUser.username);

--- a/tests/integration/api/v1/users/firewall.post.test.js
+++ b/tests/integration/api/v1/users/firewall.post.test.js
@@ -94,8 +94,8 @@ describe('POST /api/v1/users [FIREWALL]', () => {
       const user1Email = allEmails.find((email) => email.recipients.includes(`<${user1.email}>`));
       const user2Email = allEmails.find((email) => email.recipients.includes(`<${user2.email}>`));
 
-      expect(user1Email.recipients).toEqual([`<${user1.email}>`]);
-      expect(user2Email.recipients).toEqual([`<${user2.email}>`]);
+      expect(user1Email.recipients).toStrictEqual([`<${user1.email}>`]);
+      expect(user2Email.recipients).toStrictEqual([`<${user2.email}>`]);
 
       expect(user1Email.subject).toBe('Sua conta foi desativada');
       expect(user2Email.subject).toBe('Sua conta foi desativada');

--- a/tests/integration/api/v1/users/firewall.post.test.js
+++ b/tests/integration/api/v1/users/firewall.post.test.js
@@ -64,12 +64,12 @@ describe('POST /api/v1/users [FIREWALL]', () => {
         'update:content',
         'update:user',
       ]);
-      expect(user1.updated_at.toISOString()).toEqual(activatedUser1.updated_at.toISOString());
-      expect(Date.parse(user1.updated_at)).not.toEqual(NaN);
+      expect(user1.updated_at.toISOString()).toBe(activatedUser1.updated_at.toISOString());
+      expect(Date.parse(user1.updated_at)).not.toBe(NaN);
 
       expect(user2.features).toStrictEqual([]);
-      expect(user2.updated_at.toISOString()).toEqual(response2Body.updated_at);
-      expect(Date.parse(user2.updated_at)).not.toEqual(NaN);
+      expect(user2.updated_at.toISOString()).toBe(response2Body.updated_at);
+      expect(Date.parse(user2.updated_at)).not.toBe(NaN);
 
       const lastEvent = await orchestrator.getLastEvent();
 
@@ -97,8 +97,8 @@ describe('POST /api/v1/users [FIREWALL]', () => {
       expect(user1Email.recipients).toEqual([`<${user1.email}>`]);
       expect(user2Email.recipients).toEqual([`<${user2.email}>`]);
 
-      expect(user1Email.subject).toEqual('Sua conta foi desativada');
-      expect(user2Email.subject).toEqual('Sua conta foi desativada');
+      expect(user1Email.subject).toBe('Sua conta foi desativada');
+      expect(user2Email.subject).toBe('Sua conta foi desativada');
 
       expect(user1Email.text).toContain(user1.username);
       expect(user1Email.html).toContain(user1.username);

--- a/tests/integration/api/v1/users/firewall.post.test.js
+++ b/tests/integration/api/v1/users/firewall.post.test.js
@@ -65,11 +65,11 @@ describe('POST /api/v1/users [FIREWALL]', () => {
         'update:user',
       ]);
       expect(user1.updated_at.toISOString()).toBe(activatedUser1.updated_at.toISOString());
-      expect(Date.parse(user1.updated_at)).not.toBe(NaN);
+      expect(Date.parse(user1.updated_at)).not.toBeNaN();
 
       expect(user2.features).toStrictEqual([]);
       expect(user2.updated_at.toISOString()).toBe(response2Body.updated_at);
-      expect(Date.parse(user2.updated_at)).not.toBe(NaN);
+      expect(Date.parse(user2.updated_at)).not.toBeNaN();
 
       const lastEvent = await orchestrator.getLastEvent();
 
@@ -86,7 +86,7 @@ describe('POST /api/v1/users [FIREWALL]', () => {
       });
 
       expect(uuidVersion(lastEvent.id)).toBe(4);
-      expect(Date.parse(lastEvent.created_at)).not.toBe(NaN);
+      expect(Date.parse(lastEvent.created_at)).not.toBeNaN();
 
       const allEmails = await orchestrator.getEmails();
       expect(allEmails).toHaveLength(2);

--- a/tests/integration/api/v1/users/get.test.js
+++ b/tests/integration/api/v1/users/get.test.js
@@ -180,12 +180,12 @@ describe('GET /api/v1/users', () => {
       ]);
 
       expect(uuidVersion(responseBody[0].id)).toBe(4);
-      expect(Date.parse(responseBody[0].created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody[0].updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody[0].created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody[0].updated_at)).not.toBeNaN();
 
       expect(uuidVersion(responseBody[1].id)).toBe(4);
-      expect(Date.parse(responseBody[1].created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody[1].updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody[1].created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody[1].updated_at)).not.toBeNaN();
     });
 
     test('Retrieving user list with TabCoins and TabCash', async () => {
@@ -246,12 +246,12 @@ describe('GET /api/v1/users', () => {
       ]);
 
       expect(uuidVersion(responseBody[0].id)).toBe(4);
-      expect(Date.parse(responseBody[0].created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody[0].updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody[0].created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody[0].updated_at)).not.toBeNaN();
 
       expect(uuidVersion(responseBody[1].id)).toBe(4);
-      expect(Date.parse(responseBody[1].created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody[1].updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody[1].created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody[1].updated_at)).not.toBeNaN();
     });
 
     test('With a "page" out of bounds', async () => {

--- a/tests/integration/api/v1/users/get.test.js
+++ b/tests/integration/api/v1/users/get.test.js
@@ -31,7 +31,7 @@ describe('GET /api/v1/users', () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users`);
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(403);
+      expect(response.status).toBe(403);
 
       expect(responseBody).toStrictEqual({
         name: 'ForbiddenError',
@@ -42,8 +42,8 @@ describe('GET /api/v1/users', () => {
         request_id: responseBody.request_id,
         error_location_code: 'MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND',
       });
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
   });
 
@@ -60,7 +60,7 @@ describe('GET /api/v1/users', () => {
       });
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(403);
+      expect(response.status).toBe(403);
 
       expect(responseBody).toStrictEqual({
         name: 'ForbiddenError',
@@ -71,8 +71,8 @@ describe('GET /api/v1/users', () => {
         request_id: responseBody.request_id,
         error_location_code: 'MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND',
       });
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
   });
 
@@ -87,7 +87,7 @@ describe('GET /api/v1/users', () => {
       });
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
         message: '"per_page" deve possuir um valor máximo de 100.',
@@ -100,15 +100,15 @@ describe('GET /api/v1/users', () => {
         type: 'number.max',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('With an invalid value for "page"', async () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents?page=first`);
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
+      expect(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -122,8 +122,8 @@ describe('GET /api/v1/users', () => {
         type: 'number.base',
       });
 
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
     test('Retrieving user list with 2 users', async () => {
@@ -139,8 +139,8 @@ describe('GET /api/v1/users', () => {
       const responseLinkHeader = parseLinkHeader(response.headers.get('Link'));
       const responseTotalRowsHeader = response.headers.get('X-Pagination-Total-Rows');
 
-      expect(response.status).toEqual(200);
-      expect(responseTotalRowsHeader).toEqual('2');
+      expect(response.status).toBe(200);
+      expect(responseTotalRowsHeader).toBe('2');
       expect(responseLinkHeader).toStrictEqual({
         first: {
           page: '1',
@@ -179,13 +179,13 @@ describe('GET /api/v1/users', () => {
         },
       ]);
 
-      expect(uuidVersion(responseBody[0].id)).toEqual(4);
-      expect(Date.parse(responseBody[0].created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody[0].updated_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody[0].id)).toBe(4);
+      expect(Date.parse(responseBody[0].created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody[0].updated_at)).not.toBe(NaN);
 
-      expect(uuidVersion(responseBody[1].id)).toEqual(4);
-      expect(Date.parse(responseBody[1].created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody[1].updated_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody[1].id)).toBe(4);
+      expect(Date.parse(responseBody[1].created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody[1].updated_at)).not.toBe(NaN);
     });
 
     test('Retrieving user list with TabCoins and TabCash', async () => {
@@ -220,7 +220,7 @@ describe('GET /api/v1/users', () => {
       });
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(200);
+      expect(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual([
         {
@@ -245,13 +245,13 @@ describe('GET /api/v1/users', () => {
         },
       ]);
 
-      expect(uuidVersion(responseBody[0].id)).toEqual(4);
-      expect(Date.parse(responseBody[0].created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody[0].updated_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody[0].id)).toBe(4);
+      expect(Date.parse(responseBody[0].created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody[0].updated_at)).not.toBe(NaN);
 
-      expect(uuidVersion(responseBody[1].id)).toEqual(4);
-      expect(Date.parse(responseBody[1].created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody[1].updated_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody[1].id)).toBe(4);
+      expect(Date.parse(responseBody[1].created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody[1].updated_at)).not.toBe(NaN);
     });
 
     test('With a "page" out of bounds', async () => {
@@ -267,8 +267,8 @@ describe('GET /api/v1/users', () => {
       const responseLinkHeader = parseLinkHeader(response.headers.get('Link'));
       const responseTotalRowsHeader = response.headers.get('X-Pagination-Total-Rows');
 
-      expect(response.status).toEqual(200);
-      expect(responseTotalRowsHeader).toEqual('2');
+      expect(response.status).toBe(200);
+      expect(responseTotalRowsHeader).toBe('2');
       expect(responseLinkHeader).toStrictEqual({
         first: {
           page: '1',
@@ -373,8 +373,8 @@ describe('GET /api/v1/users', () => {
         const responseLinkHeader = parseLinkHeader(response.headers.get('Link'));
         const responseTotalRowsHeader = response.headers.get('X-Pagination-Total-Rows');
 
-        expect(response.status).toEqual(200);
-        expect(responseTotalRowsHeader).toEqual('60');
+        expect(response.status).toBe(200);
+        expect(responseTotalRowsHeader).toBe('60');
         expect(responseLinkHeader).toStrictEqual({
           first: {
             page: '1',
@@ -410,8 +410,8 @@ describe('GET /api/v1/users', () => {
         const page2ResponseLinkHeader = parseLinkHeader(page2Response.headers.get('Link'));
         const page2ResponseTotalRowsHeader = page2Response.headers.get('X-Pagination-Total-Rows');
 
-        expect(page2Response.status).toEqual(200);
-        expect(page2ResponseTotalRowsHeader).toEqual('60');
+        expect(page2Response.status).toBe(200);
+        expect(page2ResponseTotalRowsHeader).toBe('60');
         expect(page2ResponseLinkHeader).toStrictEqual({
           first: {
             page: '1',
@@ -463,7 +463,7 @@ describe('GET /api/v1/users', () => {
 
         const responseBody = await response.json();
 
-        expect(response.status).toEqual(200);
+        expect(response.status).toBe(200);
         expect(responseBody).toStrictEqual(getExpected());
       });
     });

--- a/tests/integration/api/v1/users/post.test.js
+++ b/tests/integration/api/v1/users/post.test.js
@@ -26,7 +26,7 @@ describe('POST /api/v1/users', () => {
       });
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(201);
+      expect(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -39,9 +39,9 @@ describe('POST /api/v1/users', () => {
         updated_at: responseBody.updated_at,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
 
       const userInDatabase = await user.findOneByUsername('uniqueUserName');
       const passwordsMatch = await password.compare('validpassword', userInDatabase.password);
@@ -49,7 +49,7 @@ describe('POST /api/v1/users', () => {
 
       expect(passwordsMatch).toBe(true);
       expect(wrongPasswordMatch).toBe(false);
-      expect(userInDatabase.email).toEqual('validemailcaps@gmail.com');
+      expect(userInDatabase.email).toBe('validemailcaps@gmail.com');
     });
 
     test('With unique and valid data, and an unknown key', async () => {
@@ -68,7 +68,7 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(201);
+      expect(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -81,12 +81,12 @@ describe('POST /api/v1/users', () => {
         updated_at: responseBody.updated_at,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
 
       const userInDatabase = await user.findOneById(responseBody.id);
-      expect(userInDatabase.email).toEqual('postwithunknownkey@gmail.com');
+      expect(userInDatabase.email).toBe('postwithunknownkey@gmail.com');
     });
 
     test('With unique and valid data, but with "untrimmed" values', async () => {
@@ -104,7 +104,7 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(201);
+      expect(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -117,9 +117,9 @@ describe('POST /api/v1/users', () => {
         updated_at: responseBody.updated_at,
       });
 
-      expect(uuidVersion(responseBody.id)).toEqual(4);
-      expect(Date.parse(responseBody.created_at)).not.toEqual(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toEqual(NaN);
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
 
       const userInDatabase = await user.findOneByUsername('extraSpaceInTheEnd');
       const passwordsMatch = await password.compare('validpassword', userInDatabase.password);
@@ -127,7 +127,7 @@ describe('POST /api/v1/users', () => {
 
       expect(passwordsMatch).toBe(true);
       expect(wrongPasswordMatch).toBe(false);
-      expect(userInDatabase.email).toEqual('space.in.the.beggining@gmail.com');
+      expect(userInDatabase.email).toBe('space.in.the.beggining@gmail.com');
     });
 
     test('With "username" duplicated exactly (same uppercase letters)', async () => {
@@ -158,15 +158,15 @@ describe('POST /api/v1/users', () => {
 
       const secondResponseBody = await secondResponse.json();
 
-      expect(secondResponse.status).toEqual(400);
-      expect(secondResponseBody.status_code).toEqual(400);
-      expect(secondResponseBody.name).toEqual('ValidationError');
-      expect(secondResponseBody.message).toEqual('O "username" informado já está sendo usado.');
-      expect(secondResponseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(secondResponseBody.error_id)).toEqual(4);
-      expect(uuidVersion(secondResponseBody.request_id)).toEqual(4);
-      expect(secondResponseBody.error_location_code).toEqual('MODEL:USER:VALIDATE_UNIQUE_USERNAME:ALREADY_EXISTS');
-      expect(secondResponseBody.key).toEqual('username');
+      expect(secondResponse.status).toBe(400);
+      expect(secondResponseBody.status_code).toBe(400);
+      expect(secondResponseBody.name).toBe('ValidationError');
+      expect(secondResponseBody.message).toBe('O "username" informado já está sendo usado.');
+      expect(secondResponseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(secondResponseBody.error_id)).toBe(4);
+      expect(uuidVersion(secondResponseBody.request_id)).toBe(4);
+      expect(secondResponseBody.error_location_code).toBe('MODEL:USER:VALIDATE_UNIQUE_USERNAME:ALREADY_EXISTS');
+      expect(secondResponseBody.key).toBe('username');
     });
 
     test('With "username" duplicated (different uppercase letters)', async () => {
@@ -197,15 +197,15 @@ describe('POST /api/v1/users', () => {
 
       const secondResponseBody = await secondResponse.json();
 
-      expect(secondResponse.status).toEqual(400);
-      expect(secondResponseBody.status_code).toEqual(400);
-      expect(secondResponseBody.name).toEqual('ValidationError');
-      expect(secondResponseBody.message).toEqual('O "username" informado já está sendo usado.');
-      expect(secondResponseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(secondResponseBody.error_id)).toEqual(4);
-      expect(uuidVersion(secondResponseBody.request_id)).toEqual(4);
-      expect(secondResponseBody.error_location_code).toEqual('MODEL:USER:VALIDATE_UNIQUE_USERNAME:ALREADY_EXISTS');
-      expect(secondResponseBody.key).toEqual('username');
+      expect(secondResponse.status).toBe(400);
+      expect(secondResponseBody.status_code).toBe(400);
+      expect(secondResponseBody.name).toBe('ValidationError');
+      expect(secondResponseBody.message).toBe('O "username" informado já está sendo usado.');
+      expect(secondResponseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(secondResponseBody.error_id)).toBe(4);
+      expect(uuidVersion(secondResponseBody.request_id)).toBe(4);
+      expect(secondResponseBody.error_location_code).toBe('MODEL:USER:VALIDATE_UNIQUE_USERNAME:ALREADY_EXISTS');
+      expect(secondResponseBody.key).toBe('username');
     });
 
     test('With "username" missing', async () => {
@@ -222,15 +222,15 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"username" é um campo obrigatório.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(responseBody.key).toEqual('username');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"username" é um campo obrigatório.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.key).toBe('username');
     });
 
     test('With "username" with a null value', async () => {
@@ -248,15 +248,15 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"username" deve ser do tipo String.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(responseBody.key).toEqual('username');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"username" deve ser do tipo String.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.key).toBe('username');
     });
 
     test('With "username" with an empty string', async () => {
@@ -274,15 +274,15 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"username" não pode estar em branco.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(responseBody.key).toEqual('username');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"username" não pode estar em branco.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.key).toBe('username');
     });
 
     test('With "username" that\'s not a String', async () => {
@@ -300,15 +300,15 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"username" deve ser do tipo String.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(responseBody.key).toEqual('username');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"username" deve ser do tipo String.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.key).toBe('username');
     });
 
     test('With "username" containing non alphanumeric characters', async () => {
@@ -326,15 +326,15 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"username" deve conter apenas caracteres alfanuméricos.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(responseBody.key).toEqual('username');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"username" deve conter apenas caracteres alfanuméricos.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.key).toBe('username');
     });
 
     test('With "username" too long', async () => {
@@ -352,15 +352,15 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"username" deve conter no máximo 30 caracteres.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(responseBody.key).toEqual('username');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"username" deve conter no máximo 30 caracteres.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.key).toBe('username');
     });
 
     test('With "username" in blocked list', async () => {
@@ -378,15 +378,15 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('Este nome de usuário não está disponível para uso.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(responseBody.key).toEqual('username');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('Este nome de usuário não está disponível para uso.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.key).toBe('username');
     });
 
     test('With "email" duplicated (same uppercase letters)', async () => {
@@ -507,15 +507,15 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"email" é um campo obrigatório.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(responseBody.key).toEqual('email');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"email" é um campo obrigatório.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.key).toBe('email');
     });
 
     test('With "email" with an empty string', async () => {
@@ -533,15 +533,15 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"email" não pode estar em branco.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(responseBody.key).toEqual('email');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"email" não pode estar em branco.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.key).toBe('email');
     });
 
     test('With "email" that\'s not a String', async () => {
@@ -559,15 +559,15 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"email" deve ser do tipo String.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(responseBody.key).toEqual('email');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"email" deve ser do tipo String.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.key).toBe('email');
     });
 
     test('With "email" with invalid format', async () => {
@@ -585,15 +585,15 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"email" deve conter um email válido.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(responseBody.key).toEqual('email');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"email" deve conter um email válido.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.key).toBe('email');
     });
 
     test('With "password" missing', async () => {
@@ -610,15 +610,15 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"password" é um campo obrigatório.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(responseBody.key).toEqual('password');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"password" é um campo obrigatório.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.key).toBe('password');
     });
 
     test('With "password" with an empty string', async () => {
@@ -636,15 +636,15 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"password" não pode estar em branco.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(responseBody.key).toEqual('password');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"password" não pode estar em branco.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.key).toBe('password');
     });
 
     test('With "password" that\'s not a String', async () => {
@@ -662,15 +662,15 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"password" deve ser do tipo String.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(responseBody.key).toEqual('password');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"password" deve ser do tipo String.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.key).toBe('password');
     });
 
     test('With "password" too short', async () => {
@@ -688,15 +688,15 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"password" deve conter no mínimo 8 caracteres.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(responseBody.key).toEqual('password');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"password" deve conter no mínimo 8 caracteres.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.key).toBe('password');
     });
 
     test('With "password" too long', async () => {
@@ -714,15 +714,15 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"password" deve conter no máximo 72 caracteres.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(responseBody.key).toEqual('password');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"password" deve conter no máximo 72 caracteres.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.key).toBe('password');
     });
 
     test('With "body" totally blank', async () => {
@@ -732,15 +732,15 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"body" enviado deve ser do tipo Object.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(responseBody.key).toEqual('object');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"body" enviado deve ser do tipo Object.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.key).toBe('object');
     });
 
     test('With "body" containing a String', async () => {
@@ -751,15 +751,15 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(400);
-      expect(responseBody.status_code).toEqual(400);
-      expect(responseBody.name).toEqual('ValidationError');
-      expect(responseBody.message).toEqual('"body" enviado deve ser do tipo Object.');
-      expect(responseBody.action).toEqual('Ajuste os dados enviados e tente novamente.');
-      expect(uuidVersion(responseBody.error_id)).toEqual(4);
-      expect(uuidVersion(responseBody.request_id)).toEqual(4);
-      expect(responseBody.error_location_code).toEqual('MODEL:VALIDATOR:FINAL_SCHEMA');
-      expect(responseBody.key).toEqual('object');
+      expect(response.status).toBe(400);
+      expect(responseBody.status_code).toBe(400);
+      expect(responseBody.name).toBe('ValidationError');
+      expect(responseBody.message).toBe('"body" enviado deve ser do tipo Object.');
+      expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+      expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
+      expect(responseBody.key).toBe('object');
     });
   });
 });

--- a/tests/integration/api/v1/users/post.test.js
+++ b/tests/integration/api/v1/users/post.test.js
@@ -40,8 +40,8 @@ describe('POST /api/v1/users', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
 
       const userInDatabase = await user.findOneByUsername('uniqueUserName');
       const passwordsMatch = await password.compare('validpassword', userInDatabase.password);
@@ -82,8 +82,8 @@ describe('POST /api/v1/users', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
 
       const userInDatabase = await user.findOneById(responseBody.id);
       expect(userInDatabase.email).toBe('postwithunknownkey@gmail.com');
@@ -118,8 +118,8 @@ describe('POST /api/v1/users', () => {
       });
 
       expect(uuidVersion(responseBody.id)).toBe(4);
-      expect(Date.parse(responseBody.created_at)).not.toBe(NaN);
-      expect(Date.parse(responseBody.updated_at)).not.toBe(NaN);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
 
       const userInDatabase = await user.findOneByUsername('extraSpaceInTheEnd');
       const passwordsMatch = await password.compare('validpassword', userInDatabase.password);

--- a/tests/integration/infra/under-maintenance.test.js
+++ b/tests/integration/infra/under-maintenance.test.js
@@ -14,10 +14,10 @@ describe('Under maintenance route', () => {
       });
       const responseBody = await response.json();
 
-      expect(response.status).toEqual(503);
-      expect(responseBody.message).toEqual('Funcionalidade em manutenção.');
-      expect(responseBody.action).toEqual('Tente novamente mais tarde.');
-      expect(responseBody.error_location_code).toEqual('INFRA:UNDER_MAINTENANCE:CHECK:IS_UNDER_MAINTENANCE');
+      expect(response.status).toBe(503);
+      expect(responseBody.message).toBe('Funcionalidade em manutenção.');
+      expect(responseBody.action).toBe('Tente novamente mais tarde.');
+      expect(responseBody.error_location_code).toBe('INFRA:UNDER_MAINTENANCE:CHECK:IS_UNDER_MAINTENANCE');
     });
 
     test('Trying to access "method" under maintenance, but distinct "path"', async () => {
@@ -25,9 +25,9 @@ describe('Under maintenance route', () => {
         method: 'POST',
       });
 
-      expect(response.status).toEqual(404);
-      expect(response.statusText).toEqual('Not Found');
-      expect(response.ok).toEqual(false);
+      expect(response.status).toBe(404);
+      expect(response.statusText).toBe('Not Found');
+      expect(response.ok).toBe(false);
     });
 
     test('Trying to access "path" under maintenance, but distinct "method"', async () => {
@@ -35,9 +35,9 @@ describe('Under maintenance route', () => {
         method: 'GET',
       });
 
-      expect(response.status).toEqual(404);
-      expect(response.statusText).toEqual('Not Found');
-      expect(response.ok).toEqual(false);
+      expect(response.status).toBe(404);
+      expect(response.statusText).toBe('Not Found');
+      expect(response.ok).toBe(false);
     });
   });
 });

--- a/tests/integration/models/event.test.js
+++ b/tests/integration/models/event.test.js
@@ -33,7 +33,7 @@ describe('models/event', () => {
       });
 
       expect(uuidVersion(lastEvent.id)).toBe(4);
-      expect(Date.parse(lastEvent.created_at)).not.toBe(NaN);
+      expect(Date.parse(lastEvent.created_at)).not.toBeNaN();
     });
   });
 
@@ -68,7 +68,7 @@ describe('models/event', () => {
       });
 
       expect(uuidVersion(lastEvent.id)).toBe(4);
-      expect(Date.parse(lastEvent.created_at)).not.toBe(NaN);
+      expect(Date.parse(lastEvent.created_at)).not.toBeNaN();
     });
 
     test('Create "create:content:text_root" event', async () => {
@@ -95,7 +95,7 @@ describe('models/event', () => {
       });
 
       expect(uuidVersion(lastEvent.id)).toBe(4);
-      expect(Date.parse(lastEvent.created_at)).not.toBe(NaN);
+      expect(Date.parse(lastEvent.created_at)).not.toBeNaN();
     });
 
     test('Create "create:content:text_child" event', async () => {
@@ -129,7 +129,7 @@ describe('models/event', () => {
       });
 
       expect(uuidVersion(lastEvent.id)).toBe(4);
-      expect(Date.parse(lastEvent.created_at)).not.toBe(NaN);
+      expect(Date.parse(lastEvent.created_at)).not.toBeNaN();
     });
 
     test('Create "update:content:text_root" event', async () => {
@@ -162,7 +162,7 @@ describe('models/event', () => {
       });
 
       expect(uuidVersion(lastEvent.id)).toBe(4);
-      expect(Date.parse(lastEvent.created_at)).not.toBe(NaN);
+      expect(Date.parse(lastEvent.created_at)).not.toBeNaN();
     });
 
     test('Create "update:content:text_child" event', async () => {
@@ -200,7 +200,7 @@ describe('models/event', () => {
       });
 
       expect(uuidVersion(lastEvent.id)).toBe(4);
-      expect(Date.parse(lastEvent.created_at)).not.toBe(NaN);
+      expect(Date.parse(lastEvent.created_at)).not.toBeNaN();
     });
 
     test('Create "update:content:tabcoins" with "transaction_type" set to "credit"', async () => {
@@ -245,7 +245,7 @@ describe('models/event', () => {
       });
 
       expect(uuidVersion(lastEvent.id)).toBe(4);
-      expect(Date.parse(lastEvent.created_at)).not.toBe(NaN);
+      expect(Date.parse(lastEvent.created_at)).not.toBeNaN();
     });
 
     test('Create "update:content:tabcoins" with "transaction_type" set to "debit"', async () => {
@@ -290,7 +290,7 @@ describe('models/event', () => {
       });
 
       expect(uuidVersion(lastEvent.id)).toBe(4);
-      expect(Date.parse(lastEvent.created_at)).not.toBe(NaN);
+      expect(Date.parse(lastEvent.created_at)).not.toBeNaN();
     });
 
     test('Create "reward:user:tabcoins" event', async () => {
@@ -320,7 +320,7 @@ describe('models/event', () => {
       });
 
       expect(uuidVersion(lastEvent.id)).toBe(4);
-      expect(Date.parse(lastEvent.created_at)).not.toBe(NaN);
+      expect(Date.parse(lastEvent.created_at)).not.toBeNaN();
       expect(Date.parse(lastEvent.created_at)).toBeGreaterThan(Date.now() - 1000);
     });
   });
@@ -353,7 +353,7 @@ describe('models/event', () => {
       });
 
       expect(uuidVersion(lastEvent.id)).toBe(4);
-      expect(Date.parse(lastEvent.created_at)).not.toBe(NaN);
+      expect(Date.parse(lastEvent.created_at)).not.toBeNaN();
     });
 
     test('Create "ban:user" event', async () => {
@@ -380,7 +380,7 @@ describe('models/event', () => {
       });
 
       expect(uuidVersion(lastEvent.id)).toBe(4);
-      expect(Date.parse(lastEvent.created_at)).not.toBe(NaN);
+      expect(Date.parse(lastEvent.created_at)).not.toBeNaN();
     });
 
     test('Create "update:content:text_root" event', async () => {
@@ -415,7 +415,7 @@ describe('models/event', () => {
       });
 
       expect(uuidVersion(lastEvent.id)).toBe(4);
-      expect(Date.parse(lastEvent.created_at)).not.toBe(NaN);
+      expect(Date.parse(lastEvent.created_at)).not.toBeNaN();
     });
 
     test('Create "update:content:text_child" event', async () => {
@@ -455,7 +455,7 @@ describe('models/event', () => {
       });
 
       expect(uuidVersion(lastEvent.id)).toBe(4);
-      expect(Date.parse(lastEvent.created_at)).not.toBe(NaN);
+      expect(Date.parse(lastEvent.created_at)).not.toBeNaN();
     });
   });
 
@@ -502,7 +502,7 @@ describe('models/event', () => {
       });
 
       expect(uuidVersion(lastEvent.id)).toBe(4);
-      expect(Date.parse(lastEvent.created_at)).not.toBe(NaN);
+      expect(Date.parse(lastEvent.created_at)).not.toBeNaN();
     });
 
     test('Create "firewall:block_contents:text_root" event', async () => {
@@ -542,7 +542,7 @@ describe('models/event', () => {
       });
 
       expect(uuidVersion(lastEvent.id)).toBe(4);
-      expect(Date.parse(lastEvent.created_at)).not.toBe(NaN);
+      expect(Date.parse(lastEvent.created_at)).not.toBeNaN();
     });
 
     test('Create "firewall:block_contents:text_child" event', async () => {
@@ -587,7 +587,7 @@ describe('models/event', () => {
       });
 
       expect(uuidVersion(lastEvent.id)).toBe(4);
-      expect(Date.parse(lastEvent.created_at)).not.toBe(NaN);
+      expect(Date.parse(lastEvent.created_at)).not.toBeNaN();
     });
   });
 });

--- a/tests/unit/infra/under-maintenance.test.js
+++ b/tests/unit/infra/under-maintenance.test.js
@@ -9,7 +9,7 @@ beforeAll(() => {
   originalUnderMaintenanceProcessEnv = process.env.UNDER_MAINTENANCE;
 });
 
-beforeEach(async () => {
+beforeEach(() => {
   vi.resetModules();
 });
 

--- a/tests/unit/interface/utils/error-message.test.js
+++ b/tests/unit/interface/utils/error-message.test.js
@@ -4,13 +4,13 @@ describe('createErrorMessage', () => {
   it('should return default error message when responseBody is null', () => {
     const responseBody = null;
     const errorMessage = createErrorMessage(responseBody);
-    expect(errorMessage).toEqual('Erro desconhecido. Tente novamente mais tarde.');
+    expect(errorMessage).toBe('Erro desconhecido. Tente novamente mais tarde.');
   });
 
   it('should return default error message when responseBody is undefined', () => {
     const responseBody = undefined;
     const errorMessage = createErrorMessage(responseBody);
-    expect(errorMessage).toEqual('Erro desconhecido. Tente novamente mais tarde.');
+    expect(errorMessage).toBe('Erro desconhecido. Tente novamente mais tarde.');
   });
 
   it('should return error message', () => {
@@ -18,7 +18,7 @@ describe('createErrorMessage', () => {
       message: 'Entrada inválida.',
     };
     const errorMessage = createErrorMessage(responseBody);
-    expect(errorMessage).toEqual('Entrada inválida.');
+    expect(errorMessage).toBe('Entrada inválida.');
   });
 
   it('should return error message with action', () => {
@@ -26,7 +26,7 @@ describe('createErrorMessage', () => {
       action: 'Tente novamente.',
     };
     const errorMessage = createErrorMessage(responseBody);
-    expect(errorMessage).toEqual('Tente novamente.');
+    expect(errorMessage).toBe('Tente novamente.');
   });
 
   it('should return error message with error_id', () => {
@@ -34,7 +34,7 @@ describe('createErrorMessage', () => {
       error_id: '123456789',
     };
     const errorMessage = createErrorMessage(responseBody);
-    expect(errorMessage).toEqual('Informe ao suporte o valor (123456789)');
+    expect(errorMessage).toBe('Informe ao suporte o valor (123456789)');
   });
 
   it('should return error message with message and action', () => {
@@ -43,7 +43,7 @@ describe('createErrorMessage', () => {
       action: 'Tente novamente.',
     };
     const errorMessage = createErrorMessage(responseBody);
-    expect(errorMessage).toEqual('Entrada inválida. Tente novamente.');
+    expect(errorMessage).toBe('Entrada inválida. Tente novamente.');
   });
 
   it('should return error message without error_id when omitErrorId is true', () => {
@@ -53,7 +53,7 @@ describe('createErrorMessage', () => {
       error_id: '123456789',
     };
     const errorMessage = createErrorMessage(responseBody, { omitErrorId: true });
-    expect(errorMessage).toEqual('Entrada inválida. Tente novamente.');
+    expect(errorMessage).toBe('Entrada inválida. Tente novamente.');
   });
 
   it('should return error message with message, action, and error_id', () => {
@@ -63,7 +63,7 @@ describe('createErrorMessage', () => {
       error_id: '123456789',
     };
     const errorMessage = createErrorMessage(responseBody);
-    expect(errorMessage).toEqual('Entrada inválida. Tente novamente. Informe ao suporte o valor (123456789)');
+    expect(errorMessage).toBe('Entrada inválida. Tente novamente. Informe ao suporte o valor (123456789)');
   });
 
   it('should return error message without action when action is a specific string', () => {
@@ -73,6 +73,6 @@ describe('createErrorMessage', () => {
       error_id: '123456789',
     };
     const errorMessage = createErrorMessage(responseBody);
-    expect(errorMessage).toEqual('Um erro interno não esperado aconteceu. Informe ao suporte o valor (123456789)');
+    expect(errorMessage).toBe('Um erro interno não esperado aconteceu. Informe ao suporte o valor (123456789)');
   });
 });


### PR DESCRIPTION
## Mudanças realizadas

### Principais

Adiciona testes para evitar a regressão do comportamento dos anúncios em relação aos ganhos de TabCoins. Os votos recebidos nos anúncios não devem influenciar os ganhos de TabCoins:

- a479c2f8642c40fe02284d6b70f5fc39ab0e698b: Ao publicar outros conteúdos.
- 8c9dc4b85637261624b83506668170ed8db0c18e: Nas recompensas diárias.

### Rafatorações

Criei os testes acima já nos novos padrões que adotamos recentemente, então aproveitei para ajustar os demais testes aos novos padrões:
- 49ffafc75aff0665826c97984ca4149eb040ed89: Usa a constante `relevantBody` para não impedir o ganho inicial ao publicar conteúdos nos testes.
- 65bb0b0dc94374b3e916a14c040f37d64d0c0d14: Usa `toBe` para comparar primitivos (ao invés de `toEqual` ou `toStrictEqual`).
- 7d5c8887d7db8563d3fa6c9d226f66b5b3d44f0e: Adota o `requestBuilder` nos demais testes do endpoint `/user`
- 5729cce0517ae3344481b2f5821cd77b7bfb6647: Habilita a regra `require-await` e adequa adicionando `await` e removendo `async`.
- 4c232ddec38558a71519b04909368f288a349e46: Habilita a regra `vitest/prefer-to-be` e adequa `toBe(NaN)` para `toBeNaN()`.
- ae027253647cad17173fff39b33601966e952957: Habilita a regra `vitest/prefer-strict-equal` e adequa `toEqual` para `toStrictEqual`.

## Tipo de mudança

- [x] Novos testes
- [x] Refatoração de testes

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
