### PR TITLE
Usa a biblioteca `resend` quando a variável `EMAIL_USER` tem valor `resend`

### DIFF
--- a/models/activation.js
+++ b/models/activation.js
@@ -31,10 +31,7 @@ async function sendEmailToUser(user, tokenId) {
   });
 
   await email.send({
-    from: {
-      name: 'TabNews',
-      address: 'contato@tabnews.com.br',
-    },
+    from: 'TabNews <contato@tabnews.com.br>',
     to: user.email,
     subject: 'Ative seu cadastro no TabNews',
     html,

--- a/models/email-confirmation.js
+++ b/models/email-confirmation.js
@@ -38,10 +38,7 @@ async function sendEmailToUser(user, newEmail, tokenId) {
   });
 
   await email.send({
-    from: {
-      name: 'TabNews',
-      address: 'contato@tabnews.com.br',
-    },
+    from: 'TabNews <contato@tabnews.com.br>',
     to: newEmail,
     subject: 'Confirme seu novo email',
     html,

--- a/models/notification.js
+++ b/models/notification.js
@@ -91,10 +91,7 @@ async function sendUserDisabled({ eventId, user }) {
 
   await email.send({
     to: user.email,
-    from: {
-      name: 'TabNews',
-      address: 'contato@tabnews.com.br',
-    },
+    from: 'TabNews <contato@tabnews.com.br>',
     subject: 'Sua conta foi desativada',
     html,
     text,
@@ -116,10 +113,7 @@ async function sendContentDeletedToUser({ contents, eventId, userId }) {
 
   await email.send({
     to: userToNotify.email,
-    from: {
-      name: 'TabNews',
-      address: 'contato@tabnews.com.br',
-    },
+    from: 'TabNews <contato@tabnews.com.br>',
     subject: subject,
     html,
     text,

--- a/models/recovery.js
+++ b/models/recovery.js
@@ -55,10 +55,7 @@ async function sendEmailToUser(user, tokenId) {
   });
 
   await email.send({
-    from: {
-      name: 'TabNews',
-      address: 'contato@tabnews.com.br',
-    },
+    from: 'TabNews <contato@tabnews.com.br>',
     to: user.email,
     subject: 'Recuperação de Senha',
     html,

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "recharts": "2.12.7",
         "rehype-external-links": "3.0.0",
         "rehype-slug": "6.0.0",
+        "resend": "4.0.1",
         "satori": "0.10.13",
         "slug": "9.1.0",
         "snakeize": "0.1.0",
@@ -15495,6 +15496,36 @@
       "dev": true,
       "optional": true,
       "peer": true
+    },
+    "node_modules/resend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-4.0.1.tgz",
+      "integrity": "sha512-EkCRfzKw9JX7N75L+0BC8oXohDBLhlhl4w7AgrkEW2TAsOMBsVcbQHPe8cRWP6Ea7KDhD158TsNjbCBcohed5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-email/render": "1.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/resend/node_modules/@react-email/render": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@react-email/render/-/render-1.0.1.tgz",
+      "integrity": "sha512-W3gTrcmLOVYnG80QuUp22ReIT/xfLsVJ+n7ghSlG2BITB8evNABn1AO2rGQoXuK84zKtDAlxCdm3hRyIpZdGSA==",
+      "license": "MIT",
+      "dependencies": {
+        "html-to-text": "9.0.5",
+        "js-beautify": "^1.14.11",
+        "react-promise-suspense": "0.3.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/resolve": {
       "version": "1.22.8",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "recharts": "2.12.7",
     "rehype-external-links": "3.0.0",
     "rehype-slug": "6.0.0",
+    "resend": "4.0.1",
     "satori": "0.10.13",
     "slug": "9.1.0",
     "snakeize": "0.1.0",


### PR DESCRIPTION
O TabNews realiza os envios de email transacionais através dos serviços Resend (principal) e Mailgun (contingência). 

Infelizmente o Resend vem apresentando alguns problemas bem esporádicos de lentidão ou perda de envios.

Apesar de ser uma parcela bem pequena dos envios que apresentam algum problema, queremos descobrir se é possível eliminar ou reduzir ainda mais essa ocorrência.

## Mudanças realizadas

Até agora a gente enviava os email usando apenas a biblioteca `nodemailer` (via `SMTP`), independentemente do serviço.

Agora adicionamos a biblioteca própria do Resend para quando os envios forem com esse serviço. Com isso, os envios com o Resend passam a ser via `HTTP`, e poderemos analisar se existe alguma alteração no comportamento pela mudança no protocolo.

A biblioteca `resend` não aceita os endereços em formato de objeto, então isso exigiu converter o remetente para ser compatível com as duas bibliotecas:

### Antes
```
{
  name: 'TabNews',
  address: 'contato@tabnews.com.br',
}
```

### Depois

 `'TabNews <contato@tabnews.com.br>'`

