### PR TITLE
 Corrige warning do `husky` sobre configuração obsoleta

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/bin/bash
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx --no -- commitlint --edit "${1}"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/bash
-. "$(dirname -- "$0")/_/husky.sh"
-
 npm run pre-commit


### PR DESCRIPTION
## Mudanças realizadas

Devido à atualização da biblioteca `husky`, cada commit está gerando o warning abaixo:

```sh
husky - DEPRECATED

Please remove the following two lines from .husky/pre-commit:

#!/usr/bin/env sh
. "$(dirname -- "$0")/_/husky.sh"

They WILL FAIL in v10.0.0
```

Para resolver, basta remover as linhas indicadas na mensagem. Ao remover de `.husky/pre-commit`, o mesmo erro ocorre para `.husky/commit-msg`, por isso ambos arquivos foram modificados.

Referência complementar: [Changelog da versão 9.0.1](https://github.com/typicode/husky/releases/tag/v9.0.1), seção "How to migrate".

## Tipo de mudança

- [x] Correção de warning

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
