### PR TITLE
Move responsabilidade de chamar `clearSessionIdCookie` do model `controller` para o `session`

### DIFF
--- a/models/authentication.js
+++ b/models/authentication.js
@@ -28,15 +28,15 @@ async function injectAnonymousOrUser(request, response, next, options = {}) {
     });
     request.cookies.session_id = cleanCookies.session_id;
 
-    await injectAuthenticatedUser(request, options);
+    await injectAuthenticatedUser(request, response, options);
     return next();
   } else {
     injectAnonymousUser(request);
     return next();
   }
 
-  async function injectAuthenticatedUser(request, options = {}) {
-    const sessionObject = await session.findOneValidFromRequest(request);
+  async function injectAuthenticatedUser(request, response, options = {}) {
+    const sessionObject = await session.findOneValidFromRequest(request, response);
     const userObject = await user.findOneById(sessionObject.user_id, options);
 
     if (!authorization.can(userObject, 'read:session')) {

--- a/models/controller.js
+++ b/models/controller.js
@@ -16,7 +16,6 @@ import {
 import logger from 'infra/logger.js';
 import webserver from 'infra/webserver.js';
 import ip from 'models/ip.js';
-import session from 'models/session.js';
 
 function injectRequestMetadata(request, response, next) {
   request.context = {
@@ -50,6 +49,7 @@ function onNoMatchHandler(request, response) {
 
 function onErrorHandler(error, request, response) {
   if (
+    error instanceof UnauthorizedError ||
     error instanceof ValidationError ||
     error instanceof MethodNotAllowedError ||
     error instanceof NotFoundError ||
@@ -61,17 +61,6 @@ function onErrorHandler(error, request, response) {
 
     const privateErrorObject = { ...publicErrorObject, context: { ...request.context } };
     logger.info(snakeize(privateErrorObject));
-
-    return errorResponse(response, error.statusCode, snakeize(publicErrorObject));
-  }
-
-  if (error instanceof UnauthorizedError) {
-    const publicErrorObject = { ...error, requestId: request.context.requestId };
-
-    const privateErrorObject = { ...publicErrorObject, context: { ...request.context } };
-    logger.info(snakeize(privateErrorObject));
-
-    session.clearSessionIdCookie(response);
 
     return errorResponse(response, error.statusCode, snakeize(publicErrorObject));
   }

--- a/models/session.js
+++ b/models/session.js
@@ -118,20 +118,7 @@ async function findOneById(sessionId) {
 }
 
 async function findOneValidFromRequest(request) {
-  validator(request.cookies, {
-    session_id: 'required',
-  });
-
-  const sessionToken = request.cookies?.session_id;
-
-  if (!sessionToken) {
-    throw new UnauthorizedError({
-      message: `Usuário não possui sessão ativa.`,
-      action: `Verifique se este usuário está logado.`,
-    });
-  }
-
-  const sessionObject = await findOneValidByToken(sessionToken);
+  const sessionObject = await findOneValidByToken(request.cookies?.session_id);
 
   if (!sessionObject) {
     throw new UnauthorizedError({

--- a/models/session.js
+++ b/models/session.js
@@ -117,10 +117,12 @@ async function findOneById(sessionId) {
   return results.rows[0];
 }
 
-async function findOneValidFromRequest(request) {
+async function findOneValidFromRequest(request, response) {
   const sessionObject = await findOneValidByToken(request.cookies?.session_id);
 
   if (!sessionObject) {
+    clearSessionIdCookie(response);
+
     throw new UnauthorizedError({
       message: `Usuário não possui sessão ativa.`,
       action: `Verifique se este usuário está logado.`,


### PR DESCRIPTION
## Mudanças realizadas

- Separa as responsabilidades e remove a dependência que o model `controller` tinha com o model `session`.
- Permite retornar um `UnauthorizedError` mesmo em situações em que não é necessário remover a sessão do usuário.

## Tipo de mudança

- [x] Refatoração

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Os testes antigos estão passando localmente.