### PR TITLE
[fix] Impedir duplicação de `slug` em comentários ao remover título herdado

### DIFF
--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -95,9 +95,8 @@ export default function Post({ contentFound, rootContentFound, parentContentFoun
                 owner_username: contentFound.owner_username,
                 parent_id: contentFound.id,
                 slug: contentFound.slug,
-                title: contentFound.title,
               }}
-              rootContent={rootContentFound}
+              rootContent={rootContentFound || contentFound}
               mode="compact"
             />
           </Box>

--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -616,7 +616,7 @@ function CompactMode({ contentObject, rootContent, setComponentMode }) {
   const { user, isLoading } = useUser();
   const confirm = useConfirm();
 
-  const isRootContent = !rootContent?.title || rootContent.id === contentObject.id;
+  const isRootContent = rootContent.id === contentObject.parent_id;
 
   const handleClick = useCallback(async () => {
     if (user && !isLoading) {
@@ -641,9 +641,12 @@ function CompactMode({ contentObject, rootContent, setComponentMode }) {
   }, [confirm, contentObject, isLoading, router, setComponentMode, user]);
 
   const handleShare = async () => {
-    const title = isRootContent
-      ? contentObject.title
-      : `Resposta de "${contentObject.owner_username}" em "${rootContent.title}"`;
+    const title =
+      isRootContent && rootContent.title
+        ? rootContent.title
+        : rootContent.title
+          ? `Comentário de "${contentObject.owner_username}" em "${rootContent.title}"`
+          : `Conteúdo de "${contentObject.owner_username}"`;
     const url = `${webserver.host}/${contentObject.owner_username}/${contentObject.slug}`;
 
     try {


### PR DESCRIPTION
Comentários podem ter títulos, mas eles são ignorados pela UI. Apesar disso, o título pode ser considerado para a geração do `slug` do comentário.

Com a adição do botão de compartilhar conteúdos (#1900), o título da publicação pai estava sendo passado para o componente responsável por criar um comentário. Isso fazia com que múltiplos comentários herdassem o mesmo título e gerassem o mesmo `slug`, impedindo o envio de mais de um comentário do mesmo usuário no mesmo conteúdo em alguns casos, devido ao conflito de URL.

A partir desta correção, apenas a publicação raiz terá título. Comentários continuarão sem título e com `slug` aleatório (`uuid`), evitando colisões.

## Mudanças realizadas

Para de enviar o título da publicação pai para o componente de criação de respostas/comentários.

## Tipo de mudança

- [x] Correção de bug

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
