### PR TITLE
Atualiza para Node 24 e actions do CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - run: npm run dev & npx vitest run
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - run: npm run lint
@@ -60,7 +60,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - run: npx commitlint --from ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} --to ${{ github.event.pull_request.head.sha }} --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Start containers
         run: npm run services:up
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -43,8 +43,8 @@ jobs:
     name: Lint Styles
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -55,10 +55,10 @@ jobs:
     name: Lint Commits
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/jod
+lts/krypton

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "uuid": "9.0.1"
       },
       "engines": {
-        "node": "22.x"
+        "node": "24.x"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "pre-commit": "lint-staged"
   },
   "engines": {
-    "node": "22.x"
+    "node": "24.x"
   },
   "name": "tabnews.com.br",
   "description": "Conteúdos para quem vive de programação e tecnologia.",


### PR DESCRIPTION
## Mudanças realizadas

O Node 26 se tornará LTS no semestre que vem, então é um ótimo momento de atualizarmos para o Node 24 (LTS).

Além disso, aproveitei para atualizar as actions do CI.

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
