### PR TITLE
Sempre validar se `username` é único antes de validar o mesmo para o `email`

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -405,24 +405,27 @@ async function validateUniqueUser(userData, options) {
 
   const results = await database.query(query, options);
 
-  if (results.rowCount > 0) {
-    const isSameUsername = results.rows[0].username.toLowerCase() === userData.username?.toLowerCase();
-    if (isSameUsername) {
-      throw new ValidationError({
-        message: `O "username" informado já está sendo usado.`,
-        stack: new Error().stack,
-        errorLocationCode: `MODEL:USER:VALIDATE_UNIQUE_USERNAME:ALREADY_EXISTS`,
-        key: 'username',
-      });
-    } else {
-      throw new ValidationError({
-        message: `O email informado já está sendo usado.`,
-        stack: new Error().stack,
-        errorLocationCode: `MODEL:USER:VALIDATE_UNIQUE_EMAIL:ALREADY_EXISTS`,
-        key: 'email',
-      });
-    }
+  if (!results.rowCount) return;
+
+  const isSameUsername = results.rows.some(
+    ({ username }) => username.toLowerCase() === userData.username?.toLowerCase(),
+  );
+
+  if (isSameUsername) {
+    throw new ValidationError({
+      message: `O "username" informado já está sendo usado.`,
+      stack: new Error().stack,
+      errorLocationCode: `MODEL:USER:VALIDATE_UNIQUE_USERNAME:ALREADY_EXISTS`,
+      key: 'username',
+    });
   }
+
+  throw new ValidationError({
+    message: `O email informado já está sendo usado.`,
+    stack: new Error().stack,
+    errorLocationCode: `MODEL:USER:VALIDATE_UNIQUE_EMAIL:ALREADY_EXISTS`,
+    key: 'email',
+  });
 }
 
 async function hashPasswordInObject(userObject) {


### PR DESCRIPTION
Após o comentário do @luanmz (https://github.com/filipedeschamps/tabnews.com.br/issues/186#issuecomment-2261675933) sobre ainda ser possível descobrir se um endereço de email está cadastrado no sistema através do `PATCH /users/[username]`, verifiquei que ainda não havia cobertura de testes para o caso que ele citou.

## Mudanças realizadas

Criei o teste e adequei o model `user` para sempre validar primeiro o `username`, o que elimina a vulnerabilidade citada.

A principal mudança é verificar `results.rows.some` ao invés de `results.rows[0]` para não depender da ordem dos usuários retornado na consulta. O restante é apenas uma refatoração adotando *early return*.

O ponto original da issue #186 ainda permanece aguardando contribuição. 👍


## Tipo de mudança

- [x] Correção de vulnerabilidade

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
