### PR TITLE
Remove configuração de memória do `vercel.json`

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,3 @@
 {
-  "functions": {
-    "pages/**/*.js": {
-      "memory": 1769
-    }
-  },
   "regions": ["gru1"]
 }


### PR DESCRIPTION
## Mudanças realizadas

Conforme [documentação](https://vercel.com/docs/functions/configuring-functions/memory#setting-your-default-function-memory-/-cpu-size):

> You cannot set your memory size using `vercel.json`. If you try to do so, you will receive a warning at build time. Only Pro and Enterprise users can set the default memory size in the dashboard. Hobby users will always use the default memory size of 1 GB (1 vCPU).