### PR TITLE
Corrige resposta falsa na atualização de email com endereço de outro usuário

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -305,7 +305,7 @@ async function update(targetUser, postedUserData, options = {}) {
         delete validPostedUserData.email;
       }
     } catch (error) {
-      if (error instanceof ValidationError && error.key === 'email' && Object.keys(validPostedUserData).length > 1) {
+      if (error instanceof ValidationError && error.key === 'email' && !options.skipEmailConfirmation) {
         delete validPostedUserData.email;
       } else {
         throw error;

--- a/models/user.js
+++ b/models/user.js
@@ -297,7 +297,7 @@ async function update(targetUser, postedUserData, options = {}) {
   if (shouldValidateUsername || shouldValidateEmail) {
     try {
       await validateUniqueUser({ ...validPostedUserData, id: currentUser.id }, { transaction: options.transaction });
-      await deleteExpiredUsers(validPostedUserData);
+      await deleteExpiredUsers(validPostedUserData, { transaction: options.transaction });
       if (shouldValidateEmail && !options.skipEmailConfirmation) {
         await emailConfirmation.createAndSendEmail(currentUser, validPostedUserData.email, {
           transaction: options.transaction,
@@ -437,7 +437,7 @@ async function validateUniqueUser(userData, options) {
   });
 }
 
-async function deleteExpiredUsers(userObject) {
+async function deleteExpiredUsers(userObject, options) {
   const query = {
     text: `
       DELETE FROM
@@ -461,7 +461,7 @@ async function deleteExpiredUsers(userObject) {
     values: [userObject.username, userObject.email],
   };
 
-  await database.query(query);
+  await database.query(query, options);
 }
 
 async function hashPasswordInObject(userObject) {

--- a/pages/api/v1/users/[username]/index.public.js
+++ b/pages/api/v1/users/[username]/index.public.js
@@ -135,10 +135,7 @@ async function patchHandler(request, response) {
     await transaction.release();
 
     if (error instanceof ValidationError && error.key === 'email') {
-      updatedUser = {
-        ...targetUser,
-        updated_at: new Date(),
-      };
+      updatedUser = targetUser;
     } else {
       throw error;
     }

--- a/pages/api/v1/users/[username]/index.public.js
+++ b/pages/api/v1/users/[username]/index.public.js
@@ -1,6 +1,6 @@
 import { createRouter } from 'next-connect';
 
-import { ForbiddenError, UnprocessableEntityError, ValidationError } from 'errors';
+import { ForbiddenError, UnprocessableEntityError } from 'errors';
 import database from 'infra/database.js';
 import authentication from 'models/authentication.js';
 import authorization from 'models/authorization.js';
@@ -129,16 +129,12 @@ async function patchHandler(request, response) {
     );
 
     await transaction.query('COMMIT');
-    await transaction.release();
   } catch (error) {
     await transaction.query('ROLLBACK');
-    await transaction.release();
 
-    if (error instanceof ValidationError && error.key === 'email') {
-      updatedUser = targetUser;
-    } else {
-      throw error;
-    }
+    throw error;
+  } finally {
+    await transaction.release();
   }
 
   const secureOutputValues = authorization.filterOutput(

--- a/tests/integration/api/v1/email-confirmation/patch.test.js
+++ b/tests/integration/api/v1/email-confirmation/patch.test.js
@@ -316,11 +316,8 @@ describe('PATCH /api/v1/email-confirmation', () => {
         features: firstUser.features,
         notifications: firstUser.notifications,
         created_at: firstUser.created_at.toISOString(),
-        updated_at: responseBody.updated_at,
+        updated_at: firstUser.updated_at.toISOString(),
       });
-
-      expect(responseBody.updated_at).not.toBe(firstUser.updated_at.toISOString());
-      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
 
       const userInDatabaseCheck1 = await user.findOneById(firstUser.id);
       expect(userInDatabaseCheck1.email).toBe('validation.error@before.com');

--- a/tests/integration/api/v1/users/[username]/patch.test.js
+++ b/tests/integration/api/v1/users/[username]/patch.test.js
@@ -562,7 +562,7 @@ describe('PATCH /api/v1/users/[username]', () => {
         features: defaultUser.features,
         notifications: defaultUser.notifications,
         created_at: defaultUser.created_at.toISOString(),
-        updated_at: responseBody.updated_at,
+        updated_at: defaultUser.updated_at.toISOString(),
       });
 
       // Attention: it should not update the email in the database
@@ -934,11 +934,8 @@ describe('PATCH /api/v1/users/[username]', () => {
           features: defaultUser.features,
           notifications: defaultUser.notifications,
           created_at: defaultUser.created_at.toISOString(),
-          updated_at: responseBody.updated_at,
+          updated_at: defaultUser.updated_at.toISOString(),
         });
-
-        expect(responseBody.updated_at).not.toBe(defaultUser.updated_at.toISOString());
-        expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
 
         const foundUser = await user.findOneById(defaultUser.id);
         expect(foundUser.email).toBe(defaultUser.email);


### PR DESCRIPTION
Ao receber uma atualização de email com um endereço já cadastrado, nós enviamos uma resposta falsa para impedir que a funcionalidade seja utilizada indevidamente para descobrir endereços de email de outros usuários.

O problema era que a resposta falsa continha o campo `updated_at` diferente do que existiria em uma resposta real. Como o email só é atualizado após a confirmação do token, o `updated_at` permanece com o valor original até essa confirmação, mas a resposta falsa estava trazendo um `updated_at` com valor do momento.

## Mudanças realizadas

- d9e3b1a259d889c11d3efe44581c389924b65bae: Corrige o problema citado, retornando o `updated_at` original do usuário na resposta falsa.
- b4945fa8f71c34f1ad23555d9f9d3e67e37b6e3a: Ao fazer a correção já citada, foi notado que daria para simplificar a lógica da resposta falsa, então foi realizado. De bônus essa simplificação garante que a gente não perca o registro do evento de tentativa de atualização do cadastro.
- 5927e9f73f54f977e853378cfb646f5ab9d105b4: Ainda nessa correção, foi notado que a função `deleteExpiredUsers` não aceitava a transação como opção. Isso exigia a abertura de uma segunda conexão com o banco de dados em caso de patch do usuário, o que também já foi corrigido.

## Tipo de mudança

- [x] Correção de bug

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adequei os testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
