### PR TITLE
Salva e-mail do usuário ao criar o `activate_account_tokens`

### DIFF
--- a/models/activation.js
+++ b/models/activation.js
@@ -13,9 +13,9 @@ async function createAndSendActivationEmail(user) {
 
 async function create(user) {
   const query = {
-    text: `INSERT INTO activate_account_tokens (user_id, expires_at)
-           VALUES($1, now() + interval '15 minutes') RETURNING *;`,
-    values: [user.id],
+    text: `INSERT INTO activate_account_tokens (user_id, expires_at, email)
+           VALUES($1, now() + interval '15 minutes', $2) RETURNING *;`,
+    values: [user.id, user.email],
   };
 
   const results = await database.query(query);


### PR DESCRIPTION
## Mudanças realizadas

A migração para criação do campo `email` na tabela `activate_account_tokens` foi feita no PR #1866, e com este PR passamos a preencher o campo no cadastro, o que torna possível identificar o primeiro e-mail usado no cadastro.

Antes deste PR, era possível identificar apenas o email atual do usuário pela tabela `users` e emails alterados por meio da tabela `email_confirmation_tokens`.

Para preencher a coluna `email` em `activate_account_tokens` dos usuários que nunca alteraram seu email, podemos rodar este SQL manualmente:

```sql
UPDATE activate_account_tokens AS a
SET email = u.email, updated_at = NOW()
FROM users AS u
WHERE a.user_id = u.id
  AND a.email IS NULL
  AND NOT EXISTS (
    SELECT 1
    FROM email_confirmation_tokens AS ect
    WHERE ect.user_id = u.id AND ect.used = true
  );
```

Não é possível preencher o `email` dos usuários que já alteraram ele alguma vez.

## Tipo de mudança

<!-- Descomente a linha abaixo que corresponde ao tipo de mudança realizada no PR. -->

- [x] Nova funcionalidade

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [ ] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
