### PR TITLE
Renderizar `TabCoinButtons` desativados em caso de conteúdo excluído

### DIFF
--- a/pages/[username]/[slug]/index.public.js
+++ b/pages/[username]/[slug]/index.public.js
@@ -236,7 +236,7 @@ function RenderChildrenTree({ childrenList, pageRootOwnerId, renderIntent, rende
                 alignItems: 'center',
                 minWidth: '28px',
               }}>
-              {isPublished && <TabCoinButtons content={child} />}
+              <TabCoinButtons content={child} />
               <Tooltip
                 direction="ne"
                 text={`Ocultar resposta${plural}`}

--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -695,7 +695,7 @@ function DeletedMode({ viewFrame }) {
         borderColor: 'border.default',
         borderStyle: 'solid',
       }}>
-      <Box sx={{ color: 'closed.fg', textAlign: 'center' }}>Conteúdo excluído</Box>
+      <Box sx={{ color: 'fg.muted', textAlign: 'center' }}>Conteúdo excluído</Box>
     </Box>
   );
 }

--- a/pages/interface/components/TabCoinButtons/index.js
+++ b/pages/interface/components/TabCoinButtons/index.js
@@ -8,6 +8,14 @@ import { ChevronDownIcon, ChevronUpIcon } from '@/TabNewsUI/icons';
 import { createErrorMessage, useUser } from 'pages/interface';
 
 export default function TabCoinButtons({ content }) {
+  if (content?.status !== 'published') {
+    return <DisabledButtons />;
+  }
+
+  return <ActiveButtons content={content} />;
+}
+
+function ActiveButtons({ content }) {
   const router = useRouter();
   const { user, isLoading, fetchUser } = useUser();
 
@@ -133,6 +141,15 @@ export default function TabCoinButtons({ content }) {
           disabled={isInAction}
         />
       </Tooltip>
+    </Box>
+  );
+}
+
+function DisabledButtons() {
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', color: 'border.muted', mt: 1, gap: 4, mb: 2 }}>
+      <ChevronUpIcon />
+      <ChevronDownIcon />
     </Box>
   );
 }


### PR DESCRIPTION
Renderiza as setas de qualificações com aspecto de botões desativados ao lado de conteúdos excluídos. Com isso facilita identificar em que nível da árvore o conteúdo excluído está.

Antes | Depois
--- | ---
<img width="318" alt="image" src="https://github.com/user-attachments/assets/c823a902-32e1-426b-b347-3cbbfdf51819" /> | <img width="318" alt="image" src="https://github.com/user-attachments/assets/a13a5e76-7ec3-464c-a3b0-81c1f93cc4ed" />
<img width="318" alt="image" src="https://github.com/user-attachments/assets/ec8e5f43-9a67-45b7-8f52-7355cd421907" /> | <img width="318" alt="image" src="https://github.com/user-attachments/assets/6a27ba2e-2920-44e3-8058-515607653813" />
