### PR TITLE
[Umami] Remove a busca de dados estatísticos de cada conteúdo durante a geração das páginas estáticas

### DIFF
--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -6,7 +6,6 @@ import { AdBanner, Box, Button, Confetti, Content, DefaultLayout, Link, TabCoinB
 import { CommentDiscussionIcon, CommentIcon, FoldIcon, UnfoldIcon } from '@/TabNewsUI/icons';
 import { NotFoundError, ValidationError } from 'errors';
 import webserver from 'infra/webserver.js';
-import analytics from 'models/analytics';
 import authorization from 'models/authorization.js';
 import content from 'models/content.js';
 import removeMarkdown from 'models/remove-markdown.js';
@@ -325,26 +324,6 @@ export async function getStaticPaths() {
 }
 
 export const getStaticProps = getStaticPropsRevalidate(async (context) => {
-  const [content, stats = {}] = await Promise.all([
-    getContentData(context),
-    analytics.getStatsByPath(`/${context.params.username}/${context.params.slug}`),
-  ]);
-
-  if (content.notFound) {
-    return content;
-  }
-
-  return {
-    props: {
-      stats,
-      ...content.props,
-    },
-    revalidate: 1,
-    swr: { revalidateOnFocus: false },
-  };
-});
-
-async function getContentData(context) {
   const userTryingToGet = user.createAnonymous();
 
   let contentTreeFound;
@@ -449,5 +428,7 @@ async function getContentData(context) {
       parentContentFound: JSON.parse(JSON.stringify(secureParentContentFound)),
       contentMetadata: JSON.parse(JSON.stringify(contentMetadata)),
     },
+    revalidate: 1,
+    swr: { revalidateOnFocus: false },
   };
-}
+});


### PR DESCRIPTION
Com isso, encerra o experimento sobre a Umami Cloud iniciado no PR #1832.

Considero que obtivemos sucesso ao conseguir as seguintes respostas:

1. Podemos substituir a Vercel Analytics, pois a Umami nos traz mais dados e funcionalidades com um menor custo. ✅
2. Os limites da API deram conta da nossa demanda normal. Tivemos raros erros com visitas de Bots.  ✅
3. A performance da API impede que os dados sejam buscados durante a geração das páginas estáticas ❌

Sobre a performance, vejam o impacto na duração da geração das páginas de conteúdos após o merge do #1832. O tempo médio subiu da casa dos 250 ms para cerca de 2 000 ms:

![image](https://github.com/user-attachments/assets/97b7c3a0-cca5-45d2-8cc6-2ce5a9dc9429)

## Conclusão

Por causa da performance, não é viável buscar as estatísticas na `getStaticProps`, mas podemos perfeitamente fazer a busca pelo _client_ usando um endpoint com cache. E a busca pelo _client_ deve reduzir ainda mais os raríssimos erros que tivemos com a API.

Esse PR ainda não implementa isso, pois precisamos de uma decisão final sobre a mudança da Vercel para a Umami, mas acredito que essa seja uma mudança bem vinda.
