### PR TITLE
Melhora o desempenho da RegEx que evita a criação de conteúdos invisíveis

### DIFF
--- a/models/remove-markdown.js
+++ b/models/remove-markdown.js
@@ -100,7 +100,7 @@ export default function removeMarkdown(md, options = {}) {
 
     if (options.trim) {
       output = output.replace(
-        /^(\s|\p{C}|\u2800|\u034f|\u115f|\u1160|\u17b4|\u17b5|\u3164|\uffa0)+|(\s|\p{C}|\u2800|\u034f|\u115f|\u1160|\u17b4|\u17b5|\u3164|\uffa0)+$|\u0000/gsu,
+        /^[\s\p{C}\u034f\u17b4\u17b5\u2800\u115f\u1160\u3164\uffa0]+|[\s\p{C}\u034f\u17b4\u17b5\u2800\u115f\u1160\u3164\uffa0]+$|\u0000/gsu,
         '',
       );
     }

--- a/models/validator.js
+++ b/models/validator.js
@@ -159,7 +159,7 @@ const schemas = {
   description: function () {
     return Joi.object({
       description: Joi.string()
-        .replace(/(\s|\p{C}|\u2800|\u034f|\u115f|\u1160|\u17b4|\u17b5|\u3164|\uffa0)+$|\u0000/gsu, '')
+        .replace(/[\s\p{C}\u034f\u17b4\u17b5\u2800\u115f\u1160\u3164\uffa0]+$|\u0000/gsu, '')
         .max(5000)
         .allow('')
         .when('$required.description', { is: 'required', then: Joi.required(), otherwise: Joi.optional() }),
@@ -231,7 +231,7 @@ const schemas = {
     return Joi.object({
       title: Joi.string()
         .replace(
-          /^(\s|\p{C}|\u2800|\u034f|\u115f|\u1160|\u17b4|\u17b5|\u3164|\uffa0)+|(\s|\p{C}|\u2800|\u034f|\u115f|\u1160|\u17b4|\u17b5|\u3164|\uffa0)+$|\u0000/gu,
+          /^[\s\p{C}\u034f\u17b4\u17b5\u2800\u115f\u1160\u3164\uffa0]+|[\s\p{C}\u034f\u17b4\u17b5\u2800\u115f\u1160\u3164\uffa0]+$|\u0000/gu,
           '',
         )
         .min(1)
@@ -243,8 +243,8 @@ const schemas = {
   body: function () {
     return Joi.object({
       body: Joi.string()
-        .pattern(/^(\s|\p{C}|\u2800|\u034f|\u115f|\u1160|\u17b4|\u17b5|\u3164|\uffa0).*$/su, { invert: true })
-        .replace(/(\s|\p{C}|\u2800|\u034f|\u115f|\u1160|\u17b4|\u17b5|\u3164|\uffa0)+$|\u0000/gsu, '')
+        .pattern(/^[\s\p{C}\u034f\u17b4\u17b5\u2800\u115f\u1160\u3164\uffa0].*$/su, { invert: true })
+        .replace(/[\s\p{C}\u034f\u17b4\u17b5\u2800\u115f\u1160\u3164\uffa0]+$|\u0000/gsu, '')
         .min(1)
         .max(20000)
         .custom(withoutMarkdown, 'check if is empty without markdown')


### PR DESCRIPTION
## Mudanças realizadas

Substituído o agrupamento com operador `|` entre parênteses `(\s|\p{C}|...)` por colchetes `[\s\p{C}...]` para representar o conjunto de caracteres que devem ser removidos do início e final das strings.

Obs. Troquei a ordem de alguns caracteres porque, com a remoção do operador `|`, algumas sequências de caracteres entravam na regra ESLint [no-misleading-character-class](https://eslint.org/docs/latest/rules/no-misleading-character-class).

Resolve https://github.com/filipedeschamps/tabnews.com.br/issues/1141#issuecomment-2507407551

## Tipo de mudança

- [x] Correção de bug

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Os testes antigos estão passando localmente.
