### PR TITLE
Cria `event` ao atualizar a senha do usuário

### DIFF
--- a/models/validator.js
+++ b/models/validator.js
@@ -657,6 +657,17 @@ const schemas = {
           }),
         },
         {
+          is: 'update:user',
+          then: Joi.object({
+            id: Joi.string().required(),
+            updatedFields: Joi.array().items(Joi.string()).required(),
+            username: Joi.object({
+              old: Joi.string().required(),
+              new: Joi.string().required(),
+            }),
+          }),
+        },
+        {
           is: 'create:content:text_root',
           then: Joi.object({
             id: Joi.string().required(),


### PR DESCRIPTION
## Mudanças realizadas

Hoje já é criado um evento ao atualizar algum dado do usuário, implementado no PR #1615 e #1727, mas a senha é atualizada por um fluxo diferente, então o evento não era criado nessa situação.

Também aproveitei para validar o campo `metadata` do `event` para o tipo `update:user`.

## Tipo de mudança

- [x] Nova funcionalidade

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
