### PR TITLE
Refatora/corrige alguns testes

### DIFF
--- a/tests/integration/api/v1/_use-cases/registration-flow.test.js
+++ b/tests/integration/api/v1/_use-cases/registration-flow.test.js
@@ -34,7 +34,7 @@ describe('Use case: Registration Flow (all successfully)', () => {
 
     postUserResponseBody = await postUserResponse.json();
 
-    expect(postUserResponse.status).toBe(201);
+    expect.soft(postUserResponse.status).toBe(201);
     expect(uuidVersion(postUserResponseBody.id)).toBe(4);
     expect(postUserResponseBody.username).toBe('RegularRegistrationFlow');
     expect(postUserResponseBody.features).toStrictEqual(['read:activation_token']);
@@ -80,7 +80,7 @@ describe('Use case: Registration Flow (all successfully)', () => {
     });
     const activationApiResponseBody = await activationApiResponse.json();
 
-    expect(activationApiResponse.status).toBe(200);
+    expect.soft(activationApiResponse.status).toBe(200);
     expect(uuidVersion(activationApiResponseBody.id)).toBe(4);
     expect(activationApiResponseBody.id).toBe(tokenObjectInDatabase.id);
     expect(activationApiResponseBody.used).toBe(true);
@@ -116,7 +116,7 @@ describe('Use case: Registration Flow (all successfully)', () => {
 
     postSessionResponseBody = await postSessionResponse.json();
 
-    expect(postSessionResponse.status).toBe(201);
+    expect.soft(postSessionResponse.status).toBe(201);
     expect(postSessionResponseBody.token.length).toBe(96);
     expect(uuidVersion(postSessionResponseBody.id)).toBe(4);
     expect(Date.parse(postSessionResponseBody.expires_at)).not.toBeNaN();
@@ -144,7 +144,7 @@ describe('Use case: Registration Flow (all successfully)', () => {
 
     const getUserResponseBody = await getUserResponse.json();
 
-    expect(getUserResponse.status).toBe(200);
+    expect.soft(getUserResponse.status).toBe(200);
     expect(getUserResponseBody).toStrictEqual({
       id: postUserResponseBody.id,
       username: postUserResponseBody.username,

--- a/tests/integration/api/v1/activation/patch.test.js
+++ b/tests/integration/api/v1/activation/patch.test.js
@@ -18,8 +18,8 @@ describe('PATCH /api/v1/activation', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"body" enviado deve ser do tipo Object.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -43,8 +43,8 @@ describe('PATCH /api/v1/activation', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"token_id" deve ser do tipo String.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -68,8 +68,8 @@ describe('PATCH /api/v1/activation', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"token_id" deve ser do tipo String.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -93,8 +93,8 @@ describe('PATCH /api/v1/activation', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"token_id" não pode estar em branco.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -118,8 +118,8 @@ describe('PATCH /api/v1/activation', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"token_id" deve possuir um token UUID na versão 4.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -154,7 +154,7 @@ describe('PATCH /api/v1/activation', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(uuidVersion(responseBody.id)).toBe(4);
       expect(responseBody.used).toBe(true);
       expect(Date.parse(activationToken.expires_at)).not.toBeNaN();
@@ -193,7 +193,7 @@ describe('PATCH /api/v1/activation', () => {
 
       const secondTryRespondeBody = await secondTryResponde.json();
 
-      expect(secondTryResponde.status).toBe(200);
+      expect.soft(secondTryResponde.status).toBe(200);
       expect(uuidVersion(secondTryRespondeBody.id)).toBe(4);
       expect(secondTryRespondeBody.used).toBe(true);
       expect(Date.parse(activationToken.expires_at)).not.toBeNaN();
@@ -201,7 +201,7 @@ describe('PATCH /api/v1/activation', () => {
       expect(Date.parse(activationToken.updated_at)).not.toBeNaN();
       expect(secondTryRespondeBody.updated_at > secondTryRespondeBody.created_at).toBe(true);
 
-      expect(firstTryResponde.status).toBe(secondTryResponde.status);
+      expect.soft(firstTryResponde.status).toBe(secondTryResponde.status);
       expect(firstTryRespondeBody).toStrictEqual(secondTryRespondeBody);
     });
 
@@ -225,8 +225,8 @@ describe('PATCH /api/v1/activation', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(404);
-      expect(responseBody.status_code).toBe(404);
+      expect.soft(response.status).toBe(404);
+      expect.soft(responseBody.status_code).toBe(404);
       expect(responseBody.name).toBe('NotFoundError');
       expect(responseBody.message).toBe('O token de ativação utilizado não foi encontrado no sistema ou expirou.');
       expect(responseBody.action).toBe('Faça login novamente para receber um novo token por email.');
@@ -256,8 +256,8 @@ describe('PATCH /api/v1/activation', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(403);
-      expect(responseBody.status_code).toBe(403);
+      expect.soft(response.status).toBe(403);
+      expect.soft(responseBody.status_code).toBe(403);
       expect(responseBody.name).toBe('ForbiddenError');
       expect(responseBody.message).toBe('Você não pode mais ler tokens de ativação.');
       expect(responseBody.action).toBe(
@@ -288,8 +288,8 @@ describe('PATCH /api/v1/activation', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(403);
-      expect(responseBody.status_code).toBe(403);
+      expect.soft(response.status).toBe(403);
+      expect.soft(responseBody.status_code).toBe(403);
       expect(responseBody.name).toBe('ForbiddenError');
       expect(responseBody.message).toBe('Usuário não pode executar esta operação.');
       expect(responseBody.action).toBe('Verifique se este usuário possui a feature "read:activation_token".');

--- a/tests/integration/api/v1/contents/[username]/[slug]/children/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/children/get.test.js
@@ -23,8 +23,8 @@ describe('GET /api/v1/contents/[username]/[slug]/children', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(404);
-      expect(responseBody.status_code).toBe(404);
+      expect.soft(response.status).toBe(404);
+      expect.soft(responseBody.status_code).toBe(404);
       expect(responseBody.name).toBe('NotFoundError');
       expect(responseBody.message).toBe('O conteúdo informado não foi encontrado no sistema.');
       expect(responseBody.action).toBe('Verifique se o "slug" está digitado corretamente.');
@@ -48,8 +48,8 @@ describe('GET /api/v1/contents/[username]/[slug]/children', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(404);
-      expect(responseBody.status_code).toBe(404);
+      expect.soft(response.status).toBe(404);
+      expect.soft(responseBody.status_code).toBe(404);
       expect(responseBody.name).toBe('NotFoundError');
       expect(responseBody.message).toBe('O conteúdo informado não foi encontrado no sistema.');
       expect(responseBody.action).toBe('Verifique se o "slug" está digitado corretamente.');
@@ -71,7 +71,7 @@ describe('GET /api/v1/contents/[username]/[slug]/children', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(responseBody).toStrictEqual([]);
     });
 
@@ -140,7 +140,7 @@ describe('GET /api/v1/contents/[username]/[slug]/children', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(responseBody.length).toBe(2);
       expect(responseBody).toStrictEqual([
         {
@@ -341,7 +341,7 @@ describe('GET /api/v1/contents/[username]/[slug]/children', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(responseBody.length).toBe(2);
       expect(responseBody).toStrictEqual([
         {
@@ -430,7 +430,7 @@ describe('GET /api/v1/contents/[username]/[slug]/children', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(responseBody.length).toBe(2);
       expect(responseBody).toStrictEqual([
         {

--- a/tests/integration/api/v1/contents/[username]/[slug]/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/get.test.js
@@ -15,8 +15,8 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents/ThisUserDoesNotExists/slug`);
       const responseBody = await response.json();
 
-      expect(response.status).toBe(404);
-      expect(responseBody.status_code).toBe(404);
+      expect.soft(response.status).toBe(404);
+      expect.soft(responseBody.status_code).toBe(404);
       expect(responseBody.name).toBe('NotFoundError');
       expect(responseBody.message).toBe('O "username" informado não foi encontrado no sistema.');
       expect(responseBody.action).toBe('Verifique se o "username" está digitado corretamente.');
@@ -34,8 +34,8 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(404);
-      expect(responseBody.status_code).toBe(404);
+      expect.soft(response.status).toBe(404);
+      expect.soft(responseBody.status_code).toBe(404);
       expect(responseBody.name).toBe('NotFoundError');
       expect(responseBody.message).toBe('O conteúdo informado não foi encontrado no sistema.');
       expect(responseBody.action).toBe('Verifique se o "slug" está digitado corretamente.');
@@ -60,8 +60,8 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(404);
-      expect(responseBody.status_code).toBe(404);
+      expect.soft(response.status).toBe(404);
+      expect.soft(responseBody.status_code).toBe(404);
       expect(responseBody.name).toBe('NotFoundError');
       expect(responseBody.message).toBe('O conteúdo informado não foi encontrado no sistema.');
       expect(responseBody.action).toBe('Verifique se o "slug" está digitado corretamente.');
@@ -87,7 +87,7 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: defaultUserContent.id,
@@ -132,7 +132,7 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(404);
+      expect.soft(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -195,7 +195,7 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: rootContent.id,
@@ -245,8 +245,8 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(404);
-      expect(responseBody.status_code).toBe(404);
+      expect.soft(response.status).toBe(404);
+      expect.soft(responseBody.status_code).toBe(404);
       expect(responseBody.name).toBe('NotFoundError');
       expect(responseBody.message).toBe('O conteúdo informado não foi encontrado no sistema.');
       expect(responseBody.action).toBe('Verifique se o "slug" está digitado corretamente.');
@@ -278,7 +278,7 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: childContent.id,
@@ -349,7 +349,7 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: childContent.id,
@@ -436,7 +436,7 @@ describe('GET /api/v1/contents/[username]/[slug]', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: defaultUserContent.id,

--- a/tests/integration/api/v1/contents/[username]/[slug]/parent/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/parent/get.test.js
@@ -24,7 +24,7 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(404);
+      expect.soft(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -56,7 +56,7 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(404);
+      expect.soft(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -86,7 +86,7 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(404);
+      expect.soft(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -128,7 +128,7 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(404);
+      expect.soft(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -173,7 +173,7 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(404);
+      expect.soft(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -214,7 +214,7 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: rootContent.id,
@@ -278,7 +278,7 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: childContentLevel2.id,
@@ -346,7 +346,7 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: childContentLevel2.id,
@@ -415,7 +415,7 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: childContentLevel2.id,
@@ -466,7 +466,7 @@ describe('GET /api/v1/contents/[username]/[slug]/parent', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: rootContent.id,

--- a/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/patch.test.js
@@ -20,8 +20,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         body: 'Não deveria conseguir.',
       });
 
-      expect(response.status).toBe(403);
-      expect(responseBody.status_code).toBe(403);
+      expect.soft(response.status).toBe(403);
+      expect.soft(responseBody.status_code).toBe(403);
       expect(responseBody.name).toBe('ForbiddenError');
       expect(responseBody.message).toBe('Usuário não pode executar esta operação.');
       expect(responseBody.action).toBe('Verifique se este usuário possui a feature "update:content".');
@@ -41,8 +41,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         body: 'Não deveria conseguir, pois não possui a feature "update:content".',
       });
 
-      expect(response.status).toBe(403);
-      expect(responseBody.status_code).toBe(403);
+      expect.soft(response.status).toBe(403);
+      expect.soft(responseBody.status_code).toBe(403);
       expect(responseBody.name).toBe('ForbiddenError');
       expect(responseBody.message).toBe('Usuário não pode executar esta operação.');
       expect(responseBody.action).toBe('Verifique se este usuário possui a feature "update:content".');
@@ -76,8 +76,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         },
       );
 
-      expect(response.status).toBe(403);
-      expect(responseBody.status_code).toBe(403);
+      expect.soft(response.status).toBe(403);
+      expect.soft(responseBody.status_code).toBe(403);
       expect(responseBody.name).toBe('ForbiddenError');
       expect(responseBody.message).toBe('Usuário não pode executar esta operação.');
       expect(responseBody.action).toBe('Verifique se este usuário possui a feature "update:content".');
@@ -106,8 +106,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         },
       );
 
-      expect(response.status).toBe(403);
-      expect(responseBody.status_code).toBe(403);
+      expect.soft(response.status).toBe(403);
+      expect.soft(responseBody.status_code).toBe(403);
       expect(responseBody.name).toBe('ForbiddenError');
       expect(responseBody.message).toBe('Você não possui permissão para editar conteúdos na raiz do site.');
       expect(responseBody.action).toBe('Verifique se você possui a feature "create:content:text_root".');
@@ -142,7 +142,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         },
       );
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -189,7 +189,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { source_url: 'http://www.tabnews.com.br/' },
       );
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -242,8 +242,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         },
       );
 
-      expect(response.status).toBe(403);
-      expect(responseBody.status_code).toBe(403);
+      expect.soft(response.status).toBe(403);
+      expect.soft(responseBody.status_code).toBe(403);
       expect(responseBody.name).toBe('ForbiddenError');
       expect(responseBody.message).toBe('Você não possui permissão para editar conteúdos dentro de outros conteúdos.');
       expect(responseBody.action).toBe('Verifique se você possui a feature "create:content:text_child".');
@@ -263,8 +263,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
 
       const { response, responseBody } = await contentsRequestBuilder.patch(`/${defaultUser.username}/slug`);
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"body" enviado deve ser do tipo Object.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -283,8 +283,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         'Texto corrido no lugar de um JSON',
       );
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"body" enviado deve ser do tipo Object.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -299,8 +299,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
 
       const { response, responseBody } = await contentsRequestBuilder.patch(`/${defaultUser.username}/slug`, {});
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('Objeto enviado deve ter no mínimo uma chave.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -315,8 +315,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
 
       const { response, responseBody } = await contentsRequestBuilder.patch(`/invalid-username/slug`, {});
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"username" deve conter apenas caracteres alfanuméricos.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -334,8 +334,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         {},
       );
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"slug" está no formato errado.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -353,8 +353,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         body: 'Não deveria conseguir',
       });
 
-      expect(response.status).toBe(404);
-      expect(responseBody.status_code).toBe(404);
+      expect.soft(response.status).toBe(404);
+      expect.soft(responseBody.status_code).toBe(404);
       expect(responseBody.name).toBe('NotFoundError');
       expect(responseBody.message).toBe('O "username" informado não foi encontrado no sistema.');
       expect(responseBody.action).toBe('Verifique se o "username" está digitado corretamente.');
@@ -381,8 +381,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         },
       );
 
-      expect(response.status).toBe(404);
-      expect(responseBody.status_code).toBe(404);
+      expect.soft(response.status).toBe(404);
+      expect.soft(responseBody.status_code).toBe(404);
       expect(responseBody.name).toBe('NotFoundError');
       expect(responseBody.message).toBe('O conteúdo informado não foi encontrado no sistema.');
       expect(responseBody.action).toBe('Verifique se o "slug" está digitado corretamente.');
@@ -410,8 +410,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         },
       );
 
-      expect(response.status).toBe(403);
-      expect(responseBody.status_code).toBe(403);
+      expect.soft(response.status).toBe(403);
+      expect.soft(responseBody.status_code).toBe(403);
       expect(responseBody.name).toBe('ForbiddenError');
       expect(responseBody.message).toBe('Você não possui permissão para atualizar o conteúdo de outro usuário.');
       expect(responseBody.action).toBe('Verifique se você possui a feature "update:content:others".');
@@ -443,7 +443,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         },
       );
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: firstUserContent.id,
@@ -487,7 +487,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { body: 'Body novo' },
       );
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -533,7 +533,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { body: 'New body' },
       );
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -576,8 +576,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { body: '' },
       );
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"body" não pode estar em branco.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -604,8 +604,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         },
       );
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('Markdown deve conter algum texto.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -634,7 +634,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         },
       );
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -679,8 +679,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         },
       );
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"body" deve começar com caracteres visíveis.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -704,8 +704,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { body: 'A'.repeat(20001) },
       );
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"body" deve conter no máximo 20000 caracteres.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -729,8 +729,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { body: ' Espaço no início e no fim ' },
       );
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"body" deve começar com caracteres visíveis.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -754,7 +754,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { body: 'Espaço só no fim ' },
       );
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -797,8 +797,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { body: null },
       );
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"body" deve ser do tipo String.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -823,7 +823,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { slug: 'slug-novo' },
       );
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -877,7 +877,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { slug: 'primeiro-conteudo' },
       );
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -919,7 +919,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { slug: 'primeiro-conteudo' },
       );
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -964,7 +964,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { slug: 'primeiro-conteudo' },
       );
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1006,8 +1006,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { slug: '' },
       );
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"slug" não pode estar em branco.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -1036,7 +1036,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         },
       );
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1082,8 +1082,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { slug: 'slug-não-pode-ter-caracteres-especiais' },
       );
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"slug" está no formato errado.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -1107,8 +1107,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { slug: null },
       );
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"slug" deve ser do tipo String.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -1134,7 +1134,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         },
       );
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1177,7 +1177,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { title: 'Título novo' },
       );
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1220,8 +1220,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { title: '' },
       );
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"title" não pode estar em branco.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -1249,7 +1249,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { title: 'Título novo' },
       );
 
-      expect(response.status).toBe(404);
+      expect.soft(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -1282,8 +1282,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         },
       );
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe(`"title" deve conter no máximo ${maxTitleLength} caracteres.`);
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -1307,8 +1307,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { title: null },
       );
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"title" é um campo obrigatório.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -1339,7 +1339,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { title: null },
       );
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: childContent.id,
@@ -1382,7 +1382,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { title: ' Título válido, mas com espaços em branco no início e no fim ' },
       );
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1425,7 +1425,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { title: `Tab & News | Conteúdos com \n valor <strong>concreto</strong> e "massa"> participe! '\\o/'` },
       );
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1468,7 +1468,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { status: 'draft' },
       );
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1512,7 +1512,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { status: 'published' },
       );
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1557,7 +1557,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { status: 'draft' },
       );
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -1589,7 +1589,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { status: 'deleted' },
       );
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1639,7 +1639,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
       const { response: republishedResponse, responseBody: republishedResponseBody } =
         await contentsRequestBuilder.patch(`/${defaultUser.username}/${originalContent.slug}`, { status: 'published' });
 
-      expect(republishedResponse.status).toBe(404);
+      expect.soft(republishedResponse.status).toBe(404);
       expect(republishedResponseBody).toStrictEqual({
         name: 'NotFoundError',
         message: 'O conteúdo informado não foi encontrado no sistema.',
@@ -1669,8 +1669,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { status: 'non_existent_status' },
       );
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe(
         '"status" deve possuir um dos seguintes valores: "draft", "published", "deleted", "firewall".',
@@ -1696,7 +1696,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { status: 'firewall' },
       );
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
       expect(responseBody).toStrictEqual({
         status_code: 400,
         name: 'ValidationError',
@@ -1727,8 +1727,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { status: null },
       );
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe(
         '"status" deve possuir um dos seguintes valores: "draft", "published", "deleted", "firewall".',
@@ -1754,8 +1754,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { status: '' },
       );
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe(
         '"status" deve possuir um dos seguintes valores: "draft", "published", "deleted", "firewall".',
@@ -1781,7 +1781,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { source_url: 'http://www.tabnews.com.br/' },
       );
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1824,7 +1824,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { source_url: 'https://www.tabnews.com.br/museu' },
       );
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1867,7 +1867,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { source_url: 'https://nic.xn--vermgensberatung-pwb/' },
       );
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1910,7 +1910,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { source_url: 'https://t.me' },
       );
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1953,8 +1953,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { source_url: 'http://invalidtl.d' },
       );
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe(
         '"source_url" deve possuir uma URL válida e utilizando os protocolos HTTP ou HTTPS.',
@@ -1980,8 +1980,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { source_url: 'https://tl.dcomvinteecincocaracteres' },
       );
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe(
         '"source_url" deve possuir uma URL válida e utilizando os protocolos HTTP ou HTTPS.',
@@ -2007,8 +2007,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { source_url: 'ftp://www.tabnews.com.br' },
       );
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe(
         '"source_url" deve possuir uma URL válida e utilizando os protocolos HTTP ou HTTPS.',
@@ -2034,8 +2034,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { source_url: 'www.tabnews.com.br' },
       );
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe(
         '"source_url" deve possuir uma URL válida e utilizando os protocolos HTTP ou HTTPS.',
@@ -2061,8 +2061,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { source_url: 'https://lol.' },
       );
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe(
         '"source_url" deve possuir uma URL válida e utilizando os protocolos HTTP ou HTTPS.',
@@ -2088,7 +2088,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { source_url: 'https://www.tabnews.com.br/api/v1/contents?strategy=old' },
       );
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -2132,7 +2132,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { source_url: 'https://www.tabnews.com.br/#:~:text=TabNews,-Status' },
       );
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -2176,8 +2176,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { source_url: '' },
       );
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"source_url" não pode estar em branco.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -2202,7 +2202,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { source_url: null },
       );
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -2251,10 +2251,10 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { parent_id: rootContent.id },
       );
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('Objeto enviado deve ter no mínimo uma chave.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -2294,7 +2294,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         },
       );
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -2339,8 +2339,8 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         { title: 'Tentando atualizar o conteúdo.' },
       );
 
-      expect(response.status).toBe(403);
-      expect(responseBody.status_code).toBe(403);
+      expect.soft(response.status).toBe(403);
+      expect.soft(responseBody.status_code).toBe(403);
       expect(responseBody.name).toBe('ForbiddenError');
       expect(responseBody.message).toBe('Você não possui permissão para atualizar o conteúdo de outro usuário.');
       expect(responseBody.action).toBe('Verifique se você possui a feature "update:content:others".');
@@ -3190,7 +3190,7 @@ describe('PATCH /api/v1/contents/[username]/[slug]', () => {
         },
       );
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: secondUserContent.id,

--- a/tests/integration/api/v1/contents/[username]/[slug]/root/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/root/get.test.js
@@ -24,7 +24,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(404);
+      expect.soft(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -56,7 +56,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(404);
+      expect.soft(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -86,7 +86,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(404);
+      expect.soft(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -128,7 +128,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(404);
+      expect.soft(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -173,7 +173,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(404);
+      expect.soft(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -214,7 +214,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: rootContent.id,
@@ -278,7 +278,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: rootContent.id,
@@ -347,7 +347,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: rootContent.id,
@@ -416,7 +416,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: rootContent.id,
@@ -486,7 +486,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: rootContent.id,
@@ -545,7 +545,7 @@ describe('GET /api/v1/contents/[username]/[slug]/root', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: rootContent.id,

--- a/tests/integration/api/v1/contents/[username]/[slug]/tabcoins/post.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/tabcoins/post.test.js
@@ -29,7 +29,7 @@ describe('POST /api/v1/contents/tabcoins', () => {
         transaction_type: 'credit',
       });
 
-      expect(response.status).toBe(403);
+      expect.soft(response.status).toBe(403);
 
       expect(responseBody).toStrictEqual({
         name: 'ForbiddenError',
@@ -60,7 +60,7 @@ describe('POST /api/v1/contents/tabcoins', () => {
 
       const { response, responseBody } = await tabcoinsRequestBuilder.post({});
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -93,7 +93,7 @@ describe('POST /api/v1/contents/tabcoins', () => {
         transaction_type: 'credit',
       });
 
-      expect(response.status).toBe(422);
+      expect.soft(response.status).toBe(422);
 
       expect(responseBody).toStrictEqual({
         name: 'UnprocessableEntityError',
@@ -131,7 +131,7 @@ describe('POST /api/v1/contents/tabcoins', () => {
           transaction_type: 'credit',
         });
 
-      expect(postTabCoinsResponse.status).toBe(201);
+      expect.soft(postTabCoinsResponse.status).toBe(201);
 
       expect(postTabCoinsResponseBody).toStrictEqual({
         tabcoins: 2,
@@ -176,7 +176,7 @@ describe('POST /api/v1/contents/tabcoins', () => {
           transaction_type: 'debit',
         });
 
-      expect(postTabCoinsResponse.status).toBe(201);
+      expect.soft(postTabCoinsResponse.status).toBe(201);
 
       expect(postTabCoinsResponseBody).toStrictEqual({
         tabcoins: 0,
@@ -221,21 +221,21 @@ describe('POST /api/v1/contents/tabcoins', () => {
         transaction_type: 'credit',
       });
 
-      expect(postTabCoinsResponse1.status).toBe(201);
+      expect.soft(postTabCoinsResponse1.status).toBe(201);
 
       // ROUND 2 OF CREDIT
       const { response: postTabCoinsResponse2 } = await tabcoinsRequestBuilder.post({
         transaction_type: 'credit',
       });
 
-      expect(postTabCoinsResponse2.status).toBe(201);
+      expect.soft(postTabCoinsResponse2.status).toBe(201);
 
       // ROUND 3 OF CREDIT
       const { response: postTabCoinsResponse3 } = await tabcoinsRequestBuilder.post({
         transaction_type: 'credit',
       });
 
-      expect(postTabCoinsResponse3.status).toBe(201);
+      expect.soft(postTabCoinsResponse3.status).toBe(201);
 
       // ROUND 4 OF CREDIT
       const { response: postTabCoinsResponse4, responseBody: postTabCoinsResponse4Body } =
@@ -243,7 +243,7 @@ describe('POST /api/v1/contents/tabcoins', () => {
           transaction_type: 'credit',
         });
 
-      expect(postTabCoinsResponse4.status).toBe(400);
+      expect.soft(postTabCoinsResponse4.status).toBe(400);
       expect(postTabCoinsResponse4Body).toStrictEqual({
         name: 'ValidationError',
         message: 'Você está tentando qualificar muitas vezes o mesmo conteúdo.',
@@ -290,21 +290,21 @@ describe('POST /api/v1/contents/tabcoins', () => {
         transaction_type: 'debit',
       });
 
-      expect(postTabCoinsResponse1.status).toBe(201);
+      expect.soft(postTabCoinsResponse1.status).toBe(201);
 
       // ROUND 2 OF DEBIT
       const { response: postTabCoinsResponse2 } = await tabcoinsRequestBuilder.post({
         transaction_type: 'debit',
       });
 
-      expect(postTabCoinsResponse2.status).toBe(201);
+      expect.soft(postTabCoinsResponse2.status).toBe(201);
 
       // ROUND 3 OF DEBIT
       const { response: postTabCoinsResponse3 } = await tabcoinsRequestBuilder.post({
         transaction_type: 'debit',
       });
 
-      expect(postTabCoinsResponse3.status).toBe(201);
+      expect.soft(postTabCoinsResponse3.status).toBe(201);
 
       // ROUND 4 OF DEBIT
       const { response: postTabCoinsResponse4, responseBody: postTabCoinsResponse4Body } =
@@ -312,7 +312,7 @@ describe('POST /api/v1/contents/tabcoins', () => {
           transaction_type: 'debit',
         });
 
-      expect(postTabCoinsResponse4.status).toBe(400);
+      expect.soft(postTabCoinsResponse4.status).toBe(400);
       expect(postTabCoinsResponse4Body).toStrictEqual({
         name: 'ValidationError',
         message: 'Você está tentando qualificar muitas vezes o mesmo conteúdo.',
@@ -360,7 +360,7 @@ describe('POST /api/v1/contents/tabcoins', () => {
           transaction_type: 'debit',
         });
 
-      expect(postTabCoinsResponse1.status).toBe(201);
+      expect.soft(postTabCoinsResponse1.status).toBe(201);
 
       expect(postTabCoinsResponse1Body).toStrictEqual({
         tabcoins: 0,
@@ -385,7 +385,7 @@ describe('POST /api/v1/contents/tabcoins', () => {
           transaction_type: 'debit',
         });
 
-      expect(postTabCoinsResponse2.status).toBe(201);
+      expect.soft(postTabCoinsResponse2.status).toBe(201);
 
       expect(postTabCoinsResponse2Body).toStrictEqual({
         tabcoins: -1,
@@ -451,7 +451,7 @@ describe('POST /api/v1/contents/tabcoins', () => {
       postTabCoinsResponsesStatus.splice(successPostIndex1, 1);
       postTabCoinsResponsesBody.splice(successPostIndex1, 1);
 
-      postTabCoinsResponsesStatus.forEach((status) => expect(status).toBe(422));
+      postTabCoinsResponsesStatus.forEach((status) => expect.soft(status).toBe(422));
 
       expect(postTabCoinsResponsesBody).toContainEqual({
         name: 'UnprocessableEntityError',
@@ -534,7 +534,7 @@ describe('POST /api/v1/contents/tabcoins', () => {
         postTabCoinsResponsesBody.splice(idx, 1);
       });
 
-      postTabCoinsResponsesStatus.forEach((status) => expect(status).toBe(422));
+      postTabCoinsResponsesStatus.forEach((status) => expect.soft(status).toBe(422));
 
       postTabCoinsResponsesBody.forEach((responseBody) =>
         expect(responseBody).toStrictEqual({

--- a/tests/integration/api/v1/contents/[username]/[slug]/thumbnail/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/thumbnail/get.test.js
@@ -25,7 +25,7 @@ describe('GET /api/v1/contents/[username]/[slug]/thumbnail', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(404);
+      expect.soft(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -58,7 +58,7 @@ describe('GET /api/v1/contents/[username]/[slug]/thumbnail', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(404);
+      expect.soft(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -114,7 +114,7 @@ describe('GET /api/v1/contents/[username]/[slug]/thumbnail', () => {
         ),
       );
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(Buffer.compare(benchmarkFile, responseBody)).toBe(0); // has the same bytes
     });
 
@@ -157,7 +157,7 @@ describe('GET /api/v1/contents/[username]/[slug]/thumbnail', () => {
         ),
       );
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(Buffer.compare(benchmarkFile, responseBody)).toBe(0); // has the same bytes
     });
 
@@ -214,7 +214,7 @@ describe('GET /api/v1/contents/[username]/[slug]/thumbnail', () => {
         ),
       );
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(Buffer.compare(benchmarkFile, responseBody)).toBe(0); // has the same bytes
     });
 
@@ -263,7 +263,7 @@ describe('GET /api/v1/contents/[username]/[slug]/thumbnail', () => {
         ),
       );
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(Buffer.compare(benchmarkFile, responseBody)).toBe(0); // has the same bytes
     });
 
@@ -313,7 +313,7 @@ describe('GET /api/v1/contents/[username]/[slug]/thumbnail', () => {
         ),
       );
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(Buffer.compare(benchmarkFile, responseBody)).toBe(0); // has the same bytes
     });
 
@@ -369,7 +369,7 @@ describe('GET /api/v1/contents/[username]/[slug]/thumbnail', () => {
         ),
       );
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(Buffer.compare(benchmarkFile, responseBody)).toBe(0); // has the same bytes
     });
 
@@ -425,7 +425,7 @@ describe('GET /api/v1/contents/[username]/[slug]/thumbnail', () => {
         ),
       );
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(Buffer.compare(benchmarkFile, responseBody)).toBe(0); // has the same bytes
     });
   });

--- a/tests/integration/api/v1/contents/[username]/get.test.js
+++ b/tests/integration/api/v1/contents/[username]/get.test.js
@@ -16,8 +16,8 @@ describe('GET /api/v1/contents/[username]', () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents/ThisUserDoesNotExists`);
       const responseBody = await response.json();
 
-      expect(response.status).toBe(404);
-      expect(responseBody.status_code).toBe(404);
+      expect.soft(response.status).toBe(404);
+      expect.soft(responseBody.status_code).toBe(404);
       expect(responseBody.name).toBe('NotFoundError');
       expect(responseBody.message).toBe('O "username" informado não foi encontrado no sistema.');
       expect(responseBody.action).toBe('Verifique se o "username" está digitado corretamente.');
@@ -40,7 +40,7 @@ describe('GET /api/v1/contents/[username]', () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}`);
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(responseBody).toStrictEqual([]);
     });
 
@@ -66,7 +66,7 @@ describe('GET /api/v1/contents/[username]', () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents/${defaultUser.username}`);
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(responseBody).toStrictEqual([]);
     });
 
@@ -106,7 +106,7 @@ describe('GET /api/v1/contents/[username]', () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents/${firstUser.username}`);
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(responseBody).toStrictEqual([
         {
           id: childContent.id,
@@ -166,7 +166,7 @@ describe('GET /api/v1/contents/[username]', () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents/${firstUser.username}`);
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(responseBody).toStrictEqual([
         {
           id: childContent.id,
@@ -234,7 +234,7 @@ describe('GET /api/v1/contents/[username]', () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents/${firstUser.username}?strategy=new`);
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual([
         {
@@ -348,7 +348,7 @@ describe('GET /api/v1/contents/[username]', () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents/${firstUser.username}?strategy=new`);
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual([
         {
@@ -444,7 +444,7 @@ describe('GET /api/v1/contents/[username]', () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents/${firstUser.username}?strategy=new`);
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual([
         {
@@ -560,7 +560,7 @@ describe('GET /api/v1/contents/[username]', () => {
       const responseLinkHeader = parseLinkHeader(response.headers.get('Link'));
       const responseTotalRowsHeader = response.headers.get('X-Pagination-Total-Rows');
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(responseTotalRowsHeader).toBe('60');
       expect(responseLinkHeader).toStrictEqual({
         first: {
@@ -601,7 +601,7 @@ describe('GET /api/v1/contents/[username]', () => {
       const page2ResponseLinkHeader = parseLinkHeader(page2Response.headers.get('Link'));
       const page2ResponseTotalRowsHeader = page2Response.headers.get('X-Pagination-Total-Rows');
 
-      expect(page2Response.status).toBe(200);
+      expect.soft(page2Response.status).toBe(200);
       expect(page2ResponseTotalRowsHeader).toBe('60');
       expect(page2ResponseLinkHeader).toStrictEqual({
         first: {
@@ -702,7 +702,7 @@ describe('GET /api/v1/contents/[username]', () => {
       const responseLinkHeader = parseLinkHeader(response.headers.get('Link'));
       const responseTotalRowsHeader = response.headers.get('X-Pagination-Total-Rows');
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(responseTotalRowsHeader).toBe('60');
       expect(responseLinkHeader).toStrictEqual({
         first: {
@@ -745,7 +745,7 @@ describe('GET /api/v1/contents/[username]', () => {
       const page2ResponseLinkHeader = parseLinkHeader(page2Response.headers.get('Link'));
       const page2ResponseTotalRowsHeader = page2Response.headers.get('X-Pagination-Total-Rows');
 
-      expect(page2Response.status).toBe(200);
+      expect.soft(page2Response.status).toBe(200);
       expect(page2ResponseTotalRowsHeader).toBe('60');
       expect(page2ResponseLinkHeader).toStrictEqual({
         first: {
@@ -824,7 +824,7 @@ describe('GET /api/v1/contents/[username]', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual([
         {
@@ -938,7 +938,7 @@ describe('GET /api/v1/contents/[username]', () => {
       );
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual([
         {

--- a/tests/integration/api/v1/contents/firewall.post.test.js
+++ b/tests/integration/api/v1/contents/firewall.post.test.js
@@ -106,8 +106,8 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
         const { response: response1, responseBody: response1Body } = await createContentViaApi(contentsRequestBuilder);
         const { response: response2, responseBody: response2Body } = await createContentViaApi(contentsRequestBuilder);
 
-        expect(response1.status).toBe(201);
-        expect(response2.status).toBe(201);
+        expect.soft(response1.status).toBe(201);
+        expect.soft(response2.status).toBe(201);
 
         const content2BeforeFirewall = await orchestrator.updateContent(response2Body.id, {
           status: 'deleted',
@@ -117,7 +117,7 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
           title: 'Título 3',
         });
 
-        expect(response3.status).toBe(429);
+        expect.soft(response3.status).toBe(429);
 
         expect(response3Body).toStrictEqual({
           name: 'TooManyRequestsError',
@@ -181,8 +181,8 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
         const { response: response1, responseBody: response1Body } = await createContentViaApi(contentsRequestBuilder);
         const { response: response2, responseBody: response2Body } = await createContentViaApi(contentsRequestBuilder);
 
-        expect(response1.status).toBe(201);
-        expect(response2.status).toBe(201);
+        expect.soft(response1.status).toBe(201);
+        expect.soft(response2.status).toBe(201);
 
         await orchestrator.createRate(response1Body, 10);
         const content1BeforeFirewall = await orchestrator.updateContent(response1Body.id, { status: 'deleted' });
@@ -258,8 +258,8 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
         const user2 = await contentsRequestBuilder.buildUser();
         const { response: response2, responseBody: response2Body } = await createContentViaApi(contentsRequestBuilder);
 
-        expect(response1.status).toBe(201);
-        expect(response2.status).toBe(201);
+        expect.soft(response1.status).toBe(201);
+        expect.soft(response2.status).toBe(201);
 
         await orchestrator.createRate(response1Body, 4);
         await orchestrator.createRate(response2Body, 2);
@@ -274,7 +274,7 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
           title: 'Título 3',
         });
 
-        expect(response3.status).toBe(429);
+        expect.soft(response3.status).toBe(429);
 
         expect(response3Body).toStrictEqual({
           name: 'TooManyRequestsError',
@@ -349,15 +349,15 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
         const { response: response1, responseBody: response1Body } = await createContentViaApi(contentsRequestBuilder);
         const { response: response2, responseBody: response2Body } = await createContentViaApi(contentsRequestBuilder);
 
-        expect(response1.status).toBe(201);
-        expect(response2.status).toBe(201);
+        expect.soft(response1.status).toBe(201);
+        expect.soft(response2.status).toBe(201);
 
         await orchestrator.updateContent(response1Body.id, { status: 'deleted' });
         await orchestrator.updateContent(response2Body.id, { status: 'deleted' });
 
         const { response: request3, responseBody: response3Body } = await createContentViaApi(contentsRequestBuilder);
 
-        expect(request3.status).toBe(429);
+        expect.soft(request3.status).toBe(429);
 
         expect(response3Body).toStrictEqual({
           name: 'TooManyRequestsError',
@@ -495,8 +495,8 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
           parent_id: rootContentBody.id,
         });
 
-        expect(response1.status).toBe(201);
-        expect(response2.status).toBe(201);
+        expect.soft(response1.status).toBe(201);
+        expect.soft(response2.status).toBe(201);
 
         const content2BeforeFirewall = await orchestrator.updateContent(response2Body.id, {
           status: 'deleted',
@@ -507,7 +507,7 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
           title: 'Título 3',
         });
 
-        expect(response3.status).toBe(429);
+        expect.soft(response3.status).toBe(429);
 
         expect(response3Body).toStrictEqual({
           name: 'TooManyRequestsError',
@@ -577,8 +577,8 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
           parent_id: rootContentBody.id,
         });
 
-        expect(response1.status).toBe(201);
-        expect(response2.status).toBe(201);
+        expect.soft(response1.status).toBe(201);
+        expect.soft(response2.status).toBe(201);
 
         await orchestrator.createRate(response1Body, 2);
         const content1BeforeFirewall = await orchestrator.updateContent(response1Body.id, {
@@ -661,8 +661,8 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
           parent_id: rootContentBody.id,
         });
 
-        expect(response1.status).toBe(201);
-        expect(response2.status).toBe(201);
+        expect.soft(response1.status).toBe(201);
+        expect.soft(response2.status).toBe(201);
 
         await orchestrator.createRate(response1Body, 1);
         await orchestrator.createRate(response1Body, -5);
@@ -734,8 +734,8 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
           parent_id: rootContentBody.id,
         });
 
-        expect(response1.status).toBe(201);
-        expect(response2.status).toBe(201);
+        expect.soft(response1.status).toBe(201);
+        expect.soft(response2.status).toBe(201);
 
         await orchestrator.createRate(response1Body, 2);
         await orchestrator.createRate(response2Body, 1);

--- a/tests/integration/api/v1/contents/get.test.js
+++ b/tests/integration/api/v1/contents/get.test.js
@@ -65,14 +65,14 @@ describe('GET /api/v1/contents', () => {
     test('With no content', async () => {
       const { response, responseBody } = await contentsRequestBuilder.get();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(responseBody).toStrictEqual([]);
     });
 
     test('With invalid strategy', async () => {
       const { response, responseBody } = await contentsRequestBuilder.get(`?strategy=invalid`);
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -138,7 +138,7 @@ describe('GET /api/v1/contents', () => {
 
       const { response, responseBody } = await contentsRequestBuilder.get(`?strategy=new`);
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual([
         {
@@ -236,7 +236,7 @@ describe('GET /api/v1/contents', () => {
 
       const { response, responseBody } = await contentsRequestBuilder.get(`?strategy=old`);
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual([
         {
@@ -327,7 +327,7 @@ describe('GET /api/v1/contents', () => {
 
       const { response, responseBody } = await contentsRequestBuilder.get();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual([
         {
@@ -369,7 +369,7 @@ describe('GET /api/v1/contents', () => {
       const responseLinkHeader = parseLinkHeader(response.headers.get('Link'));
       const responseTotalRowsHeader = response.headers.get('X-Pagination-Total-Rows');
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(responseTotalRowsHeader).toBe('60');
       expect(responseLinkHeader).toStrictEqual({
         first: {
@@ -729,7 +729,7 @@ describe('GET /api/v1/contents', () => {
       const responseLinkHeader = parseLinkHeader(response.headers.get('Link'));
       const responseTotalRowsHeader = response.headers.get('X-Pagination-Total-Rows');
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(responseTotalRowsHeader).toBe('56');
       expect(responseLinkHeader).toStrictEqual({
         first: {
@@ -799,7 +799,7 @@ describe('GET /api/v1/contents', () => {
       const page2ResponseLinkHeader = parseLinkHeader(page2Response.headers.get('Link'));
       const page2ResponseTotalRowsHeader = page2Response.headers.get('X-Pagination-Total-Rows');
 
-      expect(page2Response.status).toBe(200);
+      expect.soft(page2Response.status).toBe(200);
       expect(page2ResponseTotalRowsHeader).toBe('56');
       expect(page2ResponseLinkHeader).toStrictEqual({
         first: {
@@ -854,7 +854,7 @@ describe('GET /api/v1/contents', () => {
       const page1LinkHeader = parseLinkHeader(page1.headers.get('Link'));
       const page1TotalRowsHeader = page1.headers.get('X-Pagination-Total-Rows');
 
-      expect(page1.status).toBe(200);
+      expect.soft(page1.status).toBe(200);
       expect(page1TotalRowsHeader).toBe('9');
       expect(page1LinkHeader).toStrictEqual({
         first: {
@@ -891,7 +891,7 @@ describe('GET /api/v1/contents', () => {
       const page2LinkHeader = parseLinkHeader(page2.headers.get('Link'));
       const page2TotalRowsHeader = page2.headers.get('X-Pagination-Total-Rows');
 
-      expect(page2.status).toBe(200);
+      expect.soft(page2.status).toBe(200);
       expect(page2TotalRowsHeader).toBe('9');
       expect(page2LinkHeader).toStrictEqual({
         first: {
@@ -935,7 +935,7 @@ describe('GET /api/v1/contents', () => {
       const page3LinkHeader = parseLinkHeader(page3.headers.get('Link'));
       const page3TotalRowsHeader = page3.headers.get('X-Pagination-Total-Rows');
 
-      expect(page3.status).toBe(200);
+      expect.soft(page3.status).toBe(200);
       expect(page3TotalRowsHeader).toBe('9');
       expect(page3LinkHeader).toStrictEqual({
         first: {
@@ -972,7 +972,7 @@ describe('GET /api/v1/contents', () => {
       const firstPageLinkHeader = parseLinkHeader(firstPage.headers.get('Link'));
       const firstPageTotalRowsHeader = firstPage.headers.get('X-Pagination-Total-Rows');
 
-      expect(firstPage.status).toBe(200);
+      expect.soft(firstPage.status).toBe(200);
       expect(firstPageTotalRowsHeader).toBe(page1TotalRowsHeader);
       expect(firstPageLinkHeader).toStrictEqual(page1LinkHeader);
       expect(firstPageBody).toStrictEqual(page1Body);
@@ -982,7 +982,7 @@ describe('GET /api/v1/contents', () => {
       const lastPageLinkHeader = parseLinkHeader(lastPage.headers.get('Link'));
       const lastPageTotalRowsHeader = lastPage.headers.get('X-Pagination-Total-Rows');
 
-      expect(lastPage.status).toBe(200);
+      expect.soft(lastPage.status).toBe(200);
       expect(lastPageTotalRowsHeader).toBe(page3TotalRowsHeader);
       expect(lastPageLinkHeader).toStrictEqual(page3LinkHeader);
       expect(lastPageBody).toStrictEqual(page3Body);
@@ -1008,7 +1008,7 @@ describe('GET /api/v1/contents', () => {
       const page4LinkHeader = parseLinkHeader(page4.headers.get('Link'));
       const page4TotalRowsHeader = page4.headers.get('X-Pagination-Total-Rows');
 
-      expect(page4.status).toBe(200);
+      expect.soft(page4.status).toBe(200);
       expect(page4TotalRowsHeader).toBe('9');
       expect(page4LinkHeader).toStrictEqual({
         first: {
@@ -1040,7 +1040,7 @@ describe('GET /api/v1/contents', () => {
     test('With "page" with a String', async () => {
       const { response, responseBody } = await contentsRequestBuilder.get('?page=CINCO');
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -1061,7 +1061,7 @@ describe('GET /api/v1/contents', () => {
     test('With "page" with an invalid minimum Number', async () => {
       const { response, responseBody } = await contentsRequestBuilder.get('?page=0');
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -1082,7 +1082,7 @@ describe('GET /api/v1/contents', () => {
     test('With "page" with an invalid maximum Number', async () => {
       const { response, responseBody } = await contentsRequestBuilder.get('?page=9007199254740991');
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -1103,7 +1103,7 @@ describe('GET /api/v1/contents', () => {
     test('With "page" with an unsafe Number', async () => {
       const { response, responseBody } = await contentsRequestBuilder.get('?page=9007199254740992');
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -1124,7 +1124,7 @@ describe('GET /api/v1/contents', () => {
     test('With "page" with a Float Number', async () => {
       const { response, responseBody } = await contentsRequestBuilder.get('?page=1.5');
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -1145,7 +1145,7 @@ describe('GET /api/v1/contents', () => {
     test('With "per_page" with a String', async () => {
       const { response, responseBody } = await contentsRequestBuilder.get('?per_page=SEIS');
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -1166,7 +1166,7 @@ describe('GET /api/v1/contents', () => {
     test('With "per_page" with an invalid minimum Number', async () => {
       const { response, responseBody } = await contentsRequestBuilder.get('?per_page=0');
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -1187,7 +1187,7 @@ describe('GET /api/v1/contents', () => {
     test('With "per_page" with an invalid maximum Number', async () => {
       const { response, responseBody } = await contentsRequestBuilder.get('?per_page=9007199254740991');
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -1208,7 +1208,7 @@ describe('GET /api/v1/contents', () => {
     test('With "per_page" with an unsafe Number', async () => {
       const { response, responseBody } = await contentsRequestBuilder.get('?per_page=9007199254740992');
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -1229,7 +1229,7 @@ describe('GET /api/v1/contents', () => {
     test('With "per_page" with a Float Number', async () => {
       const { response, responseBody } = await contentsRequestBuilder.get('?per_page=1.5');
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -1419,7 +1419,7 @@ describe('GET /api/v1/contents', () => {
       ])('get $content with params: $params', async ({ params, responseLinkParams, getExpected }) => {
         const { response, responseBody } = await contentsRequestBuilder.get(`?${params.join('&')}`);
 
-        expect(response.status).toBe(200);
+        expect.soft(response.status).toBe(200);
         expect(responseBody).toStrictEqual(getExpected());
 
         const linkParamsString = responseLinkParams.join('&');
@@ -1469,7 +1469,7 @@ describe('GET /api/v1/contents', () => {
         async (params) => {
           const { response, responseBody } = await contentsRequestBuilder.get(params);
 
-          expect(response.status).toBe(200);
+          expect.soft(response.status).toBe(200);
           expect(responseBody).toStrictEqual([]);
         },
       );

--- a/tests/integration/api/v1/contents/options.test.js
+++ b/tests/integration/api/v1/contents/options.test.js
@@ -11,7 +11,7 @@ describe('OPTIONS /api/v1/contents', () => {
         method: 'options',
       });
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(response.headers.get('access-control-allow-methods')).toBe('GET,OPTIONS,PATCH,DELETE,POST,PUT');
       expect(response.headers.get('access-control-allow-origin')).toBe('*');
       expect(response.headers.get('access-control-allow-credentials')).toBe('true');

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -21,8 +21,8 @@ describe('POST /api/v1/contents', () => {
         body: 'Não deveria conseguir.',
       });
 
-      expect(response.status).toBe(403);
-      expect(responseBody.status_code).toBe(403);
+      expect.soft(response.status).toBe(403);
+      expect.soft(responseBody.status_code).toBe(403);
       expect(responseBody.name).toBe('ForbiddenError');
       expect(responseBody.message).toBe('Usuário não pode executar esta operação.');
       expect(responseBody.action).toBe('Verifique se este usuário possui a feature "create:content".');
@@ -42,8 +42,8 @@ describe('POST /api/v1/contents', () => {
         body: 'Não deveria conseguir, pois não possui a feature "create:content:text_root".',
       });
 
-      expect(response.status).toBe(403);
-      expect(responseBody.status_code).toBe(403);
+      expect.soft(response.status).toBe(403);
+      expect.soft(responseBody.status_code).toBe(403);
       expect(responseBody.name).toBe('ForbiddenError');
       expect(responseBody.message).toBe('Você não possui permissão para criar conteúdos na raiz do site.');
       expect(responseBody.action).toBe('Verifique se você possui a feature "create:content:text_root".');
@@ -75,8 +75,8 @@ describe('POST /api/v1/contents', () => {
         status: 'published',
       });
 
-      expect(response.status).toBe(403);
-      expect(responseBody.status_code).toBe(403);
+      expect.soft(response.status).toBe(403);
+      expect.soft(responseBody.status_code).toBe(403);
       expect(responseBody.name).toBe('ForbiddenError');
       expect(responseBody.message).toBe('Você não possui permissão para criar conteúdos dentro de outros conteúdos.');
       expect(responseBody.action).toBe('Verifique se você possui a feature "create:content:text_child".');
@@ -96,8 +96,8 @@ describe('POST /api/v1/contents', () => {
 
       const { response, responseBody } = await contentsRequestBuilder.post();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"body" enviado deve ser do tipo Object.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -116,8 +116,8 @@ describe('POST /api/v1/contents', () => {
         'Texto corrido no lugar de um JSON',
       );
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"body" enviado deve ser do tipo Object.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -139,7 +139,7 @@ describe('POST /api/v1/contents', () => {
         owner_id: secondUser.id,
       });
 
-      expect(response.status).toBe(201);
+      expect.soft(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -174,8 +174,8 @@ describe('POST /api/v1/contents', () => {
         title: 'Não deveria conseguir, falta o "body".',
       });
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"body" é um campo obrigatório.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -193,8 +193,8 @@ describe('POST /api/v1/contents', () => {
         body: '',
       });
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"body" não pode estar em branco.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -267,8 +267,8 @@ describe('POST /api/v1/contents', () => {
           `,
       });
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('Markdown deve conter algum texto.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -287,7 +287,7 @@ describe('POST /api/v1/contents', () => {
         source_url: 'https://teste-\u0000caractere.invalido/\u0000',
       });
 
-      expect(response.status).toBe(201);
+      expect.soft(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -323,8 +323,8 @@ describe('POST /api/v1/contents', () => {
         body: '\u200fTexto começando e terminando com caracteres inválidos.\u200e',
       });
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"body" deve começar com caracteres visíveis.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -342,8 +342,8 @@ describe('POST /api/v1/contents', () => {
         body: 'A'.repeat(20001),
       });
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"body" deve conter no máximo 20000 caracteres.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -361,8 +361,8 @@ describe('POST /api/v1/contents', () => {
         body: ' Espaço no início e no fim ',
       });
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"body" deve começar com caracteres visíveis.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -380,7 +380,7 @@ describe('POST /api/v1/contents', () => {
         body: 'Espaço só no fim ',
       });
 
-      expect(response.status).toBe(201);
+      expect.soft(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -416,8 +416,8 @@ describe('POST /api/v1/contents', () => {
         body: null,
       });
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"body" deve ser do tipo String.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -436,7 +436,7 @@ describe('POST /api/v1/contents', () => {
         slug: 'nodejs',
       });
 
-      expect(response.status).toBe(201);
+      expect.soft(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -473,8 +473,8 @@ describe('POST /api/v1/contents', () => {
         slug: '',
       });
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"slug" não pode estar em branco.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -496,7 +496,7 @@ describe('POST /api/v1/contents', () => {
         ),
       });
 
-      expect(response.status).toBe(201);
+      expect.soft(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -536,8 +536,8 @@ describe('POST /api/v1/contents', () => {
         slug: 'slug-não-pode-ter-caracteres-especiais',
       });
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"slug" está no formato errado.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -556,8 +556,8 @@ describe('POST /api/v1/contents', () => {
         slug: null,
       });
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"slug" deve ser do tipo String.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -584,7 +584,7 @@ describe('POST /api/v1/contents', () => {
         status: 'published',
       });
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -618,7 +618,7 @@ describe('POST /api/v1/contents', () => {
         status: 'published',
       });
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -656,7 +656,7 @@ describe('POST /api/v1/contents', () => {
         status: 'published',
       });
 
-      expect(response.status).toBe(201);
+      expect.soft(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -693,7 +693,7 @@ describe('POST /api/v1/contents', () => {
         slug: 'slug-with-trailing-hyphen---',
       });
 
-      expect(response.status).toBe(201);
+      expect.soft(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -729,8 +729,8 @@ describe('POST /api/v1/contents', () => {
         body: 'Qualquer coisa.',
       });
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"title" não pode estar em branco.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -748,8 +748,8 @@ describe('POST /api/v1/contents', () => {
         body: 'Qualquer coisa.',
       });
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe(`"title" deve conter no máximo ${maxTitleLength} caracteres.`);
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -771,7 +771,7 @@ describe('POST /api/v1/contents', () => {
         body: 'Instale o Node.js',
       });
 
-      expect(response.status).toBe(201);
+      expect.soft(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -814,7 +814,7 @@ describe('POST /api/v1/contents', () => {
         body: 'Instale o Node.js',
       });
 
-      expect(response.status).toBe(201);
+      expect.soft(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -850,7 +850,7 @@ describe('POST /api/v1/contents', () => {
         body: `The title is ${maxTitleLength} characters but 765 bytes and the slug should only be ${maxSlugLength} bytes`,
       });
 
-      expect(response.status).toBe(201);
+      expect.soft(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -886,7 +886,7 @@ describe('POST /api/v1/contents', () => {
         body: 'Qualquer coisa.',
       });
 
-      expect(response.status).toBe(201);
+      expect.soft(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -922,7 +922,7 @@ describe('POST /api/v1/contents', () => {
         body: 'Qualquer coisa.',
       });
 
-      expect(response.status).toBe(201);
+      expect.soft(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -959,7 +959,7 @@ describe('POST /api/v1/contents', () => {
         status: 'draft',
       });
 
-      expect(response.status).toBe(201);
+      expect.soft(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -996,7 +996,7 @@ describe('POST /api/v1/contents', () => {
         status: 'published',
       });
 
-      expect(response.status).toBe(201);
+      expect.soft(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1034,7 +1034,7 @@ describe('POST /api/v1/contents', () => {
         status: 'deleted',
       });
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
         message: 'Não é possível criar um novo conteúdo diretamente com status "deleted".',
@@ -1058,7 +1058,7 @@ describe('POST /api/v1/contents', () => {
         status: 'firewall',
       });
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
         message: 'Não é possível criar um novo conteúdo diretamente com status "firewall".',
@@ -1082,8 +1082,8 @@ describe('POST /api/v1/contents', () => {
         status: 'inexisting_status',
       });
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe(
         '"status" deve possuir um dos seguintes valores: "draft", "published", "deleted", "firewall".',
@@ -1104,8 +1104,8 @@ describe('POST /api/v1/contents', () => {
         status: null,
       });
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe(
         '"status" deve possuir um dos seguintes valores: "draft", "published", "deleted", "firewall".',
@@ -1126,8 +1126,8 @@ describe('POST /api/v1/contents', () => {
         status: '',
       });
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe(
         '"status" deve possuir um dos seguintes valores: "draft", "published", "deleted", "firewall".',
@@ -1148,7 +1148,7 @@ describe('POST /api/v1/contents', () => {
         source_url: 'http://www.tabnews.com.br/',
       });
 
-      expect(response.status).toBe(201);
+      expect.soft(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1185,7 +1185,7 @@ describe('POST /api/v1/contents', () => {
         source_url: 'https://www.tabnews.com.br/museu',
       });
 
-      expect(response.status).toBe(201);
+      expect.soft(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1222,7 +1222,7 @@ describe('POST /api/v1/contents', () => {
         source_url: 'http://nic.xn--vermgensberatung-pwb/',
       });
 
-      expect(response.status).toBe(201);
+      expect.soft(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1259,7 +1259,7 @@ describe('POST /api/v1/contents', () => {
         source_url: 'https://t.me',
       });
 
-      expect(response.status).toBe(201);
+      expect.soft(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1296,8 +1296,8 @@ describe('POST /api/v1/contents', () => {
         source_url: 'https://invalidtl.d',
       });
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe(
         '"source_url" deve possuir uma URL válida e utilizando os protocolos HTTP ou HTTPS.',
@@ -1318,8 +1318,8 @@ describe('POST /api/v1/contents', () => {
         source_url: 'http://tl.dcomvinteecincocaracteres',
       });
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe(
         '"source_url" deve possuir uma URL válida e utilizando os protocolos HTTP ou HTTPS.',
@@ -1340,8 +1340,8 @@ describe('POST /api/v1/contents', () => {
         source_url: 'ftp://www.tabnews.com.br',
       });
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe(
         '"source_url" deve possuir uma URL válida e utilizando os protocolos HTTP ou HTTPS.',
@@ -1362,8 +1362,8 @@ describe('POST /api/v1/contents', () => {
         source_url: 'www.tabnews.com.br',
       });
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe(
         '"source_url" deve possuir uma URL válida e utilizando os protocolos HTTP ou HTTPS.',
@@ -1384,8 +1384,8 @@ describe('POST /api/v1/contents', () => {
         source_url: 'https://lol.',
       });
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe(
         '"source_url" deve possuir uma URL válida e utilizando os protocolos HTTP ou HTTPS.',
@@ -1406,7 +1406,7 @@ describe('POST /api/v1/contents', () => {
         source_url: 'https://www.tabnews.com.br/api/v1/contents?strategy=old',
       });
 
-      expect(response.status).toBe(201);
+      expect.soft(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1443,7 +1443,7 @@ describe('POST /api/v1/contents', () => {
         source_url: 'http://www.tabnews.com.br/#:~:text=TabNews,-Status',
       });
 
-      expect(response.status).toBe(201);
+      expect.soft(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1480,8 +1480,8 @@ describe('POST /api/v1/contents', () => {
         source_url: '',
       });
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"source_url" não pode estar em branco.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -1500,7 +1500,7 @@ describe('POST /api/v1/contents', () => {
         source_url: null,
       });
 
-      expect(response.status).toBe(201);
+      expect.soft(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1537,7 +1537,7 @@ describe('POST /api/v1/contents', () => {
         body: 'Deveria conseguir, pois atualmente todos os usuários recebem todas as features relacionadas a "content".',
       });
 
-      expect(response.status).toBe(201);
+      expect.soft(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1581,7 +1581,7 @@ describe('POST /api/v1/contents', () => {
         body: 'Body',
       });
 
-      expect(response.status).toBe(201);
+      expect.soft(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1616,8 +1616,8 @@ describe('POST /api/v1/contents', () => {
         body: 'Não deveria conseguir, falta o "title".',
       });
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"title" é um campo obrigatório.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -1635,8 +1635,8 @@ describe('POST /api/v1/contents', () => {
         body: 'Não deveria conseguir, falta o "title".',
       });
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"title" é um campo obrigatório.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -1660,7 +1660,7 @@ describe('POST /api/v1/contents', () => {
         parent_id: rootContent.id,
       });
 
-      expect(response.status).toBe(201);
+      expect.soft(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1712,7 +1712,7 @@ describe('POST /api/v1/contents', () => {
         status: 'published',
       });
 
-      expect(response.status).toBe(201);
+      expect.soft(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1758,7 +1758,7 @@ describe('POST /api/v1/contents', () => {
         status: 'published',
       });
 
-      expect(response.status).toBe(201);
+      expect.soft(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -1795,8 +1795,8 @@ describe('POST /api/v1/contents', () => {
         parent_id: 123456,
       });
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"parent_id" deve ser do tipo String.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -1814,8 +1814,8 @@ describe('POST /api/v1/contents', () => {
         parent_id: '',
       });
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"parent_id" não pode estar em branco.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -1833,8 +1833,8 @@ describe('POST /api/v1/contents', () => {
         parent_id: 'isso não é um UUID válido',
       });
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"parent_id" deve possuir um token UUID na versão 4.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -1852,7 +1852,7 @@ describe('POST /api/v1/contents', () => {
         parent_id: 'fe2e20f5-9296-45ea-9a0f-401866819b9e',
       });
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
       expect(responseBody).toStrictEqual({
         status_code: 400,
         name: 'ValidationError',
@@ -1882,7 +1882,7 @@ describe('POST /api/v1/contents', () => {
 
         const getLastEmail = await orchestrator.getLastEmail();
 
-        expect(response.status).toBe(201);
+        expect.soft(response.status).toBe(201);
         expect(getLastEmail).toBeNull();
       });
 
@@ -1907,7 +1907,7 @@ describe('POST /api/v1/contents', () => {
 
         const getLastEmail = await orchestrator.getLastEmail();
 
-        expect(response.status).toBe(201);
+        expect.soft(response.status).toBe(201);
         expect(responseBody.parent_id).toBe(rootContent.id);
         expect(getLastEmail).toBeNull();
       });
@@ -1936,7 +1936,7 @@ describe('POST /api/v1/contents', () => {
 
         const childContentUrl = `${orchestrator.webserverUrl}/${secondUser.username}/${responseBody.slug}`;
 
-        expect(response.status).toBe(201);
+        expect.soft(response.status).toBe(201);
         expect(responseBody.parent_id).toBe(rootContent.id);
         expect(getLastEmail.recipients[0].includes(firstUser.email)).toBe(true);
         expect(getLastEmail.subject).toBe(`"${secondUser.username}" comentou em "Título curto do conteúdo raiz"`);
@@ -1976,7 +1976,7 @@ describe('POST /api/v1/contents', () => {
 
         const childContentUrl = `${orchestrator.webserverUrl}/${secondUser.username}/${responseBody.slug}`;
 
-        expect(response.status).toBe(201);
+        expect.soft(response.status).toBe(201);
         expect(responseBody.parent_id).toBe(rootContent.id);
         expect(getLastEmail.recipients[0].includes(firstUser.email)).toBe(true);
         expect(getLastEmail.subject).toBe(
@@ -2025,7 +2025,7 @@ describe('POST /api/v1/contents', () => {
 
         const childContentUrl = `${orchestrator.webserverUrl}/${firstUser.username}/${responseBody.slug}`;
 
-        expect(response.status).toBe(201);
+        expect.soft(response.status).toBe(201);
         expect(responseBody.parent_id).toBe(childContentFromSecondUser.id);
         expect(getLastEmail.recipients[0].includes(secondUser.email)).toBe(true);
         expect(getLastEmail.subject).toBe(`"${firstUser.username}" comentou em "Testando resposta ao conteúdo child"`);
@@ -2076,7 +2076,7 @@ describe('POST /api/v1/contents', () => {
 
         const childContentUrl = `${orchestrator.webserverUrl}/${firstUser.username}/${responseBody.slug}`;
 
-        expect(response.status).toBe(201);
+        expect.soft(response.status).toBe(201);
         expect(responseBody.parent_id).toBe(childContentFromSecondUser.id);
         expect(getLastEmail.recipients[0].includes(secondUser.email)).toBe(true);
         expect(getLastEmail.subject).toBe(`"${firstUser.username}" comentou em "[Não disponível]"`);
@@ -2115,7 +2115,7 @@ describe('POST /api/v1/contents', () => {
           notifications: false,
         });
 
-        expect(userPatchResponse1.status).toBe(200);
+        expect.soft(userPatchResponse1.status).toBe(200);
 
         const { responseBody: userGetResponseCheck2Body } = await userRequestBuilder.get();
 
@@ -2135,7 +2135,7 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        expect(contentResponse1.status).toBe(201);
+        expect.soft(contentResponse1.status).toBe(201);
 
         // 5) CHECK IF FIRST USER RECEIVED ANY EMAIL
         const getLastEmail1 = await orchestrator.getLastEmail();
@@ -2146,7 +2146,7 @@ describe('POST /api/v1/contents', () => {
           notifications: true,
         });
 
-        expect(userPatchResponse2.status).toBe(200);
+        expect.soft(userPatchResponse2.status).toBe(200);
 
         // 7) REPLY AGAIN TO CONTENT WITH SECOND USER
         const secondUser = await contentsRequestBuilder.buildUser();
@@ -2157,7 +2157,7 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        expect(contentResponse2.status).toBe(201);
+        expect.soft(contentResponse2.status).toBe(201);
 
         // 8) CHECK IF FIRST USER RECEIVED ANY EMAIL
         const getLastEmail2 = await orchestrator.getLastEmail();
@@ -2206,7 +2206,7 @@ describe('POST /api/v1/contents', () => {
         });
 
         expect(response.ok).toBe(true);
-        expect(response.status).toBe(201);
+        expect.soft(response.status).toBe(201);
         expect(response.headers.get('content-Type')).toBe('application/x-ndjson');
 
         const getLastEmail = await orchestrator.getLastEmail();
@@ -2372,8 +2372,8 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        expect(response.status).toBe(403);
-        expect(responseBody.status_code).toBe(403);
+        expect.soft(response.status).toBe(403);
+        expect.soft(responseBody.status_code).toBe(403);
         expect(responseBody.name).toBe('ForbiddenError');
         expect(responseBody.message).toBe(
           'Não é possível publicar porque há outras publicações mal avaliadas que ainda não foram excluídas.',
@@ -2405,8 +2405,8 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        expect(response.status).toBe(403);
-        expect(responseBody.status_code).toBe(403);
+        expect.soft(response.status).toBe(403);
+        expect.soft(responseBody.status_code).toBe(403);
         expect(responseBody.name).toBe('ForbiddenError');
         expect(responseBody.message).toBe(
           'Não é possível publicar porque há outras publicações mal avaliadas que ainda não foram excluídas.',
@@ -2431,7 +2431,7 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        expect(response.status).toBe(201);
+        expect.soft(response.status).toBe(201);
 
         expect(responseBody).toStrictEqual({
           id: responseBody.id,
@@ -2483,7 +2483,7 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        expect(response.status).toBe(201);
+        expect.soft(response.status).toBe(201);
 
         expect(responseBody).toStrictEqual({
           id: responseBody.id,
@@ -2527,7 +2527,7 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        expect(response.status).toBe(201);
+        expect.soft(response.status).toBe(201);
 
         expect(responseBody).toStrictEqual({
           id: responseBody.id,
@@ -2579,7 +2579,7 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        expect(response.status).toBe(201);
+        expect.soft(response.status).toBe(201);
 
         expect(responseBody).toStrictEqual({
           id: responseBody.id,
@@ -2623,7 +2623,7 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        expect(response.status).toBe(201);
+        expect.soft(response.status).toBe(201);
 
         expect(responseBody).toStrictEqual({
           id: responseBody.id,
@@ -2675,7 +2675,7 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        expect(response.status).toBe(201);
+        expect.soft(response.status).toBe(201);
 
         expect(responseBody).toStrictEqual({
           id: responseBody.id,
@@ -2839,8 +2839,8 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        expect(response.status).toBe(403);
-        expect(responseBody.status_code).toBe(403);
+        expect.soft(response.status).toBe(403);
+        expect.soft(responseBody.status_code).toBe(403);
         expect(responseBody.name).toBe('ForbiddenError');
         expect(responseBody.message).toBe(
           'Não é possível publicar porque há outras publicações mal avaliadas que ainda não foram excluídas.',
@@ -2865,7 +2865,7 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        expect(response.status).toBe(201);
+        expect.soft(response.status).toBe(201);
 
         expect(responseBody).toStrictEqual({
           id: responseBody.id,
@@ -2917,7 +2917,7 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        expect(response.status).toBe(201);
+        expect.soft(response.status).toBe(201);
 
         expect(responseBody).toStrictEqual({
           id: responseBody.id,
@@ -2963,7 +2963,7 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        expect(response.status).toBe(201);
+        expect.soft(response.status).toBe(201);
 
         expect(responseBody).toStrictEqual({
           id: responseBody.id,
@@ -3015,7 +3015,7 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        expect(response.status).toBe(201);
+        expect.soft(response.status).toBe(201);
 
         expect(responseBody).toStrictEqual({
           id: responseBody.id,

--- a/tests/integration/api/v1/contents/rss/get.test.js
+++ b/tests/integration/api/v1/contents/rss/get.test.js
@@ -11,12 +11,12 @@ describe('GET /recentes/rss', () => {
   describe('Anonymous user', () => {
     test('With `/rss` alias`', async () => {
       const response = await fetch(`${orchestrator.webserverUrl}/rss`);
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
     });
 
     test('With `/rss.xml` alias`', async () => {
       const response = await fetch(`${orchestrator.webserverUrl}/rss.xml`);
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
     });
 
     test('With 0 contents', async () => {
@@ -25,7 +25,7 @@ describe('GET /recentes/rss', () => {
 
       const lastBuildDateFromResponseBody = /<lastBuildDate>(.*?)<\/lastBuildDate>/.exec(responseBody)[1];
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toBe(`<?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0">
@@ -68,7 +68,7 @@ describe('GET /recentes/rss', () => {
 
       const lastBuildDateFromResponseBody = /<lastBuildDate>(.*?)<\/lastBuildDate>/.exec(responseBody)[1];
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toBe(`<?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0">
@@ -121,7 +121,7 @@ describe('GET /recentes/rss', () => {
       const response = await fetch(`${orchestrator.webserverUrl}/rss`);
       const responseBody = await response.text();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(responseBody).toBe(`<?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/">
     <channel>

--- a/tests/integration/api/v1/email-confirmation/patch.test.js
+++ b/tests/integration/api/v1/email-confirmation/patch.test.js
@@ -20,7 +20,7 @@ describe('PATCH /api/v1/email-confirmation', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -49,7 +49,7 @@ describe('PATCH /api/v1/email-confirmation', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -78,7 +78,7 @@ describe('PATCH /api/v1/email-confirmation', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -107,7 +107,7 @@ describe('PATCH /api/v1/email-confirmation', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -136,7 +136,7 @@ describe('PATCH /api/v1/email-confirmation', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -171,7 +171,7 @@ describe('PATCH /api/v1/email-confirmation', () => {
         }),
       });
 
-      expect(updateUserResponse.status).toBe(200);
+      expect.soft(updateUserResponse.status).toBe(200);
 
       // Attention: it should not update the email in the database
       // before the user clicks on the confirmation link sent to the new email.
@@ -211,7 +211,7 @@ describe('PATCH /api/v1/email-confirmation', () => {
 
       const emailConfirmationResponseBody = await emailConfirmationResponse.json();
 
-      expect(emailConfirmationResponse.status).toBe(200);
+      expect.soft(emailConfirmationResponse.status).toBe(200);
 
       expect(emailConfirmationResponseBody).toStrictEqual({
         id: emailConfirmationResponseBody.id,
@@ -247,7 +247,7 @@ describe('PATCH /api/v1/email-confirmation', () => {
         }),
       });
 
-      expect(firstTryResponse.status).toBe(200);
+      expect.soft(firstTryResponse.status).toBe(200);
 
       const userInDatabase = await user.findOneById(defaultUser.id);
       expect(userInDatabase.email).toBe('not.idempotent@patch.com');
@@ -265,7 +265,7 @@ describe('PATCH /api/v1/email-confirmation', () => {
 
       const secondTryResponseBody = await secondTryResponse.json();
 
-      expect(secondTryResponse.status).toBe(404);
+      expect.soft(secondTryResponse.status).toBe(404);
 
       expect(secondTryResponseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -353,7 +353,7 @@ describe('PATCH /api/v1/email-confirmation', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -397,7 +397,7 @@ describe('PATCH /api/v1/email-confirmation', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(404);
+      expect.soft(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',

--- a/tests/integration/api/v1/events/firewall/[id]/get.test.js
+++ b/tests/integration/api/v1/events/firewall/[id]/get.test.js
@@ -170,7 +170,7 @@ describe('GET /api/v1/events/firewall/[id]', () => {
         password: 'password',
       });
 
-      expect(user3Response.status).toBe(429);
+      expect.soft(user3Response.status).toBe(429);
 
       // Get firewall side-effect
       const firewallEvent = await orchestrator.getLastEvent();
@@ -222,7 +222,7 @@ describe('GET /api/v1/events/firewall/[id]', () => {
         password: 'password',
       });
 
-      expect(user3Response.status).toBe(429);
+      expect.soft(user3Response.status).toBe(429);
 
       const firstFirewallEvent = await orchestrator.getLastEvent();
 
@@ -232,7 +232,7 @@ describe('GET /api/v1/events/firewall/[id]', () => {
         password: 'password',
       });
 
-      expect(user4Response.status).toBe(429);
+      expect.soft(user4Response.status).toBe(429);
 
       const secondFirewallEvent = await orchestrator.getLastEvent();
 
@@ -305,7 +305,7 @@ describe('GET /api/v1/events/firewall/[id]', () => {
         password: 'password',
       });
 
-      expect(user3Response.status).toBe(429);
+      expect.soft(user3Response.status).toBe(429);
 
       // Check firewall side-effect
       const firewallEvent = await orchestrator.getLastEvent();
@@ -319,7 +319,7 @@ describe('GET /api/v1/events/firewall/[id]', () => {
       );
       await reviewFirewallRequestBuilder.setUser(firewallUser);
       const { response: reviewResponse } = await reviewFirewallRequestBuilder.post({ action: action });
-      expect(reviewResponse.status).toBe(200);
+      expect.soft(reviewResponse.status).toBe(200);
 
       // Get reviewed firewall event
       const reviewEvent = await orchestrator.getLastEvent();
@@ -371,7 +371,7 @@ describe('GET /api/v1/events/firewall/[id]', () => {
       const { responseBody: content2 } = await createContentViaApi(contentsRequestBuilder);
       const { response: responseContent3 } = await createContentViaApi(contentsRequestBuilder);
 
-      expect(responseContent3.status).toBe(429);
+      expect.soft(responseContent3.status).toBe(429);
 
       // Get firewall side-effect
       const firewallEvent = await orchestrator.getLastEvent();
@@ -517,7 +517,7 @@ describe('GET /api/v1/events/firewall/[id]', () => {
 
       const { response: responseContent3 } = await createContentViaApi(contentsRequestBuilder);
 
-      expect(responseContent3.status).toBe(429);
+      expect.soft(responseContent3.status).toBe(429);
 
       // Get firewall side-effect
       const firewallEvent = await orchestrator.getLastEvent();
@@ -572,7 +572,7 @@ describe('GET /api/v1/events/firewall/[id]', () => {
       const { responseBody: content2 } = await createContentViaApi(contentsRequestBuilder);
       const { response: responseContent3 } = await createContentViaApi(contentsRequestBuilder);
 
-      expect(responseContent3.status).toBe(429);
+      expect.soft(responseContent3.status).toBe(429);
 
       // Check firewall side-effect
       const firewallEvent = await orchestrator.getLastEvent();
@@ -587,7 +587,7 @@ describe('GET /api/v1/events/firewall/[id]', () => {
       await reviewFirewallRequestBuilder.setUser(firewallUser);
       const { response: reviewResponse } = await reviewFirewallRequestBuilder.post({ action: action });
 
-      expect(reviewResponse.status).toBe(200);
+      expect.soft(reviewResponse.status).toBe(200);
 
       // Get reviewed firewall event
       const reviewEvent = await orchestrator.getLastEvent();
@@ -653,7 +653,7 @@ describe('GET /api/v1/events/firewall/[id]', () => {
         parent_id: rootContent.id,
       });
 
-      expect(responseContent3.status).toBe(429);
+      expect.soft(responseContent3.status).toBe(429);
 
       // Get firewall side-effect
       const firewallEvent = await orchestrator.getLastEvent();
@@ -718,7 +718,7 @@ describe('GET /api/v1/events/firewall/[id]', () => {
         parent_id: rootContent.id,
       });
 
-      expect(responseContent3.status).toBe(429);
+      expect.soft(responseContent3.status).toBe(429);
 
       // Check firewall side-effect
       const firewallEvent = await orchestrator.getLastEvent();
@@ -733,7 +733,7 @@ describe('GET /api/v1/events/firewall/[id]', () => {
       await reviewFirewallRequestBuilder.setUser(firewallUser);
       const { response: reviewResponse } = await reviewFirewallRequestBuilder.post({ action: action });
 
-      expect(reviewResponse.status).toBe(200);
+      expect.soft(reviewResponse.status).toBe(200);
 
       // Get reviewed firewall event
       const reviewEvent = await orchestrator.getLastEvent();
@@ -806,7 +806,7 @@ describe('GET /api/v1/events/firewall/[id]', () => {
         parent_id: rootContent.id,
       });
 
-      expect(responseContent3.status).toBe(429);
+      expect.soft(responseContent3.status).toBe(429);
 
       // Get firewall side-effect
       const firewallEvent = await orchestrator.getLastEvent();

--- a/tests/integration/api/v1/migrations/get.test.js
+++ b/tests/integration/api/v1/migrations/get.test.js
@@ -15,11 +15,11 @@ describe('GET /api/v1/migrations', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(403);
+      expect.soft(response.status).toBe(403);
       expect(responseBody.name).toBe('ForbiddenError');
       expect(responseBody.message).toBe('Usuário não pode executar esta operação.');
       expect(responseBody.action).toBe('Verifique se este usuário possui a feature "read:migration".');
-      expect(responseBody.status_code).toBe(403);
+      expect.soft(responseBody.status_code).toBe(403);
       expect(uuidVersion(responseBody.error_id)).toBe(4);
       expect(uuidVersion(responseBody.request_id)).toBe(4);
       expect(responseBody.error_location_code).toBe('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
@@ -42,11 +42,11 @@ describe('GET /api/v1/migrations', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(403);
+      expect.soft(response.status).toBe(403);
       expect(responseBody.name).toBe('ForbiddenError');
       expect(responseBody.message).toBe('Usuário não pode executar esta operação.');
       expect(responseBody.action).toBe('Verifique se este usuário possui a feature "read:migration".');
-      expect(responseBody.status_code).toBe(403);
+      expect.soft(responseBody.status_code).toBe(403);
       expect(uuidVersion(responseBody.error_id)).toBe(4);
       expect(uuidVersion(responseBody.request_id)).toBe(4);
       expect(responseBody.error_location_code).toBe('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
@@ -75,7 +75,7 @@ describe('GET /api/v1/migrations', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(Array.isArray(responseBody)).toBe(true);
     });
 
@@ -97,7 +97,7 @@ describe('GET /api/v1/migrations', () => {
         expect(responseBody.name).toBe('ForbiddenError');
         expect(responseBody.message).toBe('Usuário não pode executar esta operação.');
         expect(responseBody.action).toBe('Verifique se este usuário possui a feature "read:migration".');
-        expect(responseBody.status_code).toBe(403);
+        expect.soft(responseBody.status_code).toBe(403);
         expect(uuidVersion(responseBody.error_id)).toBe(4);
         expect(uuidVersion(responseBody.request_id)).toBe(4);
         expect(responseBody.error_location_code).toBe('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');

--- a/tests/integration/api/v1/migrations/post.test.js
+++ b/tests/integration/api/v1/migrations/post.test.js
@@ -20,11 +20,11 @@ describe('POST /api/v1/migrations', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(403);
+      expect.soft(response.status).toBe(403);
       expect(responseBody.name).toBe('ForbiddenError');
       expect(responseBody.message).toBe('Usuário não pode executar esta operação.');
       expect(responseBody.action).toBe('Verifique se este usuário possui a feature "create:migration".');
-      expect(responseBody.status_code).toBe(403);
+      expect.soft(responseBody.status_code).toBe(403);
       expect(uuidVersion(responseBody.error_id)).toBe(4);
       expect(uuidVersion(responseBody.request_id)).toBe(4);
       expect(responseBody.error_location_code).toBe('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
@@ -47,11 +47,11 @@ describe('POST /api/v1/migrations', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(403);
+      expect.soft(response.status).toBe(403);
       expect(responseBody.name).toBe('ForbiddenError');
       expect(responseBody.message).toBe('Usuário não pode executar esta operação.');
       expect(responseBody.action).toBe('Verifique se este usuário possui a feature "create:migration".');
-      expect(responseBody.status_code).toBe(403);
+      expect.soft(responseBody.status_code).toBe(403);
       expect(uuidVersion(responseBody.error_id)).toBe(4);
       expect(uuidVersion(responseBody.request_id)).toBe(4);
       expect(responseBody.error_location_code).toBe('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
@@ -76,7 +76,7 @@ describe('POST /api/v1/migrations', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(Array.isArray(responseBody)).toBe(true);
     });
   });

--- a/tests/integration/api/v1/moderations/review_firewall/[id]/post.test.js
+++ b/tests/integration/api/v1/moderations/review_firewall/[id]/post.test.js
@@ -241,7 +241,7 @@ describe('POST /api/v1/moderations/review_firewall/[id]', () => {
         password: 'password',
       });
 
-      expect(user3Response.status).toBe(429);
+      expect.soft(user3Response.status).toBe(429);
 
       // Check firewall side-effect
       const firewallEvent = await orchestrator.getLastEvent();
@@ -259,7 +259,7 @@ describe('POST /api/v1/moderations/review_firewall/[id]', () => {
         action: 'confirm',
       });
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       // Review firewall again
       const { response: responseAgain, responseBody: responseAgainBody } = await reviewFirewallRequestBuilder.post({
@@ -308,8 +308,8 @@ describe('POST /api/v1/moderations/review_firewall/[id]', () => {
       });
       const firewallEvent2 = await orchestrator.getLastEvent();
 
-      expect(user3Response.status).toBe(429);
-      expect(user4Response.status).toBe(429);
+      expect.soft(user3Response.status).toBe(429);
+      expect.soft(user4Response.status).toBe(429);
 
       // Check firewall side-effect
       expect(firewallEvent1.type).toBe('firewall:block_users');
@@ -325,7 +325,7 @@ describe('POST /api/v1/moderations/review_firewall/[id]', () => {
         action: 'confirm',
       });
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       // Review related event
       const { response: responseAgain, responseBody: responseAgainBody } = await reviewEventRequestBuilder.post(
@@ -387,7 +387,7 @@ describe('POST /api/v1/moderations/review_firewall/[id]', () => {
           password: 'password',
         });
 
-        expect(user3Response.status).toBe(429);
+        expect.soft(user3Response.status).toBe(429);
 
         // Check firewall side-effect
         const firewallEvent = await orchestrator.getLastEvent();
@@ -475,7 +475,7 @@ describe('POST /api/v1/moderations/review_firewall/[id]', () => {
           password: 'password',
         });
 
-        expect(user3Response.status).toBe(429);
+        expect.soft(user3Response.status).toBe(429);
 
         // Check firewall side-effect
         const firewallEvent = await orchestrator.getLastEvent();
@@ -517,7 +517,7 @@ describe('POST /api/v1/moderations/review_firewall/[id]', () => {
         const { responseBody: content2 } = await createContentViaApi(contentsRequestBuilder);
         const { response: responseContent3 } = await createContentViaApi(contentsRequestBuilder);
 
-        expect(responseContent3.status).toBe(429);
+        expect.soft(responseContent3.status).toBe(429);
 
         // Check firewall side-effect
         const content1AfterSideEffect = await content.findOne({ where: { id: content1.id } });
@@ -614,7 +614,7 @@ describe('POST /api/v1/moderations/review_firewall/[id]', () => {
         await contentsRequestBuilder.setUser(user1);
         const { response: responseContent3 } = await createContentViaApi(contentsRequestBuilder);
 
-        expect(responseContent3.status).toBe(429);
+        expect.soft(responseContent3.status).toBe(429);
 
         // Check firewall side-effect
         const content1AfterSideEffect = await content.findOne({ where: { id: content1.id } });
@@ -697,7 +697,7 @@ describe('POST /api/v1/moderations/review_firewall/[id]', () => {
         await contentsRequestBuilder.setUser(user1);
         const { response: responseContent3 } = await createContentViaApi(contentsRequestBuilder);
 
-        expect(responseContent3.status).toBe(429);
+        expect.soft(responseContent3.status).toBe(429);
 
         // Check firewall side-effect
         const content1AfterSideEffect = await content.findOne({ where: { id: content1.id } });
@@ -768,9 +768,9 @@ describe('POST /api/v1/moderations/review_firewall/[id]', () => {
         const { response: responseContent5 } = await createContentViaApi(contentsRequestBuilder);
         const firewallEvent3 = await orchestrator.getLastEvent();
 
-        expect(responseContent3.status).toBe(429);
-        expect(responseContent4.status).toBe(429);
-        expect(responseContent5.status).toBe(429);
+        expect.soft(responseContent3.status).toBe(429);
+        expect.soft(responseContent4.status).toBe(429);
+        expect.soft(responseContent5.status).toBe(429);
 
         // Check firewall side-effect
         const content1AfterSideEffect = await content.findOne({ where: { id: content1.id } });
@@ -896,7 +896,7 @@ describe('POST /api/v1/moderations/review_firewall/[id]', () => {
           parent_id: rootContent.id,
         });
 
-        expect(responseContent3.status).toBe(429);
+        expect.soft(responseContent3.status).toBe(429);
 
         // Check firewall side-effect
         const content1AfterSideEffect = await content.findOne({ where: { id: content1.id } });
@@ -996,7 +996,7 @@ describe('POST /api/v1/moderations/review_firewall/[id]', () => {
           parent_id: rootContent.id,
         });
 
-        expect(responseContent3.status).toBe(429);
+        expect.soft(responseContent3.status).toBe(429);
 
         // Check firewall side-effect
         const content1AfterSideEffect = await content.findOne({ where: { id: content1.id } });
@@ -1079,7 +1079,7 @@ describe('POST /api/v1/moderations/review_firewall/[id]', () => {
           parent_id: rootContent.id,
         });
 
-        expect(responseContent3.status).toBe(429);
+        expect.soft(responseContent3.status).toBe(429);
 
         // Check firewall side-effect
         const content1AfterSideEffect = await content.findOne({ where: { id: content1.id } });
@@ -1179,7 +1179,7 @@ describe('POST /api/v1/moderations/review_firewall/[id]', () => {
           password: 'password',
         });
 
-        expect(user3Response.status).toBe(429);
+        expect.soft(user3Response.status).toBe(429);
 
         // Check firewall side-effect
         const firewallEvent = await orchestrator.getLastEvent();
@@ -1275,7 +1275,7 @@ describe('POST /api/v1/moderations/review_firewall/[id]', () => {
         await contentsRequestBuilder.setUser(user1);
         const { response: responseContent3 } = await createContentViaApi(contentsRequestBuilder);
 
-        expect(responseContent3.status).toBe(429);
+        expect.soft(responseContent3.status).toBe(429);
 
         // Check firewall side-effect
         const content1AfterSideEffect = await content.findOne({ where: { id: content1.id } });
@@ -1383,7 +1383,7 @@ describe('POST /api/v1/moderations/review_firewall/[id]', () => {
 
         const { response: responseContent3 } = await createContentViaApi(contentsRequestBuilder);
 
-        expect(responseContent3.status).toBe(429);
+        expect.soft(responseContent3.status).toBe(429);
 
         // Check firewall side-effect
         const content1AfterSideEffect = await content.findOne({ where: { id: content1.id } });
@@ -1493,7 +1493,7 @@ describe('POST /api/v1/moderations/review_firewall/[id]', () => {
           parent_id: rootContent.id,
         });
 
-        expect(responseContent3.status).toBe(429);
+        expect.soft(responseContent3.status).toBe(429);
 
         // Check firewall side-effect
         const content1AfterSideEffect = await content.findOne({ where: { id: content1.id } });

--- a/tests/integration/api/v1/recovery/patch.test.js
+++ b/tests/integration/api/v1/recovery/patch.test.js
@@ -34,7 +34,7 @@ describe('PATCH /api/v1/recovery', () => {
       const updatedTokenInDatabase = await recovery.findOneTokenById(recoveryToken.id);
       const updatedUserInDatabase = await user.findOneById(defaultUser.id);
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         used: true,
@@ -73,11 +73,11 @@ describe('PATCH /api/v1/recovery', () => {
         },
       });
 
-      expect(validSession1Response.status).toBe(200);
+      expect.soft(validSession1Response.status).toBe(200);
       const validSession1ResponseBody = await validSession1Response.json();
       expect(validSession1ResponseBody.id).toBe(defaultUser.id);
 
-      expect(validSession2Response.status).toBe(200);
+      expect.soft(validSession2Response.status).toBe(200);
       const validSession2ResponseBody = await validSession2Response.json();
       expect(validSession2ResponseBody.id).toBe(defaultUser.id);
 
@@ -96,7 +96,7 @@ describe('PATCH /api/v1/recovery', () => {
         }),
       });
 
-      expect(recoveryResponse.status).toBe(200);
+      expect.soft(recoveryResponse.status).toBe(200);
 
       // Third: test if both sessions are invalid
       const invalidSession1Response = await fetch(`${orchestrator.webserverUrl}/api/v1/user`, {
@@ -113,8 +113,8 @@ describe('PATCH /api/v1/recovery', () => {
         },
       });
 
-      expect(invalidSession1Response.status).toBe(401);
-      expect(invalidSession2Response.status).toBe(401);
+      expect.soft(invalidSession1Response.status).toBe(401);
+      expect.soft(invalidSession2Response.status).toBe(401);
     });
 
     test('With valid information, but used token', async () => {
@@ -138,7 +138,7 @@ describe('PATCH /api/v1/recovery', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(404);
+      expect.soft(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -176,7 +176,7 @@ describe('PATCH /api/v1/recovery', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(404);
+      expect.soft(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -208,7 +208,7 @@ describe('PATCH /api/v1/recovery', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(404);
+      expect.soft(response.status).toBe(404);
 
       expect(responseBody).toStrictEqual({
         name: 'NotFoundError',
@@ -239,7 +239,7 @@ describe('PATCH /api/v1/recovery', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -271,7 +271,7 @@ describe('PATCH /api/v1/recovery', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -300,7 +300,7 @@ describe('PATCH /api/v1/recovery', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -332,7 +332,7 @@ describe('PATCH /api/v1/recovery', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -359,7 +359,7 @@ describe('PATCH /api/v1/recovery', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -389,7 +389,7 @@ describe('PATCH /api/v1/recovery', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',

--- a/tests/integration/api/v1/recovery/post.test.js
+++ b/tests/integration/api/v1/recovery/post.test.js
@@ -26,7 +26,7 @@ describe('POST /api/v1/recovery', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(403);
+      expect.soft(response.status).toBe(403);
 
       expect(responseBody).toStrictEqual({
         name: 'ForbiddenError',
@@ -56,7 +56,7 @@ describe('POST /api/v1/recovery', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -92,7 +92,7 @@ describe('POST /api/v1/recovery', () => {
 
       const tokenInDatabase = await recovery.findOneTokenByUserId(defaultUser.id);
 
-      expect(response.status).toBe(201);
+      expect.soft(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         used: false,
@@ -162,7 +162,7 @@ describe('POST /api/v1/recovery', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -194,7 +194,7 @@ describe('POST /api/v1/recovery', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -219,7 +219,7 @@ describe('POST /api/v1/recovery', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -249,7 +249,7 @@ describe('POST /api/v1/recovery', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -292,7 +292,7 @@ describe('POST /api/v1/recovery', () => {
 
       const tokenInDatabase = await recovery.findOneTokenByUserId(defaultUser.id);
 
-      expect(response.status).toBe(201);
+      expect.soft(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         used: false,
@@ -334,7 +334,7 @@ describe('POST /api/v1/recovery', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',

--- a/tests/integration/api/v1/sessions/delete.test.js
+++ b/tests/integration/api/v1/sessions/delete.test.js
@@ -17,7 +17,7 @@ describe('DELETE /api/v1/sessions', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(403);
+      expect.soft(response.status).toBe(403);
 
       expect(responseBody).toStrictEqual({
         name: 'ForbiddenError',
@@ -43,7 +43,7 @@ describe('DELETE /api/v1/sessions', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -76,7 +76,7 @@ describe('DELETE /api/v1/sessions', () => {
         },
       });
 
-      expect(validSessionResponse.status).toBe(200);
+      expect.soft(validSessionResponse.status).toBe(200);
       const validSessionResponseBody = await validSessionResponse.json();
       expect(validSessionResponseBody.id).toBe(defaultUser.id);
 
@@ -90,7 +90,7 @@ describe('DELETE /api/v1/sessions', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: sessionObject.id,
@@ -132,7 +132,7 @@ describe('DELETE /api/v1/sessions', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(403);
+      expect.soft(response.status).toBe(403);
 
       expect(responseBody).toStrictEqual({
         name: 'ForbiddenError',

--- a/tests/integration/api/v1/sessions/get.test.js
+++ b/tests/integration/api/v1/sessions/get.test.js
@@ -15,7 +15,7 @@ describe('GET /api/v1/sessions', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(405);
+      expect.soft(response.status).toBe(405);
 
       expect(responseBody).toStrictEqual({
         name: 'MethodNotAllowedError',

--- a/tests/integration/api/v1/sessions/post.test.js
+++ b/tests/integration/api/v1/sessions/post.test.js
@@ -32,7 +32,7 @@ describe('POST /api/v1/sessions', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(201);
+      expect.soft(response.status).toBe(201);
       expect(responseBody.token.length).toBe(96);
       expect(uuidVersion(responseBody.id)).toBe(4);
       expect(Date.parse(responseBody.expires_at)).not.toBeNaN();
@@ -72,11 +72,11 @@ describe('POST /api/v1/sessions', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(403);
+      expect.soft(response.status).toBe(403);
       expect(responseBody.name).toBe('ForbiddenError');
       expect(responseBody.message).toBe('Você não possui permissão para fazer login.');
       expect(responseBody.action).toBe('Verifique se este usuário possui a feature "create:session".');
-      expect(responseBody.status_code).toBe(403);
+      expect.soft(responseBody.status_code).toBe(403);
       expect(uuidVersion(responseBody.error_id)).toBe(4);
       expect(uuidVersion(responseBody.request_id)).toBe(4);
       expect(responseBody.error_location_code).toBe('CONTROLLER:SESSIONS:POST_HANDLER:CAN_NOT_CREATE_SESSION');
@@ -101,11 +101,11 @@ describe('POST /api/v1/sessions', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(403);
+      expect.soft(response.status).toBe(403);
       expect(responseBody.name).toBe('ForbiddenError');
       expect(responseBody.message).toBe('O seu usuário ainda não está ativado.');
       expect(responseBody.action).toBe('Verifique seu email, pois acabamos de enviar um novo convite de ativação.');
-      expect(responseBody.status_code).toBe(403);
+      expect.soft(responseBody.status_code).toBe(403);
       expect(uuidVersion(responseBody.error_id)).toBe(4);
       expect(uuidVersion(responseBody.request_id)).toBe(4);
       expect(responseBody.error_location_code).toBe('CONTROLLER:SESSIONS:POST_HANDLER:USER_NOT_ACTIVATED');
@@ -132,11 +132,11 @@ describe('POST /api/v1/sessions', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(401);
+      expect.soft(response.status).toBe(401);
       expect(responseBody.name).toBe('UnauthorizedError');
       expect(responseBody.message).toBe('Dados não conferem.');
       expect(responseBody.action).toBe('Verifique se os dados enviados estão corretos.');
-      expect(responseBody.status_code).toBe(401);
+      expect.soft(responseBody.status_code).toBe(401);
       expect(uuidVersion(responseBody.error_id)).toBe(4);
       expect(uuidVersion(responseBody.request_id)).toBe(4);
       expect(responseBody.error_location_code).toBe('CONTROLLER:SESSIONS:POST_HANDLER:DATA_MISMATCH');
@@ -163,11 +163,11 @@ describe('POST /api/v1/sessions', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(401);
+      expect.soft(response.status).toBe(401);
       expect(responseBody.name).toBe('UnauthorizedError');
       expect(responseBody.message).toBe('Dados não conferem.');
       expect(responseBody.action).toBe('Verifique se os dados enviados estão corretos.');
-      expect(responseBody.status_code).toBe(401);
+      expect.soft(responseBody.status_code).toBe(401);
       expect(uuidVersion(responseBody.error_id)).toBe(4);
       expect(uuidVersion(responseBody.request_id)).toBe(4);
       expect(responseBody.error_location_code).toBe('CONTROLLER:SESSIONS:POST_HANDLER:DATA_MISMATCH');
@@ -186,8 +186,8 @@ describe('POST /api/v1/sessions', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"email" é um campo obrigatório.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -211,8 +211,8 @@ describe('POST /api/v1/sessions', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"email" não pode estar em branco.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -236,8 +236,8 @@ describe('POST /api/v1/sessions', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"email" deve ser do tipo String.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -261,8 +261,8 @@ describe('POST /api/v1/sessions', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"email" deve conter um email válido.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -285,8 +285,8 @@ describe('POST /api/v1/sessions', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"password" é um campo obrigatório.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -310,8 +310,8 @@ describe('POST /api/v1/sessions', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"password" não pode estar em branco.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -335,8 +335,8 @@ describe('POST /api/v1/sessions', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"password" deve conter no mínimo 8 caracteres.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -360,8 +360,8 @@ describe('POST /api/v1/sessions', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"password" deve conter no máximo 72 caracteres.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -385,8 +385,8 @@ describe('POST /api/v1/sessions', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"password" deve ser do tipo String.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -403,8 +403,8 @@ describe('POST /api/v1/sessions', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"body" enviado deve ser do tipo Object.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');

--- a/tests/integration/api/v1/sponsored-beta/get.test.js
+++ b/tests/integration/api/v1/sponsored-beta/get.test.js
@@ -56,7 +56,7 @@ describe('GET /api/v1/sponsored-beta', () => {
 
       const { response, responseBody } = await adsRequestBuilder.get();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(responseBody).toStrictEqual([]);
     });
 

--- a/tests/integration/api/v1/status/get.test.js
+++ b/tests/integration/api/v1/status/get.test.js
@@ -11,7 +11,7 @@ describe('GET /status', () => {
       const serverStatusResponse = await fetch(`${orchestrator.webserverUrl}/api/v1/status`);
       const serverStatusBody = await serverStatusResponse.json();
 
-      expect(serverStatusResponse.status).toBe(200);
+      expect.soft(serverStatusResponse.status).toBe(200);
       expect(serverStatusBody.updated_at).toBeDefined();
       expect(serverStatusBody.dependencies.database.status).toBe('healthy');
       expect(serverStatusBody.dependencies.database.opened_connections).toBeGreaterThan(0);

--- a/tests/integration/api/v1/status/votes/get.test.js
+++ b/tests/integration/api/v1/status/votes/get.test.js
@@ -16,11 +16,11 @@ describe('GET /api/v1/status/votes', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(403);
+      expect.soft(response.status).toBe(403);
       expect(responseBody.name).toBe('ForbiddenError');
       expect(responseBody.message).toBe('Usuário não pode executar esta operação.');
       expect(responseBody.action).toBe('Verifique se este usuário possui a feature "read:votes:others".');
-      expect(responseBody.status_code).toBe(403);
+      expect.soft(responseBody.status_code).toBe(403);
       expect(uuidVersion(responseBody.error_id)).toBe(4);
       expect(uuidVersion(responseBody.request_id)).toBe(4);
       expect(responseBody.error_location_code).toBe('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
@@ -43,11 +43,11 @@ describe('GET /api/v1/status/votes', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(403);
+      expect.soft(response.status).toBe(403);
       expect(responseBody.name).toBe('ForbiddenError');
       expect(responseBody.message).toBe('Usuário não pode executar esta operação.');
       expect(responseBody.action).toBe('Verifique se este usuário possui a feature "read:votes:others".');
-      expect(responseBody.status_code).toBe(403);
+      expect.soft(responseBody.status_code).toBe(403);
       expect(uuidVersion(responseBody.error_id)).toBe(4);
       expect(uuidVersion(responseBody.request_id)).toBe(4);
       expect(responseBody.error_location_code).toBe('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
@@ -76,7 +76,7 @@ describe('GET /api/v1/status/votes', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(responseBody).toStrictEqual({ updated_at: expect.any(String), votesGraph: { edges: [], nodes: [] } });
     });
 
@@ -94,7 +94,7 @@ describe('GET /api/v1/status/votes', () => {
       const responseBody = await response.json();
       const votesData = responseBody.votesGraph;
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(votesData.edges.length).toBe(1);
       expect(votesData.edges[0].type).toBe('credit');
       expect(votesData.edges[0].value).toBe(1);
@@ -122,11 +122,11 @@ describe('GET /api/v1/status/votes', () => {
 
         const responseBody = await responseAfter.json();
 
-        expect(responseAfter.status).toBe(403);
+        expect.soft(responseAfter.status).toBe(403);
         expect(responseBody.name).toBe('ForbiddenError');
         expect(responseBody.message).toBe('Usuário não pode executar esta operação.');
         expect(responseBody.action).toBe('Verifique se este usuário possui a feature "read:votes:others".');
-        expect(responseBody.status_code).toBe(403);
+        expect.soft(responseBody.status_code).toBe(403);
         expect(uuidVersion(responseBody.error_id)).toBe(4);
         expect(uuidVersion(responseBody.request_id)).toBe(4);
         expect(responseBody.error_location_code).toBe('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');

--- a/tests/integration/api/v1/swr/get.test.js
+++ b/tests/integration/api/v1/swr/get.test.js
@@ -7,7 +7,7 @@ describe('GET /swr', () => {
     const serverTimeBody = await serverTimeResponse.json();
     const serverTime = serverTimeBody.timestamp;
 
-    expect(serverTimeResponse.status).toBe(200);
+    expect.soft(serverTimeResponse.status).toBe(200);
     expect(serverTime).toBeGreaterThanOrEqual(startTime);
     expect(serverTime).toBeLessThanOrEqual(Date.now());
   });

--- a/tests/integration/api/v1/user/get.test.js
+++ b/tests/integration/api/v1/user/get.test.js
@@ -17,8 +17,8 @@ describe('GET /api/v1/user', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(403);
-      expect(responseBody.status_code).toBe(403);
+      expect.soft(response.status).toBe(403);
+      expect.soft(responseBody.status_code).toBe(403);
       expect(responseBody.name).toBe('ForbiddenError');
       expect(responseBody.message).toBe('Usuário não pode executar esta operação.');
       expect(responseBody.action).toBe('Verifique se este usuário possui a feature "read:session".');
@@ -40,8 +40,8 @@ describe('GET /api/v1/user', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"session_id" deve possuir 96 caracteres.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -64,8 +64,8 @@ describe('GET /api/v1/user', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"session_id" deve possuir 96 caracteres.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -88,8 +88,8 @@ describe('GET /api/v1/user', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"session_id" deve conter apenas caracteres alfanuméricos.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -110,7 +110,7 @@ describe('GET /api/v1/user', () => {
 
       const { response, responseBody } = await userRequestBuilder.get();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(responseBody).toStrictEqual({
         id: defaultUser.id,
         username: defaultUser.username,
@@ -137,8 +137,8 @@ describe('GET /api/v1/user', () => {
 
       const { response, responseBody } = await userRequestBuilder.get();
 
-      expect(response.status).toBe(403);
-      expect(responseBody.status_code).toBe(403);
+      expect.soft(response.status).toBe(403);
+      expect.soft(responseBody.status_code).toBe(403);
       expect(responseBody.name).toBe('ForbiddenError');
       expect(responseBody.message).toBe('Você não possui permissão para executar esta ação.');
       expect(responseBody.action).toBe(
@@ -166,8 +166,8 @@ describe('GET /api/v1/user', () => {
 
       const { response, responseBody } = await userRequestBuilder.get();
 
-      expect(response.status).toBe(401);
-      expect(responseBody.status_code).toBe(401);
+      expect.soft(response.status).toBe(401);
+      expect.soft(responseBody.status_code).toBe(401);
       expect(responseBody.name).toBe('UnauthorizedError');
       expect(responseBody.message).toBe('Usuário não possui sessão ativa.');
       expect(responseBody.action).toBe('Verifique se este usuário está logado.');
@@ -201,7 +201,7 @@ describe('GET /api/v1/user', () => {
 
         const { response, responseBody } = await userRequestBuilder.get();
 
-        expect(response.status).toBe(200);
+        expect.soft(response.status).toBe(200);
         expect(responseBody).toStrictEqual({
           id: defaultUser.id,
           username: defaultUser.username,
@@ -246,7 +246,7 @@ describe('GET /api/v1/user', () => {
 
         const { response, responseBody } = await userRequestBuilder.get();
 
-        expect(response.status).toBe(200);
+        expect.soft(response.status).toBe(200);
         expect(responseBody).toStrictEqual({
           id: defaultUser.id,
           username: defaultUser.username,
@@ -290,7 +290,7 @@ describe('GET /api/v1/user', () => {
 
         const { response, responseBody } = await userRequestBuilder.get();
 
-        expect(response.status).toBe(200);
+        expect.soft(response.status).toBe(200);
         expect(responseBody).toStrictEqual({
           id: defaultUser.id,
           username: defaultUser.username,
@@ -322,7 +322,7 @@ describe('GET /api/v1/user', () => {
 
         const { response: preRewardUserResponse, responseBody: preRewardUser } = await userRequestBuilder.get();
 
-        expect(preRewardUserResponse.status).toBe(200);
+        expect.soft(preRewardUserResponse.status).toBe(200);
         expect(preRewardUser.tabcoins).toBe(0);
         expect(preRewardUser.tabcash).toBe(0);
         expect(preRewardUser.updated_at).toBe(defaultUser.updated_at.toISOString());
@@ -334,14 +334,14 @@ describe('GET /api/v1/user', () => {
 
         const { response: rewardUserResponse, responseBody: rewardUser } = await userRequestBuilder.get();
 
-        expect(rewardUserResponse.status).toBe(200);
+        expect.soft(rewardUserResponse.status).toBe(200);
         expect(rewardUser.tabcoins).toBe(defaultTestRewardValue);
         expect(rewardUser.tabcash).toBe(0);
         expect(rewardUser.updated_at).toBe(defaultUser.updated_at.toISOString());
 
         const { response: postRewardUserResponse, responseBody: postRewardUser } = await userRequestBuilder.get();
 
-        expect(postRewardUserResponse.status).toBe(200);
+        expect.soft(postRewardUserResponse.status).toBe(200);
         expect(postRewardUser.tabcoins).toBe(defaultTestRewardValue);
         expect(postRewardUser.tabcash).toBe(0);
         expect(postRewardUser.updated_at).toBe(defaultUser.updated_at.toISOString());
@@ -354,7 +354,7 @@ describe('GET /api/v1/user', () => {
 
         const { response: preRewardUserResponse, responseBody: preRewardUser } = await userRequestBuilder.get();
 
-        expect(preRewardUserResponse.status).toBe(200);
+        expect.soft(preRewardUserResponse.status).toBe(200);
         expect(preRewardUser.tabcoins).toBe(0);
         expect(preRewardUser.tabcash).toBe(0);
         expect(preRewardUser.updated_at).toBe(defaultUser.updated_at.toISOString());
@@ -367,7 +367,7 @@ describe('GET /api/v1/user', () => {
         const simultaneousResults = await Promise.all([userRequestBuilder.get(), userRequestBuilder.get()]);
 
         const tabcoins = simultaneousResults.map((result) => {
-          expect(result.response.status).toBe(200);
+          expect.soft(result.response.status).toBe(200);
           return result.responseBody.tabcoins;
         });
 
@@ -375,7 +375,7 @@ describe('GET /api/v1/user', () => {
 
         const { response: postRewardUserResponse, responseBody: postRewardUser } = await userRequestBuilder.get();
 
-        expect(postRewardUserResponse.status).toBe(200);
+        expect.soft(postRewardUserResponse.status).toBe(200);
         expect(postRewardUser.tabcoins).toBe(defaultTestRewardValue);
         expect(postRewardUser.tabcash).toBe(0);
         expect(postRewardUser.updated_at).toBe(defaultUser.updated_at.toISOString());
@@ -387,7 +387,7 @@ describe('GET /api/v1/user', () => {
 
         const { response: preRewardUserResponse, responseBody: preRewardUser } = await userRequestBuilder.get();
 
-        expect(preRewardUserResponse.status).toBe(200);
+        expect.soft(preRewardUserResponse.status).toBe(200);
         expect(preRewardUser.tabcoins).toBe(0);
         expect(preRewardUser.tabcash).toBe(0);
         expect(preRewardUser.updated_at).toBe(defaultUser.updated_at.toISOString());
@@ -400,13 +400,13 @@ describe('GET /api/v1/user', () => {
         const simultaneousResults = await Promise.all([userRequestBuilder.get(), userRequestBuilder.get()]);
 
         simultaneousResults.forEach((result) => {
-          expect(result.response.status).toBe(200);
+          expect.soft(result.response.status).toBe(200);
           expect(result.responseBody.tabcoins).toBe(0);
         });
 
         const { response: postRewardUserResponse, responseBody: postRewardUser } = await userRequestBuilder.get();
 
-        expect(postRewardUserResponse.status).toBe(200);
+        expect.soft(postRewardUserResponse.status).toBe(200);
         expect(postRewardUser.tabcoins).toBe(0);
         expect(postRewardUser.tabcash).toBe(0);
         expect(postRewardUser.updated_at).toBe(defaultUser.updated_at.toISOString());
@@ -419,7 +419,7 @@ describe('GET /api/v1/user', () => {
 
         const { response: preRewardUserResponse, responseBody: preRewardUser } = await userRequestBuilder.get();
 
-        expect(preRewardUserResponse.status).toBe(200);
+        expect.soft(preRewardUserResponse.status).toBe(200);
         expect(preRewardUser.tabcoins).toBe(0);
         expect(preRewardUser.tabcash).toBe(0);
         expect(preRewardUser.updated_at).toBe(defaultUser.updated_at.toISOString());
@@ -432,13 +432,13 @@ describe('GET /api/v1/user', () => {
         const simultaneousResults = await Promise.all([userRequestBuilder.get(), userRequestBuilder.get()]);
 
         simultaneousResults.forEach((result) => {
-          expect(result.response.status).toBe(200);
+          expect.soft(result.response.status).toBe(200);
           expect(result.responseBody.tabcoins).toBe(0);
         });
 
         const { response: postRewardUserResponse, responseBody: postRewardUser } = await userRequestBuilder.get();
 
-        expect(postRewardUserResponse.status).toBe(200);
+        expect.soft(postRewardUserResponse.status).toBe(200);
         expect(postRewardUser.tabcoins).toBe(0);
         expect(postRewardUser.tabcash).toBe(0);
         expect(postRewardUser.updated_at).toBe(defaultUser.updated_at.toISOString());
@@ -457,7 +457,7 @@ describe('GET /api/v1/user', () => {
 
         const { response: preRewardUserResponse, responseBody: preRewardUser } = await userRequestBuilder.get();
 
-        expect(preRewardUserResponse.status).toBe(200);
+        expect.soft(preRewardUserResponse.status).toBe(200);
         expect(preRewardUser.tabcoins).toBe(1000);
         expect(preRewardUser.tabcash).toBe(0);
         expect(preRewardUser.updated_at).toBe(defaultUser.updated_at.toISOString());
@@ -470,13 +470,13 @@ describe('GET /api/v1/user', () => {
         const simultaneousResults = await Promise.all([userRequestBuilder.get(), userRequestBuilder.get()]);
 
         simultaneousResults.forEach((result) => {
-          expect(result.response.status).toBe(200);
+          expect.soft(result.response.status).toBe(200);
           expect(result.responseBody.tabcoins).toBe(1000);
         });
 
         const { response: postRewardUserResponse, responseBody: postRewardUser } = await userRequestBuilder.get();
 
-        expect(postRewardUserResponse.status).toBe(200);
+        expect.soft(postRewardUserResponse.status).toBe(200);
         expect(postRewardUser.tabcoins).toBe(1000);
         expect(postRewardUser.tabcash).toBe(0);
         expect(postRewardUser.updated_at).toBe(defaultUser.updated_at.toISOString());
@@ -512,7 +512,7 @@ describe('GET /api/v1/user', () => {
 
         const preRewardUser = await userRequestBuilder.get();
 
-        expect(preRewardUser.response.status).toBe(200);
+        expect.soft(preRewardUser.response.status).toBe(200);
         expect(preRewardUser.responseBody.tabcoins).toBe(-999);
         expect(preRewardUser.responseBody.tabcash).toBe(0);
 
@@ -523,7 +523,7 @@ describe('GET /api/v1/user', () => {
 
         const rewardedUser = await userRequestBuilder.get();
 
-        expect(rewardedUser.response.status).toBe(200);
+        expect.soft(rewardedUser.response.status).toBe(200);
         expect(rewardedUser.responseBody.tabcoins).toBe(defaultTestRewardValue - 999);
         expect(rewardedUser.responseBody.tabcash).toBe(0);
       });
@@ -558,7 +558,7 @@ describe('GET /api/v1/user', () => {
 
         const preRewardUser = await userRequestBuilder.get();
 
-        expect(preRewardUser.response.status).toBe(200);
+        expect.soft(preRewardUser.response.status).toBe(200);
         expect(preRewardUser.responseBody.tabcoins).toBe(999);
         expect(preRewardUser.responseBody.tabcash).toBe(0);
 
@@ -569,7 +569,7 @@ describe('GET /api/v1/user', () => {
 
         const notRewardedUser = await userRequestBuilder.get();
 
-        expect(notRewardedUser.response.status).toBe(200);
+        expect.soft(notRewardedUser.response.status).toBe(200);
         expect(notRewardedUser.responseBody.tabcoins).toBe(999);
         expect(notRewardedUser.responseBody.tabcash).toBe(0);
       });

--- a/tests/integration/api/v1/user/post.test.js
+++ b/tests/integration/api/v1/user/post.test.js
@@ -17,7 +17,7 @@ describe('POST /api/v1/user', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(405);
+      expect.soft(response.status).toBe(405);
 
       expect(responseBody).toStrictEqual({
         name: 'MethodNotAllowedError',

--- a/tests/integration/api/v1/users/[username]/delete.test.js
+++ b/tests/integration/api/v1/users/[username]/delete.test.js
@@ -27,7 +27,7 @@ describe('DELETE /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(403);
+      expect.soft(response.status).toBe(403);
 
       expect(responseBody).toStrictEqual({
         name: 'ForbiddenError',
@@ -66,7 +66,7 @@ describe('DELETE /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(403);
+      expect.soft(response.status).toBe(403);
 
       expect(responseBody).toStrictEqual({
         name: 'ForbiddenError',
@@ -104,7 +104,7 @@ describe('DELETE /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -144,7 +144,7 @@ describe('DELETE /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -366,7 +366,7 @@ describe('DELETE /api/v1/users/[username]', () => {
       );
       const firstUserRootContentCheck1Body = await firstUserRootContentCheck1.json();
 
-      expect(firstUserRootContentCheck1.status).toBe(200);
+      expect.soft(firstUserRootContentCheck1.status).toBe(200);
       expect(firstUserRootContentCheck1Body.status).toBe('published');
       expect(firstUserRootContentCheck1Body.tabcoins).toBe(2);
       expect(firstUserRootContentCheck1Body.children_deep_count).toBe(3);
@@ -377,7 +377,7 @@ describe('DELETE /api/v1/users/[username]', () => {
       );
       const firstUserChildCheck1Body = await firstUserChildCheck1.json();
 
-      expect(firstUserChildCheck1.status).toBe(200);
+      expect.soft(firstUserChildCheck1.status).toBe(200);
       expect(firstUserRootContentCheck1Body.status).toBe('published');
       expect(firstUserChildCheck1Body.tabcoins).toBe(-1);
       expect(firstUserChildCheck1Body.children_deep_count).toBe(0);
@@ -397,11 +397,11 @@ describe('DELETE /api/v1/users/[username]', () => {
       const secondUserChildContent1Check1Body = await secondUserChildContent1Check1.json();
       const secondUserChildContent2Check1Body = await secondUserChildContent2Check1.json();
 
-      expect(secondUserRootContentCheck1.status).toBe(200);
+      expect.soft(secondUserRootContentCheck1.status).toBe(200);
       expect(secondUserRootContentCheck1Body.status).toBe('published');
-      expect(secondUserChildContent1Check1.status).toBe(200);
+      expect.soft(secondUserChildContent1Check1.status).toBe(200);
       expect(secondUserChildContent1Check1Body.status).toBe('published');
-      expect(secondUserChildContent2Check1.status).toBe(200);
+      expect.soft(secondUserChildContent2Check1.status).toBe(200);
       expect(secondUserChildContent2Check1Body.status).toBe('published');
 
       // 11) NUKE THE SECOND USER
@@ -419,7 +419,7 @@ describe('DELETE /api/v1/users/[username]', () => {
 
       const nukeResponseBody = await nukeResponse.json();
 
-      expect(nukeResponse.status).toBe(200);
+      expect.soft(nukeResponse.status).toBe(200);
 
       expect(nukeResponseBody).toStrictEqual({
         id: secondUser.id,
@@ -452,12 +452,11 @@ describe('DELETE /api/v1/users/[username]', () => {
 
       const secondUserCheck2Body = await secondUserCheck2.json();
 
-      expect(secondUserCheck2.status).toBe(404);
-      expect(secondUserCheck2Body.status_code).toBe(404);
+      expect.soft(secondUserCheck2.status).toBe(404);
       expect(secondUserCheck2Body.name).toBe('NotFoundError');
       expect(secondUserCheck2Body.message).toBe('O "username" informado não foi encontrado no sistema.');
       expect(secondUserCheck2Body.action).toBe('Verifique se o "username" está digitado corretamente.');
-      expect(secondUserCheck2Body.status_code).toBe(404);
+      expect.soft(secondUserCheck2Body.status_code).toBe(404);
       expect(secondUserCheck2Body.error_location_code).toBe('MODEL:USER:FIND_ONE_BY_USERNAME:NOT_FOUND');
       expect(uuidVersion(secondUserCheck2Body.error_id)).toBe(4);
       expect(uuidVersion(secondUserCheck2Body.request_id)).toBe(4);
@@ -480,7 +479,7 @@ describe('DELETE /api/v1/users/[username]', () => {
       );
       const firstUserChildCheck2Body = await firstUserChildCheck2.json();
 
-      expect(firstUserChildCheck2.status).toBe(200);
+      expect.soft(firstUserChildCheck2.status).toBe(200);
       expect(firstUserRootContentCheck2Body.status).toBe('published');
       expect(firstUserChildCheck2Body.tabcoins).toBe(0);
       expect(firstUserChildCheck2Body.children_deep_count).toBe(0);
@@ -496,9 +495,9 @@ describe('DELETE /api/v1/users/[username]', () => {
         `${orchestrator.webserverUrl}/api/v1/contents/${secondUser.username}/${secondUserChildContent2Body.slug}`,
       );
 
-      expect(secondUserRootContentCheck2.status).toBe(404);
-      expect(secondUserChildContent1Check2.status).toBe(404);
-      expect(secondUserChildContent2Check2.status).toBe(404);
+      expect.soft(secondUserRootContentCheck2.status).toBe(404);
+      expect.soft(secondUserChildContent1Check2.status).toBe(404);
+      expect.soft(secondUserChildContent2Check2.status).toBe(404);
 
       // 17) TRY TO CREATE NEW CONTENT AS THE SECOND USER
       const secondUserRootContent2 = await fetch(`${orchestrator.webserverUrl}/api/v1/contents`, {
@@ -516,7 +515,7 @@ describe('DELETE /api/v1/users/[username]', () => {
 
       const secondUserRootContent2Body = await secondUserRootContent2.json();
 
-      expect(secondUserRootContent2.status).toBe(401);
+      expect.soft(secondUserRootContent2.status).toBe(401);
 
       expect(secondUserRootContent2Body).toStrictEqual({
         name: 'UnauthorizedError',
@@ -548,12 +547,11 @@ describe('DELETE /api/v1/users/[username]', () => {
 
       const nukeResponseBody = await nukeResponse.json();
 
-      expect(nukeResponse.status).toBe(404);
-      expect(nukeResponseBody.status_code).toBe(404);
+      expect.soft(nukeResponse.status).toBe(404);
       expect(nukeResponseBody.name).toBe('NotFoundError');
       expect(nukeResponseBody.message).toBe('O "username" informado não foi encontrado no sistema.');
       expect(nukeResponseBody.action).toBe('Verifique se o "username" está digitado corretamente.');
-      expect(nukeResponseBody.status_code).toBe(404);
+      expect.soft(nukeResponseBody.status_code).toBe(404);
       expect(nukeResponseBody.error_location_code).toBe('MODEL:USER:FIND_ONE_BY_USERNAME:NOT_FOUND');
       expect(uuidVersion(nukeResponseBody.error_id)).toBe(4);
       expect(uuidVersion(nukeResponseBody.request_id)).toBe(4);
@@ -584,7 +582,7 @@ describe('DELETE /api/v1/users/[username]', () => {
 
       const nuke1ResponseBody = await nuke1Response.json();
 
-      expect(nuke1Response.status).toBe(200);
+      expect.soft(nuke1Response.status).toBe(200);
 
       expect(nuke1ResponseBody).toStrictEqual({
         id: secondUser.id,
@@ -609,12 +607,11 @@ describe('DELETE /api/v1/users/[username]', () => {
 
       const nuke2ResponseBody = await nuke2Response.json();
 
-      expect(nuke2Response.status).toBe(404);
-      expect(nuke2ResponseBody.status_code).toBe(404);
+      expect.soft(nuke2Response.status).toBe(404);
       expect(nuke2ResponseBody.name).toBe('NotFoundError');
       expect(nuke2ResponseBody.message).toBe('O "username" informado não foi encontrado no sistema.');
       expect(nuke2ResponseBody.action).toBe('Verifique se o "username" está digitado corretamente.');
-      expect(nuke2ResponseBody.status_code).toBe(404);
+      expect.soft(nuke2ResponseBody.status_code).toBe(404);
       expect(nuke2ResponseBody.error_location_code).toBe('MODEL:USER:FIND_ONE_BY_USERNAME:NOT_FOUND');
       expect(uuidVersion(nuke2ResponseBody.error_id)).toBe(4);
       expect(uuidVersion(nuke2ResponseBody.request_id)).toBe(4);

--- a/tests/integration/api/v1/users/[username]/get.test.js
+++ b/tests/integration/api/v1/users/[username]/get.test.js
@@ -15,12 +15,11 @@ describe('GET /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(404);
-      expect(responseBody.status_code).toBe(404);
+      expect.soft(response.status).toBe(404);
       expect(responseBody.name).toBe('NotFoundError');
       expect(responseBody.message).toBe('O "username" informado não foi encontrado no sistema.');
       expect(responseBody.action).toBe('Verifique se o "username" está digitado corretamente.');
-      expect(responseBody.status_code).toBe(404);
+      expect.soft(responseBody.status_code).toBe(404);
       expect(responseBody.error_location_code).toBe('MODEL:USER:FIND_ONE_BY_USERNAME:NOT_FOUND');
       expect(uuidVersion(responseBody.error_id)).toBe(4);
       expect(uuidVersion(responseBody.request_id)).toBe(4);
@@ -32,8 +31,8 @@ describe('GET /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"username" deve conter no mínimo 3 caracteres.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -48,8 +47,8 @@ describe('GET /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"username" deve conter no máximo 30 caracteres.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -64,8 +63,8 @@ describe('GET /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"username" deve conter apenas caracteres alfanuméricos.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -84,7 +83,7 @@ describe('GET /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: userCreated.id,
@@ -113,7 +112,7 @@ describe('GET /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: userCreated.id,
@@ -142,12 +141,11 @@ describe('GET /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(404);
-      expect(responseBody.status_code).toBe(404);
+      expect.soft(response.status).toBe(404);
       expect(responseBody.name).toBe('NotFoundError');
       expect(responseBody.message).toBe('O "username" informado não foi encontrado no sistema.');
       expect(responseBody.action).toBe('Verifique se o "username" está digitado corretamente.');
-      expect(responseBody.status_code).toBe(404);
+      expect.soft(responseBody.status_code).toBe(404);
       expect(responseBody.error_location_code).toBe('MODEL:USER:FIND_ONE_BY_USERNAME:NOT_FOUND');
       expect(uuidVersion(responseBody.error_id)).toBe(4);
       expect(uuidVersion(responseBody.request_id)).toBe(4);

--- a/tests/integration/api/v1/users/[username]/patch.test.js
+++ b/tests/integration/api/v1/users/[username]/patch.test.js
@@ -30,11 +30,11 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(403);
+      expect.soft(response.status).toBe(403);
       expect(responseBody.name).toBe('ForbiddenError');
       expect(responseBody.message).toBe('Usuário não pode executar esta operação.');
       expect(responseBody.action).toBe('Verifique se este usuário possui a feature "update:user".');
-      expect(responseBody.status_code).toBe(403);
+      expect.soft(responseBody.status_code).toBe(403);
       expect(uuidVersion(responseBody.error_id)).toBe(4);
       expect(uuidVersion(responseBody.request_id)).toBe(4);
       expect(responseBody.error_location_code).toBe('MODEL:AUTHORIZATION:CAN_REQUEST:FEATURE_NOT_FOUND');
@@ -62,11 +62,11 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(403);
+      expect.soft(response.status).toBe(403);
       expect(responseBody.name).toBe('ForbiddenError');
       expect(responseBody.message).toBe('Você não possui permissão para atualizar outro usuário.');
       expect(responseBody.action).toBe('Verifique se você possui a feature "update:user:others".');
-      expect(responseBody.status_code).toBe(403);
+      expect.soft(responseBody.status_code).toBe(403);
       expect(uuidVersion(responseBody.error_id)).toBe(4);
       expect(uuidVersion(responseBody.request_id)).toBe(4);
       expect(responseBody.error_location_code).toBe('CONTROLLER:USERS:USERNAME:PATCH:USER_CANT_UPDATE_OTHER_USER');
@@ -97,8 +97,8 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(401);
-      expect(responseBody.status_code).toBe(401);
+      expect.soft(response.status).toBe(401);
+      expect.soft(responseBody.status_code).toBe(401);
       expect(responseBody.name).toBe('UnauthorizedError');
       expect(responseBody.message).toBe('Usuário não possui sessão ativa.');
       expect(responseBody.action).toBe('Verifique se este usuário está logado.');
@@ -135,7 +135,7 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: defaultUser.id,
@@ -180,7 +180,7 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: defaultUser.id,
@@ -223,7 +223,7 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual({
         id: defaultUser.id,
@@ -264,8 +264,8 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('O "username" informado já está sendo usado.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -297,8 +297,8 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('O "username" informado já está sendo usado.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -327,8 +327,8 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"username" deve ser do tipo String.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -357,8 +357,8 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"username" não pode estar em branco.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -387,8 +387,8 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"username" deve ser do tipo String.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -417,8 +417,8 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"username" deve conter apenas caracteres alfanuméricos.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -447,8 +447,8 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"username" deve conter no mínimo 3 caracteres.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -477,8 +477,8 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"username" deve conter no máximo 30 caracteres.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -507,8 +507,8 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('Este nome de usuário não está disponível para uso.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -532,8 +532,8 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"body" enviado deve ser do tipo Object.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -558,8 +558,8 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"body" enviado deve ser do tipo Object.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -586,8 +586,8 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('Objeto enviado deve ter no mínimo uma chave.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -799,7 +799,7 @@ describe('PATCH /api/v1/users/[username]', () => {
         email: defaultUser.email,
       });
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(responseBody).toStrictEqual({
         id: defaultUser.id,
         username: defaultUser.username,
@@ -836,7 +836,7 @@ describe('PATCH /api/v1/users/[username]', () => {
         }),
       });
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       const userInDatabase = await user.findOneById(defaultUser.id);
       expect(userInDatabase.notifications).toBe(false);
@@ -860,7 +860,7 @@ describe('PATCH /api/v1/users/[username]', () => {
       });
 
       const responseBody = await response.json();
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(responseBody).toStrictEqual({
         id: defaultUser.id,
         username: defaultUser.username,
@@ -901,8 +901,8 @@ describe('PATCH /api/v1/users/[username]', () => {
       });
 
       const responseBody = await response.json();
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"description" deve conter no máximo 5000 caracteres.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -930,8 +930,8 @@ describe('PATCH /api/v1/users/[username]', () => {
       });
 
       const responseBody = await response.json();
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"description" deve ser do tipo String.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -960,7 +960,7 @@ describe('PATCH /api/v1/users/[username]', () => {
         description: 'new description',
       });
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(responseBody).toStrictEqual({
         id: defaultUser.id,
         username: defaultUser.username,
@@ -1037,7 +1037,7 @@ describe('PATCH /api/v1/users/[username]', () => {
           }),
         });
 
-        expect(response.status).toBe(400);
+        expect.soft(response.status).toBe(400);
 
         const defaultUserInDatabase = await user.findOneById(defaultUser.id);
         const passwordsMatch = await password.compare('thisPasswordWillNotChange', defaultUserInDatabase.password);
@@ -1075,8 +1075,8 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('Objeto enviado deve ter no mínimo uma chave.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -1115,7 +1115,7 @@ describe('PATCH /api/v1/users/[username]', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(responseBody).toStrictEqual({
         id: secondUser.id,
         username: secondUser.username,

--- a/tests/integration/api/v1/users/get.test.js
+++ b/tests/integration/api/v1/users/get.test.js
@@ -31,7 +31,7 @@ describe('GET /api/v1/users', () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users`);
       const responseBody = await response.json();
 
-      expect(response.status).toBe(403);
+      expect.soft(response.status).toBe(403);
 
       expect(responseBody).toStrictEqual({
         name: 'ForbiddenError',
@@ -60,7 +60,7 @@ describe('GET /api/v1/users', () => {
       });
       const responseBody = await response.json();
 
-      expect(response.status).toBe(403);
+      expect.soft(response.status).toBe(403);
 
       expect(responseBody).toStrictEqual({
         name: 'ForbiddenError',
@@ -87,7 +87,7 @@ describe('GET /api/v1/users', () => {
       });
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
         message: '"per_page" deve possuir um valor máximo de 100.',
@@ -108,7 +108,7 @@ describe('GET /api/v1/users', () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents?page=first`);
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
+      expect.soft(response.status).toBe(400);
 
       expect(responseBody).toStrictEqual({
         name: 'ValidationError',
@@ -139,7 +139,7 @@ describe('GET /api/v1/users', () => {
       const responseLinkHeader = parseLinkHeader(response.headers.get('Link'));
       const responseTotalRowsHeader = response.headers.get('X-Pagination-Total-Rows');
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(responseTotalRowsHeader).toBe('2');
       expect(responseLinkHeader).toStrictEqual({
         first: {
@@ -220,7 +220,7 @@ describe('GET /api/v1/users', () => {
       });
       const responseBody = await response.json();
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
 
       expect(responseBody).toStrictEqual([
         {
@@ -267,7 +267,7 @@ describe('GET /api/v1/users', () => {
       const responseLinkHeader = parseLinkHeader(response.headers.get('Link'));
       const responseTotalRowsHeader = response.headers.get('X-Pagination-Total-Rows');
 
-      expect(response.status).toBe(200);
+      expect.soft(response.status).toBe(200);
       expect(responseTotalRowsHeader).toBe('2');
       expect(responseLinkHeader).toStrictEqual({
         first: {
@@ -373,7 +373,7 @@ describe('GET /api/v1/users', () => {
         const responseLinkHeader = parseLinkHeader(response.headers.get('Link'));
         const responseTotalRowsHeader = response.headers.get('X-Pagination-Total-Rows');
 
-        expect(response.status).toBe(200);
+        expect.soft(response.status).toBe(200);
         expect(responseTotalRowsHeader).toBe('60');
         expect(responseLinkHeader).toStrictEqual({
           first: {
@@ -410,7 +410,7 @@ describe('GET /api/v1/users', () => {
         const page2ResponseLinkHeader = parseLinkHeader(page2Response.headers.get('Link'));
         const page2ResponseTotalRowsHeader = page2Response.headers.get('X-Pagination-Total-Rows');
 
-        expect(page2Response.status).toBe(200);
+        expect.soft(page2Response.status).toBe(200);
         expect(page2ResponseTotalRowsHeader).toBe('60');
         expect(page2ResponseLinkHeader).toStrictEqual({
           first: {
@@ -463,7 +463,7 @@ describe('GET /api/v1/users', () => {
 
         const responseBody = await response.json();
 
-        expect(response.status).toBe(200);
+        expect.soft(response.status).toBe(200);
         expect(responseBody).toStrictEqual(getExpected());
       });
     });

--- a/tests/integration/api/v1/users/post.test.js
+++ b/tests/integration/api/v1/users/post.test.js
@@ -26,7 +26,7 @@ describe('POST /api/v1/users', () => {
       });
       const responseBody = await response.json();
 
-      expect(response.status).toBe(201);
+      expect.soft(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -68,7 +68,7 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(201);
+      expect.soft(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -104,7 +104,7 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(201);
+      expect.soft(response.status).toBe(201);
 
       expect(responseBody).toStrictEqual({
         id: responseBody.id,
@@ -158,8 +158,8 @@ describe('POST /api/v1/users', () => {
 
       const secondResponseBody = await secondResponse.json();
 
-      expect(secondResponse.status).toBe(400);
-      expect(secondResponseBody.status_code).toBe(400);
+      expect.soft(secondResponse.status).toBe(400);
+      expect.soft(secondResponseBody.status_code).toBe(400);
       expect(secondResponseBody.name).toBe('ValidationError');
       expect(secondResponseBody.message).toBe('O "username" informado já está sendo usado.');
       expect(secondResponseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -197,8 +197,8 @@ describe('POST /api/v1/users', () => {
 
       const secondResponseBody = await secondResponse.json();
 
-      expect(secondResponse.status).toBe(400);
-      expect(secondResponseBody.status_code).toBe(400);
+      expect.soft(secondResponse.status).toBe(400);
+      expect.soft(secondResponseBody.status_code).toBe(400);
       expect(secondResponseBody.name).toBe('ValidationError');
       expect(secondResponseBody.message).toBe('O "username" informado já está sendo usado.');
       expect(secondResponseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -222,8 +222,8 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"username" é um campo obrigatório.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -248,8 +248,8 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"username" deve ser do tipo String.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -274,8 +274,8 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"username" não pode estar em branco.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -300,8 +300,8 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"username" deve ser do tipo String.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -326,8 +326,8 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"username" deve conter apenas caracteres alfanuméricos.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -352,8 +352,8 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"username" deve conter no máximo 30 caracteres.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -378,8 +378,8 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('Este nome de usuário não está disponível para uso.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -507,8 +507,8 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"email" é um campo obrigatório.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -533,8 +533,8 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"email" não pode estar em branco.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -559,8 +559,8 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"email" deve ser do tipo String.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -585,8 +585,8 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"email" deve conter um email válido.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -610,8 +610,8 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"password" é um campo obrigatório.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -636,8 +636,8 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"password" não pode estar em branco.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -662,8 +662,8 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"password" deve ser do tipo String.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -688,8 +688,8 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"password" deve conter no mínimo 8 caracteres.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -714,8 +714,8 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"password" deve conter no máximo 72 caracteres.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -732,8 +732,8 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"body" enviado deve ser do tipo Object.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');
@@ -751,8 +751,8 @@ describe('POST /api/v1/users', () => {
 
       const responseBody = await response.json();
 
-      expect(response.status).toBe(400);
-      expect(responseBody.status_code).toBe(400);
+      expect.soft(response.status).toBe(400);
+      expect.soft(responseBody.status_code).toBe(400);
       expect(responseBody.name).toBe('ValidationError');
       expect(responseBody.message).toBe('"body" enviado deve ser do tipo Object.');
       expect(responseBody.action).toBe('Ajuste os dados enviados e tente novamente.');

--- a/tests/integration/infra/under-maintenance.test.js
+++ b/tests/integration/infra/under-maintenance.test.js
@@ -14,7 +14,7 @@ describe('Under maintenance route', () => {
       });
       const responseBody = await response.json();
 
-      expect(response.status).toBe(503);
+      expect.soft(response.status).toBe(503);
       expect(responseBody.message).toBe('Funcionalidade em manutenção.');
       expect(responseBody.action).toBe('Tente novamente mais tarde.');
       expect(responseBody.error_location_code).toBe('INFRA:UNDER_MAINTENANCE:CHECK:IS_UNDER_MAINTENANCE');
@@ -25,7 +25,7 @@ describe('Under maintenance route', () => {
         method: 'POST',
       });
 
-      expect(response.status).toBe(404);
+      expect.soft(response.status).toBe(404);
       expect(response.statusText).toBe('Not Found');
       expect(response.ok).toBe(false);
     });
@@ -35,7 +35,7 @@ describe('Under maintenance route', () => {
         method: 'GET',
       });
 
-      expect(response.status).toBe(404);
+      expect.soft(response.status).toBe(404);
       expect(response.statusText).toBe('Not Found');
       expect(response.ok).toBe(false);
     });

--- a/tests/unit/interface/components/Pagination/index.test.js
+++ b/tests/unit/interface/components/Pagination/index.test.js
@@ -1,6 +1,5 @@
 import { render } from '@testing-library/react';
 
-import webserver from 'infra/webserver';
 import Pagination from 'pages/interface/components/Pagination';
 
 describe('Pagination', () => {
@@ -13,18 +12,18 @@ describe('Pagination', () => {
   it('should not render a link to previous page if there is no previous page', () => {
     const { getByText } = render(<Pagination basePath="/pagina" nextPage="2" />);
     expect(getByText('Anterior')).not.toHaveProperty('href');
-    expect(getByText('Próximo')).toHaveProperty('href', `${webserver.host}/pagina/2`);
+    expect(getByText('Próximo')).toHaveProperty('href', 'http://localhost:3000/pagina/2');
   });
 
   it('should not render a link to next page if there is no next page', () => {
     const { getByText } = render(<Pagination basePath="/conteudos" previousPage="7" />);
-    expect(getByText('Anterior')).toHaveProperty('href', `${webserver.host}/conteudos/7`);
+    expect(getByText('Anterior')).toHaveProperty('href', 'http://localhost:3000/conteudos/7');
     expect(getByText('Próximo')).not.toHaveProperty('href');
   });
 
   it('should render a link to previous and next pages', () => {
     const { getByText } = render(<Pagination basePath="/recentes/comentarios" previousPage="1" nextPage="3" />);
-    expect(getByText('Anterior')).toHaveProperty('href', `${webserver.host}/recentes/comentarios/1`);
-    expect(getByText('Próximo')).toHaveProperty('href', `${webserver.host}/recentes/comentarios/3`);
+    expect(getByText('Anterior')).toHaveProperty('href', 'http://localhost:3000/recentes/comentarios/1');
+    expect(getByText('Próximo')).toHaveProperty('href', 'http://localhost:3000/recentes/comentarios/3');
   });
 });


### PR DESCRIPTION
## Mudanças realizadas

Usa o padrão recomendado pelo Vitest para criar o mock de `database` nos testes de `reward`.

Nos testes de unidade do componente `Pagination`, deixa de usar a variável `webserver.host` e utiliza sempre `localhost:3000`. Os componentes isoladamente não lêem as variáveis de ambientes, mas `webserver.host` muda se usarmos valores diferentes em `NEXT_PUBLIC_WEBSERVER_HOST` e/ou `NEXT_PUBLIC_WEBSERVER_PORT`, o que faria os testes falharem.

## Tipo de mudança

- [x] Refatoração e correção de bug nos testes

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
