### PR TITLE
test(login): adiciona testes MC/DC para o método onSubmit

### DIFF
--- a/tests/interface/LoginForm.test.js
+++ b/tests/interface/LoginForm.test.js
@@ -1,0 +1,131 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import Login from '../../pages/login/index.public';
+
+vi.mock('pages/interface', async () => {
+  const original = await vi.importActual('pages/interface');
+  return {
+    ...original,
+    useUser: () => ({
+      fetchUser: vi.fn(),
+      user: null,
+    }),
+    createErrorMessage: (msg) => msg?.message || 'erro padrão',
+    Head: () => null,
+  };
+});
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({
+    isReady: true,
+    query: {},
+    replace: vi.fn(),
+    asPath: '/',
+    pathname: '/',
+  }),
+}));
+
+vi.mock('@tabnews/forms', () => ({
+  email: {
+    name: 'email',
+    validate: () => null,
+  },
+  password: {
+    name: 'password',
+    validate: () => null,
+  },
+  useForm: () => ({
+    getFieldProps: (field) => ({
+      name: field,
+      onChange: () => {},
+      value: '',
+    }),
+    handleSubmit: (cb) => (event) => {
+      event.preventDefault();
+      cb({ email: 'user@example.com', password: '123456' });
+    },
+    state: {
+      globalMessage: { error: null },
+      loading: { value: false },
+    },
+    updateState: vi.fn(),
+  }),
+}));
+
+beforeEach(() => {
+  vi.spyOn(global, 'fetch').mockImplementation();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('LoginForm - Cobertura de MC/DC', () => {
+  it('TC1 - Login com sucesso (status 201)', async () => {
+    fetch.mockResolvedValueOnce({
+      status: 201,
+      json: async () => ({}),
+    });
+
+    render(<Login />);
+    fireEvent.submit(screen.getByRole('button', { name: /login/i }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalled();
+    });
+  });
+
+  it('TC2 - Erro 400 com campo válido (key=email)', async () => {
+    fetch.mockResolvedValueOnce({
+      status: 400,
+      json: async () => ({ key: 'email', message: 'E-mail inválido' }),
+    });
+
+    render(<Login />);
+    fireEvent.submit(screen.getByRole('button', { name: /login/i }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalled();
+    });
+  });
+
+  it('TC3 - Erro 400 com campo inválido', async () => {
+    fetch.mockResolvedValueOnce({
+      status: 400,
+      json: async () => ({ key: 'foo', message: 'Erro desconhecido' }),
+    });
+
+    render(<Login />);
+    fireEvent.submit(screen.getByRole('button', { name: /login/i }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalled();
+    });
+  });
+
+  it('TC4 - Erro inesperado (status 500)', async () => {
+    fetch.mockResolvedValueOnce({
+      status: 500,
+      json: async () => ({ message: 'Erro interno' }),
+    });
+
+    render(<Login />);
+    fireEvent.submit(screen.getByRole('button', { name: /login/i }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalled();
+    });
+  });
+
+  it('TC5 - Erro de rede (fetch lança exceção)', async () => {
+    fetch.mockRejectedValueOnce(new Error('Erro de rede'));
+
+    render(<Login />);
+    fireEvent.submit(screen.getByRole('button', { name: /login/i }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,8 +1,25 @@
-// Mock only in jsdom environment.
+// Só define mocks quando está em jsdom
 if (typeof document !== 'undefined') {
   global.CSS = {
-    supports: vi.fn().mockImplementation(() => {
-      return false;
-    }),
+    supports: vi.fn().mockImplementation(() => false),
   };
+
+  // matchMedia
+  vi.spyOn(window, 'matchMedia').mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+  }));
+
+  // IntersectionObserver
+  class IntersectionObserver {
+    constructor() {}
+    observe() {}
+    disconnect() {}
+    unobserve() {}
+  }
+
+  global.IntersectionObserver = IntersectionObserver;
 }


### PR DESCRIPTION
Este Pull Request adiciona uma suíte de testes unitários criando cobertura MC/DC para o método onSubmit() presente no componente LoginForm, localizado em pages/login/index.public.js.

A motivação se baseia nos critérios da atividade acadêmica relacionados à cobertura de decisões e condições modificadas (MC/DC) para garantir confiabilidade no fluxo de autenticação da aplicação.

Foram implementados cinco casos de teste (TC1 a TC5), simulando diferentes cenários de resposta da API:

- Sucesso (201)
- Erro 400 com campo válido (email)
- Erro 400 com campo inválido
- Erro inesperado (ex: 500)
- Erro de rede (exceção no fetch())

Todos os testes foram desenvolvidos utilizando Vitest e @testing-library/react, com suporte ao ambiente jsdom via workspace ui.

As dependências do roteador (useRouter) e do layout (Head) foram mockadas para garantir isolamento do componente em teste.

Este PR não altera a interface gráfica (UI).

Este PR não altera a API pública.

Tipo de mundança:
[X] Nova funcionalidade (adição de testes)

Checklist:
[X] As modificações não geram novos logs de erro ou aviso (warnings)
[X] Eu adicionei testes que provam que a funcionalidade está conforme o esperado
[X] Os testes (novos e antigos) estão passando localmente

![Captura de tela 2025-06-19 233344](https://github.com/user-attachments/assets/6ca42881-3c92-4d7c-9312-7fb12b052e1d)