### PR TITLE
Define o remetente de email sempre no formato string

### DIFF
--- a/models/notification.js
+++ b/models/notification.js
@@ -52,10 +52,7 @@ async function sendReplyEmailToParentUser(createdContent) {
 
     await email.send({
       to: parentContentUser.email,
-      from: {
-        name: 'TabNews',
-        address: 'contato@tabnews.com.br',
-      },
+      from: 'TabNews <contato@tabnews.com.br>',
       subject: subject,
       html,
       text,


### PR DESCRIPTION
No PR #1828, o formato do remetente foi alterado de objeto para string para ser compatível com o SDK do Resend. Mas faltou realizar a mudança dentro da função `sendReplyEmailToParentUser`, e por isso as notificações sobre novos comentários estavam sendo enviados apenas na segunda tentativa, pela contingência (Mailgun).

## Mudanças realizadas

Define o `from` como `string` na `sendReplyEmailToParentUser`.

## Tipo de mudança

- [x] Correção de bug

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Os testes antigos estão passando localmente.
