### PR TITLE
Considera `username` único no banco de dados ignorando capitalização

### DIFF
--- a/infra/migrations/1725403837939_alter-table-users-username-lower-index.js
+++ b/infra/migrations/1725403837939_alter-table-users-username-lower-index.js
@@ -1,0 +1,18 @@
+exports.up = (pgm) => {
+  pgm.dropConstraint('users', 'users_username_key');
+
+  pgm.createIndex('users', 'LOWER(username)', {
+    unique: true,
+    name: 'users_username_lower_idx',
+  });
+};
+
+exports.down = (pgm) => {
+  pgm.dropIndex('users', 'LOWER(username)', {
+    name: 'users_username_lower_idx',
+  });
+
+  pgm.addConstraint('users', 'users_username_key', {
+    unique: ['username'],
+  });
+};


### PR DESCRIPTION
## Mudanças realizadas

Conforme discutido no PR #1790, essa alteração é uma garantia extra de que usuários duplicados não serão inseridos no banco de dados.

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [ ] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
