### PR TITLE
Formata contagem de conteúdos no perfil do usuário

### DIFF
--- a/pages/[username]/index.public.js
+++ b/pages/[username]/index.public.js
@@ -486,8 +486,6 @@ export const getStaticProps = getStaticPropsRevalidate(async (context) => {
   try {
     context.params = validator(context.params, {
       username: 'required',
-      page: 'optional',
-      per_page: 'optional',
     });
   } catch (error) {
     return {

--- a/pages/interface/components/UserHeader/index.js
+++ b/pages/interface/components/UserHeader/index.js
@@ -18,7 +18,7 @@ export default function UserHeader({ username, children, rootContentCount, child
             pathname: '/[username]/conteudos/[page]',
             query: { username, page: 1 },
           }}>
-          Publicações {!!rootContentCount && <CounterLabel>{rootContentCount}</CounterLabel>}
+          Publicações {!!rootContentCount && <CounterLabel>{rootContentCount.toLocaleString('pt-BR')}</CounterLabel>}
         </TabNavLink>
 
         <TabNavLink
@@ -26,7 +26,7 @@ export default function UserHeader({ username, children, rootContentCount, child
             pathname: '/[username]/comentarios/[page]',
             query: { username, page: 1 },
           }}>
-          Comentários {!!childContentCount && <CounterLabel>{childContentCount}</CounterLabel>}
+          Comentários {!!childContentCount && <CounterLabel>{childContentCount.toLocaleString('pt-BR')}</CounterLabel>}
         </TabNavLink>
 
         <TabNavLink
@@ -34,7 +34,7 @@ export default function UserHeader({ username, children, rootContentCount, child
             pathname: '/[username]/classificados/[page]',
             query: { username, page: 1 },
           }}>
-          Classificados {!!adContentCount && <CounterLabel>{adContentCount}</CounterLabel>}
+          Classificados {!!adContentCount && <CounterLabel>{adContentCount.toLocaleString('pt-BR')}</CounterLabel>}
         </TabNavLink>
       </TabNav>
     </>


### PR DESCRIPTION
## Mudanças realizadas

Formata a contagem de conteúdos que aparece no perfil do usuário para ter a separação de milhares.

| Antes | Depois |
| --- | --- |
| <img width="217" height="55" alt="123456" src="https://github.com/user-attachments/assets/67ccb198-589a-490f-91ca-29094f0e7591" /> | <img width="217" height="55" alt="123.456" src="https://github.com/user-attachments/assets/9d1142ee-7b44-4b88-b32d-50fb361fb1d1" /> |

Além disso, para de validar `page` e `per_page` na página `/[username]`, porque esses parâmetros não são usados.

## Tipo de mudança

- [x] Nova funcionalidade

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
