### PR TITLE
Volta a usar a biblioteca `remove-markdown`

### DIFF
--- a/models/remove-markdown.js
+++ b/models/remove-markdown.js
@@ -99,14 +99,34 @@ export default function removeMarkdown(md, options = {}) {
     }
 
     if (options.trim) {
-      output = output.replace(
-        /^[\s\p{C}\u034f\u17b4\u17b5\u2800\u115f\u1160\u3164\uffa0]+|[\s\p{C}\u034f\u17b4\u17b5\u2800\u115f\u1160\u3164\uffa0]+$|\u0000/gsu,
-        '',
-      );
+      output = trimStart(output);
+      output = trimEnd(output);
     }
   } catch (e) {
     logger.error(e);
     return md;
   }
   return output;
+}
+
+const whitespaceAndControlCharRegex = /[\s\p{C}\u034f\u17b4\u17b5\u2800\u115f\u1160\u3164\uffa0]/u;
+
+export function trimStart(str) {
+  let i = 0;
+
+  while (i < str.length && whitespaceAndControlCharRegex.test(str[i])) {
+    i++;
+  }
+
+  return str.slice(i);
+}
+
+export function trimEnd(str) {
+  let i = str.length - 1;
+
+  while (i >= 0 && whitespaceAndControlCharRegex.test(str[i])) {
+    i--;
+  }
+
+  return str.slice(0, i + 1);
 }

--- a/models/remove-markdown.js
+++ b/models/remove-markdown.js
@@ -1,91 +1,15 @@
-// Original code from: https://github.com/stiang/remove-markdown
-// With a fix by @aprendendofelipe https://github.com/stiang/remove-markdown/pull/57
+import removeMarkdown from 'remove-markdown';
+
 import logger from 'infra/logger';
 
-export default function removeMarkdown(md, options = {}) {
+export default function customRemoveMarkdown(md, options = {}) {
   options.oneLine = Object.hasOwn(options, 'oneLine') ? options.oneLine : true;
-  options.listUnicodeChar = Object.hasOwn(options, 'listUnicodeChar') ? options.listUnicodeChar : false;
-  options.stripListLeaders = Object.hasOwn(options, 'stripListLeaders') ? options.stripListLeaders : true;
-  options.gfm = Object.hasOwn(options, 'gfm') ? options.gfm : true;
-  options.useImgAltText = Object.hasOwn(options, 'useImgAltText') ? options.useImgAltText : true;
-  options.abbr = Object.hasOwn(options, 'abbr') ? options.abbr : false;
-  options.replaceLinksWithURL = Object.hasOwn(options, 'replaceLinksWithURL') ? options.replaceLinksWithURL : false;
-  options.htmlTagsToSkip = Object.hasOwn(options, 'htmlTagsToSkip') ? options.htmlTagsToSkip : [];
+  options.throwError = Object.hasOwn(options, 'logError') ? options.throwError : true;
 
-  var output = md || '';
-
-  // Remove horizontal rules (stripListHeaders conflict with this rule, which is why it has been moved to the top)
-  output = output.replace(/^(-\s*?|\*\s*?|_\s*?){3,}\s*/gm, '');
+  let output = md || '';
 
   try {
-    if (options.stripListLeaders) {
-      if (options.listUnicodeChar)
-        output = output.replace(/^([\s\t]*)([*\-+]|\d+\.)\s+/gm, options.listUnicodeChar + ' $1');
-      else output = output.replace(/^([\s\t]*)([*\-+]|\d+\.)\s+/gm, '$1');
-    }
-    if (options.gfm) {
-      output = output
-        // Header
-        .replace(/\n={2,}/g, '\n')
-        // Fenced codeblocks
-        .replace(/~{3}.*\n/g, '')
-        // Strikethrough
-        .replace(/~~/g, '')
-        // Fenced codeblocks
-        .replace(/`{3}.*\n/g, '');
-    }
-    if (options.abbr) {
-      // Remove abbreviations
-      output = output.replace(/\*\[.*\]:.*\n/, '');
-    }
-    output = output
-      // Remove HTML tags
-      .replace(/<[^>]*>/g, '');
-
-    var htmlReplaceRegex = new RegExp('<[^>]*>', 'g');
-    if (options.htmlTagsToSkip.length > 0) {
-      // Using negative lookahead. Eg. (?!sup|sub) will not match 'sup' and 'sub' tags.
-      var joinedHtmlTagsToSkip = '(?!' + options.htmlTagsToSkip.join('|') + ')';
-
-      // Adding the lookahead literal with the default regex for html. Eg./<(?!sup|sub)[^>]*>/ig
-      htmlReplaceRegex = new RegExp('<' + joinedHtmlTagsToSkip + '[^>]*>', 'ig');
-    }
-
-    output = output
-      // Remove HTML tags
-      .replace(htmlReplaceRegex, '')
-      // Remove setext-style headers
-      .replace(/^[=-]{2,}\s*$/g, '')
-      // Remove footnotes?
-      .replace(/\[\^.+?\](: .*?$)?/g, '')
-      .replace(/\s{0,2}\[.*?\]: .*?$/g, '')
-      // Remove images
-      .replace(/!\[(.*?)\][[(].*?[\])]/g, options.useImgAltText ? '$1' : '')
-      // Remove inline links
-      .replace(/\[([^\]]*?)\][[(].*?[\])]/g, options.replaceLinksWithURL ? '$2' : '$1')
-      // Remove blockquotes
-      .replace(/^(\n)?\s{0,3}>\s?/gm, '$1')
-      // .replace(/(^|\n)\s{0,3}>\s?/g, '\n\n')
-      // Remove reference-style links?
-      .replace(/^\s{1,2}\[(.*?)\]: (\S+)( ".*?")?\s*$/g, '')
-      // Remove atx-style headers
-      .replace(/^(\n)?\s{0,}#{1,6}\s*( (.+))? +#+$|^(\n)?\s{0,}#{1,6}\s*( (.+))?$/gm, '$1$3$4$6')
-      // Remove * emphasis
-      .replace(/([*]+)(\S)(.*?\S)??\1/g, '$2$3')
-      // Remove _ emphasis. Unlike *, _ emphasis gets rendered only if
-      //   1. Either there is a whitespace character before opening _ and after closing _.
-      //   2. Or _ is at the start/end of the string.
-      .replace(/(^|\W)([_]+)(\S)(.*?\S)??\2($|\W)/g, '$1$3$4$5')
-      // Remove code blocks
-      .replace(/(`{3,})(.*?)\1/gm, '$2')
-      // Remove inline code
-      .replace(/`(.+?)`/g, '$1')
-      // // Replace two or more newlines with exactly two? Not entirely sure this belongs here...
-      // .replace(/\n{2,}/g, '\n\n')
-      // // Remove newlines in a paragraph
-      // .replace(/(\S+)\n\s*(\S+)/g, '$1 $2')
-      // Replace strike through
-      .replace(/~(.*?)~/g, '$1');
+    output = removeMarkdown(md, options);
 
     if (options.oneLine) {
       output = output.replace(/\s+/g, ' ');
@@ -103,7 +27,10 @@ export default function removeMarkdown(md, options = {}) {
       output = trimEnd(output);
     }
   } catch (e) {
-    logger.error(e);
+    if (options.throwError) {
+      logger.error(e);
+    }
+
     return md;
   }
   return output;

--- a/models/validator.js
+++ b/models/validator.js
@@ -2,7 +2,7 @@ import Joi from 'joi';
 
 import { ValidationError } from 'errors';
 import webserver from 'infra/webserver';
-import removeMarkdown from 'models/remove-markdown';
+import removeMarkdown, { trimEnd, trimStart } from 'models/remove-markdown';
 import availableFeatures from 'models/user-features';
 
 const MAX_INTEGER = 2147483647;
@@ -159,8 +159,9 @@ const schemas = {
   description: function () {
     return Joi.object({
       description: Joi.string()
-        .replace(/[\s\p{C}\u034f\u17b4\u17b5\u2800\u115f\u1160\u3164\uffa0]+$|\u0000/gsu, '')
         .max(5000)
+        .replace(/\u0000/gu, '')
+        .custom(trimEnd)
         .allow('')
         .when('$required.description', { is: 'required', then: Joi.required(), otherwise: Joi.optional() }),
     });
@@ -230,12 +231,11 @@ const schemas = {
   title: function () {
     return Joi.object({
       title: Joi.string()
-        .replace(
-          /^[\s\p{C}\u034f\u17b4\u17b5\u2800\u115f\u1160\u3164\uffa0]+|[\s\p{C}\u034f\u17b4\u17b5\u2800\u115f\u1160\u3164\uffa0]+$|\u0000/gu,
-          '',
-        )
         .min(1)
         .max(255)
+        .replace(/\u0000/gu, '')
+        .custom(trimStart)
+        .custom(trimEnd)
         .when('$required.title', { is: 'required', then: Joi.required(), otherwise: Joi.optional().allow(null) }),
     });
   },
@@ -244,9 +244,10 @@ const schemas = {
     return Joi.object({
       body: Joi.string()
         .pattern(/^[\s\p{C}\u034f\u17b4\u17b5\u2800\u115f\u1160\u3164\uffa0].*$/su, { invert: true })
-        .replace(/[\s\p{C}\u034f\u17b4\u17b5\u2800\u115f\u1160\u3164\uffa0]+$|\u0000/gsu, '')
         .min(1)
         .max(20000)
+        .replace(/\u0000/gu, '')
+        .custom(trimEnd)
         .custom(withoutMarkdown, 'check if is empty without markdown')
         .when('$required.body', { is: 'required', then: Joi.required(), otherwise: Joi.optional() })
         .messages({

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "recharts": "2.12.7",
         "rehype-external-links": "3.0.0",
         "rehype-slug": "6.0.0",
+        "remove-markdown": "0.6.0",
         "resend": "4.0.1",
         "satori": "0.10.13",
         "slug": "9.1.0",
@@ -15464,6 +15465,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/remove-markdown": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/remove-markdown/-/remove-markdown-0.6.0.tgz",
+      "integrity": "sha512-B9g8yo5Zp1wXfZ77M1RLpqI7xrBBERkp7+3/Btm9N/uZV5xhXZjzIxDbCKz7CSj141lWDuCnQuH12DKLUv4Ghw==",
+      "license": "MIT"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "recharts": "2.12.7",
     "rehype-external-links": "3.0.0",
     "rehype-slug": "6.0.0",
+    "remove-markdown": "0.6.0",
     "resend": "4.0.1",
     "satori": "0.10.13",
     "slug": "9.1.0",

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -1867,6 +1867,62 @@ describe('POST /api/v1/contents', () => {
       expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
+    test('Content with "title" containing 100.000 invalid characters', async () => {
+      const contentsRequestBuilder = new RequestBuilder('/api/v1/contents');
+      await contentsRequestBuilder.buildUser();
+
+      const { response, responseBody } = await contentsRequestBuilder.post({
+        title: '!' + '\uffa0'.repeat(100_000) + '\uffa0!',
+        body: 'With invalid title',
+        slug: 'nodejs',
+      });
+
+      expect.soft(response.status).toBe(400);
+
+      expect(responseBody).toStrictEqual({
+        status_code: 400,
+        name: 'ValidationError',
+        message: '"title" deve conter no máximo 255 caracteres.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
+        key: 'title',
+        type: 'string.max',
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+      });
+
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+    });
+
+    test('Content with "body" containing 100.000 invalid characters', async () => {
+      const contentsRequestBuilder = new RequestBuilder('/api/v1/contents');
+      await contentsRequestBuilder.buildUser();
+
+      const { response, responseBody } = await contentsRequestBuilder.post({
+        title: 'With invalid body',
+        body: '!' + '\u034f'.repeat(100_000) + '\u034f!',
+        slug: 'nodejs',
+      });
+
+      expect.soft(response.status).toBe(400);
+
+      expect(responseBody).toStrictEqual({
+        status_code: 400,
+        name: 'ValidationError',
+        message: '"body" deve conter no máximo 20000 caracteres.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
+        key: 'body',
+        type: 'string.max',
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+      });
+
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+    });
+
     describe('Notifications', () => {
       test('Create "root" content', async () => {
         await orchestrator.deleteAllEmails();


### PR DESCRIPTION
## Mudanças realizadas

A biblioteca `remove-markdown` passou por um bom período sem manutenção, por isso fizemos melhorias no código dela e trouxemos para dentro do nosso repositório.

Só que agora a biblioteca voltou a ser mantida e já possui as melhorias que fizemos localmente, além de outras melhorias, então podemos voltar a usá-la.

Aproveitei para melhorar a performance do nosso `trim` customizado, adicionando testes que não passariam com a versão anterior.

## Tipo de mudança

- [x] Correção de bug

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
