### PR TITLE
[Continuação] Adequações no pool de conexões para compatibilidade com Fluid Compute da Vercel

### DIFF
--- a/infra/database.js
+++ b/infra/database.js
@@ -14,7 +14,7 @@ const configurations = {
   port: process.env.POSTGRES_PORT,
   connectionTimeoutMillis: 2000,
   idleTimeoutMillis: 30000,
-  max: 2,
+  max: 3,
   ssl: {
     rejectUnauthorized: false,
   },


### PR DESCRIPTION
Continuação dos testes iniciados no PR #1852.

Habilitar [Fluid Compute](https://vercel.com/blog/introducing-fluid-compute) é recomendado para economizar recursos na Vercel  (GB-hrs), pois ela tenta processar mais requisições com menos lambdas, aproveitando o tempo ocioso das que já estão atendendo outras requisições.

Mas ela não consegue evitar que uma requisição tenha que aguardar o processamento de outra (ou a liberação de uma conexão com o banco de dados), então essa mudança, por si só, pode acarretar alguma perda de performance em contrapartida à economia de recursos.

A perda pode ser perceptível ou não, dependendo do caso. Isso foi confirmado em um teste em que comparei o tempo médio das requisições com e sem Fluid Compute, mantendo as outras configurações idênticas. Em algumas rotas a performance é visivelmente pior com Fluid Compute habilitado. Mas pode ser que nesses casos seja mais por competição de conexões com o banco de dados do que de recursos da própria instância.

## Mas então por que habilitar Fluid Compute?

### Usar instâncias melhores

Já que a Fluid Compute economiza GB-hrs, somado ao fato de que atualmente utilizamos cerca de 1/4 da cota mensal de 1.000 GB-Hrs, podemos aumentar a capacidade de cada instância e talvez ainda permanecer dentro da cota. Pelos nossos testes, aumentar a capacidade da instância de _basic_ para _standard_ (a própria Vercel muda isso quando habilitamos a Fluid Compute) proporciona uma melhora significativa nos tempos médios de processamento das requisições.

### Reduzir inicializações a frio

Outra razão para habilitar Fluid Compute é que usar mais as lambdas pré aquecidas pode melhorar o tempo de resposta das requisições em alguns casos. Eu até acredito que isso eventualmente ocorra, mas não considero isso por si só como um bom motivo. Inclusive seria bastante difícil medir esse impacto isolado.

## Próximo teste

Apesar da melhora geral no tempo de processamento da maioria das requisições devido ao aumento da capacidade da instância, algumas rotas que estão entre as mais utilizadas tiveram piora com a Fluid Compute habilitada, mesmo subindo ainda mais a instância, de _standard_ para _performance_.

Na verdade, a mudança na instância praticamente não fez diferença para essas rotas, o que me faz acreditar que pode estar ocorrendo concorrência nas conexões com o banco de dados. Por isso que esse PR aumenta o limite do _pool_ de 2 para 3 conexões simultâneas. Vamos analisar se essa mudança afeta esses casos. Se afetar, podemos analisar se é o caso de aumentar ainda mais as conexões.

Falando em conexões... Com a Fluid Compute habilitada estou observando uma oscilação bem maior na quantidade de conexões simultâneas com o Postgres. O patamar inferior permanece igual, mas os picos aumentaram, tanto em frequência, como em amplitude.

![image](https://github.com/user-attachments/assets/1c83cc89-f7cd-4122-9799-5c2ea84f19d0)

Esse aumento no número de conexões abertas em momentos de maior necessidade deve contribuir também para manter a performance mais equilibrada entre momentos com fluxos diferentes.

## Mudanças realizadas

Aumenta de 2 para 3 o limite do Pool de conexões de cada lambda com o Postgres.

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Os testes antigos estão passando localmente.
