### PR TITLE
Exibe erro de descrição ao atualizar pelo perfil do usuário

### DIFF
--- a/pages/[username]/index.public.js
+++ b/pages/[username]/index.public.js
@@ -385,13 +385,17 @@ function DescriptionForm({
           Descrição
         </FormControl.Label>
         <Editor
-          isValid={errorObject?.key === 'body'}
+          isValid={errorObject?.key === 'description'}
           value={description}
           onChange={handleDescriptionChange}
           onKeyDown={handleKeyDown}
           compact
           clobberPrefix={`${user.username}-content-`}
         />
+
+        {errorObject?.key === 'description' && (
+          <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
+        )}
       </FormControl>
 
       {globalMessageObject?.position === 'description' && (


### PR DESCRIPTION
## Mudanças realizadas

Quando ocorre um erro na atualização da descrição por causa de alguma validação do campo, esse erro não era exibido para o usuário. Percebi isso ao tentar atualizar para uma descrição com mais de 5.000 caracteres.

![Erro no campo de descrição ao atualizá-la pela página de perfil.](https://github.com/user-attachments/assets/0f64a766-cc89-427f-b8ac-5225a002148c)

## Tipo de mudança

 - [x] Correção de bug

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [ ] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
