### PR TITLE
Corrige falsos positivos de TimeoutError ao enviar logs para o Axiom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -108,32 +108,6 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
     },
-    "node_modules/@axiomhq/js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@axiomhq/js/-/js-1.3.1.tgz",
-      "integrity": "sha512-Ytf5V3wKz8FKNiqJxnqZmUhjgJ7TItKUoyHVNE/H2V9dN1ozD6NNnsueenOjKdA48cm2sGRyP432nworst18aA==",
-      "license": "MIT",
-      "dependencies": {
-        "fetch-retry": "^6.0.0",
-        "uuid": "^11.0.2"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@axiomhq/js/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
@@ -2287,17 +2261,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/source-map": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
-      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
@@ -4096,17 +4059,6 @@
         "@types/ms": "*"
       }
     },
-    "node_modules/@types/eslint": {
-      "version": "8.56.10",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
-      "integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
@@ -4196,18 +4148,6 @@
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
       "integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g=="
     },
-    "node_modules/@types/pg": {
-      "version": "8.11.6",
-      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.6.tgz",
-      "integrity": "sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*",
-        "pg-protocol": "*",
-        "pg-types": "^4.0.1"
-      }
-    },
     "node_modules/@types/prop-types": {
       "version": "15.7.12",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
@@ -4220,16 +4160,6 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@types/react-dom": {
-      "version": "18.3.0",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
-      "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/react": "*"
       }
     },
     "node_modules/@types/react-is": {
@@ -5806,13 +5736,6 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "optional": true,
-      "peer": true
     },
     "node_modules/busboy": {
       "version": "1.6.0",
@@ -9244,12 +9167,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/fetch-retry": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-6.0.0.tgz",
-      "integrity": "sha512-BUFj1aMubgib37I3v4q78fYo63Po7t4HUPTpQ6/QE6yK6cIQrP+W43FYToeTEyg5m2Y7eFUtijUuAv/PDlWuag==",
-      "license": "MIT"
     },
     "node_modules/fflate": {
       "version": "0.7.4",
@@ -13909,13 +13826,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/obuf": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
-      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
@@ -14358,16 +14268,6 @@
         "node": ">=4.0.0"
       }
     },
-    "node_modules/pg-numeric": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pg-numeric/-/pg-numeric-1.0.2.tgz",
-      "integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/pg-pool": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.0.tgz",
@@ -14382,25 +14282,6 @@
       "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.0.tgz",
       "integrity": "sha512-IpdytjudNuLv8nhlHs/UrVBhU0e78J0oIS/0AVdTbWxSOkFUVdsHC/NrorO6nXsQNDTT1kzDSOMJubBQviX18Q==",
       "license": "MIT"
-    },
-    "node_modules/pg-types": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-4.0.2.tgz",
-      "integrity": "sha512-cRL3JpS3lKMGsKaWndugWQoLOCoP+Cic8oseVcbr0qhPzYD5DWXK+RZ9LY9wxRf7RQia4SCwQlXk0q6FCPrVng==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "pg-int8": "1.0.1",
-        "pg-numeric": "1.0.2",
-        "postgres-array": "~3.0.1",
-        "postgres-bytea": "~3.0.0",
-        "postgres-date": "~2.1.0",
-        "postgres-interval": "^3.0.0",
-        "postgres-range": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/pg/node_modules/pg-types": {
       "version": "2.2.0",
@@ -14590,56 +14471,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
-    },
-    "node_modules/postgres-array": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.2.tgz",
-      "integrity": "sha512-6faShkdFugNQCLwucjPcY5ARoW1SlbnrZjmGl0IrrqewpvxvhSLHimCVzqeuULCbG0fQv7Dtk1yDbG3xv7Veog==",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/postgres-bytea": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-3.0.0.tgz",
-      "integrity": "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "obuf": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/postgres-date": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-2.1.0.tgz",
-      "integrity": "sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/postgres-interval": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-3.0.0.tgz",
-      "integrity": "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/postgres-range": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.4.tgz",
-      "integrity": "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==",
-      "optional": true,
-      "peer": true
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -16762,16 +16593,6 @@
         "atomic-sleep": "^1.0.0"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -16779,17 +16600,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
       }
     },
     "node_modules/space-separated-tokens": {
@@ -17321,32 +17131,6 @@
       "funding": {
         "url": "https://opencollective.com/synckit"
       }
-    },
-    "node_modules/terser": {
-      "version": "5.31.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.1.tgz",
-      "integrity": "sha512-37upzU1+viGvuFtBo9NPufCb9dwM0+l9hMxYyWfBA+fbwrPqNJAhbZ6W47bBFnZHKHTUBnMvi87434qq+qnxOg==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.8.2",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/terser/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "optional": true,
-      "peer": true
     },
     "node_modules/test-exclude": {
       "version": "7.0.1",
@@ -19493,10 +19277,10 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@axiomhq/js": "1.3.1",
         "@tabnews/helpers": "*",
         "@vercel/functions": "2.1.0",
-        "pino": "9.7.0"
+        "pino": "9.7.0",
+        "pino-abstract-transport": "2.0.0"
       }
     },
     "packages/ui": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2524,6 +2524,12 @@
       "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
       "license": "MIT"
     },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -9112,15 +9118,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
-    "node_modules/fast-redact": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
-      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/fast-uri": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
@@ -14371,31 +14368,31 @@
       }
     },
     "node_modules/pino": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-9.7.0.tgz",
-      "integrity": "sha512-vnMCM6xZTb1WDmLvtG2lE/2p+t9hDEIvTWJsu6FejkE62vB7gDhvzrpFR4Cw2to+9JNQxVnkAKVPA1KPB98vWg==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
       "license": "MIT",
       "dependencies": {
+        "@pinojs/redact": "^0.4.0",
         "atomic-sleep": "^1.0.0",
-        "fast-redact": "^3.1.1",
         "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "^2.0.0",
+        "pino-abstract-transport": "^3.0.0",
         "pino-std-serializers": "^7.0.0",
         "process-warning": "^5.0.0",
         "quick-format-unescaped": "^4.0.3",
         "real-require": "^0.2.0",
         "safe-stable-stringify": "^2.3.1",
         "sonic-boom": "^4.0.1",
-        "thread-stream": "^3.0.0"
+        "thread-stream": "^4.0.0"
       },
       "bin": {
         "pino": "bin.js"
       }
     },
     "node_modules/pino-abstract-transport": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
-      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
       "license": "MIT",
       "dependencies": {
         "split2": "^4.0.0"
@@ -17214,13 +17211,22 @@
       }
     },
     "node_modules/thread-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
+      "integrity": "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==",
       "license": "MIT",
       "dependencies": {
-        "real-require": "^0.2.0"
+        "real-require": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
+    },
+    "node_modules/thread-stream/node_modules/real-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+      "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+      "license": "MIT"
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -19279,8 +19285,8 @@
       "dependencies": {
         "@tabnews/helpers": "*",
         "@vercel/functions": "2.1.0",
-        "pino": "9.7.0",
-        "pino-abstract-transport": "2.0.0"
+        "pino": "10.3.1",
+        "pino-abstract-transport": "3.0.0"
       }
     },
     "packages/ui": {

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -19,8 +19,8 @@
   "dependencies": {
     "@tabnews/helpers": "*",
     "@vercel/functions": "2.1.0",
-    "pino": "9.7.0",
-    "pino-abstract-transport": "2.0.0"
+    "pino": "10.3.1",
+    "pino-abstract-transport": "3.0.0"
   },
   "author": "TabNews",
   "repository": {

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -17,10 +17,10 @@
     "format": "eslint --fix . && prettier --write ."
   },
   "dependencies": {
-    "@axiomhq/js": "1.3.1",
     "@tabnews/helpers": "*",
     "@vercel/functions": "2.1.0",
-    "pino": "9.7.0"
+    "pino": "9.7.0",
+    "pino-abstract-transport": "2.0.0"
   },
   "author": "TabNews",
   "repository": {

--- a/packages/infra/src/logger/axiom-transport.js
+++ b/packages/infra/src/logger/axiom-transport.js
@@ -1,21 +1,24 @@
-// Inspired by `@axiomhq/pino`, but compatible with `waitUntil` from `@vercel/functions`
-import { Axiom } from '@axiomhq/js';
+import { noop } from '@tabnews/helpers';
 import { waitUntil } from '@vercel/functions';
 import build from 'pino-abstract-transport';
+
+const INGEST_TIMEOUT_MS = 20_000;
+const DEFAULT_AXIOM_URL = 'https://api.axiom.co';
 
 export function axiomTransport({
   dataset = process.env.AXIOM_DATASET,
   token = process.env.AXIOM_TOKEN,
-  url = process.env.AXIOM_URL,
+  url = process.env.AXIOM_URL || DEFAULT_AXIOM_URL,
 } = {}) {
   if (!process?.versions?.node || !dataset || !token) return;
 
+  const pendingEvents = [];
+  const pendingIngests = [];
+  const MAX_BATCH_SIZE = 1000;
   let parsedCount = 0;
   let ingestedCount = 0;
   let waitingFlush = false;
   let resolve, reject;
-
-  const axiom = new Axiom({ dataset, token, url, onError });
 
   const transport = build(
     async function (source) {
@@ -39,11 +42,6 @@ export function axiomTransport({
 
   return transport;
 
-  function onError(err) {
-    rejectPendingPromise(err);
-    console.error('Error sending logs to Axiom:\n', err);
-  }
-
   function parseLine(line) {
     const value = JSON.parse(line);
     parsedCount++;
@@ -51,24 +49,66 @@ export function axiomTransport({
   }
 
   function ingestLogs(event) {
-    axiom.ingest(dataset, event);
+    pendingEvents.push(event);
     ingestedCount++;
 
     if (waitingFlush) {
       flushPendingLogs();
+    } else if (pendingEvents.length >= MAX_BATCH_SIZE) {
+      pendingIngests.push(ingest(pendingEvents.splice(0, pendingEvents.length)));
     }
   }
 
   function flushPendingLogs() {
-    if (ingestedCount === 0 || parsedCount > ingestedCount) {
+    if (parsedCount > ingestedCount) {
       waitingFlush = true;
       ensurePendingPromise();
       return;
     }
 
     waitingFlush = false;
-    waitUntil(axiom.flush());
-    resolvePendingPromise();
+
+    const events = pendingEvents.splice(0, pendingEvents.length);
+    const allIngests = pendingIngests.splice(0);
+    if (events.length > 0) allIngests.push(ingest(events));
+
+    if (allIngests.length > 0) {
+      ensurePendingPromise();
+      Promise.all(allIngests).then(resolvePendingPromise, rejectPendingPromise);
+    } else {
+      resolvePendingPromise();
+    }
+  }
+
+  async function ingest(events) {
+    const start = Date.now();
+    const body = events.map((event) => JSON.stringify(event)).join('\n');
+
+    try {
+      const response = await fetch(`${url}/v1/datasets/${dataset}/ingest`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-ndjson',
+          Authorization: `Bearer ${token}`,
+        },
+        body,
+        signal: AbortSignal.timeout(INGEST_TIMEOUT_MS),
+        keepalive: true,
+      });
+
+      response.body?.cancel().catch(noop);
+
+      if (!response.ok) {
+        onError(new Error(`Axiom ingest failed with status ${response.status}`), events.length, Date.now() - start);
+      }
+    } catch (err) {
+      onError(err, events.length, Date.now() - start);
+    }
+  }
+
+  function onError(err, eventCount, durationMs) {
+    rejectPendingPromise(err);
+    console.error(`Error sending logs to Axiom (${eventCount} events, after ${durationMs}ms):\n`, err);
   }
 
   function ensurePendingPromise() {

--- a/packages/infra/src/logger/axiom-transport.test.js
+++ b/packages/infra/src/logger/axiom-transport.test.js
@@ -2,32 +2,39 @@ import { noop } from 'packages/helpers';
 
 const mocks = vi.hoisted(() => {
   const waitUntil = vi.fn().mockImplementation((promise) => promise);
-  const ingest = vi.fn();
-  const flush = vi.fn().mockResolvedValue();
-  const Axiom = vi.fn().mockImplementation(() => ({
-    ingest,
-    flush,
-  }));
 
   return {
-    ingest,
-    flush,
-    Axiom,
     waitUntil,
   };
 });
-
-vi.mock('@axiomhq/js', () => ({
-  Axiom: mocks.Axiom,
-}));
 
 vi.mock('@vercel/functions', () => ({
   waitUntil: mocks.waitUntil,
 }));
 
+vi.spyOn(global, 'fetch');
+
+function parseIngestEvents(call) {
+  return call[1].body
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function mockOkResponse() {
+  return {
+    ok: true,
+    status: 200,
+    body: {
+      cancel: vi.fn().mockResolvedValue(undefined),
+    },
+  };
+}
+
 describe('axiomTransport', () => {
   const dataset = 'test-dataset';
   const token = 'test-token';
+  const url = 'https://api.axiom.co';
 
   let axiomTransport, consoleErrorSpy;
 
@@ -40,6 +47,7 @@ describe('axiomTransport', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    fetch.mockResolvedValue(mockOkResponse());
   });
 
   afterAll(() => {
@@ -78,8 +86,26 @@ describe('axiomTransport', () => {
 
       await transport.write(JSON.stringify({ time: new Date().toISOString(), level: 30, msg: 'test log' }) + '\n');
 
-      await vi.waitUntil(() => mocks.ingest.mock.calls.length === 1);
-      expect(mocks.ingest).toHaveBeenCalledWith(dataset, expect.objectContaining({ level: 'info', msg: 'test log' }));
+      transport.flush();
+      await vi.waitUntil(() => fetch.mock.calls.length === 1);
+
+      expect(fetch).toHaveBeenCalledOnce();
+      expect(fetch).toHaveBeenCalledWith(
+        `${url}/v1/datasets/${dataset}/ingest`,
+        expect.objectContaining({
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-ndjson',
+            Authorization: `Bearer ${token}`,
+          },
+          keepalive: true,
+          signal: expect.any(AbortSignal),
+          body: expect.any(String),
+        }),
+      );
+      expect(parseIngestEvents(fetch.mock.calls[0])).toStrictEqual([
+        expect.objectContaining({ level: 'info', msg: 'test log' }),
+      ]);
     });
 
     it('should ingest logs in chunks', async () => {
@@ -93,8 +119,13 @@ describe('axiomTransport', () => {
       await transport.write(part2);
       await transport.write('\n');
 
-      await vi.waitUntil(() => mocks.ingest.mock.calls.length === 1);
-      expect(mocks.ingest).toHaveBeenCalledWith(dataset, expect.objectContaining({ level: 'info', msg: 'test log' }));
+      transport.flush();
+      await vi.waitUntil(() => fetch.mock.calls.length === 1);
+
+      expect(fetch).toHaveBeenCalledOnce();
+      expect(parseIngestEvents(fetch.mock.calls[0])).toStrictEqual([
+        expect.objectContaining({ level: 'info', msg: 'test log' }),
+      ]);
     });
 
     it('should flush without logs', async () => {
@@ -102,8 +133,8 @@ describe('axiomTransport', () => {
 
       await transport.flush();
 
-      expect(mocks.waitUntil).toHaveBeenCalledWith(mocks.flush());
-      expect(mocks.waitUntil).toHaveBeenCalledOnce();
+      expect(fetch).not.toHaveBeenCalled();
+      expect(mocks.waitUntil).not.toHaveBeenCalled();
     });
 
     it('should flush with logs', async () => {
@@ -112,26 +143,23 @@ describe('axiomTransport', () => {
       await transport.write(JSON.stringify({ time: new Date().toISOString(), level: 40, msg: 'test log 1' }) + '\n');
       await transport.write(JSON.stringify({ time: new Date().toISOString(), level: 50, msg: 'test log 2' }) + '\n');
 
-      await vi.waitUntil(() => mocks.ingest.mock.calls.length === 2);
-      await transport.flush();
+      transport.flush();
+      await vi.waitUntil(() => fetch.mock.calls.length === 1);
 
-      expect(mocks.ingest).toHaveBeenCalledWith(dataset, expect.objectContaining({ level: 'warn', msg: 'test log 1' }));
-      expect(mocks.ingest).toHaveBeenCalledWith(
-        dataset,
+      expect(fetch).toHaveBeenCalledOnce();
+      expect(parseIngestEvents(fetch.mock.calls[0])).toStrictEqual([
+        expect.objectContaining({ level: 'warn', msg: 'test log 1' }),
         expect.objectContaining({ level: 'error', msg: 'test log 2' }),
-      );
-
-      expect(mocks.waitUntil).toHaveBeenCalledWith(mocks.flush());
-      expect(mocks.waitUntil).toHaveBeenCalledOnce();
+      ]);
     });
 
     it('should not ingest invalid logs', async () => {
       const transport = axiomTransport({ dataset, token });
 
-      transport.write('invalid chunk \n');
+      await transport.write('invalid chunk \n');
+      transport.flush();
 
-      await new Promise((resolve) => setTimeout(resolve, 100));
-      expect(mocks.ingest).not.toHaveBeenCalled();
+      expect(fetch).not.toHaveBeenCalled();
       expect(mocks.waitUntil).not.toHaveBeenCalled();
     });
 
@@ -147,57 +175,113 @@ describe('axiomTransport', () => {
       await transport.write('\n');
       await transport.write(JSON.stringify({ time: new Date().toISOString(), level: 60, msg: 'test log 3' }) + '\n');
 
-      await transport.flush();
+      transport.flush();
+      await vi.waitUntil(() => fetch.mock.calls.length === 1);
 
-      await vi.waitUntil(() => mocks.ingest.mock.calls.length === 3);
-      expect(mocks.ingest).toHaveBeenCalledWith(
-        dataset,
+      expect(fetch).toHaveBeenCalledOnce();
+      expect(parseIngestEvents(fetch.mock.calls[0])).toStrictEqual([
         expect.objectContaining({ level: 'trace', msg: 'test log 1' }),
-      );
-      expect(mocks.ingest).toHaveBeenCalledWith(
-        dataset,
         expect.objectContaining({ level: 'debug', msg: 'test log 2' }),
-      );
-      expect(mocks.ingest).toHaveBeenCalledWith(
-        dataset,
         expect.objectContaining({ level: 'fatal', msg: 'test log 3' }),
-      );
-      expect(mocks.waitUntil).toHaveBeenCalledWith(mocks.flush());
-      expect(mocks.waitUntil).toHaveBeenCalledTimes(2);
+      ]);
     });
 
-    it('should continue logging even if an error occurs with Axiom', async () => {
-      const error = new Error('test error');
+    it('should flush in batches when exceeding max batch size', async () => {
+      const transport = axiomTransport({ dataset, token });
 
-      mocks.Axiom.mockImplementationOnce(({ onError }) => ({
-        ingest: mocks.ingest.mockImplementationOnce(() => onError(error)),
-        flush: mocks.flush,
-      }));
+      for (let i = 0; i < 1001; i++) {
+        transport.write(JSON.stringify({ time: new Date().toISOString(), level: 30, msg: `log ${i}` }) + '\n');
+      }
+
+      await vi.waitUntil(() => fetch.mock.calls.length >= 1);
+      expect(fetch).toHaveBeenCalledOnce();
+      expect(parseIngestEvents(fetch.mock.calls[0])).toHaveLength(1000);
+
+      transport.flush();
+      await vi.waitUntil(() => fetch.mock.calls.length >= 2);
+
+      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(parseIngestEvents(fetch.mock.calls[1])).toHaveLength(1);
+    });
+
+    it('should log error with duration when ingest fails with network error', async () => {
+      const fetchError = new Error('network failure');
+      fetch.mockRejectedValueOnce(fetchError);
 
       const transport = axiomTransport({ dataset, token });
 
+      await transport.write(
+        JSON.stringify({ time: new Date().toISOString(), level: 'silent', msg: 'test log 1' }) + '\n',
+      );
       transport.flush();
-      transport.write(JSON.stringify({ time: new Date().toISOString(), level: 'silent', msg: 'test log 1' }) + '\n');
-      await vi.waitUntil(() => mocks.ingest.mock.calls.length === 1);
+      await vi.waitUntil(() => fetch.mock.calls.length === 1);
+      await vi.waitUntil(() => consoleErrorSpy.mock.calls.length >= 1);
 
-      expect(consoleErrorSpy).toHaveBeenCalledWith('Error sending logs to Axiom:\n', error);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/^Error sending logs to Axiom \(1 events, after \d+ms\):\n$/),
+        fetchError,
+      );
+    });
 
-      transport.write(JSON.stringify({ time: new Date().toISOString(), level: 70, msg: 'test log 2' }) + '\n');
-      await vi.waitUntil(() => mocks.ingest.mock.calls.length === 2);
+    it('should log error with duration when ingest responds with non-ok status', async () => {
+      fetch.mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        body: { cancel: vi.fn().mockResolvedValue(undefined) },
+      });
 
-      expect(mocks.ingest).toHaveBeenCalledWith(
-        dataset,
+      const transport = axiomTransport({ dataset, token });
+
+      await transport.write(JSON.stringify({ time: new Date().toISOString(), level: 30, msg: 'test log' }) + '\n');
+      transport.flush();
+      await vi.waitUntil(() => fetch.mock.calls.length === 1);
+      await vi.waitUntil(() => consoleErrorSpy.mock.calls.length >= 1);
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/^Error sending logs to Axiom \(1 events, after \d+ms\):\n$/),
+        expect.objectContaining({ message: 'Axiom ingest failed with status 503' }),
+      );
+    });
+
+    it('should continue logging even if an error occurs with Axiom', async () => {
+      fetch.mockRejectedValueOnce(new Error('first error'));
+
+      const transport = axiomTransport({ dataset, token });
+
+      await transport.write(
+        JSON.stringify({ time: new Date().toISOString(), level: 'silent', msg: 'test log 1' }) + '\n',
+      );
+      transport.flush();
+      await vi.waitUntil(() => fetch.mock.calls.length === 1);
+
+      await transport.write(JSON.stringify({ time: new Date().toISOString(), level: 70, msg: 'test log 2' }) + '\n');
+      transport.flush();
+      await vi.waitUntil(() => fetch.mock.calls.length === 2);
+
+      expect(parseIngestEvents(fetch.mock.calls[0])).toStrictEqual([
         expect.objectContaining({ level: 'silent', msg: 'test log 1' }),
-      );
-      expect(mocks.ingest).toHaveBeenCalledWith(
-        dataset,
+      ]);
+      expect(parseIngestEvents(fetch.mock.calls[1])).toStrictEqual([
         expect.objectContaining({ level: 'silent', msg: 'test log 2' }),
-      );
+      ]);
+    });
+
+    it('should cancel response body to release connection', async () => {
+      const cancelSpy = vi.fn().mockResolvedValue(undefined);
+      fetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        body: { cancel: cancelSpy },
+      });
+
+      const transport = axiomTransport({ dataset, token });
+
+      await transport.write(JSON.stringify({ time: new Date().toISOString(), level: 30, msg: 'test log' }) + '\n');
 
       transport.flush();
+      await vi.waitUntil(() => cancelSpy.mock.calls.length === 1);
 
-      expect(mocks.waitUntil).toHaveBeenCalledWith(mocks.flush());
-      expect(mocks.waitUntil).toHaveBeenCalledTimes(3);
+      expect(cancelSpy).toHaveBeenCalledOnce();
     });
   });
 });

--- a/packages/infra/src/logger/logger.test.js
+++ b/packages/infra/src/logger/logger.test.js
@@ -16,18 +16,35 @@ const consoleLevels = {
 const dataset = 'test-dataset';
 const token = 'test-token';
 
+vi.spyOn(global, 'fetch');
+
+function parseIngestEvents(call) {
+  return call[1].body
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function mockOkResponse() {
+  return {
+    ok: true,
+    status: 200,
+    body: {
+      cancel: vi.fn().mockResolvedValue(undefined),
+    },
+  };
+}
+
+async function flushUntilIngest() {
+  await vi.waitUntil(() => {
+    logger.flush();
+    return fetch.mock.calls.length >= 1;
+  });
+}
+
+let logger;
+
 describe('infra/logger', () => {
-  const mocks = vi.hoisted(() => ({
-    axiomIngest: vi.fn(),
-  }));
-
-  vi.mock('@axiomhq/js', () => ({
-    Axiom: vi.fn().mockImplementation(() => ({
-      ingest: mocks.axiomIngest,
-      flush: vi.fn().mockResolvedValue(),
-    })),
-  }));
-
   let stdoutSpy;
   const consoleSpy = {};
 
@@ -43,11 +60,10 @@ describe('infra/logger', () => {
     });
   });
 
-  let logger;
-
   beforeEach(async () => {
     vi.clearAllMocks();
     vi.resetModules();
+    fetch.mockResolvedValue(mockOkResponse());
     logger = await import('..').then((m) => m.getLogger).then((getLogger) => getLogger());
   });
 
@@ -73,7 +89,7 @@ describe('infra/logger', () => {
         expect(consoleSpy[level]).toHaveBeenCalledWith('logger.' + level);
       });
 
-      expect(mocks.axiomIngest).not.toHaveBeenCalled();
+      expect(fetch).not.toHaveBeenCalled();
     });
 
     it('should ignore "info" level', () => {
@@ -126,7 +142,7 @@ describe('infra/logger', () => {
           );
         });
 
-        expect(mocks.axiomIngest).not.toHaveBeenCalled();
+        expect(fetch).not.toHaveBeenCalled();
       });
     });
   });
@@ -156,7 +172,7 @@ describe('infra/logger', () => {
         );
       });
 
-      expect(mocks.axiomIngest).not.toHaveBeenCalled();
+      expect(fetch).not.toHaveBeenCalled();
     });
 
     it('should ignore dev levels', async () => {
@@ -179,13 +195,11 @@ describe('infra/logger', () => {
     it('should log production levels', async () => {
       productionLevels.forEach((level) => logger[level]('logger.' + level));
 
-      await vi.waitUntil(() => mocks.axiomIngest.mock.calls.length === productionLevels.length);
+      await flushUntilIngest();
 
+      const events = parseIngestEvents(fetch.mock.calls[0]);
       productionLevels.forEach((level) => {
-        expect(mocks.axiomIngest).toHaveBeenCalledWith(
-          dataset,
-          expect.objectContaining({ level, msg: 'logger.' + level }),
-        );
+        expect(events).toContainEqual(expect.objectContaining({ level, msg: 'logger.' + level }));
       });
     });
 
@@ -193,7 +207,7 @@ describe('infra/logger', () => {
       onlyDevLevels.forEach((level) => logger[level]('logger.' + level));
 
       await new Promise((resolve) => setTimeout(resolve, 100));
-      expect(mocks.axiomIngest).not.toHaveBeenCalled();
+      expect(fetch).not.toHaveBeenCalled();
     });
 
     it('should not throw error on flush', () => {
@@ -208,8 +222,8 @@ describe('infra/logger', () => {
 
       logger.info('logger.info');
 
-      await vi.waitUntil(() => mocks.axiomIngest.mock.calls.length === 1);
-      expect(mocks.axiomIngest).toHaveBeenCalledWith(dataset, expect.objectContaining({ key: 'value' }));
+      await flushUntilIngest();
+      expect(parseIngestEvents(fetch.mock.calls[0])).toContainEqual(expect.objectContaining({ key: 'value' }));
     });
 
     it('should pass redact options to pino', async () => {
@@ -218,8 +232,8 @@ describe('infra/logger', () => {
 
       logger.info({ key: 'value' });
 
-      await vi.waitUntil(() => mocks.axiomIngest.mock.calls.length === 1);
-      expect(mocks.axiomIngest).toHaveBeenCalledWith(dataset, expect.objectContaining({ key: '[Redacted]' }));
+      await flushUntilIngest();
+      expect(parseIngestEvents(fetch.mock.calls[0])).toContainEqual(expect.objectContaining({ key: '[Redacted]' }));
     });
   });
 });


### PR DESCRIPTION
## Mudanças realizadas

O logger registrava erros recorrentes `Error sending logs to Axiom: TimeoutError` na Vercel, mesmo com o Axiom respondendo normalmente (POST 200, sem picos de P99). Eram falsos positivos com três possíveis causas combinadas:

1. Excesso de requests sequenciais: a classe Batch do `@axiomhq/js` auto-flusheia a cada 1s e, em baixo tráfego, dispara um HTTP request por evento em vez de agrupá-los, sobrecarregando a conexão.
2. Promise resolvida cedo demais: o `waitUntil` era resolvido antes do ingest completar, fazendo a Vercel encerrar a lambda e abortar o fetch em andamento.
3. Leitura desnecessária do body: o SDK fazia `await resp.json()` dentro do mesmo `AbortSignal.timeout(20s)` do `fetch`; quando o body demorava, o signal disparava durante a leitura, mesmo já tendo recebido os headers 200.

Para corrigir, o `axiomTransport` foi reimplementado de forma mais simples, atendendo nossas necessidades:

- Substitui o `@axiomhq/js` por fetch direto para `POST /v1/datasets/{dataset}/ingest`, removendo a dependência.
- Acumula eventos localmente e envia em batch único no flush (com limite de 1000 eventos por batch como proteção).
- Usa `Promise.all` sobre todos os ingests pendentes e só resolve a `Promise` do `waitUntil` após todas completarem.
- Cancela `response.body` logo após os headers, fechando a janela em que o `AbortSignal` dispararia durante a leitura do body. Mantém o timeout de 20s apenas como segurança para travamentos de conexão/headers e usa `keepalive: true`.
- Inclui a duração até o erro no `console.error` (`after {ms}ms`) para diagnosticar eventuais timeouts remanescentes.

Também atualiza `pino` e `pino-abstract-transport`.

## Tipo de mudança

- [x] Correção de bug

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
