### PR TITLE
Executa testes de arquivos `.jsx` e corrige a poluição entre arquivos

### DIFF
--- a/packages/ui/src/GoToTopButton/GoToTopButton.test.jsx
+++ b/packages/ui/src/GoToTopButton/GoToTopButton.test.jsx
@@ -4,7 +4,7 @@ import { act } from 'react';
 
 import { GoToTopButton } from './GoToTopButton';
 
-const IntersectionObserver = global.IntersectionObserver;
+const originalIntersectionObserver = global.IntersectionObserver;
 let lastObserver = null;
 
 const MockIntersectionObserver = vi.fn((callback) => {
@@ -16,15 +16,14 @@ const MockIntersectionObserver = vi.fn((callback) => {
   return lastObserver;
 });
 
-global.IntersectionObserver = MockIntersectionObserver;
-
-afterEach(() => {
-  lastObserver = null;
-  MockIntersectionObserver.mockClear();
+beforeEach(() => {
+  global.IntersectionObserver = MockIntersectionObserver;
 });
 
-afterAll(() => {
-  global.IntersectionObserver = IntersectionObserver;
+afterEach(() => {
+  global.IntersectionObserver = originalIntersectionObserver;
+  lastObserver = null;
+  MockIntersectionObserver.mockClear();
 });
 
 describe('ui', () => {

--- a/packages/ui/src/PrimerRoot/PrimerRoot.test.jsx
+++ b/packages/ui/src/PrimerRoot/PrimerRoot.test.jsx
@@ -34,6 +34,7 @@ describe('ui', () => {
 
     beforeEach(() => {
       vi.clearAllMocks();
+      mockCookieStore.get.mockReset().mockResolvedValue(null);
       cookies.mockReturnValue(mockCookieStore);
     });
 

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,8 +1,31 @@
-import { cleanup } from '@testing-library/react';
+import { getQueriesForElement } from '@testing-library/dom';
+import { cleanup, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 
 // Mock only in jsdom environment.
 if (typeof document !== 'undefined') {
+  // Vitest gives each test file a fresh jsdom document, but the testing-library
+  // modules persist across files, so the global references they capture at import
+  // time go stale. The two patches below re-point them at the current document so
+  // tests don't silently target a detached one (which made every file after the
+  // first fail).
+
+  // `screen` is bound to `document.body` at import. Rebind it to the live body.
+  beforeEach(() => {
+    Object.assign(screen, getQueriesForElement(document.body));
+  });
+
+  // `userEvent` captures `globalThis.document` at import. Inject the live one so
+  // `userEvent.setup()` dispatches events to the document the test renders into.
+  // Imported lazily because the module touches `navigator`, which breaks the
+  // node-environment suites that also load this file.
+  const { userEvent } = await import('@testing-library/user-event');
+  if (!userEvent.setup.boundToCurrentDocument) {
+    const setup = userEvent.setup;
+    userEvent.setup = (options = {}) => setup({ document: globalThis.document, ...options });
+    userEvent.setup.boundToCurrentDocument = true;
+  }
+
   afterEach(() => {
     cleanup();
   });
@@ -12,4 +35,16 @@ if (typeof document !== 'undefined') {
       return false;
     }),
   };
+
+  // jsdom doesn't implement matchMedia, which @primer/react's useMedia hook relies on.
+  vi.spyOn(window, 'matchMedia').mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
 }

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -29,7 +29,7 @@ export default defineConfig({
         test: {
           name: 'ui',
           environment: 'jsdom',
-          include: ['**/interface/**/*.{test,spec}.{js,ts}'],
+          include: ['**/interface/**/*.{test,spec}.{js,jsx,ts,tsx}'],
           exclude: ['packages/**', ...defaultExclude],
         },
       },
@@ -38,7 +38,7 @@ export default defineConfig({
         test: {
           name: 'packages',
           environment: 'jsdom',
-          include: ['packages/**/*.{test,spec}.{js,ts}'],
+          include: ['packages/**/*.{test,spec}.{js,jsx,ts,tsx}'],
           isolate: true,
         },
       },


### PR DESCRIPTION
## Mudanças realizadas

O projeto `packages` do vitest só executava arquivos `{js,ts}`, então cinco arquivos `*.test.jsx` em `packages/ui` (`GoToTopButton`, `PrimerRoot` e as três suítes de Notifications) nunca rodavam. Este PR amplia o glob para `{js,jsx,ts,tsx}` e corrige tudo que quebrou quando eles passaram a rodar.

Dois eram problemas reais: o `useMedia` do `@primer/react` chama `window.matchMedia`, que o jsdom não implementa, e o `PrimerRoot` vazava um `mockResolvedValueOnce` entre testes. O resto era poluição entre arquivos no mesmo processo: o vitest entrega um `document` jsdom novo por arquivo enquanto os módulos do testing-library persistem, então o `screen` e o `userEvent` continuavam presos ao `document` (já descartado) do primeiro arquivo e todo arquivo seguinte falhava. O `tests/setup.js` agora re-vincula ambos ao `document` atual por arquivo.

Também tornei o mock de `IntersectionObserver` do `GoToTopButton` por-teste (em vez de no escopo do módulo) e ampliei o glob do projeto `ui` para `{js,jsx,ts,tsx}` por consistência.

## Tipo de mudança

<!-- Descomente a linha abaixo que corresponde ao tipo de mudança realizada no PR. -->

 - [x] Correção de bug
 
## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
