### PR TITLE
Limita a alocação de memória em 1GB no `vercel.json`

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,8 @@
 {
+  "functions": {
+    "pages/**/*.js": {
+      "memory": 1024
+    }
+  },
   "regions": ["gru1"]
 }


### PR DESCRIPTION
Com a ativação do Fluid Compute da Vercel, aumentamos a capacidade das instâncias para o nível `Performance`, que oferece 1.7 vCPUs e 3 GB de memória. No entanto, mesmo com o compartilhamento de recursos, o consumo de memória raramente ultrapassa 500 MB. Com base nisso, podemos limitar a alocação de memória das funções para otimizar o uso de recursos da Vercel, que são medidos em GB-Hrs.

## Mudanças realizadas

Configuramos o `vercel.json` para restringir a alocação de memória das funções a, no máximo, 1024 MB. Esse já era o nosso valor padrão antes da ativação do Fluid Compute.