### PR TITLE
Elimina tráfego de dados desnecessários nas páginas de comentários

### DIFF
--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -412,14 +412,12 @@ export const getStaticProps = getStaticPropsRevalidate(async (context) => {
       where: {
         id: secureContentFound.parent_id,
       },
+      attributes: { exclude: ['body'] },
     });
 
     secureParentContentFound = authorization.filterOutput(userTryingToGet, 'read:content', parentContentFound);
 
-    secureRootContentFound = secureParentContentFound;
-
-    delete secureRootContentFound.body;
-    secureParentContentFound.body = removeMarkdown(secureParentContentFound.body, { maxLength: 50 });
+    secureRootContentFound = { id: secureParentContentFound.id };
   }
 
   return {


### PR DESCRIPTION
Nas páginas de comentários que são filhos diretos de conteúdos root, não precisamos duplicar os dados de `parent` e `root`, que são os mesmos, e também não precisamos do `body` do `parent`/`root`, pois apenas o título é renderizado.

## Mudanças realizadas

- Remove o `body` que não é necessário para renderizar a página de um comentário. Na verdade ele já não era enviado para o client, mas era enviado do banco de dados para a lambda.
- Quando o `parent` e o `root` são o mesmo, envia apenas o `id` do `root` que é o único dado utilizado nesses casos.

## Tipo de mudança

- [x] Otimização/Performance

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Os testes antigos estão passando localmente.
