### PR TITLE
feat: add keyboard shortcut '/' to open search

### DIFF
--- a/pages/interface/components/SearchBox/index.js
+++ b/pages/interface/components/SearchBox/index.js
@@ -7,12 +7,36 @@ const searchURL = process.env.NEXT_PUBLIC_SEARCH_URL + process.env.NEXT_PUBLIC_S
 
 export default function useSearchBox() {
   const [isOpen, setIsOpen] = useState(false);
-  const buttonRef = useRef();
+  const returnFocusRef = useRef();
 
   function onClickSearchButton(e) {
-    buttonRef.current = e.target;
+    returnFocusRef.current = e.target;
     setIsOpen(true);
   }
+
+  useEffect(() => {
+    const TYPING_TAGS = ['INPUT', 'TEXTAREA', 'SELECT'];
+
+    function handleKeyDown(event) {
+      if (event.key !== '/') return;
+      if (event.ctrlKey || event.metaKey || event.altKey) return;
+
+      const activeElement = document.activeElement;
+      const isTyping = TYPING_TAGS.includes(activeElement?.tagName) || activeElement?.isContentEditable;
+
+      if (isTyping) return;
+
+      event.preventDefault();
+      returnFocusRef.current = activeElement;
+      setIsOpen(true);
+    }
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, []);
 
   function SearchIconButton({ sx, ...props }) {
     return (
@@ -101,8 +125,8 @@ export default function useSearchBox() {
 
     return (
       <Overlay
-        returnFocusRef={buttonRef}
-        ignoreClickRefs={[suggestionsRef, buttonRef]}
+        returnFocusRef={returnFocusRef}
+        ignoreClickRefs={[suggestionsRef, returnFocusRef]}
         onEscape={handleClose}
         onClickOutside={handleClose}
         aria-labelledby="Pesquisar com o Google"


### PR DESCRIPTION
## Mudanças realizadas

Adicionado atalho de teclado `/` para abrir a busca do site.

Essa alteração faz parte da issue #1872 e melhora a navegação por teclado, permitindo abrir a pesquisa rapidamente sem precisar clicar no botão de busca.

Resolve #1872

## Tipo de mudança

- [x] Nova funcionalidade

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [ ] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.