### PR TITLE
Atualiza o cache local do usuário após confirmar a alteração do email cadastrado

### DIFF
--- a/pages/perfil/confirmar-email/[token].public.js
+++ b/pages/perfil/confirmar-email/[token].public.js
@@ -2,17 +2,17 @@ import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
 import { Box, Confetti, DefaultLayout, Flash } from '@/TabNewsUI';
-import { createErrorMessage } from 'pages/interface';
+import { createErrorMessage, useUser } from 'pages/interface';
 
-export default function ActiveUser() {
+export default function ConfirmEmail() {
   const router = useRouter();
   const { token } = router.query;
-
+  const { fetchUser } = useUser();
   const [globalMessage, setGlobalMessage] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
-  const handleEmailConfirmation = async (token) => {
+  const handleEmailConfirmation = async (token, updateUserCache) => {
     try {
       setIsLoading(true);
 
@@ -29,7 +29,7 @@ export default function ActiveUser() {
       if (response.status === 200) {
         setIsSuccess(true);
         setGlobalMessage('Seu email foi alterado com sucesso!');
-
+        updateUserCache();
         return;
       }
 
@@ -55,9 +55,9 @@ export default function ActiveUser() {
 
   useEffect(() => {
     if (token) {
-      handleEmailConfirmation(token);
+      handleEmailConfirmation(token, fetchUser);
     }
-  }, [token]);
+  }, [fetchUser, token]);
 
   return (
     <>


### PR DESCRIPTION
O cache dos dados do usuário no client não era forçado a ser atualizado após uma confirmação de alteração do email. Com isso, retornar para a página de edição do perfil logo após alterar o email poderia confundir o usuário ao mostrar ainda o endereço anterior.

## Mudanças realizadas

Atualiza o cache dos dados do usuário no client após uma confirmação de alteração do email.

## Tipo de mudança

- [x] Correção de bug

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
