### PR TITLE
Exibe link para o FAQ na mensagem de erro sobre não conseguir criar conteúdos por causa das avaliações

### DIFF
--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -164,7 +164,7 @@ function ViewMode({ setComponentMode, contentObject, isPageRootOwner, viewFrame 
     if (response.status === 200) {
       setComponentMode('deleted');
     } else {
-      setGlobalErrorMessage(createErrorMessage(responseBody));
+      setGlobalErrorMessage({ error: responseBody });
     }
   };
 
@@ -187,11 +187,7 @@ function ViewMode({ setComponentMode, contentObject, isPageRootOwner, viewFrame 
         wordBreak: 'break-word',
       }}>
       <Box>
-        {globalErrorMessage && (
-          <Flash variant="danger" sx={{ mb: 4 }}>
-            {globalErrorMessage}
-          </Flash>
-        )}
+        {globalErrorMessage && <ErrorMessage {...globalErrorMessage} sx={{ mb: 4 }} />}
 
         <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
           <Box
@@ -374,7 +370,9 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
       })
         .then(processResponse)
         .catch(() => {
-          setGlobalErrorMessage('Não foi possível se conectar ao TabNews. Por favor, verifique sua conexão.');
+          setGlobalErrorMessage({
+            error: { message: 'Não foi possível se conectar ao TabNews. Por favor, verifique sua conexão.' },
+          });
           setIsPosting(false);
         });
 
@@ -402,7 +400,7 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
         if (response.status === 201) {
           return (responseBody) => {
             if (responseBody.message) {
-              setGlobalErrorMessage(createErrorMessage(responseBody));
+              setGlobalErrorMessage({ error: responseBody });
               console.error(responseBody);
               return;
             }
@@ -423,14 +421,14 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
             setErrorObject(responseBody);
 
             if (responseBody.key === 'slug') {
-              setGlobalErrorMessage(createErrorMessage(responseBody, { omitErrorId: true }));
+              setGlobalErrorMessage({ error: responseBody, omitErrorId: true });
             }
           };
         }
 
         if (response.status >= 401) {
           return (responseBody) => {
-            setGlobalErrorMessage(createErrorMessage(responseBody));
+            setGlobalErrorMessage({ error: responseBody });
           };
         }
       }
@@ -493,7 +491,7 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
     <Box sx={{ mb: 4, width: '100%' }}>
       <form onSubmit={handleSubmit} style={{ width: '100%' }} noValidate>
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
-          {globalErrorMessage && <Flash variant="danger">{globalErrorMessage}</Flash>}
+          {globalErrorMessage && <ErrorMessage {...globalErrorMessage} />}
 
           {!contentObject?.parent_id && (
             <FormControl id="title" required>
@@ -666,6 +664,24 @@ function DeletedMode({ viewFrame }) {
         Conteúdo apagado com sucesso.
       </Box>
     </Box>
+  );
+}
+
+function ErrorMessage({ error, omitErrorId, ...props }) {
+  const isErrorWithReadMore =
+    error.error_location_code === 'MODEL:CONTENT:CREDIT_OR_DEBIT_TABCOINS:NEGATIVE_USER_EARNINGS';
+
+  return (
+    <Flash variant="danger" {...props}>
+      {createErrorMessage(error, { omitErrorId: omitErrorId || isErrorWithReadMore })}
+
+      {isErrorWithReadMore && (
+        <Text sx={{ display: 'block', mt: 1 }}>
+          Para mais informações, leia:{' '}
+          <Link href="/faq#erro-nova-publicacao">Não consigo criar novas publicações. O que fazer?</Link>
+        </Text>
+      )}
+    </Flash>
   );
 }
 


### PR DESCRIPTION
## Mudanças realizadas

Na mensagem de erro, adicionei o link ao [FAQ](https://www.tabnews.com.br/faq#erro-nova-publicacao) e também removi o identificador do erro, pois é algo que o usuário deve conseguir resolver sozinho. Vale lembrar que a mensagem é igual para publicações e comentários.

| Cenário | Resultado |
| :---: | --- |
| Antes | ![Erro: "Não é possível publicar porque há outras publicações mal avaliadas que ainda não foram excluídas. Exclua seus conteúdos mais recentes que estiverem classificados como não relevantes. Informe ao suporte o valor (<codigo uuid v4>)"](https://github.com/filipedeschamps/tabnews.com.br/assets/26308880/2140f1d0-bcbd-4289-8e1a-5d31795b6bd1) |
| Agora | ![A mensagem de erro anterior com uma quebra de linha e um novo parágrafo contendo um link para o FAQ: "Para mais informações, leia: Não consigo criar novas publicações. O que fazer?"](https://github.com/filipedeschamps/tabnews.com.br/assets/26308880/b7186124-746d-41a5-a015-548d27804bf4) |

Resolve #1540

## Tipo de mudança

- [x] Nova funcionalidade

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [ ] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
