### PR TITLE
Carrega anúncio após carregar a página do conteúdo para não indexá-lo

### DIFF
--- a/pages/interface/components/AdBanner/index.js
+++ b/pages/interface/components/AdBanner/index.js
@@ -1,23 +1,32 @@
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
-import { Box, Link, Text, Tooltip } from '@/TabNewsUI';
+import { Box, Link, SkeletonLoader, Text, Tooltip } from '@/TabNewsUI';
 import { LinkExternalIcon } from '@/TabNewsUI/icons';
 import { getDomain, isExternalLink, isTrustedDomain } from 'pages/interface';
 
-export default function AdBanner({ ad: newAd, ...props }) {
+export default function AdBanner({ ad: newAd, isLoading, ...props }) {
   const [ad, setAd] = useState(newAd);
   const router = useRouter();
+
+  useEffect(() => {
+    if (newAd && !ad) {
+      setAd(newAd);
+    }
+  }, [router.asPath, newAd, ad]);
+
+  if (isLoading || (newAd && !ad)) {
+    return <AdBannerLoading />;
+  }
+
+  if (!ad) {
+    return null;
+  }
 
   const link = ad.source_url || `/${ad.owner_username}/${ad.slug}`;
   const isAdToExternalLink = isExternalLink(link);
   const domain = isAdToExternalLink ? `(${getDomain(link)})` : '';
   const title = ad.title.length > 70 ? ad.title.substring(0, 67).trim().concat('...') : ad.title;
-
-  useEffect(() => {
-    setAd(newAd);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [router.asPath]);
 
   return (
     <Box {...props} as="aside" sx={{ display: 'grid', ...props.sx }}>
@@ -57,5 +66,21 @@ export default function AdBanner({ ad: newAd, ...props }) {
         </Tooltip>
       </Text>
     </Box>
+  );
+}
+
+function AdBannerLoading() {
+  const spaceBetweenRows = 8;
+  const titleHeight = 16;
+  const titleY = 2;
+
+  return (
+    <SkeletonLoader
+      title="Carregando publicação patrocinada..."
+      style={{ height: '2.3rem', width: '100%' }}
+      uniqueKey="ad-loading">
+      <rect x="28" y={titleY} rx="5" ry="5" width="600" height={titleHeight} />
+      <rect x="28" y={titleY + spaceBetweenRows + titleHeight} rx="5" ry="5" width="180" height="12" />
+    </SkeletonLoader>
   );
 }


### PR DESCRIPTION
## Mudanças realizadas

Busca publicação patrocinada pela API ao invés de `getStaticProps`, conforme comentado em https://github.com/filipedeschamps/tabnews.com.br/issues/1491#issuecomment-2226440549 e https://github.com/filipedeschamps/tabnews.com.br/issues/1491#issuecomment-2293638640, para não indexar o título e fonte da publicação patrocinada em mecanismos de busca. Não tenho certeza se isso irá funcionar porque quase não encontrei conteúdos sobre como não indexar anúncios ou textos de uma paǵina.

Optei por fazer essa alteração inicialmente apenas nas páginas de conteúdos, porque isso já diminuirá bastante a indexação de títulos de publicações patrocinadas, e também para acompanharmos os efeitos colaterais dessa alteração, seja em SEO, seja na Vercel.

![Carregamento do anúncio dentro de uma publicação, skeleton loading](https://github.com/user-attachments/assets/58fc50a5-dc2a-46e8-8ddc-705b3c2baea6)

Um problema é que em telas pequenas a barra de carregamento fica cortada, sem o arredondamento. Quando implementarmos esse carregamento nas outras páginas, pensei em exibir duas linhas para o título em telas pequenas (e.g. < 470px), porque dentre as publicações patrocinadas que temos hoje, está mais comum ocuparem 2 ou 3 linhas do que apenas 1, então o deslocamento do layout seria menor. Por ora, deixei mais simples, já que nos conteúdos o anúncio não é exibido logo no topo da tela.

Se acharem que faz sentido, posso adicionar o `<meta name="robots" content="noindex">` num outro commit em páginas de publicações patrocinadas, e talvez nas páginas "Classificados". 

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [ ] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
