### PR TITLE
feat: retorna 404 para usuário inexistente na recuperação de senha

### DIFF
--- a/pages/api/v1/recovery/index.public.js
+++ b/pages/api/v1/recovery/index.public.js
@@ -7,6 +7,7 @@ import cacheControl from 'models/cache-control';
 import controller from 'models/controller.js';
 import event from 'models/event';
 import recovery from 'models/recovery.js';
+import user from 'models/user.js';
 import validator from 'models/validator.js';
 
 export default createRouter()
@@ -32,6 +33,20 @@ function postValidationHandler(request, response, next) {
 async function postHandler(request, response) {
   const userTryingToRecover = request.context.user;
   const validatedInputValues = request.body;
+
+  const { email, username } = validatedInputValues;
+
+  try {
+    if (email) {
+      await user.findOneByEmail(email);
+    } else if (username) {
+      await user.findOneByUsername(username);
+    } else {
+      return response.status(400).json({ message: 'É necessário informar um e-mail ou username.' });
+    }
+  } catch (error) {
+    return response.status(404).json({ message: 'O e-mail ou nome de usuário informado não está cadastrado.' });
+  }
 
   if (validatedInputValues.username && !authorization.can(userTryingToRecover, 'create:recovery_token:username')) {
     throw new ForbiddenError({

--- a/tests/integration/api/v1/recovery/index.test.js
+++ b/tests/integration/api/v1/recovery/index.test.js
@@ -1,0 +1,60 @@
+import orchestrator from 'tests/orchestrator.js';
+
+describe('POST /api/v1/recovery', () => {
+  beforeAll(async () => {
+    await orchestrator.waitForAllServices();
+  });
+
+  it('deve retornar 404 se o email não estiver cadastrado', async () => {
+    // CORREÇÃO APLICADA AQUI
+    const response = await fetch(`${orchestrator.webserverUrl}/api/v1/recovery`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        email: 'email.nao.cadastrado@example.com',
+      }),
+    });
+
+    const responseBody = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(responseBody.message).toBe('O e-mail ou nome de usuário informado não está cadastrado.');
+  });
+
+  it('deve retornar 404 se o username não estiver cadastrado', async () => {
+    // CORREÇÃO APLICADA AQUI
+    const response = await fetch(`${orchestrator.webserverUrl}/api/v1/recovery`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        username: 'usuarioinexistente',
+      }),
+    });
+
+    const responseBody = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(responseBody.message).toBe('O e-mail ou nome de usuário informado não está cadastrado.');
+  });
+
+  it('deve retornar 201 se o email estiver cadastrado', async () => {
+    const user = await orchestrator.createUser();
+
+    // CORREÇÃO APLICADA AQUI
+    const response = await fetch(`${orchestrator.webserverUrl}/api/v1/recovery`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        email: user.email,
+      }),
+    });
+
+    expect(response.status).toBe(201);
+  });
+});


### PR DESCRIPTION
### ## Mudanças realizadas

Atualmente, o fluxo de recuperação de senha pode gerar dúvidas no usuário. Ao submeter um email, a API sempre retorna a mesma mensagem genérica: `Caso o e-mail "usuario@exemplo.com" esteja cadastrado, um link será enviado para definir uma nova senha.`.

Isso faz com que o usuário não tenha certeza se o email que ele digitou é de fato o correto que está em seu cadastro, ou se ele simplesmente precisa esperar por um email que talvez nunca chegue.

Este PR melhora essa experiência de forma significativa, fornecendo um feedback imediato e preciso. Com esta mudança, a API primeiro verifica a existência do email ou nome de usuário no banco de dados.

-   **Se o usuário não for encontrado:** A API retorna um erro `404 Not Found` com a mensagem "O e-mail ou nome de usuário informado não está cadastrado.", eliminando qualquer dúvida.
-   **Se o usuário for encontrado:** A API retorna `201 Created` e o fluxo de envio de email continua normalmente, como antes.

Dessa forma, a comunicação com o usuário se torna mais transparente e objetiva. O endpoint de API afetado é o `POST /api/v1/recovery`.


### ## Tipo de mudança

-   [x] Nova funcionalidade
### ## Checklist:

-   [x] As modificações não geram novos logs de erro ou aviso (_warning_).
-   [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
-   [x] Tanto os novos testes quanto os antigos estão passando localmente.