### PR TITLE
Responde requisições sem aguardar envio de emails

### DIFF
--- a/infra/email.js
+++ b/infra/email.js
@@ -1,3 +1,4 @@
+import { waitUntil } from '@vercel/functions';
 import retry from 'async-retry';
 import nodemailer from 'nodemailer';
 import { Resend } from 'resend';
@@ -47,6 +48,16 @@ const transporters = transporterConfigs.map((config) => {
 });
 
 const retries = (retriesPerService + 1) * transporters.length - 1;
+
+// Intentionally async for future compatibility (e.g., switching to a queue system)
+// eslint-disable-next-line require-await
+async function triggerSend(params) {
+  waitUntil(
+    send(params).catch(() => {
+      // The error has already been logged in the send function
+    }),
+  );
+}
 
 async function send({ from, to, subject, html, text }) {
   const mailOptions = {
@@ -108,4 +119,5 @@ async function send({ from, to, subject, html, text }) {
 
 export default Object.freeze({
   send,
+  triggerSend,
 });

--- a/models/activation.js
+++ b/models/activation.js
@@ -30,7 +30,7 @@ async function sendEmailToUser(user, tokenId) {
     activationLink: activationPageEndpoint,
   });
 
-  await email.send({
+  await email.triggerSend({
     from: 'TabNews <contato@tabnews.com.br>',
     to: user.email,
     subject: 'Ative seu cadastro no TabNews',

--- a/models/email-confirmation.js
+++ b/models/email-confirmation.js
@@ -37,7 +37,7 @@ async function sendEmailToUser(user, newEmail, tokenId) {
     confirmationLink: emailConfirmationPageEndpoint,
   });
 
-  await email.send({
+  await email.triggerSend({
     from: 'TabNews <contato@tabnews.com.br>',
     to: newEmail,
     subject: 'Confirme seu novo email',

--- a/models/notification.js
+++ b/models/notification.js
@@ -52,7 +52,7 @@ async function sendReplyEmailToParentUser(createdContent) {
       contentLink: childContentUrl,
     });
 
-    await email.send({
+    await email.triggerSend({
       to: parentContentUser.email,
       from: 'TabNews <contato@tabnews.com.br>',
       subject: subject,
@@ -89,7 +89,7 @@ async function sendUserDisabled({ eventId, user }) {
     username: user.username,
   });
 
-  await email.send({
+  await email.triggerSend({
     to: user.email,
     from: 'TabNews <contato@tabnews.com.br>',
     subject: 'Sua conta foi desativada',
@@ -111,7 +111,7 @@ async function sendContentDeletedToUser({ contents, eventId, userId }) {
     username: userToNotify.username,
   });
 
-  await email.send({
+  await email.triggerSend({
     to: userToNotify.email,
     from: 'TabNews <contato@tabnews.com.br>',
     subject: subject,

--- a/models/recovery.js
+++ b/models/recovery.js
@@ -54,7 +54,7 @@ async function sendEmailToUser(user, tokenId) {
     recoveryLink: recoverPageEndpoint,
   });
 
-  await email.send({
+  await email.triggerSend({
     from: 'TabNews <contato@tabnews.com.br>',
     to: user.email,
     subject: 'Recuperação de Senha',

--- a/tests/integration/api/v1/_use-cases/registration-flow.test.js
+++ b/tests/integration/api/v1/_use-cases/registration-flow.test.js
@@ -53,7 +53,7 @@ describe('Use case: Registration Flow (all successfully)', () => {
   });
 
   test('Receive email (successfully)', async () => {
-    const activationEmail = await orchestrator.getLastEmail();
+    const activationEmail = await orchestrator.waitForFirstEmail();
 
     tokenObjectInDatabase = await activation.findOneTokenByUserId(postUserResponseBody.id);
     const activationPageEndpoint = `${activation.getActivationPageEndpoint()}/${tokenObjectInDatabase.id}`;

--- a/tests/integration/api/v1/contents/firewall.post.test.js
+++ b/tests/integration/api/v1/contents/firewall.post.test.js
@@ -95,8 +95,7 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
         expect(uuidVersion(lastEvent.id)).toBe(4);
         expect(Date.parse(lastEvent.created_at)).not.toBeNaN();
 
-        const allEmails = await orchestrator.getEmails();
-        expect(allEmails).toHaveLength(0);
+        expect(await orchestrator.hasEmailsAfterDelay()).toBe(false);
       });
 
       test('Spamming valid "root" contents with a content deleted', async () => {
@@ -170,8 +169,7 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
         expect(uuidVersion(lastEvent.id)).toBe(4);
         expect(Date.parse(lastEvent.created_at)).not.toBeNaN();
 
-        const allEmails = await orchestrator.getEmails();
-        expect(allEmails).toHaveLength(0);
+        expect(await orchestrator.hasEmailsAfterDelay()).toBe(false);
       });
 
       test('Spamming valid "root" contents with TabCoins earnings', async () => {
@@ -245,8 +243,7 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
         const userAfterFirewallCatch = await user.findOneById(defaultUser.id, { withBalance: true });
         expect(userAfterFirewallCatch.tabcoins).toBe(0);
 
-        const allEmails = await orchestrator.getEmails();
-        expect(allEmails).toHaveLength(0);
+        expect(await orchestrator.hasEmailsAfterDelay()).toBe(false);
       });
 
       test('Different users spamming valid "root" contents with TabCoins earnings', async () => {
@@ -478,8 +475,7 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
         expect(uuidVersion(lastEvent.id)).toBe(4);
         expect(Date.parse(lastEvent.created_at)).not.toBeNaN();
 
-        const allEmails = await orchestrator.getEmails();
-        expect(allEmails).toHaveLength(0);
+        expect(await orchestrator.hasEmailsAfterDelay()).toBe(false);
       });
 
       test('Spamming valid "child" contents with a content deleted', async () => {
@@ -560,8 +556,7 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
         expect(uuidVersion(lastEvent.id)).toBe(4);
         expect(Date.parse(lastEvent.created_at)).not.toBeNaN();
 
-        const allEmails = await orchestrator.getEmails();
-        expect(allEmails).toHaveLength(0);
+        expect(await orchestrator.hasEmailsAfterDelay()).toBe(false);
       });
 
       test('Spamming valid "child" contents with TabCoins earnings', async () => {
@@ -644,8 +639,7 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
         const userAfterFirewallCatch = await user.findOneById(defaultUser.id, { withBalance: true });
         expect(userAfterFirewallCatch.tabcoins).toBe(0);
 
-        const allEmails = await orchestrator.getEmails();
-        expect(allEmails).toHaveLength(0);
+        expect(await orchestrator.hasEmailsAfterDelay()).toBe(false);
       });
 
       test('Spamming valid "child" contents with one with negative TabCoins', async () => {
@@ -806,7 +800,7 @@ describe('POST /api/v1/contents [FIREWALL]', () => {
         });
         expect(user2AfterFirewallCatch.tabcoins).toBe(0);
 
-        const allEmails = await orchestrator.getEmails();
+        const allEmails = await orchestrator.getEmails(2);
         expect(allEmails).toHaveLength(2);
 
         const user1Email = allEmails.find((email) => email.recipients.includes(`<${user1.email}>`));

--- a/tests/integration/api/v1/contents/post.test.js
+++ b/tests/integration/api/v1/contents/post.test.js
@@ -1972,10 +1972,8 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        const getLastEmail = await orchestrator.getLastEmail();
-
         expect.soft(response.status).toBe(201);
-        expect(getLastEmail).toBeNull();
+        expect(await orchestrator.hasEmailsAfterDelay()).toBe(false);
       });
 
       test('My "root" content replied by myself', async () => {
@@ -1997,11 +1995,9 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        const getLastEmail = await orchestrator.getLastEmail();
-
         expect.soft(response.status).toBe(201);
         expect(responseBody.parent_id).toBe(rootContent.id);
-        expect(getLastEmail).toBeNull();
+        expect(await orchestrator.hasEmailsAfterDelay()).toBe(false);
       });
 
       test('My "root" content with short "title" replied by other user', async () => {
@@ -2024,7 +2020,7 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        const getLastEmail = await orchestrator.getLastEmail();
+        const getLastEmail = await orchestrator.waitForFirstEmail();
 
         const childContentUrl = `${orchestrator.webserverUrl}/${secondUser.username}/${responseBody.slug}`;
 
@@ -2064,7 +2060,7 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        const getLastEmail = await orchestrator.getLastEmail();
+        const getLastEmail = await orchestrator.waitForFirstEmail();
 
         const childContentUrl = `${orchestrator.webserverUrl}/${secondUser.username}/${responseBody.slug}`;
 
@@ -2106,11 +2102,9 @@ describe('POST /api/v1/contents', () => {
         });
         expect.soft(response.status).toBe(201);
 
-        const getLastEmail = await orchestrator.getLastEmail();
-
         expect(responseBody.parent_id).toBe(rootContent.id);
         expect(responseBody.owner_id).not.toBe(rootContent.owner_id);
-        expect(getLastEmail).toBeNull();
+        expect(await orchestrator.hasEmailsAfterDelay()).toBe(false);
       });
 
       test('My "child" content replied by other user', async () => {
@@ -2141,7 +2135,7 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        const getLastEmail = await orchestrator.getLastEmail();
+        const getLastEmail = await orchestrator.waitForNthEmail(2);
 
         const childContentUrl = `${orchestrator.webserverUrl}/${firstUser.username}/${responseBody.slug}`;
 
@@ -2192,7 +2186,7 @@ describe('POST /api/v1/contents', () => {
           status: 'published',
         });
 
-        const getLastEmail = await orchestrator.getLastEmail();
+        const getLastEmail = await orchestrator.waitForNthEmail(2);
 
         const childContentUrl = `${orchestrator.webserverUrl}/${firstUser.username}/${responseBody.slug}`;
 
@@ -2258,8 +2252,7 @@ describe('POST /api/v1/contents', () => {
         expect.soft(contentResponse1.status).toBe(201);
 
         // 5) CHECK IF FIRST USER RECEIVED ANY EMAIL
-        const getLastEmail1 = await orchestrator.getLastEmail();
-        expect(getLastEmail1).toBeNull();
+        expect(await orchestrator.hasEmailsAfterDelay()).toBe(false);
 
         // 6) ENABLE NOTIFICATIONS FOR FIRST USER
         const { response: userPatchResponse2 } = await usersRequestBuilder.patch(`/${firstUser.username}`, {
@@ -2280,7 +2273,7 @@ describe('POST /api/v1/contents', () => {
         expect.soft(contentResponse2.status).toBe(201);
 
         // 8) CHECK IF FIRST USER RECEIVED ANY EMAIL
-        const getLastEmail2 = await orchestrator.getLastEmail();
+        const getLastEmail2 = await orchestrator.waitForFirstEmail();
 
         const childContentUrl = `${orchestrator.webserverUrl}/${secondUser.username}/${contentResponse2Body.slug}`;
 
@@ -2329,7 +2322,7 @@ describe('POST /api/v1/contents', () => {
         expect.soft(response.status).toBe(201);
         expect(response.headers.get('content-Type')).toBe('application/x-ndjson');
 
-        const getLastEmail = await orchestrator.getLastEmail();
+        const getLastEmail = await orchestrator.waitForFirstEmail();
 
         const childContentUrl = `${orchestrator.webserverUrl}/${secondUser.username}/${responseBody.slug}`;
 

--- a/tests/integration/api/v1/email-confirmation/patch.test.js
+++ b/tests/integration/api/v1/email-confirmation/patch.test.js
@@ -180,7 +180,7 @@ describe('PATCH /api/v1/email-confirmation', () => {
       expect(userInDatabaseCheck1.email).toBe('fresh.valid.token@email.com');
 
       // 2) RECEIVE CONFIRMATION EMAIL
-      const confirmationEmail = await orchestrator.getLastEmail();
+      const confirmationEmail = await orchestrator.waitForFirstEmail();
 
       const tokenObjectInDatabase = await emailConfirmation.findOneTokenByUserId(defaultUser.id);
       const emailConfirmationPageEndpoint = emailConfirmation.getEmailConfirmationPageEndpoint(
@@ -325,8 +325,7 @@ describe('PATCH /api/v1/email-confirmation', () => {
       const userInDatabaseCheck1 = await user.findOneById(firstUser.id);
       expect(userInDatabaseCheck1.email).toBe('validation.error@before.com');
 
-      const confirmationEmail = await orchestrator.getLastEmail();
-      expect(confirmationEmail).toBeNull();
+      expect(await orchestrator.hasEmailsAfterDelay()).toBe(false);
     });
 
     test('With an already used email (after creating the token)', async () => {

--- a/tests/integration/api/v1/recovery/post.test.js
+++ b/tests/integration/api/v1/recovery/post.test.js
@@ -106,7 +106,7 @@ describe('POST /api/v1/recovery', () => {
       expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
       expect(responseBody.expires_at > responseBody.created_at).toBe(true);
 
-      const lastEmail = await orchestrator.getLastEmail();
+      const lastEmail = await orchestrator.waitForFirstEmail();
       expect(lastEmail.recipients[0].includes(defaultUser.email)).toBe(true);
       expect(lastEmail.subject).toBe('Recuperação de Senha');
       expect(lastEmail.text).toContain(defaultUser.username);
@@ -144,8 +144,7 @@ describe('POST /api/v1/recovery', () => {
       expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
       expect(responseBody.expires_at > responseBody.created_at).toBe(true);
 
-      const lastEmail = await orchestrator.getLastEmail();
-      expect(lastEmail).toBeNull();
+      expect(await orchestrator.hasEmailsAfterDelay()).toBe(false);
     });
 
     test('With "email" malformatted', async () => {
@@ -306,7 +305,7 @@ describe('POST /api/v1/recovery', () => {
       expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
       expect(responseBody.expires_at > responseBody.created_at).toBe(true);
 
-      const lastEmail = await orchestrator.getLastEmail();
+      const lastEmail = await orchestrator.waitForFirstEmail();
       expect(lastEmail.recipients[0].includes(defaultUser.email)).toBe(true);
       expect(lastEmail.subject).toBe('Recuperação de Senha');
       expect(lastEmail.text).toContain(defaultUser.username);

--- a/tests/integration/api/v1/users/firewall.post.test.js
+++ b/tests/integration/api/v1/users/firewall.post.test.js
@@ -9,6 +9,7 @@ beforeAll(async () => {
   await orchestrator.dropAllTables();
   await orchestrator.runPendingMigrations();
   await orchestrator.createFirewallTestFunctions();
+  await orchestrator.deleteAllEmails();
 });
 
 describe('POST /api/v1/users [FIREWALL]', () => {
@@ -29,6 +30,7 @@ describe('POST /api/v1/users [FIREWALL]', () => {
         password: 'validpassword',
       });
 
+      await orchestrator.waitForNthEmail(2);
       await orchestrator.deleteAllEmails();
 
       const { response: response3, responseBody: response3Body } = await usersRequestBuilder.post({
@@ -88,7 +90,7 @@ describe('POST /api/v1/users [FIREWALL]', () => {
       expect(uuidVersion(lastEvent.id)).toBe(4);
       expect(Date.parse(lastEvent.created_at)).not.toBeNaN();
 
-      const allEmails = await orchestrator.getEmails();
+      const allEmails = await orchestrator.getEmails(2);
       expect(allEmails).toHaveLength(2);
 
       const user1Email = allEmails.find((email) => email.recipients.includes(`<${user1.email}>`));


### PR DESCRIPTION
## Mudanças realizadas

Passa a utilizar a função `waitUntil` da Vercel para os envios de emails. Com isso, as funções lambdas respondem às requisições sem aguardar o envio, que continua mesmo após a resposta.

A maior parte das mudanças está nos testes. Como as requisições agora são respondidas antes do envio dos e-mails, a responsabilidade de aguardar os envios passou para o orquestrador (nos testes em que os emails são verificados).

Além da melhoria de performance em algumas requisições, essa mudança também dificulta a varredura de endereços cadastrados através de alguns endpoints.

## Tipo de mudança

- [x] Nova funcionalidade

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Os testes antigos foram ajustados e estão passando localmente.