### PR TITLE
[Umami] Testa compartilhamento de dados estatísticos junto dos conteúdos

### DIFF
--- a/models/analytics.js
+++ b/models/analytics.js
@@ -1,6 +1,7 @@
 import crypto from 'node:crypto';
 
 import database from 'infra/database.js';
+import umami from 'models/umami';
 
 async function getChildContentsPublished() {
   const results = await database.query(`
@@ -257,9 +258,14 @@ async function getVotesTaken() {
   });
 }
 
+async function getStatsByPath(path) {
+  return await umami.getStatsByPath(path);
+}
+
 export default Object.freeze({
   getChildContentsPublished,
   getRootContentsPublished,
+  getStatsByPath,
   getUsersCreated,
   getVotesGraph,
   getVotesTaken,

--- a/models/umami.js
+++ b/models/umami.js
@@ -1,0 +1,109 @@
+import snakeize from 'snakeize';
+
+import { ServiceError } from 'errors';
+import logger from 'infra/logger';
+
+function createUmamiService() {
+  const apiEndpoint = process.env.UMAMI_API_ENDPOINT || `${process.env.UMAMI_ENDPOINT}/api`;
+  const websiteId = process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID;
+  const username = process.env.UMAMI_API_CLIENT_USERNAME || 'admin';
+  const password = process.env.UMAMI_API_CLIENT_PASSWORD || 'umami';
+  const apiKeys = [];
+
+  while (process.env[`UMAMI_API_KEY_${apiKeys.length + 1}`]) {
+    apiKeys.push(process.env[`UMAMI_API_KEY_${apiKeys.length + 1}`]);
+  }
+
+  apiKeys.sort(() => Math.random() - 0.5);
+
+  const cache = {
+    currentKeyIndex: 0,
+  };
+
+  cache.statsUrl = new URL(`${apiEndpoint}/websites/${websiteId}/stats`);
+  cache.statsUrl.searchParams.append('startAt', 0);
+  cache.statsUrl.searchParams.append('endAt', 8000000000000); // 2223-07-06T14:13:20.000Z
+
+  async function getStatsByPath(path, attempt = 1) {
+    const url = new URL(cache.statsUrl);
+    url.searchParams.append('url', path);
+
+    let response;
+
+    try {
+      response = await fetch(url, {
+        headers: await getHeaders(),
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+
+        return {
+          pageviews: data.pageviews?.value,
+          visitors: data.visitors?.value,
+          visits: data.visits?.value,
+        };
+      }
+
+      if (response.status === 429) {
+        throw new Error('Umami API rate limit exceeded');
+      }
+
+      throw new Error(`Failed to fetch data from Umami API: ${response.statusText}`);
+    } catch (error) {
+      const errorObject = new ServiceError({
+        message: error.message || 'Failed to fetch data from Umami API',
+        statusCode: response?.status,
+        errorLocationCode: 'INFRA:ANALYTICS:GET_STATS_BY_PATH',
+      });
+
+      logger.error(snakeize(errorObject));
+
+      if (attempt < apiKeys.length) {
+        return await getStatsByPath(path, attempt + 1);
+      }
+    }
+  }
+
+  async function getHeaders() {
+    if (apiKeys.length) {
+      const apiKey = apiKeys[cache.currentKeyIndex];
+      cache.currentKeyIndex = (cache.currentKeyIndex + 1) % apiKeys.length;
+
+      return {
+        'x-umami-api-key': apiKey,
+      };
+    }
+
+    return {
+      Authorization: await getAuthorization(),
+    };
+  }
+
+  async function getAuthorization() {
+    if (!cache.authorization) {
+      const token = await fetch(`${apiEndpoint}/auth/login`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          username,
+          password,
+        }),
+      })
+        .then((res) => res.json())
+        .then((data) => data.token);
+
+      cache.authorization = `Bearer ${token}`;
+    }
+
+    return cache.authorization;
+  }
+
+  return Object.freeze({
+    getStatsByPath,
+  });
+}
+
+export default createUmamiService();

--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -6,6 +6,7 @@ import { AdBanner, Box, Button, Confetti, Content, DefaultLayout, Link, TabCoinB
 import { CommentDiscussionIcon, CommentIcon, FoldIcon, UnfoldIcon } from '@/TabNewsUI/icons';
 import { NotFoundError, ValidationError } from 'errors';
 import webserver from 'infra/webserver.js';
+import analytics from 'models/analytics';
 import authorization from 'models/authorization.js';
 import content from 'models/content.js';
 import removeMarkdown from 'models/remove-markdown.js';
@@ -324,6 +325,26 @@ export async function getStaticPaths() {
 }
 
 export const getStaticProps = getStaticPropsRevalidate(async (context) => {
+  const [content, stats = {}] = await Promise.all([
+    getContentData(context),
+    analytics.getStatsByPath(`/${context.params.username}/${context.params.slug}`),
+  ]);
+
+  if (content.notFound) {
+    return content;
+  }
+
+  return {
+    props: {
+      stats,
+      ...content.props,
+    },
+    revalidate: 1,
+    swr: { revalidateOnFocus: false },
+  };
+});
+
+async function getContentData(context) {
   const userTryingToGet = user.createAnonymous();
 
   let contentTreeFound;
@@ -428,7 +449,5 @@ export const getStaticProps = getStaticPropsRevalidate(async (context) => {
       parentContentFound: JSON.parse(JSON.stringify(secureParentContentFound)),
       contentMetadata: JSON.parse(JSON.stringify(contentMetadata)),
     },
-    revalidate: 1,
-    swr: { revalidateOnFocus: false },
   };
-});
+}

--- a/pages/interface/components/Analytics/index.js
+++ b/pages/interface/components/Analytics/index.js
@@ -8,7 +8,6 @@ export default function Analytics() {
         id="umami-script"
         src="/analytics.js"
         data-website-id={process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID}
-        data-path-matcher="^(/login|/cadastro|/publicar)$"
         data-exclude-search="true"
         strategy="lazyOnload"
       />


### PR DESCRIPTION
## Mudanças realizadas

O primeiro commit habilita a Umami para coletar dados de todas as páginas do TabNews. No teste inicial estávamos coletando dados apenas de algumas páginas. Agora vamos verificar o comportamento com nossa demanda total, e assim poder decidir sobre a substituição completa do Analytics da Vercel pela Umami Cloud.

O segundo commit trata do primeiro teste sobre a capacidade de compartilhar os dados estatísticos dos conteúdos. As estatísticas de cada conteúdo são buscadas no `getStaticProps` e já estão sendo enviadas para o client, mas o objetivo inicialmente é testar a integração com a API da Umami, então a interface ainda não foi preparada para apresentar esses dados.

As principais perguntas que precisamos responder são se os limites da API dão conta da nossa demanda e se a performance da API não irá prejudicar a performance da geração das páginas de conteúdos.

## Tipo de mudança

- [x] Nova funcionalidade experimental
