### PR TITLE
Corrige remoção indevida de emojis no `trim` da `removeMarkdown`

### DIFF
--- a/models/remove-markdown.js
+++ b/models/remove-markdown.js
@@ -15,16 +15,13 @@ export default function customRemoveMarkdown(md, options = {}) {
       output = output.replace(/\s+/g, ' ');
     }
 
-    if (output.length > options.maxLength) {
-      output = output
-        .substring(0, options.maxLength - 3)
-        .trim()
-        .concat('...');
-    }
-
     if (options.trim) {
       output = trimStart(output);
       output = trimEnd(output);
+    }
+
+    if (output.length > options.maxLength) {
+      output = trimEnd(output.substring(0, options.maxLength - 3)).concat('...');
     }
   } catch (e) {
     if (options.throwError) {
@@ -36,24 +33,22 @@ export default function customRemoveMarkdown(md, options = {}) {
   return output;
 }
 
-const whitespaceAndControlCharRegex = /[\s\p{C}\u034f\u17b4\u17b5\u2800\u115f\u1160\u3164\uffa0]/u;
+const invisibleCharRegex = '[\\s\\p{C}\u034f\u17b4\u17b5\u2800\u115f\u1160\u3164\uffa0]';
+const trimStartRegex = new RegExp('^' + invisibleCharRegex, 'u');
+const trimEndRegex = new RegExp(invisibleCharRegex + '$', 'u');
 
 export function trimStart(str) {
-  let i = 0;
-
-  while (i < str.length && whitespaceAndControlCharRegex.test(str[i])) {
-    i++;
+  while (trimStartRegex.test(str)) {
+    str = str.replace(trimStartRegex, '');
   }
 
-  return str.slice(i);
+  return str;
 }
 
 export function trimEnd(str) {
-  let i = str.length - 1;
-
-  while (i >= 0 && whitespaceAndControlCharRegex.test(str[i])) {
-    i--;
+  while (trimEndRegex.test(str)) {
+    str = str.replace(trimEndRegex, '');
   }
 
-  return str.slice(0, i + 1);
+  return str;
 }

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -1923,6 +1923,42 @@ describe('POST /api/v1/contents', () => {
       expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
+    test('Content containing emojis', async () => {
+      const contentsRequestBuilder = new RequestBuilder('/api/v1/contents');
+      const defaultUser = await contentsRequestBuilder.buildUser();
+
+      const { response, responseBody } = await contentsRequestBuilder.post({
+        title: '🚀 🎉 🙃',
+        body: '👍 🤔 🤷',
+      });
+
+      expect.soft(response.status).toBe(201);
+
+      expect(responseBody).toStrictEqual({
+        id: responseBody.id,
+        owner_id: defaultUser.id,
+        parent_id: null,
+        slug: '8jagcdwn46jipcfmym',
+        title: '🚀 🎉 🙃',
+        body: '👍 🤔 🤷',
+        status: 'draft',
+        type: 'content',
+        source_url: null,
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+        published_at: null,
+        deleted_at: null,
+        tabcoins: 0,
+        tabcoins_credit: 0,
+        tabcoins_debit: 0,
+        owner_username: defaultUser.username,
+      });
+
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+    });
+
     describe('Notifications', () => {
       test('Create "root" content', async () => {
         await orchestrator.deleteAllEmails();


### PR DESCRIPTION
Minha última publicação no TabNews continha emojis no final do título e do corpo. Depois de um tempo, notei que esses emojis foram removidos na versão publicada.

O `trim` usado na `removeMarkdown`, aprimorado no #1843 para mitigar ReDoS (corrigindo uma vulnerabilidade reportada pelo @pabloemanuelpbl 💪), acabou introduzindo um bug que removia certos emojis. O problema ocorre porque o `trim` analisava os caracteres individualmente em **Unicode UTF-16**, e alguns emojis são representados por **pares de surrogates** nesse formato. Como resultado, esses emojis eram tratados incorretamente e removidos.

## Mudanças realizadas

Foi ajustada a função para que o `trim` opere corretamente em **Unicode completo**, garantindo que emojis não sejam mais removidos indevidamente.

Aproveitei para inverter a ordem entre a execução do `trim` e do limitador de caracteres, de forma que o limitador atue apenas após o `trim`.

## Tipo de mudança

- [x] Correção de bug

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
