### PR TITLE
Melhorias no envio de emails (timeout, variáveis de ambiente e testes)

### DIFF
--- a/.env
+++ b/.env
@@ -13,7 +13,7 @@ EMAIL_SMTP_HOST=localhost
 EMAIL_SMTP_PORT=1025
 EMAIL_HTTP_HOST=localhost
 EMAIL_HTTP_PORT=1080
-EMAIL_USER=
+EMAIL_USER=nodemailer
 EMAIL_PASSWORD=
 UNDER_MAINTENANCE={"methodsAndPaths":["POST /api/v1/under-maintenance-test$"]}
 

--- a/infra/email.js
+++ b/infra/email.js
@@ -6,7 +6,7 @@ import { ServiceError } from 'errors';
 import logger from 'infra/logger.js';
 import webserver from 'infra/webserver.js';
 
-const RETRIES_PER_EMAIL_SERVICE = 1;
+const retriesPerService = parseInt(process.env.RETRIES_PER_EMAIL_SERVICE) || 1;
 
 const transporterConfigs = [];
 let configNumber = '';
@@ -45,7 +45,7 @@ const transporters = transporterConfigs.map((config) => {
   return nodemailer.createTransport(config);
 });
 
-const retries = (RETRIES_PER_EMAIL_SERVICE + 1) * transporters.length - 1;
+const retries = (retriesPerService + 1) * transporters.length - 1;
 
 async function send({ from, to, subject, html, text }) {
   const mailOptions = {

--- a/infra/email.js
+++ b/infra/email.js
@@ -11,7 +11,7 @@ const RETRIES_PER_EMAIL_SERVICE = 1;
 const transporterConfigs = [];
 let configNumber = '';
 
-while (process.env['EMAIL_SMTP_HOST' + configNumber]) {
+while (process.env['EMAIL_USER' + configNumber]) {
   transporterConfigs.push({
     host: process.env['EMAIL_SMTP_HOST' + configNumber],
     port: process.env['EMAIL_SMTP_PORT' + configNumber],


### PR DESCRIPTION
## Mudanças realizadas

### Timeout de envio

A principal mudança é a adição de um tempo limite de 40 segundos para cada tentativa de envio de emails.

Isso é necessário porque já ocorreu de o serviço não responder dentro do limite de tempo das lambdas. Nesses casos, a gente nem tentava usar a contingência, já que nenhum erro era recebido.

Como atualmente as nossas lambdas tem limite de 60 segundos, foi adicionado um timeout de 40 segundos, o que deixa tempo mais do que suficiente para tentar o envio pela contingência.

### Variáveis de ambiente

Como agora utilizamos o SDK do Resend, então para esse serviço só são utilizadas as variáveis `EMAIL_USER` e `EMAIL_PASSWORD` (ou `EMAIL_USERn` e `EMAIL_PASSWORDn`, com `n` = `1`, `2`...), mas ainda estava sendo necessário adicionar a `EMAIL_SMTP_HOST`, o que foi corrigido. Para outros serviços de email, as demais variáveis ainda são necessárias: `EMAIL_SMTP_HOST` e `EMAIL_SMTP_PORT`.

Agora é possível alterar a quantidade de retentativas de envio por cada serviço através da variável `RETRIES_PER_EMAIL_SERVICE`. O valor padrão continua sendo 1, ou seja, uma tentativa extra para cada serviço configurado.

Também é possível alterar o timeout de `40` segundos através da variável `EMAIL_ATTEMPT_TIMEOUT_IN_SECONDS`.

### Testes

Foram adicionados testes para as novas funcionalidades, e também os testes que estavam pendentes, que verificam se o envio ocorre via SDK do Resend nas situações específicas que isso deve ocorrer.

## Tipo de mudança

- [x] Novas funcionalidades

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
