### PR TITLE
Adiciona props para traduzir o texto das notas de rodapé do markdown e label do botão de voltar

### DIFF
--- a/packages/ui/src/Markdown/Markdown.jsx
+++ b/packages/ui/src/Markdown/Markdown.jsx
@@ -65,6 +65,8 @@ export function MarkdownViewer({
   areLinksTrusted,
   clobberPrefix,
   copyAnchorLink,
+  footnoteBackLabel = 'Voltar ao conteúdo',
+  footnoteLabel = 'Notas de rodapé',
   shouldAddNofollow,
   ...props
 }) {
@@ -88,7 +90,7 @@ export function MarkdownViewer({
   return (
     <ByteMdViewer
       sanitize={sanitize({ clobberPrefix })}
-      remarkRehype={{ clobberPrefix }}
+      remarkRehype={{ clobberPrefix, footnoteBackLabel, footnoteLabel }}
       plugins={bytemdPluginList}
       value={value}
       {...props}
@@ -100,6 +102,8 @@ export function MarkdownEditor({
   areLinksTrusted,
   clobberPrefix,
   editorConfig = {},
+  footnoteBackLabel = 'Voltar ao conteúdo',
+  footnoteLabel = 'Notas de rodapé',
   initialHeight = '30vh',
   isInvalid,
   mode = 'split', // 'tab'
@@ -132,7 +136,7 @@ export function MarkdownEditor({
         locale={byteMDLocale}
         sanitize={sanitize({ clobberPrefix })}
         editorConfig={{ autocapitalize: 'sentences', inputStyle: 'contenteditable', spellcheck: true, ...editorConfig }}
-        remarkRehype={{ clobberPrefix }}
+        remarkRehype={{ clobberPrefix, footnoteBackLabel, footnoteLabel }}
         {...props}
       />
       <EditorStyles height={initialHeight} mode={mode} />


### PR DESCRIPTION
## Mudanças realizadas

Adiciona as props `footnoteLabel` e `footnoteBackLabel` aos componentes `MarkdownViewer` e `MarkdownEditor`, permitindo customizar o título da seção de notas de rodapé e o `aria-label` do link de retorno ao conteúdo. Por padrão, ambas passam a usar texto em português ("Notas de rodapé" e "Voltar ao conteúdo") em vez dos valores padrão em inglês do `remark-rehype`.

Pode ser visto [aqui](https://tabnews-git-feat-footnotes-label-tabnews.vercel.app/rafael/teste-de-markdown-pr-1734#rafael-content-footnote-label)

<img width="320" alt="Notas de rodapé" src="https://github.com/user-attachments/assets/426fff7c-746f-4b5c-a557-b0d22ec9deb8" />

## Tipo de mudança

- [x] Nova funcionalidade

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [ ] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
