### PR TITLE
Adiciona `noindex` às páginas de anúncios e Classificados

### DIFF
--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -380,6 +380,7 @@ export const getStaticProps = getStaticPropsRevalidate(async (context) => {
     canonical: secureContentFound.parent_id
       ? undefined
       : `${webserver.host}/${secureContentFound.owner_username}/${secureContentFound.slug}`,
+    noIndex: secureContentFound.type === 'ad',
   };
 
   let secureRootContentFound = null;

--- a/pages/[username]/classificados/[page]/index.public.js
+++ b/pages/[username]/classificados/[page]/index.public.js
@@ -16,7 +16,8 @@ export default function RootContent({ contentListFound, pagination, username }) 
   const isAuthenticatedUser = user && user.username === username;
 
   return (
-    <DefaultLayout metadata={{ title: `Classificados · Página ${pagination.currentPage} · ${username}` }}>
+    <DefaultLayout
+      metadata={{ title: `Classificados · Página ${pagination.currentPage} · ${username}`, noIndex: true }}>
       <UserHeader username={username} adContentCount={pagination.totalRows} />
 
       <ContentList

--- a/pages/recentes/classificados/[page]/index.public.js
+++ b/pages/recentes/classificados/[page]/index.public.js
@@ -13,6 +13,7 @@ export default function ContentsPage({ contentListFound, pagination }) {
       metadata={{
         title: `Página ${pagination.currentPage} · Classificados Recentes`,
         description: 'Classificados do TabNews ordenados pelos mais recentes.',
+        noIndex: true,
       }}>
       <RecentTabNav />
       <ContentList


### PR DESCRIPTION
## Mudanças realizadas

Seguindo o que foi comentado em https://github.com/filipedeschamps/tabnews.com.br/pull/1786, adicionei `noindex` às páginas de publicações patrocinadas e também às de Classificados.

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [ ] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
