### PR TITLE
Elimina warnings de `act()` nos testes

### DIFF
--- a/packages/ui/src/FormField/FormField.test.js
+++ b/packages/ui/src/FormField/FormField.test.js
@@ -1,4 +1,4 @@
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import React from 'react';
 
@@ -175,7 +175,9 @@ describe('ui', () => {
         const passwordInput = getByLabelText('Test Label');
         expect(passwordInput).not.toHaveFocus();
 
-        inputRef.current.focus();
+        act(() => {
+          inputRef.current.focus();
+        });
         expect(passwordInput).toHaveFocus();
       });
     });
@@ -220,7 +222,9 @@ describe('ui', () => {
           const inputElement = getByRole('textbox');
           expect(inputElement).not.toHaveFocus();
 
-          inputRef.current.focus();
+          act(() => {
+            inputRef.current.focus();
+          });
           expect(inputElement).toHaveFocus();
         });
       });

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -11,8 +11,11 @@ if (typeof document !== 'undefined') {
   // first fail).
 
   // `screen` is bound to `document.body` at import. Rebind it to the live body.
+  // Also restore the React act() flag, which rendering async Server Components
+  // (e.g. PrimerRoot) leaves unset and would otherwise leak into later files.
   beforeEach(() => {
     Object.assign(screen, getQueriesForElement(document.body));
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
   });
 
   // `userEvent` captures `globalThis.document` at import. Inject the live one so


### PR DESCRIPTION
## Mudanças realizadas

Continuação do PR #2036. Depois que as suítes `.jsx` de `packages` passaram a rodar juntas, a renderização de Server Components assíncronos no `PrimerRoot` deixava `globalThis.IS_REACT_ACT_ENVIRONMENT` desativado, o que vazava warnings "The current testing environment is not configured to support act(...)" para arquivos jsdom seguintes (ex.: as chamadas `act()` do `GoToTopButton`). Este PR restaura o flag no `beforeEach` compartilhado do `tests/setup.js`, eliminando os warnings sem alterar nenhum resultado de teste.

Com `IS_REACT_ACT_ENVIRONMENT` ligado, o React passou a reportar  atualizações de estado que ocorrem fora de `act()`. Esses casos foram encapsulados em `act()`, sem alterar o que os testes verificam.


## Tipo de mudança

- [x] Correção de bug

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
