### PR TITLE
Omite header `x-vercel-oidc-token` dos logs

### DIFF
--- a/models/controller.js
+++ b/models/controller.js
@@ -122,7 +122,13 @@ function logRequest(request, response, next) {
 }
 
 const headersToRedact = ['authorization', 'cookie'];
-const headerToOmit = ['access-control-allow-headers', 'forwarded', 'x-vercel-proxy-signature', 'x-vercel-sc-headers'];
+const headerToOmit = [
+  'access-control-allow-headers',
+  'forwarded',
+  'x-vercel-proxy-signature',
+  'x-vercel-sc-headers',
+  'x-vercel-oidc-token',
+];
 
 function clearHeaders(headers) {
   const cleanHeaders = { ...headers };

--- a/tests/unit/models/controller.test.js
+++ b/tests/unit/models/controller.test.js
@@ -103,6 +103,7 @@ describe('Controller', () => {
           forwarded: 'omit',
           'x-vercel-proxy-signature': 'omit',
           'x-vercel-sc-headers': 'omit',
+          'x-vercel-oidc-token': 'omit',
           'other-header': 'test',
         },
         body: {


### PR DESCRIPTION
## Mudanças realizadas

O header em questão é um token JWT. É um [token da Vercel](https://vercel.com/docs/oidc) que não utilizamos para nada nos logs, então removê-lo deixará os logs mais limpos e consumirá menos recursos do Axiom.

## Tipo de mudança

- [x] Melhoria

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
