### PR TITLE
feat: adiciona aviso visual no editor ao usar H1 no corpo do texto

### DIFF
--- a/pages/interface/components/Content/index.js
+++ b/pages/interface/components/Content/index.js
@@ -531,6 +531,13 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
               clobberPrefix={`${contentObject?.owner_username ?? user?.username}-content-`}
             />
 
+            {!contentObject?.parent_id && (newData.body?.startsWith('# ') || newData.body?.startsWith('<h1>')) && (
+              <Flash variant="warning" sx={{ mt: 2 }}>
+                <strong>⚠️ Dica de formatação:</strong> O título da publicação já é renderizado como título principal
+                (H1). Recomendamos usar <code>##</code> (H2) para subtítulos no corpo do texto.
+              </Flash>
+            )}
+
             <Box sx={{ display: 'flex', width: '100%' }}>
               {errorObject?.key === 'body' && (
                 <FormControl.Validation variant="error">{errorObject.message}</FormControl.Validation>


### PR DESCRIPTION
## Mudanças realizadas

<!-- Por favor, inclua uma descrição sobre o que foi modificado nesse PR. Inclua também qualquer motivação ou contexto relevante.  -->
Conforme discutido na issue #1982, a alteração automática da tag `h1` para `h2` via backend poderia prejudicar a intenção semântica do autor. 

Para resolver o problema da hierarquia visual duplicada (Título do Post + Título do Corpo) sem ser invasivo, implementei um **feedback visual (warning)** diretamente no Editor.

<img width="985" height="526" alt="image" src="https://github.com/user-attachments/assets/cf395fe1-a5b2-467b-b721-e32bde71fac3" />

<!-- Se o PR contém uma modificação da interface gráfica (UI), adicione fotos ou vídeos comparando o antes e depois. -->

<!-- Se o PR contém modificações de API, mencione os endpoints afetados. -->

<!-- Caso esse PR resolva algum issue, você pode descomentar a linha abaixo e substituir (issue) pelo número dele. -->
<!-- Resolve #(issue) -->
## Tipo de mudança

<!-- Descomente a linha abaixo que corresponde ao tipo de mudança realizada no PR. -->
<!-- - [x] Correção de bug -->
- [x] Nova funcionalidade
<!-- - [x] _**Breaking change**_ (a alteração causa uma quebra de compatibilidade na API ou em links públicos do site) -->
<!-- - [x] Atualização de documentação -->

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.


_Obs: Teste realizado manualmente (visual) no ambiente de desenvolvimento._
