### PR TITLE
feat: botão de compartilhar adicionado

### DIFF
--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -92,10 +92,12 @@ export default function Post({ contentFound, rootContentFound, parentContentFoun
               key={contentFound.id}
               content={{
                 owner_id: contentFound.owner_id,
-                parent_id: contentFound.id,
                 owner_username: contentFound.owner_username,
+                parent_id: contentFound.id,
                 slug: contentFound.slug,
+                title: contentFound.title,
               }}
+              rootContent={rootContentFound}
               mode="compact"
             />
           </Box>
@@ -109,6 +111,7 @@ export default function Post({ contentFound, rootContentFound, parentContentFoun
             pageRootOwnerId={contentFound.owner_id}
             renderIntent={childrenToShow}
             renderIncrement={Math.ceil(childrenToShow / 2)}
+            rootContent={rootContentFound || contentFound}
           />
         </Box>
       </DefaultLayout>
@@ -191,11 +194,21 @@ function InReplyToLinks({ content, parentContent, rootContent }) {
   );
 }
 
-function RenderChildrenTree({ childrenList, pageRootOwnerId, renderIntent, renderIncrement }) {
+function RenderChildrenTree({ childrenList, pageRootOwnerId, renderIntent, renderIncrement, rootContent }) {
   const { childrenState, handleCollapse, handleExpand } = useCollapse({ childrenList, renderIntent, renderIncrement });
 
   return childrenState.map((child) => {
-    const { children, children_deep_count, groupedCount, id, owner_id, renderIntent, renderShowMore } = child;
+    const {
+      children,
+      children_deep_count,
+      groupedCount,
+      id,
+      owner_id,
+      owner_username,
+      renderIntent,
+      renderShowMore,
+      slug,
+    } = child;
     const labelShowMore = Math.min(groupedCount, renderIncrement) || '';
     const plural = labelShowMore != 1 ? 's' : '';
     const isPageRootOwner = pageRootOwnerId === owner_id;
@@ -276,13 +289,9 @@ function RenderChildrenTree({ childrenList, pageRootOwnerId, renderIntent, rende
 
               <Box sx={{ display: 'flex', flex: 1, mt: 4, alignItems: 'end' }}>
                 <Content
-                  content={{
-                    owner_id,
-                    parent_id: id,
-                    owner_username: child.owner_username,
-                    slug: child.slug,
-                  }}
+                  content={{ owner_id, owner_username, parent_id: id, slug }}
                   mode="compact"
+                  rootContent={rootContent}
                   viewFrame={true}
                 />
               </Box>
@@ -294,6 +303,7 @@ function RenderChildrenTree({ childrenList, pageRootOwnerId, renderIntent, rende
                   pageRootOwnerId={pageRootOwnerId}
                   renderIntent={renderIntent - 1}
                   renderIncrement={renderIncrement}
+                  rootContent={rootContent}
                 />
               )}
             </Box>
@@ -431,7 +441,7 @@ export const getStaticProps = getStaticPropsRevalidate(async (context) => {
 
     secureParentContentFound = authorization.filterOutput(userTryingToGet, 'read:content', parentContentFound);
 
-    secureRootContentFound = { id: secureParentContentFound.id };
+    secureRootContentFound = { id: secureParentContentFound.id, title: secureParentContentFound.title };
   }
 
   return {

--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -90,7 +90,12 @@ export default function Post({ contentFound, rootContentFound, parentContentFoun
             }}>
             <Content
               key={contentFound.id}
-              content={{ owner_id: contentFound.owner_id, parent_id: contentFound.id }}
+              content={{
+                owner_id: contentFound.owner_id,
+                parent_id: contentFound.id,
+                owner_username: contentFound.owner_username,
+                slug: contentFound.slug,
+              }}
               mode="compact"
             />
           </Box>
@@ -270,7 +275,16 @@ function RenderChildrenTree({ childrenList, pageRootOwnerId, renderIntent, rende
               <Content content={child} isPageRootOwner={isPageRootOwner} mode="view" />
 
               <Box sx={{ display: 'flex', flex: 1, mt: 4, alignItems: 'end' }}>
-                <Content content={{ owner_id, parent_id: id }} mode="compact" viewFrame={true} />
+                <Content
+                  content={{
+                    owner_id,
+                    parent_id: id,
+                    owner_username: child.owner_username,
+                    slug: child.slug,
+                  }}
+                  mode="compact"
+                  viewFrame={true}
+                />
               </Box>
 
               {children_deep_count > 0 && (

--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -26,7 +26,7 @@ import {
   useConfirm,
   Viewer,
 } from '@/TabNewsUI';
-import { KebabHorizontalIcon, LinkIcon, PencilIcon, TrashIcon } from '@/TabNewsUI/icons';
+import { KebabHorizontalIcon, LinkIcon, PencilIcon, ShareIcon, TrashIcon } from '@/TabNewsUI/icons';
 import webserver from 'infra/webserver';
 import { createErrorMessage, isTrustedDomain, isValidJsonString, processNdJsonStream, useUser } from 'pages/interface';
 
@@ -42,7 +42,7 @@ const CONTENT_TITLE_PLACEHOLDER_EXAMPLES = [
 
 const BODY_MAX_LENGTH = 20_000;
 
-export default function Content({ content, isPageRootOwner, mode = 'view', viewFrame = false }) {
+export default function Content({ content, isPageRootOwner, mode = 'view', rootContent, viewFrame = false }) {
   const [componentMode, setComponentMode] = useState(mode);
   const [contentObject, setContentObject] = useState(content);
   const { user } = useUser();
@@ -86,7 +86,7 @@ export default function Content({ content, isPageRootOwner, mode = 'view', viewF
       />
     );
   } else if (componentMode === 'compact') {
-    return <CompactMode setComponentMode={setComponentMode} contentObject={contentObject} />;
+    return <CompactMode setComponentMode={setComponentMode} contentObject={contentObject} rootContent={rootContent} />;
   } else if (componentMode === 'edit') {
     return (
       <EditMode
@@ -610,10 +610,13 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
   );
 }
 
-function CompactMode({ contentObject, setComponentMode }) {
+function CompactMode({ contentObject, rootContent, setComponentMode }) {
+  const [isLinkCopied, setCopied] = useState(false);
   const router = useRouter();
   const { user, isLoading } = useUser();
   const confirm = useConfirm();
+
+  const isRootContent = !rootContent?.title || rootContent.id === contentObject.id;
 
   const handleClick = useCallback(async () => {
     if (user && !isLoading) {
@@ -637,16 +640,22 @@ function CompactMode({ contentObject, setComponentMode }) {
     }
   }, [confirm, contentObject, isLoading, router, setComponentMode, user]);
 
-  const handleShare = () => {
+  const handleShare = async () => {
+    const title = isRootContent
+      ? contentObject.title
+      : `Resposta de "${contentObject.owner_username}" em "${rootContent.title}"`;
     const url = `${webserver.host}/${contentObject.owner_username}/${contentObject.slug}`;
-    if (navigator.share) {
-      navigator.share({
-        title: document.title,
-        url,
-      });
-    } else if (navigator.clipboard) {
-      navigator.clipboard.writeText(url);
-      alert('Link copiado para a área de transferência!');
+
+    try {
+      await navigator.share({ title, url });
+    } catch {
+      try {
+        await navigator.clipboard.writeText(url);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      } catch {
+        alert('Não foi possível copiar o link. Verifique as permissões e se o navegador suporta a funcionalidade.');
+      }
     }
   };
 
@@ -660,16 +669,14 @@ function CompactMode({ contentObject, setComponentMode }) {
         onClick={handleClick}>
         Responder
       </Button>
-      <Button
-        sx={{
-          maxWidth: 'fit-content',
-          display: 'flex',
-          alignItems: 'center',
-          flexWrap: 'nowrap',
-        }}
-        onClick={handleShare}>
-        Compartilhar
-      </Button>
+      <Tooltip
+        text={`Compartilhar ${isRootContent ? 'publicação' : 'comentário'}`}
+        direction="n"
+        sx={{ position: 'absolute' }}>
+        <Button onClick={handleShare}>
+          {isLinkCopied ? <Text sx={{ color: 'fg.muted' }}>Link copiado!</Text> : <ShareIcon size={16} />}
+        </Button>
+      </Tooltip>
     </Box>
   );
 }

--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -661,14 +661,9 @@ function CompactMode({ contentObject, rootContent, setComponentMode }) {
 
   return (
     <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
-      <Button
-        sx={{
-          maxWidth: 'fit-content',
-          flexWrap: 'nowrap',
-        }}
-        onClick={handleClick}>
-        Responder
-      </Button>
+      <Tooltip text={`Responder para ${contentObject.owner_username}`} direction="n" sx={{ position: 'absolute' }}>
+        <Button onClick={handleClick}>Responder</Button>
+      </Tooltip>
       <Tooltip
         text={`Compartilhar ${isRootContent ? 'publicação' : 'comentário'}`}
         direction="n"

--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -27,6 +27,7 @@ import {
   Viewer,
 } from '@/TabNewsUI';
 import { KebabHorizontalIcon, LinkIcon, PencilIcon, TrashIcon } from '@/TabNewsUI/icons';
+import webserver from 'infra/webserver';
 import { createErrorMessage, isTrustedDomain, isValidJsonString, processNdJsonStream, useUser } from 'pages/interface';
 
 const CONTENT_TITLE_PLACEHOLDER_EXAMPLES = [
@@ -636,14 +637,40 @@ function CompactMode({ contentObject, setComponentMode }) {
     }
   }, [confirm, contentObject, isLoading, router, setComponentMode, user]);
 
+  const handleShare = () => {
+    const url = `${webserver.host}/${contentObject.owner_username}/${contentObject.slug}`;
+    if (navigator.share) {
+      navigator.share({
+        title: document.title,
+        url,
+      });
+    } else if (navigator.clipboard) {
+      navigator.clipboard.writeText(url);
+      alert('Link copiado para a área de transferência!');
+    }
+  };
+
   return (
-    <Button
-      sx={{
-        maxWidth: 'fit-content',
-      }}
-      onClick={handleClick}>
-      Responder
-    </Button>
+    <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+      <Button
+        sx={{
+          maxWidth: 'fit-content',
+          flexWrap: 'nowrap',
+        }}
+        onClick={handleClick}>
+        Responder
+      </Button>
+      <Button
+        sx={{
+          maxWidth: 'fit-content',
+          display: 'flex',
+          alignItems: 'center',
+          flexWrap: 'nowrap',
+        }}
+        onClick={handleShare}>
+        Compartilhar
+      </Button>
+    </Box>
   );
 }
 

--- a/pages/interface/components/TabNewsUI/icons/index.js
+++ b/pages/interface/components/TabNewsUI/icons/index.js
@@ -24,6 +24,7 @@ export {
   PlusIcon,
   SearchIcon,
   SignOutIcon,
+  ShareIcon,
   SquareFillIcon,
   SunIcon,
   ThreeBarsIcon,


### PR DESCRIPTION
## Mudanças realizadas

Adicionei um botão de compartilhar ao lado do botão de *responder* em `pages/interface/components/Content/index.js`.

<!-- Descomente a linha abaixo que corresponde ao tipo de mudança realizada no PR. -->

## Tipo de mudança

<!-- - [ ] Correção de bug -->
- [x] Nova funcionalidade 
<!-- - [ ] _**Breaking change**_ (a alteração causa uma quebra de compatibilidade na API ou em links públicos do site) -->
<!-- - [ ] Atualização de documentação -->

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [ ] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.

## Imagens

| Imagem 1 | Imagem 2 |
|:---:|:---:|
| ![Screenshot_20250604-114532](https://github.com/user-attachments/assets/ae3c567c-ee53-4c10-9f80-1fd997ac813a) | ![Screenshot_20250604-145350.png](https://github.com/user-attachments/assets/8762535d-5f58-4f43-a956-53371e80b779) |


> Modo PWA.

## Motivo

Atualmente, para compartilhar um post é necessário copiar manualmente a URL completa da barra de endereços, o que não é prático nem acessível. Esta PR propõe a adição de um botão que copia automaticamente o link do post para a área de transferência, facilitando o compartilhamento.

Além disso, ao utilizar o aplicativo como PWA, a ausência de uma opção de compartilhamento integrada dificulta ainda mais essa ação. Com essa melhoria, o compartilhamento se torna mais simples, intuitivo e acessível para todos os usuários.

🤝