### PR TITLE
Adequações no pool de conexões para compatibilidade com Fluid Compute da Vercel

### DIFF
--- a/tests/integration/api/v1/contents/[username]/[slug]/tabcoins/post.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/tabcoins/post.test.js
@@ -590,17 +590,11 @@ describe('POST /api/v1/contents/tabcoins', () => {
 
       const postTabCoinsResponses = await Promise.all(postTabCoinsPromises);
 
-      const postTabCoinsResponsesBodyPromises = postTabCoinsResponses.map((postTabCoinsResponse) =>
-        postTabCoinsResponse.json(),
-      );
+      const postTabCoinsResponsesBody = postTabCoinsResponses.map(({ responseBody }) => responseBody);
 
-      const postTabCoinsResponsesStatus = postTabCoinsResponses.map(
-        (postTabCoinsResponse) => postTabCoinsResponse.status,
-      );
+      const postTabCoinsResponsesStatus = postTabCoinsResponses.map(({ response }) => response.status);
 
-      const postTabCoinsResponsesBody = await Promise.all(postTabCoinsResponsesBodyPromises);
-
-      expect([201, 422]).toBe(expect.arrayContaining(postTabCoinsResponsesStatus));
+      expect([201, 422]).toStrictEqual(expect.arrayContaining(postTabCoinsResponsesStatus));
 
       expect(postTabCoinsResponsesBody).toContainEqual(
         expect.objectContaining({


### PR DESCRIPTION
## Mudanças realizadas

Aumenta o limite do Pool de conexões do Postgres para permitir testar a funcionalidade [Fluid Compute](https://vercel.com/blog/introducing-fluid-compute) da Vercel. Como primeiro teste, o limite foi alterado de 1 para 2.

Agora o pool não vai mais descartar todas as conexões se ele tiver clientes na fila aguardando para realizar consultas.

Também foi aprimorado o tratamento de erro em caso de falha na obtenção de uma conexão do pool. Agora teremos logs se isso ocorrer, mesmo que uma conexão ocorra com sucesso em uma segunda tentativa. Com isso, conseguiremos analisar melhor a viabilidade de habilitar a Fluid Compute, além de saber se é preciso ajustar novamente o limite de conexões.

---

Aproveitei para corrigir um teste que não está mais habilitado, mas que eu costumo habilitar localmente quando altero configurações do banco de dados.

Obs. Para esse teste funcionar, é preciso desabilitar o limite de 3 votos por IP.

## Tipo de mudança

- [x] Nova funcionalidade

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Os testes antigos estão passando localmente.
