### PR TITLE
Aumenta o timeout de conexão com o banco de dados e melhora os logs de erros de conexão

### DIFF
--- a/errors/index.js
+++ b/errors/index.js
@@ -3,6 +3,7 @@ class BaseError extends Error {
     name,
     message,
     stack,
+    cause,
     action,
     statusCode,
     errorId,
@@ -16,6 +17,7 @@ class BaseError extends Error {
     super();
     this.name = name;
     this.message = message;
+    this.cause = cause;
     this.action = action;
     this.statusCode = statusCode || 500;
     this.errorId = errorId || crypto.randomUUID();
@@ -61,12 +63,13 @@ export class NotFoundError extends BaseError {
 }
 
 export class ServiceError extends BaseError {
-  constructor({ message, action, stack, context, statusCode, errorLocationCode, databaseErrorCode }) {
+  constructor({ message, action, stack, context, statusCode, errorLocationCode, databaseErrorCode, cause }) {
     super({
       name: 'ServiceError',
       message: message || 'Serviço indisponível no momento.',
       action: action || 'Verifique se o serviço está disponível.',
       stack: stack,
+      cause: cause,
       statusCode: statusCode || 503,
       context: context,
       errorLocationCode: errorLocationCode,

--- a/infra/database.js
+++ b/infra/database.js
@@ -12,7 +12,7 @@ const configurations = {
   database: process.env.POSTGRES_DB,
   password: process.env.POSTGRES_PASSWORD,
   port: process.env.POSTGRES_PORT,
-  connectionTimeoutMillis: 2000,
+  connectionTimeoutMillis: 10_000,
   idleTimeoutMillis: 30000,
   max: 3,
   ssl: {

--- a/infra/database.js
+++ b/infra/database.js
@@ -72,6 +72,7 @@ async function tryToGetNewClientFromPool() {
       const errorObject = new ServiceError({
         message: error.message,
         stack: error.stack,
+        cause: error.cause,
         context: {
           attempt,
           databaseCache: {


### PR DESCRIPTION
Recentemente estamos recebendo muitos erros de timeout de conexão com o banco de dados durante a tentativa de obter uma nova conexão do pool.

## Mudanças realizadas

Aumenta o timeout de 2s para 10s para tentar isolar se o problema é realmente o tempo de 2s não ser suficiente em alguns momentos ou se existe algum outro problema que ocasiona o erro de timeout.

Também para facilitar a identificação do problema, se o erro original da biblioteca `pg` contiver a propriedade `cause`, ela também estará disponível nos nossos logs.

Vou mesclar logo o PR para iniciar imediatamente o experimento. 🤝