### PR TITLE
Otimiza renderização do Katex e corrige renderização estática no App Router

### DIFF
--- a/packages/ui/src/KatexLoader/KatexLoader.jsx
+++ b/packages/ui/src/KatexLoader/KatexLoader.jsx
@@ -1,0 +1,24 @@
+export function KatexLoader() {
+  return (
+    <>
+      <link
+        rel="preload"
+        href="https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.css"
+        as="style"
+        integrity="sha384-5TcZemv2l/9On385z///+d7MSYlvIEw9FuZTIdZ14vJLqWphw7e7ZPuOiCHJcFCP"
+        crossOrigin="anonymous"
+      />
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `
+            var katexLink = document.currentScript.previousElementSibling;
+            katexLink.onload = function () {
+              this.onload = null;
+              this.rel = 'stylesheet';
+            };
+          `,
+        }}
+      />
+    </>
+  );
+}

--- a/packages/ui/src/KatexLoader/index.js
+++ b/packages/ui/src/KatexLoader/index.js
@@ -1,0 +1,1 @@
+export * from './KatexLoader';

--- a/packages/ui/src/PrimerRoot/PrimerRoot.jsx
+++ b/packages/ui/src/PrimerRoot/PrimerRoot.jsx
@@ -7,10 +7,24 @@ import { COLOR_MODE_COOKIE } from '../constants/public';
 import { KatexLoader } from '../KatexLoader/KatexLoader';
 import { StyledComponentsRegistry } from '../SCRegistry/SCRegistry';
 
-export async function PrimerRoot({ children, colorMode, defaultColorMode, headChildren, htmlProps, lang, ...props }) {
-  const cookieStore = await cookies();
-  const cachedColorMode = await cookieStore.get(COLOR_MODE_COOKIE);
-  const ssrColorMode = (colorMode || cachedColorMode?.value || defaultColorMode) === 'dark' ? 'dark' : 'light';
+export async function PrimerRoot({
+  children,
+  colorMode,
+  defaultColorMode = 'light',
+  headChildren = null,
+  htmlProps = {},
+  lang,
+  ...props
+}) {
+  let ssrColorMode;
+
+  if (colorMode) {
+    ssrColorMode = colorMode === 'dark' ? 'dark' : 'light';
+  } else {
+    const cookieStore = await cookies();
+    const cachedColorMode = await cookieStore.get(COLOR_MODE_COOKIE);
+    ssrColorMode = (cachedColorMode?.value || defaultColorMode) === 'dark' ? 'dark' : 'light';
+  }
 
   return (
     <html lang={lang} suppressHydrationWarning data-color-mode={ssrColorMode} {...htmlProps}>

--- a/packages/ui/src/PrimerRoot/PrimerRoot.jsx
+++ b/packages/ui/src/PrimerRoot/PrimerRoot.jsx
@@ -4,6 +4,7 @@ import { cookies } from 'next/headers';
 
 import { AutoThemeProvider } from '../AutoThemeProvider/AutoThemeProvider';
 import { COLOR_MODE_COOKIE } from '../constants/public';
+import { KatexLoader } from '../KatexLoader/KatexLoader';
 import { StyledComponentsRegistry } from '../SCRegistry/SCRegistry';
 
 export async function PrimerRoot({ children, colorMode, defaultColorMode, headChildren, htmlProps, lang, ...props }) {
@@ -15,12 +16,7 @@ export async function PrimerRoot({ children, colorMode, defaultColorMode, headCh
     <html lang={lang} suppressHydrationWarning data-color-mode={ssrColorMode} {...htmlProps}>
       <head>
         {headChildren}
-        <link
-          rel="stylesheet"
-          href="https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.css"
-          integrity="sha384-5TcZemv2l/9On385z///+d7MSYlvIEw9FuZTIdZ14vJLqWphw7e7ZPuOiCHJcFCP"
-          crossOrigin="anonymous"
-        />
+        <KatexLoader />
       </head>
       <body data-light-theme="light" data-dark-theme="dark">
         <StyledComponentsRegistry>

--- a/packages/ui/src/__snapshots__/_document.test.js.snap
+++ b/packages/ui/src/__snapshots__/_document.test.js.snap
@@ -10,11 +10,21 @@ exports[`ui > _document > renders correctly 1`] = `
       data-testid="Next Head"
     >
       <link
+        as="style"
         crossorigin="anonymous"
         href="https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.css"
         integrity="sha384-5TcZemv2l/9On385z///+d7MSYlvIEw9FuZTIdZ14vJLqWphw7e7ZPuOiCHJcFCP"
-        rel="stylesheet"
+        rel="preload"
       />
+      <script>
+        
+            var katexLink = document.currentScript.previousElementSibling;
+            katexLink.onload = function () {
+              this.onload = null;
+              this.rel = 'stylesheet';
+            };
+          
+      </script>
     </head>
     <body>
       <main

--- a/packages/ui/src/_document.jsx
+++ b/packages/ui/src/_document.jsx
@@ -2,6 +2,8 @@ import NextDocument, { Head, Html, Main, NextScript } from 'next/document.js';
 import Script from 'next/script.js';
 import { ServerStyleSheet } from 'styled-components';
 
+import { KatexLoader } from './KatexLoader/KatexLoader';
+
 // Script related to `AutoThemeProvider`
 export const noFlashScript = `if (['auto','night','dark','day','light'].includes(localStorage.getItem('colorMode')))
 document.documentElement.setAttribute('data-no-flash', true)`;
@@ -53,12 +55,7 @@ export class Document extends Doc {
       <Html {...htmlProps}>
         <Head>
           {headChildren}
-          <link
-            rel="stylesheet"
-            href="https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.css"
-            integrity="sha384-5TcZemv2l/9On385z///+d7MSYlvIEw9FuZTIdZ14vJLqWphw7e7ZPuOiCHJcFCP"
-            crossOrigin="anonymous"
-          />
+          <KatexLoader />
         </Head>
         <body>
           <Main />


### PR DESCRIPTION
## Mudanças realizadas

Duas correções no pacote `@tabnews/ui`, aplicadas em `_document.jsx` (Pages Router) e `PrimerRoot.jsx` (App Router):

1. O `<link rel="stylesheet">` do Katex bloqueava a renderização. Foi extraído um componente compartilhado `KatexLoader`, que carrega o CSS via `<link rel="preload" as="style">` e o promove a `stylesheet` no `onload`, evitando o bloqueio do render.
2. O `await cookies()` no `PrimerRoot` era executado em toda renderização, forçando todas as páginas do App Router a serem tratadas como dinâmicas. Agora ele só é chamado quando a prop `colorMode` não é fornecida, permitindo que as páginas voltem a ser renderizadas estaticamente.

## Tipo de mudança

 - [x] Correção de bug
 
## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [ ] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
