### PR TITLE
Aumenta tentativas de conexão do Umami; permite não configurar Umami; remove `redirect` de `/analytics`

### DIFF
--- a/infra/scripts/config-umami.js
+++ b/infra/scripts/config-umami.js
@@ -15,6 +15,13 @@ const client = new Client({
   allowExitOnIdle: false,
 });
 
+if (!endpoint || !websiteId) {
+  console.log(
+    '> Skipping Umami configuration because NEXT_PUBLIC_UMAMI_ENDPOINT or NEXT_PUBLIC_UMAMI_WEBSITE_ID is missing.',
+  );
+  process.exit(0);
+}
+
 configUmami();
 
 async function configUmami() {
@@ -77,7 +84,7 @@ async function configUmami() {
   console.log('> Umami configuration created!');
 }
 
-async function waitForServer(attempts = 5) {
+async function waitForServer(attempts = 15) {
   try {
     return await fetch(`${endpoint}/api/heartbeat`);
   } catch (error) {
@@ -87,7 +94,7 @@ async function waitForServer(attempts = 5) {
       return waitForServer(attempts - 1);
     }
 
-    console.error('🔴 Umami is not ready, exiting...');
+    console.error('> Umami is not ready, exiting...');
     process.exit(1);
   }
 }

--- a/next.config.js
+++ b/next.config.js
@@ -64,10 +64,6 @@ module.exports = {
         source: '/recentes/rss',
         destination: '/api/v1/contents/rss',
       },
-      {
-        source: '/api/v1/analytics',
-        destination: `${process.env.NEXT_PUBLIC_UMAMI_ENDPOINT}/api/send`,
-      },
     ];
   },
   headers() {


### PR DESCRIPTION
## Mudanças realizadas

Duas mudanças que haviam sido sugeridas em #1989:

- Aumenta tentativas de espera do servidor do Umami (deixei em `15` ao invés do `30` sugerido inicialmente).
- Permite pular configurações do Umami ao não ter `NEXT_PUBLIC_UMAMI_ENDPOINT` ou `NEXT_PUBLIC_UMAMI_WEBSITE_ID` definido.

E também, conforme mencionado em #1837, remove o `redirect`:

> O redirecionamento de `/api/v1/analytics` para a Umami foi mantido provisoriamente. Ele atenderá apenas visitantes que já estiverem navegando no TabNews durante o deploy desta modificação, e poderá ser removido futuramente.

Resolve #2002
Resolve #2001

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [ ] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
