### PR TITLE
Aguarda ingestão do Axiom completar antes de liberar a lambda

### DIFF
--- a/packages/infra/src/logger/axiom-transport.js
+++ b/packages/infra/src/logger/axiom-transport.js
@@ -18,7 +18,8 @@ export function axiomTransport({
   let parsedCount = 0;
   let ingestedCount = 0;
   let waitingFlush = false;
-  let resolve, reject;
+  let pendingPromise = null;
+  let resolve;
 
   const transport = build(
     async function (source) {
@@ -62,8 +63,7 @@ export function axiomTransport({
   function flushPendingLogs() {
     if (parsedCount > ingestedCount) {
       waitingFlush = true;
-      ensurePendingPromise();
-      return;
+      return ensurePendingPromise();
     }
 
     waitingFlush = false;
@@ -73,11 +73,13 @@ export function axiomTransport({
     if (events.length > 0) allIngests.push(ingest(events));
 
     if (allIngests.length > 0) {
-      ensurePendingPromise();
-      Promise.all(allIngests).then(resolvePendingPromise, rejectPendingPromise);
-    } else {
-      resolvePendingPromise();
+      const promise = ensurePendingPromise();
+      Promise.all(allIngests).then(resolvePendingPromise, resolvePendingPromise);
+      return promise;
     }
+
+    resolvePendingPromise();
+    return Promise.resolve();
   }
 
   async function ingest(events) {
@@ -107,34 +109,25 @@ export function axiomTransport({
   }
 
   function onError(err, eventCount, durationMs) {
-    rejectPendingPromise(err);
     console.error(`Error sending logs to Axiom (${eventCount} events, after ${durationMs}ms):\n`, err);
   }
 
   function ensurePendingPromise() {
     if (!resolve) {
-      waitUntil(
-        new Promise((res, rej) => {
-          resolve = res;
-          reject = rej;
-        }),
-      );
+      pendingPromise = new Promise((res) => {
+        resolve = res;
+      });
+      waitUntil(pendingPromise);
     }
+
+    return pendingPromise;
   }
 
   function resolvePendingPromise() {
     if (resolve) {
       resolve();
       resolve = null;
-      reject = null;
-    }
-  }
-
-  function rejectPendingPromise(err) {
-    if (reject) {
-      reject(err);
-      resolve = null;
-      reject = null;
+      pendingPromise = null;
     }
   }
 }

--- a/packages/infra/src/logger/axiom-transport.test.js
+++ b/packages/infra/src/logger/axiom-transport.test.js
@@ -186,6 +186,40 @@ describe('axiomTransport', () => {
       ]);
     });
 
+    it('should resolve the flush promise only after the ingest settles', async () => {
+      let resolveFetch;
+      fetch.mockImplementationOnce(
+        () =>
+          new Promise((res) => {
+            resolveFetch = () => res(mockOkResponse());
+          }),
+      );
+
+      const transport = axiomTransport({ dataset, token });
+
+      await transport.write(JSON.stringify({ time: new Date().toISOString(), level: 30, msg: 'test log' }) + '\n');
+
+      let flushed = false;
+      const flushPromise = Promise.resolve(transport.flush()).then(() => (flushed = true));
+
+      await vi.waitUntil(() => fetch.mock.calls.length === 1);
+      expect(flushed).toBe(false);
+
+      resolveFetch();
+      await flushPromise;
+      expect(flushed).toBe(true);
+    });
+
+    it('should resolve the flush promise even when the ingest fails', async () => {
+      fetch.mockRejectedValueOnce(new Error('network failure'));
+
+      const transport = axiomTransport({ dataset, token });
+
+      await transport.write(JSON.stringify({ time: new Date().toISOString(), level: 30, msg: 'test log' }) + '\n');
+
+      await expect(transport.flush()).resolves.toBeUndefined();
+    });
+
     it('should flush in batches when exceeding max batch size', async () => {
       const transport = axiomTransport({ dataset, token });
 


### PR DESCRIPTION
## Mudanças realizadas

O PR #2032 portou as correções do Axiom logger do curso.dev, onde havia reduzido os `TimeoutError` em mais de 99%. No TabNews, os casos continuaram frequentes.

Um possível problema era o `flushPendingLogs()`, que disparava o ingest mas retornava `undefined`, então o `await logger.flush()` no controller resolvia antes do envio terminar. O lambda ficava livre para congelar com o fetch pendente.

Agora o `flushPendingLogs()` passa a retornar o promise do ingest, fazendo o `await logger.flush()` aguardar de fato — assim o `waitUntil(flushPromise)` do controller cobre o envio até o fim. O promise sempre resolve (nunca rejeita), pois o `ingest` já loga seus próprios erros.

Vamos experimentar essa correção e acompanhar se elimina os timeouts.

## Tipo de mudança

- [x] Correção de bug

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
