### PR TITLE
Remove a lógica de redirecionamento pós-login de dentro do hook `useUser`

### DIFF
--- a/pages/interface/hooks/useUser/index.js
+++ b/pages/interface/hooks/useUser/index.js
@@ -1,4 +1,3 @@
-import { useRouter } from 'next/router';
 import { createContext, useCallback, useContext, useEffect, useState } from 'react';
 
 const userEndpoint = '/api/v1/user';
@@ -17,7 +16,6 @@ export function UserProvider({ children }) {
   const [user, setUser] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(undefined);
-  const router = useRouter();
 
   const fetchUser = useCallback(async () => {
     try {
@@ -73,21 +71,6 @@ export function UserProvider({ children }) {
 
     return () => removeEventListener('focus', onFocus);
   }, [fetchUser, isLoading]);
-
-  useEffect(() => {
-    if (!user?.id || router?.pathname !== '/login') return;
-
-    if (
-      router.query?.redirect?.startsWith('/') &&
-      !router.query?.redirect?.startsWith('//') &&
-      !router.query.redirect.startsWith('/login') &&
-      !router.query.redirect.startsWith('/cadastro')
-    ) {
-      router.replace(router.query.redirect);
-    } else {
-      router.replace('/');
-    }
-  }, [user, router]);
 
   const logout = useCallback(async () => {
     try {

--- a/pages/login/index.public.js
+++ b/pages/login/index.public.js
@@ -1,5 +1,7 @@
 import { email, password, useForm } from '@tabnews/forms';
 import { FormField } from '@tabnews/ui';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 
 import { Box, ButtonWithLoader, DefaultLayout, Flash, Heading, Link, Text } from '@/TabNewsUI';
 import { createErrorMessage, useUser } from 'pages/interface';
@@ -12,6 +14,24 @@ const formConfig = {
 };
 
 export default function Login() {
+  const { user } = useUser();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!user?.id) return;
+
+    if (
+      router.query?.redirect?.startsWith('/') &&
+      !router.query?.redirect?.startsWith('//') &&
+      !router.query.redirect.startsWith('/login') &&
+      !router.query.redirect.startsWith('/cadastro')
+    ) {
+      router.replace(router.query.redirect);
+    } else {
+      router.replace('/');
+    }
+  }, [user, router]);
+
   return (
     <DefaultLayout containerWidth="small" metadata={{ title: 'Login', canonical: '/login' }}>
       <Heading as="h1" sx={{ mb: 3 }}>


### PR DESCRIPTION
O redirecionamento pós-login depende do router do Next.js, cuja configuração varia entre a App Router e a Pages Router.

Como essa lógica só é necessária na própria página de login, movê-la para lá permite que o `useUser` funcione de forma independente do roteamento do Next.js. Com isso, o `useUser` agora pode ser utilizado também com a App Router.

## Mudanças realizadas

Move essa lógica do arquivo `hooks/useUser/index.js` para o arquivo `pages/login.public.js`.

## Tipo de mudança

- [x] Refatoração

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Os testes estão passando localmente.
