### PR TITLE
feat: implementa agendamento de conteúdos

### DIFF
--- a/models/authorization.js
+++ b/models/authorization.js
@@ -79,6 +79,7 @@ function filterInput(user, feature, input, target) {
       status: input.status,
       type: input.type,
       source_url: input.source_url,
+      future_published_time: input.future_published_time,
     };
   }
 
@@ -90,6 +91,7 @@ function filterInput(user, feature, input, target) {
       body: input.body,
       status: input.status,
       source_url: input.source_url,
+      future_published_time: input.future_published_time,
     };
   }
 

--- a/models/validator.js
+++ b/models/validator.js
@@ -347,6 +347,16 @@ const schemas = {
     });
   },
 
+  future_published_time: function () {
+    return Joi.object({
+      future_published_time: Joi.date().when('$required.future_published_time', {
+        is: 'required',
+        then: Joi.required(),
+        otherwise: Joi.optional().allow(null),
+      }),
+    });
+  },
+
   used: function () {
     return Joi.object({
       used: Joi.boolean().when('$required.used', { is: 'required', then: Joi.required(), otherwise: Joi.optional() }),
@@ -537,6 +547,7 @@ const schemas = {
       'tabcoins_credit',
       'tabcoins_debit',
       'tabcash',
+      'future_published_time',
     ]) {
       const keyValidationFunction = schemas[key];
       contentSchema = contentSchema.concat(keyValidationFunction());

--- a/pages/api/v1/contents/index.public.js
+++ b/pages/api/v1/contents/index.public.js
@@ -56,6 +56,7 @@ async function getHandler(request, response) {
       status: 'published',
       type: 'content',
       $not_null: request.query.with_root === false ? ['parent_id'] : undefined,
+      published_at: new Date(),
     },
     attributes: {
       exclude: request.query.with_children ? undefined : ['body'],
@@ -92,6 +93,7 @@ function postValidationHandler(request, response, next) {
     status: 'optional',
     content_type: 'optional',
     source_url: 'optional',
+    future_published_time: 'optional',
   });
 
   request.body = cleanValues;
@@ -121,7 +123,6 @@ async function postHandler(request, response) {
         errorLocationCode: 'CONTROLLER:CONTENT:POST_HANDLER:CREATE:CONTENT:TEXT_ROOT:FEATURE_NOT_FOUND',
       });
     }
-
     secureInputValues = authorization.filterInput(userTryingToCreate, 'create:content:text_root', insecureInputValues);
   } else {
     if (!authorization.can(userTryingToCreate, 'create:content:text_child')) {

--- a/tests/integration/api/v1/contents/get.test.js
+++ b/tests/integration/api/v1/contents/get.test.js
@@ -18,6 +18,24 @@ describe('GET /api/v1/contents', () => {
       await orchestrator.runPendingMigrations();
     });
 
+    test('With future post created should get empty list', async () => {
+      const defaultUser = await orchestrator.createUser();
+
+      await orchestrator.createContent({
+        owner_id: defaultUser.id,
+        title: 'Conteúdo futuro',
+        body: 'Este conteúdo não deverá aparecer na lista retornada pelo /contents, porque ele possui uma data de publicação futura.',
+        type: 'content',
+        status: 'published',
+        future_published_time: '2030-01-01T00:00:00.00Z',
+      });
+
+      const { response, responseBody } = await contentsRequestBuilder.get('?strategy=new');
+
+      expect(response.status).toBe(200);
+      expect(responseBody).toStrictEqual([]);
+    });
+
     test('With CORS and Security Headers enabled', async () => {
       const { response } = await contentsRequestBuilder.get();
 

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -106,6 +106,36 @@ describe('POST /api/v1/contents', () => {
       expect(responseBody.error_location_code).toBe('MODEL:VALIDATOR:FINAL_SCHEMA');
     });
 
+    test('Should be able to create a content to future data of publish', async () => {
+      const contentsRequestBuilder = new RequestBuilder('/api/v1/contents');
+      await contentsRequestBuilder.buildUser();
+
+      const { response } = await contentsRequestBuilder.post({
+        title: 'Título normal',
+        body: 'Teste',
+        type: 'content',
+        status: 'published',
+        future_published_time: '2024-10-08T16:15:00Z',
+      });
+
+      expect(response.status).toBe(201);
+    });
+
+    test('Should not be able to create a content to future data of publish with a old data', async () => {
+      const contentsRequestBuilder = new RequestBuilder('/api/v1/contents');
+      await contentsRequestBuilder.buildUser();
+
+      const { response } = await contentsRequestBuilder.post({
+        title: 'Título normal',
+        body: 'Teste',
+        type: 'content',
+        status: 'published',
+        future_published_time: '2022-10-08T16:15:00Z',
+      });
+
+      expect(response.status).toBe(400);
+    });
+
     test('Content with POST Body containing an invalid JSON string', async () => {
       const contentsRequestBuilder = new RequestBuilder();
       await contentsRequestBuilder.buildUser();

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -218,6 +218,7 @@ async function createContent(contentObject) {
       status: contentObject?.status || 'draft',
       type: contentObject?.type || 'content',
       source_url: contentObject?.source_url || undefined,
+      future_published_time: contentObject?.future_published_time || undefined,
     },
     {
       eventId: currentEvent.id,


### PR DESCRIPTION
## Mudanças realizadas
Adiciona campo `future_published_time` ao criar conteúdo e ajusta query de listagem para listar apenas publicações que não foram agendadas. A ideia surgiu a partir da issue #1479.

Esse PR afeta o endpoint `api/v1/contents`, onde agora é possível agenda uma publicação.
<!-- Por favor, inclua uma descrição sobre o que foi modificado nesse PR. Inclua também qualquer motivação ou contexto relevante.  -->

<!-- Se o PR contém uma modificação da interface gráfica (UI), adicione fotos ou vídeos comparando o antes e depois. -->

<!-- Se o PR contém modificações de API, mencione os endpoints afetados. -->

<!-- Caso esse PR resolva algum issue, você pode descomentar a linha abaixo e substituir (issue) pelo número dele. -->
<!-- Resolve #(issue) -->
O PR não resolve completamente a issue, mas é um bom ponto de partida para implementa-la.
## Tipo de mudança

<!-- Descomente a linha abaixo que corresponde ao tipo de mudança realizada no PR. -->


- [x] Nova funcionalidade 


## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
