### PR TITLE
Corrige contagem de usuários e endpoint em teste de `/users`

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -89,7 +89,7 @@ async function findAllWithPagination(values) {
 }
 
 async function countTotalRows() {
-  const countQuery = `SELECT COUNT(*) OVER()::INTEGER as total_rows FROM users`;
+  const countQuery = `SELECT COUNT(*)::INTEGER as total_rows FROM users`;
   const countResult = await database.query(countQuery);
   return countResult.rows[0].total_rows;
 }

--- a/tests/integration/api/v1/users/get.test.js
+++ b/tests/integration/api/v1/users/get.test.js
@@ -111,7 +111,7 @@ describe('GET /api/v1/users', () => {
     });
 
     test('With an invalid value for "page"', async () => {
-      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/contents?page=first`);
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/users?page=first`);
       const responseBody = await response.json();
 
       expect.soft(response.status).toBe(400);


### PR DESCRIPTION
## Mudanças realizadas

Duas correções:

1. Endpoint no teste de usuários, que estava verificando `/contents` ao invés de `/users`.
2. Contagem de usuários quando a busca não retornava nenhum usuário.

Sobre o ponto `2`, o uso desnecessário de `OVER()` fazia com que a consulta não colapsasse os resultados, então numa base com 1.000 usuários, seriam retornadas 1.000 linhas contendo a quantidade de usuários. Como esse endpoint só é usado por moderadores e só ocorria ao consultar uma página além da última, isso não se tornou um problema real na prática.

## Tipo de mudança

- [x] Correção de teste
- [x] Melhoria de desempenho

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
