### PR TITLE
Corrige warnings de divergência na hidratação por causa de `autoCapitalize`

### DIFF
--- a/pages/[username]/index.public.js
+++ b/pages/[username]/index.public.js
@@ -338,12 +338,11 @@ function DescriptionForm({
           type="button"
           disabled={isPosting}
           sx={{ fontWeight: 'normal', color: 'fg.muted' }}
-          aria-label="Cancelar alteração"
           onClick={handleCancel}>
           Cancelar
         </Button>
 
-        <ButtonWithLoader variant="primary" type="submit" aria-label="Salvar" isLoading={isPosting}>
+        <ButtonWithLoader variant="primary" type="submit" isLoading={isPosting}>
           Salvar
         </ButtonWithLoader>
       </Box>

--- a/pages/cadastro/index.public.js
+++ b/pages/cadastro/index.public.js
@@ -110,7 +110,6 @@ function SignUpForm() {
         size="large"
         type="submit"
         sx={{ width: '100%', mt: 3 }}
-        aria-label="Criar cadastro"
         disabled={!state.termsAccepted.checked}
         isLoading={state.loading.value}>
         Criar cadastro

--- a/pages/cadastro/recuperar/[token].public.js
+++ b/pages/cadastro/recuperar/[token].public.js
@@ -95,7 +95,6 @@ function RecoverPasswordForm() {
         size="large"
         type="submit"
         sx={{ width: '100%', mt: 3 }}
-        aria-label="Alterar senha"
         isLoading={state.loading.value}>
         Alterar senha
       </ButtonWithLoader>

--- a/pages/cadastro/recuperar/index.public.js
+++ b/pages/cadastro/recuperar/index.public.js
@@ -131,7 +131,6 @@ function RecoverPasswordForm() {
               autoCapitalize="none"
               spellCheck={false}
               block={true}
-              aria-label="Digite seu e-mail ou o nome de usuário de outra pessoa"
             />
             {['userInput', 'email', 'username'].includes(errorObject?.key) && (
               <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
@@ -159,7 +158,6 @@ function RecoverPasswordForm() {
               autoCapitalize="none"
               spellCheck={false}
               block={true}
-              aria-label="Seu e-mail"
             />
             {['userInput', 'email'].includes(errorObject?.key) && (
               <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
@@ -173,13 +171,7 @@ function RecoverPasswordForm() {
 
         <FormControl>
           <FormControl.Label visuallyHidden>Recuperar</FormControl.Label>
-          <ButtonWithLoader
-            variant="primary"
-            size="large"
-            type="submit"
-            sx={{ width: '100%' }}
-            aria-label="Recuperar"
-            isLoading={isLoading}>
+          <ButtonWithLoader variant="primary" size="large" type="submit" sx={{ width: '100%' }} isLoading={isLoading}>
             Recuperar
           </ButtonWithLoader>
         </FormControl>

--- a/pages/cadastro/recuperar/index.public.js
+++ b/pages/cadastro/recuperar/index.public.js
@@ -128,7 +128,7 @@ function RecoverPasswordForm() {
               name="userInput"
               size="large"
               autoCorrect="off"
-              autoCapitalize="off"
+              autoCapitalize="none"
               spellCheck={false}
               block={true}
               aria-label="Digite seu e-mail ou o nome de usuário de outra pessoa"
@@ -156,7 +156,7 @@ function RecoverPasswordForm() {
               name="userInput"
               size="large"
               autoCorrect="off"
-              autoCapitalize="off"
+              autoCapitalize="none"
               spellCheck={false}
               block={true}
               aria-label="Seu e-mail"

--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -592,16 +592,11 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
                 type="button"
                 disabled={isPosting}
                 sx={{ marginRight: 3, fontSize: 1, fontWeight: 'normal', cursor: 'pointer', color: 'fg.muted' }}
-                aria-label="Cancelar alteração"
                 onClick={handleCancel}>
                 Cancelar
               </Button>
             )}
-            <ButtonWithLoader
-              variant="primary"
-              type="submit"
-              aria-label={isPosting ? 'Carregando...' : contentObject?.id ? 'Atualizar' : 'Publicar'}
-              isLoading={isPosting}>
+            <ButtonWithLoader variant="primary" type="submit" isLoading={isPosting}>
               {contentObject?.id ? 'Atualizar' : 'Publicar'}
             </ButtonWithLoader>
           </Box>

--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -555,7 +555,7 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
                 name="source_url"
                 size="large"
                 autoCorrect="off"
-                autoCapitalize="off"
+                autoCapitalize="none"
                 spellCheck={false}
                 placeholder="https://origem.site/noticia"
                 block={true}

--- a/pages/login/index.public.js
+++ b/pages/login/index.public.js
@@ -111,7 +111,6 @@ function LoginForm() {
         size="large"
         type="submit"
         sx={{ width: '100%', mt: 3 }}
-        aria-label="Login"
         isLoading={state.loading.value}>
         Login
       </ButtonWithLoader>

--- a/pages/perfil/index.public.js
+++ b/pages/perfil/index.public.js
@@ -200,7 +200,6 @@ function EditProfileForm() {
             autoCapitalize="none"
             spellCheck={false}
             block={true}
-            aria-label="Seu nome de usuário"
             contrast
             sx={{ px: 2, '&:focus-within': { backgroundColor: 'canvas.default' } }}
             onChange={() => setShowUsernameCaption(true)}
@@ -232,7 +231,6 @@ function EditProfileForm() {
             autoCapitalize="none"
             spellCheck={false}
             block={true}
-            aria-label="Seu email"
             contrast
             sx={{ px: 2, '&:focus-within': { backgroundColor: 'canvas.default' } }}
           />
@@ -286,12 +284,7 @@ function EditProfileForm() {
         <FormControl id="notifications" sx={{ gap: 2, alignItems: 'center' }}>
           <FormControl.Label>Receber notificações por email</FormControl.Label>
 
-          <Checkbox
-            sx={{ display: 'flex' }}
-            ref={notificationsRef}
-            name="notifications"
-            aria-label="Você deseja receber notificações?"
-          />
+          <Checkbox sx={{ display: 'flex' }} ref={notificationsRef} name="notifications" />
 
           {errorObject?.key === 'notifications' && (
             <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>
@@ -311,13 +304,7 @@ function EditProfileForm() {
 
         <FormControl>
           <FormControl.Label visuallyHidden>Salvar</FormControl.Label>
-          <ButtonWithLoader
-            variant="primary"
-            size="large"
-            type="submit"
-            sx={{ width: '100%' }}
-            aria-label="Salvar"
-            isLoading={isLoading}>
+          <ButtonWithLoader variant="primary" size="large" type="submit" sx={{ width: '100%' }} isLoading={isLoading}>
             Salvar
           </ButtonWithLoader>
         </FormControl>

--- a/pages/perfil/index.public.js
+++ b/pages/perfil/index.public.js
@@ -197,7 +197,7 @@ function EditProfileForm() {
             name="username"
             size="large"
             autoCorrect="off"
-            autoCapitalize="off"
+            autoCapitalize="none"
             spellCheck={false}
             block={true}
             aria-label="Seu nome de usuário"
@@ -229,7 +229,7 @@ function EditProfileForm() {
             name="email"
             size="large"
             autoCorrect="off"
-            autoCapitalize="off"
+            autoCapitalize="none"
             spellCheck={false}
             block={true}
             aria-label="Seu email"


### PR DESCRIPTION
## Mudanças realizadas

Corrige o warning:

> Warning: Prop `autoCapitalize` did not match. Server: "none" Client: "off" Component Stack: (...)

Além disso, em `/cadastro` mudei o `autoCapitalize` de `fullName` para `words`. Isso sempre ajudará mais do que deixar desligado, e atrapalhará menos os casos que não devem ser capitalizados ("João dos Santos") do que não capitalizar nada. O campo `activationCode` deixei `autoCapitalize="characters"`.

Também removi os `aria-label` desnecessários (se já tem `label`, não precisa de `aria-label`).

[Deploy em Preview](https://tabnews-git-fix-hydration-warnings-tabnews.vercel.app?_vercel_share=Jb08SkRDQWOsqj7QVf4kMIKClS0PqXq8)

## Tipo de mudança

- [x] Correção de bug

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
