### PR TITLE
feat(auth): novo teste de authorization e alteração do método can()

### DIFF
--- a/models/authorization.js
+++ b/models/authorization.js
@@ -10,7 +10,7 @@ function can(user, feature, resource) {
 
   switch (feature) {
     case 'update:user':
-      return resource?.id && user.id === resource.id;
+      return Boolean(resource?.id && user.id === resource.id);
 
     case 'update:content':
       return (resource?.owner_id && user.id === resource.owner_id) || user.features.includes('update:content:others');

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "dotenv": "16.5.0",
         "dotenv-expand": "12.0.2",
         "husky": "9.1.7",
-        "kill-port": "1.6.1",
+        "kill-port": "^1.6.1",
         "lint-staged": "16.0.0",
         "react-email": "4.0.15",
         "set-cookie-parser": "2.7.1",
@@ -11681,6 +11681,7 @@
       "resolved": "https://registry.npmjs.org/kill-port/-/kill-port-1.6.1.tgz",
       "integrity": "sha512-un0Y55cOM7JKGaLnGja28T38tDDop0AQ8N0KlAdyh+B1nmMoX8AnNmqPNZbS3mUMgiST51DCVqmbFT1gNJpVNw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "get-them-args": "1.3.2",
         "shell-exec": "1.0.2"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "dotenv": "16.5.0",
     "dotenv-expand": "12.0.2",
     "husky": "9.1.7",
-    "kill-port": "1.6.1",
+    "kill-port": "^1.6.1",
     "lint-staged": "16.0.0",
     "react-email": "4.0.15",
     "set-cookie-parser": "2.7.1",

--- a/tests/integration/api/v1/authorization.test.js
+++ b/tests/integration/api/v1/authorization.test.js
@@ -1,0 +1,54 @@
+import authorization from '../../../../models/authorization.js';
+
+const { can } = authorization;
+describe('Função can(user, feature, resource)', () => {
+  const user_no_feature = { id: 1, features: [] };
+  const user_owner = { id: 1, features: ['update:user', 'update:content', 'read'] };
+  const user_admin = { id: 99, features: ['update:content:others', 'update:content', 'read'] };
+  const res_owner_1 = { id: 1, owner_id: 1 };
+  const res_other = { id: 2, owner_id: 2 };
+  const res_no_id = { owner_id: 1 };
+  const res_no_owner = { id: 1 };
+  it('CT1 - Feature não permitida', () => {
+    const result = can(user_no_feature, 'update:user', res_owner_1);
+    expect(result).toBe(false);
+  });
+  it("CT2 - Pode 'update:user' (Dono)", () => {
+    const result = can(user_owner, 'update:user', res_owner_1);
+    expect(result).toBe(true);
+  });
+  it("CT3 - Não pode 'update:user' (Não dono)", () => {
+    const result = can(user_owner, 'update:user', res_other);
+    expect(result).toBe(false);
+  });
+  it("CT4 - Não pode 'update:user' (Recurso sem ID)", () => {
+    const result = can(user_owner, 'update:user', res_no_id);
+    expect(result).toBe(false);
+  });
+  it("CT5 - Pode 'update:content' (Dono)", () => {
+    const result = can(user_owner, 'update:content', res_owner_1);
+    expect(result).toBe(true);
+  });
+  it("CT6 - Não pode 'update:content' (Recurso sem Dono)", () => {
+    const result = can(user_owner, 'update:content', res_no_owner);
+    expect(result).toBe(false);
+  });
+  it("CT7 - Não pode 'update:content' (Não dono)", () => {
+    const result = can(user_owner, 'update:content', res_other);
+    expect(result).toBe(false);
+  });
+  it("CT8 - Pode 'update:content' (Não dono, mas tem permissão de outros)", () => {
+    const result = can(user_admin, 'update:content', res_other);
+    expect(result).toBe(true);
+  });
+  it('CT9 - Pode feature genérica (sem recurso)', () => {
+    const user_owner = { id: 1, features: ['update:user', 'update:content', 'read:user'] };
+
+    const result = can(user_owner, 'read:user');
+    expect(result).toBe(true);
+  });
+  it('CT10 - Não pode feature genérica (com recurso)', () => {
+    const result = can(user_owner, 'read:user', res_owner_1);
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
## Mudanças realizadas

Este Pull Request (PR) tem como objetivo principal aumentar a cobertura de código do módulo de autorização (authorization.js) e corrigir um defeito de tipo identificado durante a execução dos novos testes.

### Alterações

#### Aumento da Cobertura de Testes: 

Foram adicionados testes abrangentes para a função can() em tests/integration/api/v1/authorization.test.js, focando em cenários de permissão, posse de recurso e ausência de IDs. Isso elevou a cobertura de Funções no authorization.js de 27.27% para 68.75%.

### Correção de Bug (Tipo de Retorno):

- Arquivo/Função: authorization.js -> can()

- Problema: A função podia retornar undefined (em vez de false) quando a verificação de posse do recurso falhava por falta de ID no recurso. O teste CT4 demonstrou essa falha.

- Solução: A expressão de retorno foi encapsulada pelo construtor Boolean() para forçar um retorno explícito (true ou false):

// Linha Corrigida:
return Boolean(resource?.id && user.id === resource.id);

## Tipo de mudança


[x] Correção de bug 
[x] Nova funcionalidade  (Adição de novos testes)

## Checklist:

[x] As modificações não geram novos logs de erro ou aviso (_warning_).
[ x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
[ x] Tanto os novos testes quanto os antigos estão passando localmente.
