### PR TITLE
feat: add `curso.dev` backlink to `Footer`

### DIFF
--- a/pages/interface/components/Footer/index.js
+++ b/pages/interface/components/Footer/index.js
@@ -59,6 +59,7 @@ export default function Footer(props) {
           </Link>
           <Link href="/status">Status</Link>
           <Link href="/termos-de-uso">Termos de Uso</Link>
+          <Link href="https://curso.dev">curso.dev</Link>
         </Box>
       </Box>
     </Box>


### PR DESCRIPTION
Para fortalecer o projeto do [TabNews](https://www.tabnews.com.br/) e [curso.dev](https://curso.dev/), acabei de lá no curso.dev adicionar um link de volta para o TabNews:

<img width="830" height="109" alt="image" src="https://github.com/user-attachments/assets/06fd55f7-f690-4f1d-b8cf-eb02847dfeda" />

Estou agora adicionando o link de volta para o curso.dev no `Footer` do TabNews.