### PR TITLE
fix: prevent search dialog from breaking on rapid clicks (#1841)

### DIFF
--- a/pages/interface/components/SearchBox/index.js
+++ b/pages/interface/components/SearchBox/index.js
@@ -93,7 +93,7 @@ export default function useSearchBox() {
 
     const handleClose = () => {
       setIsOpen(false);
-      setTimeout(() => inputRef.current.offsetParent === null && clearGoogleBox(), 800);
+      clearGoogleBox();
     };
 
     if (!isOpen) return null;


### PR DESCRIPTION
## Mudanças realizadas

This pull request fixes issue #1841, where repeatedly clicking multiple times would prevent the styles from loading.

<!-- Por favor, inclua uma descrição sobre o que foi modificado nesse PR. Inclua também qualquer motivação ou contexto relevante.  -->

<!-- Se o PR contém uma modificação da interface gráfica (UI), adicione fotos ou vídeos comparando o antes e depois. -->

<!-- Se o PR contém modificações de API, mencione os endpoints afetados. -->


### Before
https://github.com/user-attachments/assets/f53b5ef3-a4a2-4e25-b0da-60c6b8f9f9d7

### After
https://github.com/user-attachments/assets/a3dc180b-9d36-4ffd-84fa-2f1ee06fd045

## Tipo de mudança

<!-- Descomente a linha abaixo que corresponde ao tipo de mudança realizada no PR. -->

- [x] Correção de bug
<!-- - [x] Nova funcionalidade -->
<!-- - [x] _**Breaking change**_ (a alteração causa uma quebra de compatibilidade na API ou em links públicos do site) -->
<!-- - [x] Atualização de documentação -->

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [ ] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
