### PR TITLE
feat(notifications): criado endpoints de notificacao

### DIFF
--- a/infra/migrations/1768561332899_create-notifications-table.js
+++ b/infra/migrations/1768561332899_create-notifications-table.js
@@ -1,0 +1,61 @@
+/**
+ * @type {import('node-pg-migrate').MigrationBuilder}
+ */
+
+exports.up = (pgm) => {
+  pgm.createTable('notifications', {
+    id: {
+      type: 'uuid',
+      default: pgm.func('gen_random_uuid()'),
+      notNull: true,
+      primaryKey: true,
+    },
+    user_id: {
+      type: 'uuid',
+      notNull: true,
+      references: '"users"',
+      onDelete: 'CASCADE',
+    },
+    type: {
+      type: 'varchar(50)',
+      notNull: true,
+    },
+    message: {
+      type: 'text',
+      notNull: true,
+    },
+    entity_id: {
+      type: 'uuid',
+      notNull: true,
+      references: '"contents"',
+      onDelete: 'CASCADE',
+    },
+    content_link: {
+      type: 'text',
+      notNull: true,
+    },
+    is_read: {
+      type: 'boolean',
+      notNull: true,
+      default: false,
+    },
+    created_at: {
+      type: 'timestamp with time zone',
+      notNull: true,
+      default: pgm.func("(now() at time zone 'utc')"),
+    },
+    updated_at: {
+      type: 'timestamp with time zone',
+      notNull: true,
+      default: pgm.func("(now() at time zone 'utc')"),
+    },
+  });
+
+  pgm.createIndex('notifications', 'user_id');
+  pgm.createIndex('notifications', ['user_id', 'is_read']);
+  pgm.createIndex('notifications', [{ name: 'created_at', sort: 'DESC' }]);
+};
+
+exports.down = (pgm) => {
+  pgm.dropTable('notifications');
+};

--- a/models/notification.js
+++ b/models/notification.js
@@ -1,11 +1,148 @@
 import { truncate } from '@tabnews/helpers';
 
+import database from 'infra/database';
 import email from 'infra/email.js';
 import webserver from 'infra/webserver.js';
 import authorization from 'models/authorization.js';
 import content from 'models/content.js';
 import { FirewallEmail, NotificationEmail } from 'models/transactional';
 import user from 'models/user.js';
+
+async function create(postedNotificationData) {
+  maybeDeleteOld();
+
+  const query = {
+    text: `
+      INSERT INTO
+        notifications (user_id, type, entity_id, content_link, message)
+      VALUES
+        ($1, $2, $3, $4, $5)
+      RETURNING
+        *
+      ;`,
+    values: [
+      postedNotificationData.user_id,
+      postedNotificationData.type,
+      postedNotificationData.entity_id,
+      postedNotificationData.content_link,
+      postedNotificationData.message,
+    ],
+  };
+
+  const results = await database.query(query);
+  const newNotification = results.rows[0];
+  return newNotification;
+}
+
+let lastCleanupAt = null;
+
+async function maybeDeleteOld() {
+  const ONE_DAY = 24 * 60 * 60 * 1000;
+
+  if (lastCleanupAt && Date.now() - lastCleanupAt < ONE_DAY) {
+    return;
+  }
+
+  await database.query(`
+    DELETE FROM notifications
+    WHERE created_at < NOW() - INTERVAL '90 days';
+  `);
+
+  lastCleanupAt = Date.now();
+}
+
+function setLastCleanupAt(value) {
+  lastCleanupAt = value;
+}
+
+async function read(notificationId, user_id) {
+  const query = {
+    text: `
+      UPDATE
+        notifications
+      SET
+        is_read = TRUE,
+        updated_at = (now() at time zone 'utc')
+      WHERE
+        id = $1 AND user_id = $2
+      ;`,
+    values: [notificationId, user_id],
+  };
+
+  await database.query(query);
+}
+
+async function markAllAsRead(userId) {
+  const query = {
+    text: `
+      UPDATE
+        notifications
+      SET
+        is_read = TRUE,
+        updated_at = (now() at time zone 'utc')
+      WHERE
+        user_id = $1
+      ;`,
+    values: [userId],
+  };
+
+  await database.query(query);
+}
+
+async function count(values = {}, options = {}) {
+  const where = values.where ?? {};
+
+  const whereClause = buildWhereClause(where);
+  const query = {
+    text: `
+      SELECT
+        COUNT(1)
+      FROM
+        notifications
+        ${whereClause.text}
+      ;`,
+    values: whereClause.values,
+  };
+
+  const results = await database.query(query, options);
+  return results.rows[0];
+}
+
+async function findAll(values = {}, options = {}) {
+  const where = values.where ?? {};
+  const { limit = 5, offset = 0 } = options;
+
+  const whereClause = buildWhereClause(where);
+  const query = {
+    text: `
+      SELECT
+        *
+      FROM
+        notifications
+        ${whereClause.text}
+      ORDER BY
+        is_read ASC, created_at DESC
+      LIMIT $${whereClause.values.length + 1} OFFSET $${whereClause.values.length + 2};`,
+    values: [...whereClause.values, limit, offset],
+  };
+
+  const results = await database.query(query);
+  return results.rows;
+}
+
+function buildWhereClause(where, nextArgumentIndex = 1) {
+  const values = [];
+  const conditions = Object.entries(where).map(([column, value]) => {
+    values.push(value);
+    return Array.isArray(value) ? `${column} = ANY ($${nextArgumentIndex++})` : `${column} = $${nextArgumentIndex++}`;
+  });
+
+  return {
+    text: conditions.length ? `WHERE ${conditions.join(' AND ')}` : '',
+    values: values,
+    nextArgumentIndex: nextArgumentIndex,
+  };
+}
 
 async function sendReplyEmailToParentUser(createdContent) {
   const anonymousUser = user.createAnonymous();
@@ -50,6 +187,14 @@ async function sendReplyEmailToParentUser(createdContent) {
       username: parentContentUser.username,
       bodyReplyLine: bodyReplyLine,
       contentLink: childContentUrl,
+    });
+
+    create({
+      user_id: secureRootContent.owner_id,
+      type: 'reply',
+      entity_id: secureCreatedContent.id,
+      content_link: childContentUrl,
+      message: bodyReplyLine,
     });
 
     await email.triggerSend({
@@ -150,7 +295,13 @@ function getFirewallDeletedContentLine(contents) {
 }
 
 export default Object.freeze({
+  findAll,
+  count,
+  read,
+  markAllAsRead,
   sendContentDeletedToUser,
   sendReplyEmailToParentUser,
   sendUserDisabled,
 });
+
+export { create, setLastCleanupAt }; // Only use in tests

--- a/models/user-features.js
+++ b/models/user-features.js
@@ -18,6 +18,9 @@ const availableFeatures = new Set([
   // EMAIL_CONFIRMATION_TOKEN
   'read:email_confirmation_token',
 
+  // NOTIFICATIONS
+  'read:notifications',
+
   // SESSION
   'create:session',
   'read:session',

--- a/pages/api/v1/notifications/[id]/read/index.public.js
+++ b/pages/api/v1/notifications/[id]/read/index.public.js
@@ -1,0 +1,34 @@
+import { createRouter } from 'next-connect';
+
+import authentication from 'models/authentication.js';
+import authorization from 'models/authorization.js';
+import cacheControl from 'models/cache-control';
+import controller from 'models/controller.js';
+import notification from 'models/notification';
+import validator from 'models/validator.js';
+
+export default createRouter()
+  .use(controller.injectRequestMetadata)
+  .use(authentication.injectAnonymousOrUser)
+  .use(controller.logRequest)
+  .use(cacheControl.noCache)
+  .patch(authorization.canRequest('read:session'), patchValidationHandler, patchHandler)
+  .handler(controller.handlerOptions);
+
+function patchValidationHandler(request, response, next) {
+  const cleanValues = validator(request.query, {
+    id: 'required',
+  });
+
+  request.query = cleanValues;
+
+  return next();
+}
+
+async function patchHandler(request, response) {
+  const authenticatedUser = request.context.user;
+
+  await notification.read(request.query.id, authenticatedUser.id);
+
+  return response.status(200).json({ success: true });
+}

--- a/pages/api/v1/notifications/index.public.js
+++ b/pages/api/v1/notifications/index.public.js
@@ -1,0 +1,27 @@
+import { createRouter } from 'next-connect';
+
+import authentication from 'models/authentication.js';
+import authorization from 'models/authorization.js';
+import cacheControl from 'models/cache-control';
+import controller from 'models/controller.js';
+import notification from 'models/notification';
+
+export default createRouter()
+  .use(controller.injectRequestMetadata)
+  .use(authentication.injectAnonymousOrUser)
+  .use(controller.logRequest)
+  .use(cacheControl.noCache)
+  .get(authorization.canRequest('read:session'), getHandler)
+  .handler(controller.handlerOptions);
+
+async function getHandler(request, response) {
+  const authenticatedUser = request.context.user;
+
+  const notifications = await notification.findAll(
+    { where: { user_id: authenticatedUser.id } },
+    { limit: 5, offset: 0 },
+  );
+  const countNotifications = await notification.count({ where: { user_id: authenticatedUser.id, is_read: false } });
+
+  return response.status(200).json({ notifications: notifications, unreadCount: Number(countNotifications.count) });
+}

--- a/pages/api/v1/notifications/mark-all-read/index.public.js
+++ b/pages/api/v1/notifications/mark-all-read/index.public.js
@@ -1,0 +1,23 @@
+import { createRouter } from 'next-connect';
+
+import authentication from 'models/authentication.js';
+import authorization from 'models/authorization.js';
+import cacheControl from 'models/cache-control';
+import controller from 'models/controller.js';
+import notification from 'models/notification';
+
+export default createRouter()
+  .use(controller.injectRequestMetadata)
+  .use(authentication.injectAnonymousOrUser)
+  .use(controller.logRequest)
+  .use(cacheControl.noCache)
+  .patch(authorization.canRequest('read:session'), patchHandler)
+  .handler(controller.handlerOptions);
+
+async function patchHandler(request, response) {
+  const authenticatedUser = request.context.user;
+
+  await notification.markAllAsRead(authenticatedUser.id);
+
+  return response.status(200).json({ success: true });
+}

--- a/tests/integration/api/v1/notifications/[id]/read/patch.test.js
+++ b/tests/integration/api/v1/notifications/[id]/read/patch.test.js
@@ -1,0 +1,66 @@
+import orchestrator from 'tests/orchestrator.js';
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.dropAllTables();
+  await orchestrator.runPendingMigrations();
+});
+
+describe('PATCH /api/v1/notifications/[id]/read', () => {
+  describe('Anonymous User', () => {
+    it('403 - Marking notification as read as anonymous user', async () => {
+      const mockId = crypto.randomUUID();
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/notifications/${mockId}/read`, {
+        method: 'PATCH',
+        headers: {},
+      });
+
+      const responseBody = await response.json();
+
+      expect.soft(response.status).toBe(403);
+      expect.soft(response.headers.get('Content-Type')).toContain('application/json');
+      expect.soft(responseBody.message).toBe('Usuário não pode executar esta operação.');
+    });
+  });
+  describe('Authenticated User', () => {
+    it('200 - Marking notification as read', async () => {
+      const mockId = crypto.randomUUID();
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const defaultUserSession = await orchestrator.createSession(defaultUser);
+
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/notifications/${mockId}/read`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          cookie: `session_id=${defaultUserSession.token}`,
+        },
+      });
+
+      const responseBody = await response.json();
+
+      expect.soft(response.status).toBe(200);
+      expect.soft(response.headers.get('Content-Type')).toContain('application/json');
+      expect.soft(responseBody.success).toBe(true);
+    });
+    it('400 - Marking notification as read with invalid id', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const defaultUserSession = await orchestrator.createSession(defaultUser);
+
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/notifications/1/read`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          cookie: `session_id=${defaultUserSession.token}`,
+        },
+      });
+
+      const responseBody = await response.json();
+
+      expect.soft(response.status).toBe(400);
+      expect.soft(response.headers.get('Content-Type')).toContain('application/json');
+      expect.soft(responseBody.message).toBe('"id" deve possuir um token UUID na versão 4.');
+    });
+  });
+});

--- a/tests/integration/api/v1/notifications/get.test.js
+++ b/tests/integration/api/v1/notifications/get.test.js
@@ -1,0 +1,47 @@
+import orchestrator from 'tests/orchestrator.js';
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.dropAllTables();
+  await orchestrator.runPendingMigrations();
+});
+
+describe('GET /api/v1/notifications', () => {
+  describe('Anonymous user', () => {
+    test('403 - Retrieving notifications as anonymous user', async () => {
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/notifications`, {
+        method: 'GET',
+        headers: {},
+      });
+
+      const responseBody = await response.json();
+
+      expect.soft(response.status).toBe(403);
+      expect.soft(response.headers.get('Content-Type')).toContain('application/json');
+      expect.soft(responseBody.message).toBe('Usuário não pode executar esta operação.');
+    });
+  });
+  describe('Authenticated User', () => {
+    test('200 - Retrieving notifications as authenticated user when is empty', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const defaultUserSession = await orchestrator.createSession(defaultUser);
+
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/notifications`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          cookie: `session_id=${defaultUserSession.token}`,
+        },
+      });
+
+      const responseBody = await response.json();
+
+      expect.soft(response.status).toBe(200);
+      expect.soft(response.headers.get('Content-Type')).toContain('application/json');
+
+      expect.soft(Array.isArray(responseBody.notifications)).toBe(true);
+      expect.soft(typeof responseBody.unreadCount === 'number').toBe(true);
+    });
+  });
+});

--- a/tests/integration/api/v1/notifications/mark-all-read/patch.test.js
+++ b/tests/integration/api/v1/notifications/mark-all-read/patch.test.js
@@ -1,0 +1,45 @@
+import orchestrator from 'tests/orchestrator.js';
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.dropAllTables();
+  await orchestrator.runPendingMigrations();
+});
+
+describe('PATCH /api/v1/notifications/mark-all-read', () => {
+  describe('Anonymous User', () => {
+    it('403 - Marking notification as read as anonymous user', async () => {
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/notifications/mark-all-read`, {
+        method: 'PATCH',
+        headers: {},
+      });
+
+      const responseBody = await response.json();
+
+      expect.soft(response.status).toBe(403);
+      expect.soft(response.headers.get('Content-Type')).toContain('application/json');
+      expect.soft(responseBody.message).toBe('Usuário não pode executar esta operação.');
+    });
+  });
+  describe('Authenticated User', () => {
+    it('200 - Marking notification as read', async () => {
+      const defaultUser = await orchestrator.createUser();
+      await orchestrator.activateUser(defaultUser);
+      const defaultUserSession = await orchestrator.createSession(defaultUser);
+
+      const response = await fetch(`${orchestrator.webserverUrl}/api/v1/notifications/mark-all-read`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          cookie: `session_id=${defaultUserSession.token}`,
+        },
+      });
+
+      const responseBody = await response.json();
+
+      expect.soft(response.status).toBe(200);
+      expect.soft(response.headers.get('Content-Type')).toContain('application/json');
+      expect.soft(responseBody.success).toBe(true);
+    });
+  });
+});

--- a/tests/unit/models/notification.test.js
+++ b/tests/unit/models/notification.test.js
@@ -1,0 +1,175 @@
+import { afterEach } from 'vitest';
+
+import notification, { create, setLastCleanupAt } from 'models/notification';
+
+const mocks = vi.hoisted(() => {
+  return {
+    query: vi.fn(),
+    release: vi.fn(),
+  };
+});
+
+vi.mock('infra/database', () => {
+  return {
+    default: {
+      query: mocks.query,
+      transaction: vi.fn().mockResolvedValue({
+        query: mocks.query,
+        release: mocks.release,
+      }),
+      errorCodes: {
+        SERIALIZATION_FAILURE: '40001',
+      },
+    },
+  };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('Notification model operations Database', () => {
+  describe('create', () => {
+    it('should call database.query with correct parameters', async () => {
+      const mockData = {
+        user_id: 1,
+        type: 'reply',
+        entity_id: 2,
+        content_link: 'http://example.com',
+        message: 'Test message',
+      };
+      mocks.query.mockResolvedValue({ rows: [mockData] });
+
+      await create(mockData);
+
+      const calls = mocks.query.mock.calls;
+      expect(calls.length).toBe(2);
+      expect(calls[0][0]).toContain('DELETE FROM notifications');
+      expect(calls[1][0].text.replaceAll(/\s+/g, ' ')).toContain('INSERT INTO notifications');
+      expect(calls[1][0].values).toStrictEqual([1, 'reply', 2, 'http://example.com', 'Test message']);
+    });
+
+    it('should call database.query with correct parameters with delete in cache', async () => {
+      const mockData = {
+        user_id: 1,
+        type: 'reply',
+        entity_id: 2,
+        content_link: 'http://example.com',
+        message: 'Test message',
+      };
+      mocks.query.mockResolvedValue({ rows: [mockData] });
+
+      setLastCleanupAt(Date.now());
+      await create(mockData);
+
+      const calls = mocks.query.mock.calls;
+      expect(calls.length).toBe(1);
+      expect(calls[0][0].text.replaceAll(/\s+/g, ' ')).toContain('INSERT INTO notifications');
+      expect(calls[0][0].values).toStrictEqual([1, 'reply', 2, 'http://example.com', 'Test message']);
+    });
+  });
+  describe('read', () => {
+    it('should call database.query with correct parameters', async () => {
+      // Arrange
+      const mockNotificationId = 1;
+      const mockUserId = 1;
+
+      // Act
+      await notification.read(mockNotificationId, mockUserId);
+
+      // Assert
+      const calls = mocks.query.mock.calls;
+      expect(calls.length).toBe(1);
+      expect(calls[0][0].text.replaceAll(/\s+/g, ' ')).toContain('UPDATE notifications SET is_read = TRUE');
+      expect(calls[0][0].values).toStrictEqual([mockNotificationId, mockUserId]);
+    });
+  });
+  describe('markAllAsRead', () => {
+    it('should call database.query with correct parameters', async () => {
+      // Arrange
+      const mockUserId = 1;
+
+      // Act
+      await notification.markAllAsRead(mockUserId);
+
+      // Assert
+      const calls = mocks.query.mock.calls;
+      expect(calls.length).toBe(1);
+      expect(calls[0][0].text.replaceAll(/\s+/g, ' ')).toContain('UPDATE notifications SET is_read = TRUE');
+      expect(calls[0][0].values).toStrictEqual([mockUserId]);
+    });
+  });
+
+  describe('count', () => {
+    it('should call database.query with correct parameters', async () => {
+      // Arrange
+      const mockWhere = { user_id: 1, is_read: false };
+      mocks.query.mockResolvedValue({ rows: [{ count: '3' }] });
+
+      // Act
+      await notification.count({ where: mockWhere });
+
+      // Assert
+      const calls = mocks.query.mock.calls;
+      expect(calls.length).toBe(1);
+      expect(calls[0][0].text.replaceAll(/\s+/g, ' ')).toContain(
+        'SELECT COUNT(1) FROM notifications WHERE user_id = $1 AND is_read = $2',
+      );
+      expect(calls[0][0].values).toStrictEqual([1, false]);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should call database.query with correct parameters', async () => {
+      // Arrange
+      const mockWhere = { user_id: 1 };
+      const mockOptions = { limit: 10, offset: 0 };
+      mocks.query.mockResolvedValue({ rows: [] });
+
+      // Act
+      await notification.findAll({ where: mockWhere }, mockOptions);
+
+      // Assert
+      const calls = mocks.query.mock.calls;
+      expect(calls.length).toBe(1);
+      expect(calls[0][0].text.replaceAll(/\s+/g, ' ')).toContain(
+        'SELECT * FROM notifications WHERE user_id = $1 ORDER BY is_read ASC, created_at DESC LIMIT $2 OFFSET $3',
+      );
+      expect(calls[0][0].values).toStrictEqual([1, 10, 0]);
+    });
+
+    it('should call database.query without where', async () => {
+      // Arrange
+      const mockOptions = { limit: 10, offset: 0 };
+      mocks.query.mockResolvedValue({ rows: [] });
+
+      // Act
+      await notification.findAll({}, mockOptions);
+
+      // Assert
+      const calls = mocks.query.mock.calls;
+      expect(calls.length).toBe(1);
+      expect(calls[0][0].text.replaceAll(/\s+/g, ' ')).toContain(
+        'SELECT * FROM notifications ORDER BY is_read ASC, created_at DESC LIMIT $1 OFFSET $2',
+      );
+      expect(calls[0][0].values).toStrictEqual([10, 0]);
+    });
+
+    it('should call database.query without limit and offset', async () => {
+      // Arrange
+      const mockWhere = { user_id: 1 };
+      mocks.query.mockResolvedValue({ rows: [] });
+
+      // Act
+      await notification.findAll({ where: mockWhere });
+
+      // Assert
+      const calls = mocks.query.mock.calls;
+      expect(calls.length).toBe(1);
+      expect(calls[0][0].text.replaceAll(/\s+/g, ' ')).toContain(
+        'SELECT * FROM notifications WHERE user_id = $1 ORDER BY is_read ASC, created_at DESC LIMIT $2 OFFSET $3',
+      );
+      expect(calls[0][0].values).toStrictEqual([1, 5, 0]);
+    });
+  });
+});


### PR DESCRIPTION
re #2000

## Mudanças realizadas

<!-- Por favor, inclua uma descrição sobre o que foi modificado nesse PR. Inclua também qualquer motivação ou contexto relevante.  -->

**Motivação:** Facilitar a navegação no site. Quando o sininho tiver implementado vai ser possível ir rapidamente na resposta ao invés de precisa ficar validando email ou ficar procurando comentário/post para visualizar as respostas.

Nesse PR foi realizado:
- Criação de endpoints de notificações para dar suporte ao **sininho de notificações** na UI.
- Criação da nova tabela **`notifications`** no banco de dados.
- Implementação de **3 novos endpoints** para gerenciamento de notificações.
- Desenvolvimento das **funções de operação** (CRUD) para a tabela `notifications`.
- Implementação do **primeiro fluxo de notificações**, responsável por registrar notificações de **respostas (reply)**.

## Endpoints criados

- **GET `/notifications`**  
  Responsável por retornar as **5 notificações mais recentes não lidas** do usuário autenticado.

- **PATCH `/notifications/{id}/read`**  
  Atualiza uma notificação específica, **marcando-a como lida**.

- **PATCH `/notifications/mark-all-read`**  
  Marca **todas as notificações do usuário** como lidas.

---

## Primeiro fluxo de notificação

O primeiro fluxo implementado é o de **respostas (reply)**.

- A notificação é criada no momento em que o sistema envia o e-mail de *reply* para o usuário, por meio da função `sendReplyEmailToParentUser`, localizada no módulo `notification.js`..
- Além do envio do e-mail, agora também é **inserido um registro na tabela `notifications`**, contendo o `content_link`, que permite ao usuário **navegar diretamente até o conteúdo da resposta**.

### Ponto de atenção

Não identifiquei a existência de um *job* ou processo agendado no sistema para limpeza de dados.  
Por esse motivo, foi implementada uma **função de deleção de notificações com mais de 90 dias**, evitando o acúmulo de registros desnecessários no banco.

Atualmente, essa rotina:
- É executada **no fluxo de criação de uma nova notificação**.
- Roda **no máximo uma vez por dia**, controlada por uma **variável global de tempo**.
- Sempre que o intervalo de **24 horas** é atingido, a função realiza a limpeza dos registros antigos.

Essa abordagem garante a manutenção da base sem impacto frequente no desempenho, até que exista (se necessário) um *job* dedicado para esse tipo de tarefa.

## Detalhes
<details>
  <summary><strong> Estrutura da tabela <code>notifications</code></strong></summary>

  <br />

  A tabela <code>notifications</code> foi criada para armazenar e gerenciar as notificações dos usuários,
  dando suporte ao sininho de notificações no front-end.

  ### Campos principais

  - **id**  
    Identificador único da notificação.

  - **user_id**  
    Referência ao usuário que receberá a notificação.

  - **type**  
    Define o tipo da notificação (ex.: `reply`, `mention`, etc.), permitindo expansão futura.

  - **message**  
    Texto exibido ao usuário no sininho de notificações.

  - **entity_id**  
    Identificador da entidade relacionada à notificação (conteúdo, comentário ou post).

  - **content_link**  
    Link direto para o conteúdo relacionado.

  - **is_read**  
    Indica se a notificação já foi lida.

  - **created_at / updated_at**  
    Datas de criação e atualização do registro (UTC).

  ### Índices

  - Busca otimizada por notificações mais recentes.
  - Listagem eficiente por usuário.
  - Consulta rápida de notificações não lidas para o sininho.

</details>

---

O objetivo deste PR é **preparar o backend** para a implementação do sininho de notificações no front-end, garantindo que a integração ocorra sem maiores impactos ou retrabalho.

Este PR **não contém modificações na UI**. A implementação do sininho no front-end será enviada em um **PR separado**, que já está preparado.

Nenhum endpoint existente foi alterado — foram **apenas adicionados três novos endpoints**, mantendo total compatibilidade com as funcionalidades atuais.



 Resolve #2000

## Tipo de mudança

- [x] Nova funcionalidade

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
