### PR TITLE
Atualiza `next` para corrigir a CVE-2025-55183 e CVE-2025-55184

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "feed": "4.2.2",
         "is-in-subnet": "4.0.1",
         "joi": "18.0.2",
-        "next": "15.5.7",
+        "next": "15.5.8",
         "next-connect": "1.0.0",
         "next-swr": "0.2.0-canary.0",
         "node-pg-migrate": "7.9.1",
@@ -2413,9 +2413,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.7.tgz",
-      "integrity": "sha512-4h6Y2NyEkIEN7Z8YxkA27pq6zTkS09bUSYC0xjd0NpwFxjnIKeZEeH591o5WECSmjpUhLn3H2QLJcDye3Uzcvg=="
+      "version": "15.5.8",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.8.tgz",
+      "integrity": "sha512-ejZHa3ogTxcy851dFoNtfB5B2h7AbSAtHbR5CymUlnz4yW1QjHNufVpvTu8PTnWBKFKjrd4k6Gbi2SsCiJKvxw=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "15.3.2",
@@ -13737,11 +13737,11 @@
       }
     },
     "node_modules/next": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.7.tgz",
-      "integrity": "sha512-+t2/0jIJ48kUpGKkdlhgkv+zPTEOoXyr60qXe68eB/pl3CMJaLeIGjzp5D6Oqt25hCBiBTt8wEeeAzfJvUKnPQ==",
+      "version": "15.5.8",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.8.tgz",
+      "integrity": "sha512-Tma2R50eiM7Fx6fbDeHiThq7sPgl06mBr76j6Ga0lMFGrmaLitFsy31kykgb8Z++DR2uIEKi2RZ0iyjIwFd15Q==",
       "dependencies": {
-        "@next/env": "15.5.7",
+        "@next/env": "15.5.8",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "feed": "4.2.2",
     "is-in-subnet": "4.0.1",
     "joi": "18.0.2",
-    "next": "15.5.7",
+    "next": "15.5.8",
     "next-connect": "1.0.0",
     "next-swr": "0.2.0-canary.0",
     "node-pg-migrate": "7.9.1",


### PR DESCRIPTION
## Mudanças realizadas

Contexto: https://nextjs.org/blog/security-update-2025-12-11


## Tipo de mudança

- [x] Correção de segurança

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [ ] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
