### PR TITLE
[Analytics] Remove Vercel Analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "@tabnews/ui": "0.3.1",
         "@upstash/ratelimit": "1.2.1",
         "@upstash/redis": "1.31.6",
-        "@vercel/analytics": "1.3.1",
         "async-retry": "1.3.3",
         "bcryptjs": "2.4.3",
         "cookie": "0.6.0",
@@ -4753,26 +4752,6 @@
       "license": "MIT",
       "dependencies": {
         "crypto-js": "^4.2.0"
-      }
-    },
-    "node_modules/@vercel/analytics": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.3.1.tgz",
-      "integrity": "sha512-xhSlYgAuJ6Q4WQGkzYTLmXwhYl39sWjoMA3nHxfkvG+WdBT25c563a7QhwwKivEOZtPJXifYHR1m2ihoisbWyA==",
-      "dependencies": {
-        "server-only": "^0.0.1"
-      },
-      "peerDependencies": {
-        "next": ">= 13",
-        "react": "^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "next": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        }
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -15967,11 +15946,6 @@
       "dependencies": {
         "randombytes": "^2.1.0"
       }
-    },
-    "node_modules/server-only": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
-      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA=="
     },
     "node_modules/set-cookie-parser": {
       "version": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@tabnews/ui": "0.3.1",
     "@upstash/ratelimit": "1.2.1",
     "@upstash/redis": "1.31.6",
-    "@vercel/analytics": "1.3.1",
     "async-retry": "1.3.3",
     "bcryptjs": "2.4.3",
     "cookie": "0.6.0",

--- a/pages/interface/components/Analytics/index.js
+++ b/pages/interface/components/Analytics/index.js
@@ -1,4 +1,3 @@
-import { Analytics as VercelAnalytics } from '@vercel/analytics/react';
 import Script from 'next/script';
 
 export default function Analytics() {
@@ -10,15 +9,6 @@ export default function Analytics() {
         data-website-id={process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID}
         data-exclude-search="true"
         strategy="lazyOnload"
-      />
-      <VercelAnalytics
-        beforeSend={(event) => {
-          const { pathname } = new URL(event.url);
-          if (['/', '/publicar'].includes(pathname)) {
-            return null;
-          }
-          return event;
-        }}
       />
     </>
   );


### PR DESCRIPTION
A Umami já está habilitada para coleta de dados de todas as páginas, então esse PR remove a Vercel Analytics que estava coletando dados de quase todas (menos `/`e `/publicar`).

Nossa fatura com a Vercel fechou ontem e em um dia já usamos quase metade da cota grátis de Analytics (25k eventos). Se mesclarmos esse PR hoje, teremos uma economia estimada em $70 com a Vercel, ou $56 se deixar para depois, desde que dentro dos primeiros 125k eventos.

Considerando que para isso precisamos assinar o plano Pro da Umami, isso representa um custo de $20 mensais, então o líquido será uma economia de $50 mensais, mas com as vantagens de poder rastrear também a Home (`/`), já que teremos 1M de eventos inclusos, fora diversas outras vantagens da Umami.

Esse PR remove a integração com a Vercel Analytics do código, mas acredito que vale a pena deixar habilitada a configuração na Vercel, pois assim mantemos o acesso aos dados antigos, e sem custo, já que não estarão entrando mais nenhum evento.