### PR TITLE
Endurece a instalação de dependências contra supply chain

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
 save-exact=true
+min-release-age=7
+ignore-scripts=true


### PR DESCRIPTION
## Mudanças realizadas

Para melhorar a segurança na instalação de pacotes, que podem ter uma versão maliciosa publicada e instalada  automaticamente antes de ser detectada e removida do registry, adicionei duas proteções no `.npmrc`:

- `min-release-age=7`: o npm só instala versões publicadas há mais de 7 dias, criando uma janela para que pacotes comprometidos sejam detectados e despublicados antes de chegarem aqui.
- `ignore-scripts=true`: impede que scripts de instalação de dependências rodem automaticamente, bloqueando o principal vetor de execução de código malicioso.

## Tipo de mudança

- [x] Melhoria de segurança

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [ ] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
