### PR TITLE
Corrige validação de UUIDs

### DIFF
--- a/models/validator.js
+++ b/models/validator.js
@@ -101,11 +101,14 @@ export default function validator(object, keys) {
 }
 
 const schemas = {
+  uuidV4: function () {
+    return Joi.string().trim().guid({ version: 'uuidv4', separator: '-', wrapper: false });
+  },
+
   id: function () {
     return Joi.object({
-      id: Joi.string()
-        .trim()
-        .guid({ version: 'uuidv4' })
+      id: schemas
+        .uuidV4()
         .when('$required.id', { is: 'required', then: Joi.required(), otherwise: Joi.optional().allow(null) }),
     });
   },
@@ -191,9 +194,8 @@ const schemas = {
 
   token_id: function () {
     return Joi.object({
-      token_id: Joi.string()
-        .trim()
-        .guid({ version: 'uuidv4' })
+      token_id: schemas
+        .uuidV4()
         .when('$required.token_id', { is: 'required', then: Joi.required(), otherwise: Joi.optional() }),
     });
   },
@@ -209,9 +211,8 @@ const schemas = {
 
   parent_id: function () {
     return Joi.object({
-      parent_id: Joi.string()
-        .trim()
-        .guid({ version: 'uuidv4' })
+      parent_id: schemas
+        .uuidV4()
         .when('$required.parent_id', { is: 'required', then: Joi.required(), otherwise: Joi.optional().allow(null) }),
     });
   },
@@ -292,9 +293,8 @@ const schemas = {
 
   owner_id: function () {
     return Joi.object({
-      owner_id: Joi.string()
-        .trim()
-        .guid({ version: 'uuidv4' })
+      owner_id: schemas
+        .uuidV4()
         .when('$required.owner_id', { is: 'required', then: Joi.required(), otherwise: Joi.optional().allow(null) }),
     });
   },
@@ -410,7 +410,7 @@ const schemas = {
 
   ignore_id: function () {
     return Joi.object({
-      ignore_id: schemas.id().extract('id'),
+      ignore_id: schemas.uuidV4().when('$required.optional', { is: 'required', then: Joi.required() }),
     });
   },
 
@@ -644,7 +644,7 @@ const schemas = {
         .messages({
           'any.only': '{#label} não aceita o valor "{#value}".',
         }),
-      originator_user_id: Joi.string().allow(null).guid({ version: 'uuidv4' }).optional(),
+      originator_user_id: schemas.uuidV4().optional().allow(null),
       originator_ip: Joi.string()
         .ip({
           version: ['ipv4', 'ipv6'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "date-fns": "4.1.0",
         "feed": "4.2.2",
         "is-in-subnet": "4.0.1",
-        "joi": "17.13.3",
+        "joi": "18.0.2",
         "next": "15.3.2",
         "next-connect": "1.0.0",
         "next-swr": "0.2.0-canary.0",
@@ -1632,17 +1632,46 @@
       "integrity": "sha512-WkaM4mfs8x7dXRWEaDb5deC0OhH6sGQ5cw8i/sVw25gikl4f8C7mHj0kihL5k3eKIIqmGT1Fdswdoi+9ZLDpRA==",
       "license": "MIT"
     },
+    "node_modules/@hapi/address": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
+      "integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/formula": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
+      "integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw=="
+    },
     "node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
+      "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ=="
+    },
+    "node_modules/@hapi/pinpoint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.1.tgz",
+      "integrity": "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q=="
+    },
+    "node_modules/@hapi/tlds": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.4.tgz",
+      "integrity": "sha512-Fq+20dxsxLaUn5jSSWrdtSRcIUba2JquuorF9UW1wIJS5cSUwxIsO2GIhaWynPRflvxSzFN+gxKte2HEW1OuoA==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@hapi/topo": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
-      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
+      "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
       "dependencies": {
-        "@hapi/hoek": "^9.0.0"
+        "@hapi/hoek": "^11.0.2"
       }
     },
     "node_modules/@humanfs/core": {
@@ -3487,30 +3516,17 @@
         "node": ">= 8.0.0"
       }
     },
-    "node_modules/@sideway/address": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
-      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "node_modules/@sideway/formula": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
-      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
-    },
-    "node_modules/@sideway/pinpoint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
-    },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="
     },
     "node_modules/@styled-system/background": {
       "version": "5.1.2",
@@ -11348,16 +11364,20 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.13.3",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
-      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
-      "license": "BSD-3-Clause",
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.0.2.tgz",
+      "integrity": "sha512-RuCOQMIt78LWnktPoeBL0GErkNaJPTBGcYuyaBvUOQSpcpcLfWrHPPihYdOGbV5pam9VTWbeoF7TsGiHugcjGA==",
       "dependencies": {
-        "@hapi/hoek": "^9.3.0",
-        "@hapi/topo": "^5.1.0",
-        "@sideway/address": "^4.1.5",
-        "@sideway/formula": "^3.0.1",
-        "@sideway/pinpoint": "^2.0.0"
+        "@hapi/address": "^5.1.1",
+        "@hapi/formula": "^3.0.2",
+        "@hapi/hoek": "^11.0.7",
+        "@hapi/pinpoint": "^2.0.1",
+        "@hapi/tlds": "^1.1.1",
+        "@hapi/topo": "^6.0.2",
+        "@standard-schema/spec": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/js-beautify": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "date-fns": "4.1.0",
     "feed": "4.2.2",
     "is-in-subnet": "4.0.1",
-    "joi": "17.13.3",
+    "joi": "18.0.2",
     "next": "15.3.2",
     "next-connect": "1.0.0",
     "next-swr": "0.2.0-canary.0",

--- a/tests/integration/api/v1/activation/patch.test.js
+++ b/tests/integration/api/v1/activation/patch.test.js
@@ -129,6 +129,156 @@ describe('PATCH /api/v1/activation', () => {
       expect(responseBody.key).toBe('token_id');
     });
 
+    test('Activating using a malformatted array-like uuid without hyphens', async () => {
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/activation`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+
+        body: JSON.stringify({
+          token_id: '[41aae2b4c8cc41a58443c5f8589b32dc]',
+        }),
+      });
+
+      const responseBody = await response.json();
+
+      expect.soft(response.status).toBe(400);
+      expect(responseBody).toStrictEqual({
+        status_code: 400,
+        name: 'ValidationError',
+        message: '"token_id" deve possuir um token UUID na versão 4.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
+        key: 'token_id',
+        type: 'string.guid',
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+      });
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+    });
+
+    test('Activating using a malformatted uuid with square brackets', async () => {
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/activation`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+
+        body: JSON.stringify({
+          token_id: '[7c19bfe3-1602-4ce2-ba16-5e4a6b6fb375]',
+        }),
+      });
+
+      const responseBody = await response.json();
+
+      expect.soft(response.status).toBe(400);
+      expect(responseBody).toStrictEqual({
+        status_code: 400,
+        name: 'ValidationError',
+        message: '"token_id" deve possuir um token UUID na versão 4.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
+        key: 'token_id',
+        type: 'string.guid',
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+      });
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+    });
+
+    test('Activating using a malformatted uuid with brackets', async () => {
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/activation`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+
+        body: JSON.stringify({
+          token_id: '{2d825c13-7206-46e2-8d8d-783dc36d5731}',
+        }),
+      });
+
+      const responseBody = await response.json();
+
+      expect.soft(response.status).toBe(400);
+      expect(responseBody).toStrictEqual({
+        status_code: 400,
+        name: 'ValidationError',
+        message: '"token_id" deve possuir um token UUID na versão 4.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
+        key: 'token_id',
+        type: 'string.guid',
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+      });
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+    });
+
+    test('Activating using a malformatted uuid with ":" as separators', async () => {
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/activation`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+
+        body: JSON.stringify({
+          token_id: '0a2a951d:70c7:424a:aa5d:cc7a2fc1fd59',
+        }),
+      });
+
+      const responseBody = await response.json();
+
+      expect.soft(response.status).toBe(400);
+      expect(responseBody).toStrictEqual({
+        status_code: 400,
+        name: 'ValidationError',
+        message: '"token_id" deve possuir um token UUID na versão 4.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
+        key: 'token_id',
+        type: 'string.guid',
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+      });
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+    });
+
+    test('Activating using a malformatted uuid without separators', async () => {
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/activation`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+
+        body: JSON.stringify({
+          token_id: '41aae2b4c8cc41a58443c5f8589b32dc',
+        }),
+      });
+
+      const responseBody = await response.json();
+
+      expect.soft(response.status).toBe(400);
+      expect(responseBody).toStrictEqual({
+        status_code: 400,
+        name: 'ValidationError',
+        message: '"token_id" deve possuir um token UUID na versão 4.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
+        key: 'token_id',
+        type: 'string.guid',
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+      });
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+    });
+
     test('Activating using a fresh and valid token', async () => {
       const defaultUser = await orchestrator.createUser();
       const activationToken = await activation.create(defaultUser);

--- a/tests/integration/api/v1/email-confirmation/patch.test.js
+++ b/tests/integration/api/v1/email-confirmation/patch.test.js
@@ -151,6 +151,35 @@ describe('PATCH /api/v1/email-confirmation', () => {
       });
     });
 
+    test('With a malformatted uuid token with square brackets', async () => {
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/email-confirmation`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+
+        body: JSON.stringify({
+          token_id: '[ab5db012-d162-41c6-a5f6-a8fe0aa6cd38]',
+        }),
+      });
+
+      const responseBody = await response.json();
+
+      expect.soft(response.status).toBe(400);
+
+      expect(responseBody).toStrictEqual({
+        name: 'ValidationError',
+        message: '"token_id" deve possuir um token UUID na versão 4.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        status_code: 400,
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+        error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
+        key: 'token_id',
+        type: 'string.guid',
+      });
+    });
+
     test('With a fresh and valid token', async () => {
       // 1) UPDATE USER EMAIL
       const defaultUser = await orchestrator.createUser({

--- a/tests/integration/api/v1/recovery/patch.test.js
+++ b/tests/integration/api/v1/recovery/patch.test.js
@@ -318,6 +318,36 @@ describe('PATCH /api/v1/recovery', () => {
       expect(uuidVersion(responseBody.request_id)).toBe(4);
     });
 
+    test('With token_id as a malformatted uuid with square brackets', async () => {
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/recovery`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+
+        body: JSON.stringify({
+          token_id: '[c604e22e-514d-4bf4-82b9-9fcf64ab04ba]',
+        }),
+      });
+
+      const responseBody = await response.json();
+
+      expect.soft(response.status).toBe(400);
+      expect(responseBody).toStrictEqual({
+        status_code: 400,
+        name: 'ValidationError',
+        message: '"token_id" deve possuir um token UUID na versão 4.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
+        key: 'token_id',
+        type: 'string.guid',
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+      });
+      expect(uuidVersion(responseBody.error_id)).toBe(4);
+      expect(uuidVersion(responseBody.request_id)).toBe(4);
+    });
+
     test('With "password" missing', async () => {
       const response = await fetch(`${orchestrator.webserverUrl}/api/v1/recovery`, {
         method: 'PATCH',

--- a/tests/integration/api/v1/sponsored-beta/get.test.js
+++ b/tests/integration/api/v1/sponsored-beta/get.test.js
@@ -7,8 +7,49 @@ beforeAll(async () => {
 });
 
 describe('GET /api/v1/sponsored-beta', () => {
+  const adsRequestBuilder = new RequestBuilder('/api/v1/sponsored-beta');
+
   describe('Anonymous user', () => {
-    const adsRequestBuilder = new RequestBuilder('/api/v1/sponsored-beta');
+    it('should not accept "owner_id" with square brackets', async () => {
+      const { response, responseBody } = await adsRequestBuilder.get(
+        '?owner_id=[e627895c-7988-417d-8700-2cbdc75ad104]',
+      );
+
+      expect.soft(response.status).toBe(400);
+      expect(responseBody).toStrictEqual({
+        status_code: 400,
+        name: 'ValidationError',
+        message: '"owner_id" deve possuir um token UUID na versão 4.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
+        key: 'owner_id',
+        type: 'string.guid',
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+      });
+    });
+
+    it('should not accept "ignore_id" with brackets', async () => {
+      const { response, responseBody } = await adsRequestBuilder.get(
+        '?ignore_id={54490da8-b75d-4e96-ac9d-9fe4c509537e}',
+      );
+
+      expect.soft(response.status).toBe(400);
+      expect(responseBody).toStrictEqual({
+        status_code: 400,
+        name: 'ValidationError',
+        message: '"ignore_id" deve possuir um token UUID na versão 4.',
+        action: 'Ajuste os dados enviados e tente novamente.',
+        error_location_code: 'MODEL:VALIDATOR:FINAL_SCHEMA',
+        key: 'ignore_id',
+        type: 'string.guid',
+        error_id: responseBody.error_id,
+        request_id: responseBody.request_id,
+      });
+    });
+  });
+
+  describe('Anonymous user (with beforeEach)', () => {
     let owner;
 
     beforeEach(async () => {


### PR DESCRIPTION
## Mudanças realizadas

Atualmente, um UUID sem hífen e com colchetes é considerado válido pelo Joi, chegando ao banco de dados e lançando uma exceção por ser inválido.

Encontrei o [PR #3082 do Joi](https://github.com/hapijs/joi/pull/3082) que adiciona a opção `wrapper` na versão 18. Por isso, neste PR atualizo o Joi e padronizo a validação do UUID para evitar erros no banco de dados.

Exemplo de URL que causaria erro 500 antes na chamada da API, mas agora é validada corretamente:

- https://www.tabnews.com.br/cadastro/ativar/[54490da8-b75d-4e96-ac9d-9fe4c509537e]

## Tipo de mudança

- [x] Correção de bug

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
