### PR TITLE
Aumenta o limite de alocação de memória para 1769MB no `vercel.json`

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "functions": {
     "pages/**/*.js": {
-      "memory": 1024
+      "memory": 1769
     }
   },
   "regions": ["gru1"]


### PR DESCRIPTION
Após o PR #1859, que limitou a alocação de memória a 1GB, observamos um impacto negativo na performance. O tempo médio de resposta das requisições piorou em relação ao período anterior ao PR e também ficou pior do que antes da ativação do Fluid Compute.

Curiosamente, nos últimos 30 dias, o uso de memória nunca passou de 680MB, ficando geralmente na faixa dos 400MB. Além disso, antes do Fluid Compute, o limite era de 0.6 vCPU e 1GB de memória, enquanto com o PR #1859 passamos a ter 1.7 vCPU, mas mantendo o limite de 1GB.

Isso levanta a questão: será que, com o Fluid Compute ativado, os valores de utilização de memória que a Vercel exibe não refletem mais o uso real de cada instância quando ela atende múltiplas requisições simultaneamente?

Outro ponto a registrar é que, após o PR #1859, houve algumas falhas de timeout ao conectar com o banco de dados. Mas isso pode ter sido apenas coincidência.

## Mudanças realizadas

Dado o impacto observado, estou aumentando o limite de alocação de memória para 1769MB, que é o padrão das instâncias com Fluid Compute ativado.
