### PR TITLE
Deixa mais claro qual é o nome da tabela em que são armazenadas as `migrations`

### DIFF
--- a/infra/migrator.js
+++ b/infra/migrator.js
@@ -7,7 +7,7 @@ import logger from 'infra/logger.js';
 const defaultConfigurations = {
   dir: join(resolve('.'), 'infra', 'migrations'),
   direction: 'up',
-  migrationsTable: 'migrations',
+  migrationsTable: 'pgmigrations',
   verbose: true,
   log: (log) => {
     logger.info({
@@ -24,7 +24,6 @@ async function listPendingMigrations() {
       ...defaultConfigurations,
       dbClient: databaseClient,
       dryRun: true,
-      migrationsTable: 'pgmigrations',
     });
 
     return pendingMigrations;
@@ -41,7 +40,6 @@ async function runPendingMigrations() {
       ...defaultConfigurations,
       dbClient: databaseClient,
       dryRun: false,
-      migrationsTable: 'pgmigrations',
     });
 
     return migratedMigrations;

--- a/infra/under-maintenance.js
+++ b/infra/under-maintenance.js
@@ -1,6 +1,5 @@
+import logger from 'infra/logger';
 import webserver from 'infra/webserver';
-
-import logger from './logger';
 
 let underMaintenance;
 


### PR DESCRIPTION
Antes era criada a `defaultConfigurations` passando `migrationsTable: 'migrations'` e depois isso era sobrescrito por `pgmigrations` na hora de utilizar as configurações.

## Mudanças realizadas

- Agora já é definida corretamente `migrationsTable: 'pgmigrations'` em  `defaultConfigurations`.
- Aproveitei o PR para fazer uma simples mudança na importação de `logger` seguindo o padrão `infra/logger` ao invés de `./logger`.

## Tipo de mudança

- [x] Refatoração

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Os testes antigos estão passando localmente.
