### PR TITLE
Adiciona contador de caracteres onde o Editor é usado

### DIFF
--- a/pages/[username]/index.public.js
+++ b/pages/[username]/index.public.js
@@ -8,6 +8,7 @@ import {
   Box,
   Button,
   ButtonWithLoader,
+  CharacterCount,
   DefaultLayout,
   Editor,
   Flash,
@@ -52,6 +53,8 @@ export default function Page({ userFound: userFoundFallback }) {
     </DefaultLayout>
   );
 }
+
+const DESCRIPTION_MAX_LENGTH = 5_000;
 
 function UserProfile({ userFound, onUpdate }) {
   const { user } = useUser();
@@ -400,7 +403,7 @@ function DescriptionForm({
           Descrição
         </FormControl.Label>
         <Editor
-          isInvalid={errorObject?.key === 'description'}
+          isInvalid={errorObject?.key === 'description' || description.length > DESCRIPTION_MAX_LENGTH}
           value={description}
           onChange={handleDescriptionChange}
           onKeyDown={handleKeyDown}
@@ -408,9 +411,13 @@ function DescriptionForm({
           clobberPrefix={`${user.username}-content-`}
         />
 
-        {errorObject?.key === 'description' && (
-          <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
-        )}
+        <Box sx={{ display: 'flex', width: '100%' }}>
+          {errorObject?.key === 'description' && (
+            <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
+          )}
+
+          <CharacterCount maxLength={DESCRIPTION_MAX_LENGTH} value={description} />
+        </Box>
       </FormControl>
 
       {globalMessageObject?.position === 'description' && (

--- a/pages/[username]/index.public.js
+++ b/pages/[username]/index.public.js
@@ -400,7 +400,7 @@ function DescriptionForm({
           Descrição
         </FormControl.Label>
         <Editor
-          isValid={errorObject?.key === 'description'}
+          isInvalid={errorObject?.key === 'description'}
           value={description}
           onChange={handleDescriptionChange}
           onKeyDown={handleKeyDown}

--- a/pages/interface/components/CharacterCount/index.js
+++ b/pages/interface/components/CharacterCount/index.js
@@ -1,0 +1,16 @@
+import { Text } from '@tabnews/ui';
+
+export default function CharacterCount({ maxLength, value }) {
+  return (
+    <Text
+      sx={{
+        ml: 'auto',
+        fontSize: 0,
+        pl: 1,
+        color: value.length > maxLength ? 'danger.fg' : undefined,
+        fontWeight: value.length > maxLength ? 'bold' : undefined,
+      }}>
+      {value.length}/{maxLength}
+    </Text>
+  );
+}

--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -523,7 +523,7 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
           <FormControl id="body" required={!contentObject?.parent_id}>
             <FormControl.Label>{contentObject?.parent_id ? 'Seu comentário' : 'Corpo da publicação'}</FormControl.Label>
             <Editor
-              isValid={errorObject?.key === 'body'}
+              isInvalid={errorObject?.key === 'body'}
               value={newData.body}
               onChange={handleChange}
               onKeyDown={onKeyDown}

--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -8,6 +8,7 @@ import {
   BranchName,
   Button,
   ButtonWithLoader,
+  CharacterCount,
   Checkbox,
   Editor,
   Flash,
@@ -37,6 +38,8 @@ const CONTENT_TITLE_PLACEHOLDER_EXAMPLES = [
   'e.g. Ferramentas para melhorar sua produtividade',
   'e.g. Como renomear uma branch local no Git?',
 ];
+
+const BODY_MAX_LENGTH = 20_000;
 
 export default function Content({ content, isPageRootOwner, mode = 'view', viewFrame = false }) {
   const [componentMode, setComponentMode] = useState(mode);
@@ -523,7 +526,7 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
           <FormControl id="body" required={!contentObject?.parent_id}>
             <FormControl.Label>{contentObject?.parent_id ? 'Seu comentário' : 'Corpo da publicação'}</FormControl.Label>
             <Editor
-              isInvalid={errorObject?.key === 'body'}
+              isInvalid={errorObject?.key === 'body' || newData.body.length > BODY_MAX_LENGTH}
               value={newData.body}
               onChange={handleChange}
               onKeyDown={onKeyDown}
@@ -531,9 +534,13 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
               clobberPrefix={`${contentObject?.owner_username ?? user?.username}-content-`}
             />
 
-            {errorObject?.key === 'body' && (
-              <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
-            )}
+            <Box sx={{ display: 'flex', width: '100%' }}>
+              {errorObject?.key === 'body' && (
+                <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
+              )}
+
+              <CharacterCount maxLength={BODY_MAX_LENGTH} value={newData.body} />
+            </Box>
           </FormControl>
 
           {!contentObject?.parent_id && (

--- a/pages/interface/components/Markdown/index.js
+++ b/pages/interface/components/Markdown/index.js
@@ -83,7 +83,7 @@ export default function Viewer({ value: _value, areLinksTrusted, clobberPrefix, 
 }
 
 // Editor is not part of Primer, so error messages and styling need to be created manually
-export function Editor({ isValid, onKeyDown, compact, areLinksTrusted, clobberPrefix, ...props }) {
+export function Editor({ isInvalid, onKeyDown, compact, areLinksTrusted, clobberPrefix, ...props }) {
   clobberPrefix = clobberPrefix?.toLowerCase();
   const bytemdPluginList = usePlugins({ areLinksTrusted, clobberPrefix });
   const editorMode = 'split'; // 'tab'
@@ -103,7 +103,7 @@ export function Editor({ isValid, onKeyDown, compact, areLinksTrusted, clobberPr
   }, []);
 
   return (
-    <Box sx={{ width: '100%' }} ref={editorRef} className={isValid ? 'is-invalid' : ''}>
+    <Box sx={{ width: '100%' }} ref={editorRef} className={isInvalid ? 'is-invalid' : ''}>
       <ByteMdEditor
         plugins={bytemdPluginList}
         mode={editorMode}

--- a/pages/interface/components/TabNewsUI/index.js
+++ b/pages/interface/components/TabNewsUI/index.js
@@ -1,5 +1,6 @@
 export { default as AdBanner } from '@/AdBanner';
 export { default as ButtonWithLoader } from '@/ButtonWithLoader';
+export { default as CharacterCount } from '@/CharacterCount';
 export { default as Confetti } from '@/Confetti';
 export { default as Content } from '@/Content';
 export { default as ContentList } from '@/ContentList';

--- a/pages/perfil/index.public.js
+++ b/pages/perfil/index.public.js
@@ -267,7 +267,7 @@ function EditProfileForm() {
               setDescription(value);
             }}
             value={description}
-            isValid={errorObject?.key === 'description'}
+            isInvalid={errorObject?.key === 'description'}
             compact={true}
             clobberPrefix={`${user?.username}-content-`}
           />

--- a/pages/perfil/index.public.js
+++ b/pages/perfil/index.public.js
@@ -5,6 +5,7 @@ import {
   Box,
   Button,
   ButtonWithLoader,
+  CharacterCount,
   Checkbox,
   DefaultLayout,
   Editor,
@@ -28,6 +29,8 @@ export default function EditProfile() {
     </DefaultLayout>
   );
 }
+
+const DESCRIPTION_MAX_LENGTH = 5_000;
 
 function EditProfileForm() {
   const router = useRouter();
@@ -267,14 +270,18 @@ function EditProfileForm() {
               setDescription(value);
             }}
             value={description}
-            isInvalid={errorObject?.key === 'description'}
+            isInvalid={errorObject?.key === 'description' || description.length > DESCRIPTION_MAX_LENGTH}
             compact={true}
             clobberPrefix={`${user?.username}-content-`}
           />
 
-          {errorObject?.key === 'description' && errorObject.type === 'string.max' && (
-            <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
-          )}
+          <Box sx={{ display: 'flex', width: '100%' }}>
+            {errorObject?.key === 'description' && errorObject.type === 'string.max' && (
+              <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
+            )}
+
+            <CharacterCount maxLength={DESCRIPTION_MAX_LENGTH} value={description} />
+          </Box>
         </FormControl>
 
         <FormControl id="notifications" sx={{ gap: 2, alignItems: 'center' }}>


### PR DESCRIPTION
## Mudanças realizadas

Foi adicionado um contador de caracteres onde o `Editor` é usado. Esse comportamento não foi adicionado diretamente no `Editor` para conseguir estilizar o conteúdo na mesma linha da mensagem de erro.

Implementação baseada no que foi feito e discutido em https://github.com/filipedeschamps/tabnews.com.br/pull/1813, resolvendo os comentários pendentes.

Também corrigi  o nome da propriedade que era chamada de `isValid`, mas na verdade serve para indicar o erro do `Editor`.

Resolve #1806


https://github.com/user-attachments/assets/5cf17de6-c15f-4bda-8ab4-5a90fe96c553

Resultado numa tela super estreita:

![Erro numa coluna, contagem noutra](https://github.com/user-attachments/assets/a6fded02-95f8-47dc-89d1-9822a9408876)


## Tipo de mudança

 - [x] Nova funcionalidade 
  
## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [ ] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
