### PR TITLE
Uso correto da gramática portuguesa

### DIFF
--- a/pages/interface/components/ContentList/index.js
+++ b/pages/interface/components/ContentList/index.js
@@ -48,7 +48,7 @@ export default function ContentList({ ad, contentList: list, pagination, paginat
 
   function RenderItems() {
     function ChildrenDeepCountText({ count }) {
-      return count > 1 ? `${count} comentários` : `${count} comentário`;
+      return count === 1 ? `${count} comentário` : `${count} comentários`;
     }
 
     function TabCoinsText({ count }) {


### PR DESCRIPTION
## Mudanças realizadas

Na página que mostra os cards de cada uma das publicações feitas pelo usuário (`/[username]/conteudos/[page]`), percebi um minúsculo problema: um "errinho de portugês". No texto que mostra quantos comentários um post tem, mesmo quando haviam 0 comentários, estava escrito: "0 comentário". Então, achei que eu poderia contribuir com essa mudança simples que fiz.

### Antes (perceba a contagem de comentários que diz "0 comentário")
![Como estava antes](https://i.imgur.com/hIqJhkJ.png)

### Depois (perceba novamente)
![Como está agora](https://i.imgur.com/f2SgHSq.png)

Isso se mantém gramaticalmente correto para todas as outras possíveis quantidades.

Eu preciso adicionar um teste para essa alteração simples? Talvez não seja necessário... Não sei, me digam aí.

## Tipo de mudança

[x] Nova funcionalidade

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [ ] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
