### PR TITLE
Migração: adiciona coluna `email` em `activate_account_tokens`

### DIFF
--- a/infra/migrations/1742688128056_alter-table-activate-account-tokens-add-column-email.js
+++ b/infra/migrations/1742688128056_alter-table-activate-account-tokens-add-column-email.js
@@ -1,0 +1,12 @@
+exports.up = (pgm) => {
+  pgm.addColumns('activate_account_tokens', {
+    // Why 254 in length? https://stackoverflow.com/a/1199238
+    email: {
+      type: 'varchar(254)',
+      notNull: false,
+      unique: false,
+    },
+  });
+};
+
+exports.down = false;


### PR DESCRIPTION
## Mudanças realizadas

Adiciona coluna email em `activate_account_tokens` para ser preenchida no cadastro, assim teremos uma forma de identificar qual é o email inicial do usuário.

Este PR contém apenas a migração, para que o código possa ser mesclado e a migração executada sem o risco de ocorrer algum cadastro tentando salvar um valor numa coluna inexistente antes de rodar a migração.

## Tipo de mudança

- [x] Migração

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [ ] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
