### PR TITLE
Atualiza Node.js para v20 e usa o `crypto` de maneira compatível com a Edge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
       - run: npm ci
       - run: npm run dev & npx vitest run
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
       - run: npm ci
       - run: npm run lint

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/hydrogen
+lts/iron

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Rodar o TabNews em sua máquina local é uma tarefa extremamente simples.
 
 Você precisa ter duas principais dependências instaladas:
 
-- Node.js LTS v18 (ou qualquer versão superior)
+- Node.js LTS v20 (ou qualquer versão superior)
 - Docker Engine v17.12.0 com Docker Compose v1.29.2 (ou qualquer versão superior)
 
 ### Dependências locais

--- a/errors/index.js
+++ b/errors/index.js
@@ -1,5 +1,3 @@
-import { randomUUID as uuid } from 'crypto';
-
 class BaseError extends Error {
   constructor({
     name,
@@ -20,7 +18,7 @@ class BaseError extends Error {
     this.message = message;
     this.action = action;
     this.statusCode = statusCode || 500;
-    this.errorId = errorId || uuid();
+    this.errorId = errorId || crypto.randomUUID();
     this.requestId = requestId;
     this.context = context;
     this.stack = stack;

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,7 @@
         "vitest": "1.6.0"
       },
       "engines": {
-        "node": "18"
+        "node": "20"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     ]
   },
   "engines": {
-    "node": "18"
+    "node": "20"
   },
   "name": "tabnews.com.br",
   "description": "Conteúdos para quem vive de programação e tecnologia.",


### PR DESCRIPTION
Recentemente começamos a receber alertas esporádicos do erro `EDGE_FUNCTION_INVOCATION_FAILED`.

Coincidentemente (ou não) os problemas começaram a ocorrer ao mesmo tempo que a Vercel estava com um incidente aberto que causava o mesmo erro, então não investiguei melhor, pensando ser algo que eles iriam resolver.

Mas agora resolvi investigar e vi que nos logs da Vercel temos uma mensagem que não está indo para o Axiom, que é `The edge runtime does not support Node.js 'crypto' module.`

## Mudanças realizadas

Usa o `crypto` nativo sem `import` em `errors/index.js` para ser compatível com a Edge da Vercel.

Para isso não causar problemas no CI, precisamos atualizar para o Node.js v20. Anteriormente tivemos problemas ao usar a v20 na Vercel, mas agora não é para termos problemas, pois é a versão que recomendam.

## Tipo de mudança

- [x] Correção de bug

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Os testes antigos estão passando localmente.
