### PR TITLE
Restringe votos repetidos do mesmo usuário no mesmo conteúdo

### DIFF
--- a/pages/api/v1/contents/[username]/[slug]/tabcoins/index.js
+++ b/pages/api/v1/contents/[username]/[slug]/tabcoins/index.js
@@ -69,7 +69,7 @@ async function postHandler(request, response) {
 
   // TODO: Refactor firewall.js to accept other parameters such as content.id
   // and move this function to there.
-  await canIpUpdateContentTabCoins(request.context.clientIp, contentFound.id);
+  await canUpdateContentTabCoins(request.context.clientIp, userTryingToPost.id, contentFound.id);
 
   let currentContentTabCoinsBalance;
 
@@ -152,25 +152,25 @@ async function postHandler(request, response) {
   return response.status(201).json(secureOutputValues);
 }
 
-async function canIpUpdateContentTabCoins(clientIp, contentId) {
+async function canUpdateContentTabCoins(clientIp, userId, contentId) {
   const results = await database.query({
     text: `
       SELECT
-        count(*)
+        count(*) FILTER (WHERE originator_ip = $1) AS ip_count,
+        count(*) FILTER (WHERE originator_user_id = $2) AS user_count
       FROM
         events
       WHERE
         type = 'update:content:tabcoins'
-        AND originator_ip = $1
-        AND metadata->>'content_id' = $2
+        AND metadata->>'content_id' = $3
         AND created_at > NOW() - INTERVAL '72 hours'
       ;`,
-    values: [clientIp, contentId],
+    values: [clientIp, userId, contentId],
   });
 
-  const pass = results.rows[0].count > 2 ? false : true;
+  const { ip_count, user_count } = results.rows[0];
 
-  if (!pass) {
+  if (ip_count > 2 || user_count > 2) {
     throw new ValidationError({
       message: 'Você está tentando qualificar muitas vezes o mesmo conteúdo.',
       action: 'Esta operação não poderá ser repetida dentro de 72 horas.',

--- a/tests/integration/api/v1/contents/[username]/[slug]/tabcoins/post.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/tabcoins/post.test.js
@@ -693,14 +693,9 @@ describe('POST /api/v1/contents/tabcoins', () => {
       expect(secondUserResponseBody.tabcash).toBe(1);
     });
 
-    // This tests are being temporarily skipped because of the new feature of not allowing
-    // to credit/debit four times the same content. This feature is just a temporary test
-    // to a more sophisticated feature that will be implemented in the future.
-
-    // eslint-disable-next-line vitest/no-disabled-tests
-    test.skip('With 100 simultaneous posts, but enough TabCoins for 6', async () => {
+    test('With 100 simultaneous posts from the same user, but enough TabCoins for 3', async () => {
       const timesToFetch = 100;
-      const timesSuccessfully = 6;
+      const timesSuccessfully = 3;
 
       const firstUser = await orchestrator.createUser();
       const firstUserContent = await orchestrator.createContent({
@@ -721,55 +716,46 @@ describe('POST /api/v1/contents/tabcoins', () => {
         amount: 2 * timesSuccessfully,
       });
 
-      const postTabCoinsPromises = Array(timesToFetch)
-        .fill()
-        .map(() => tabcoinsRequestBuilder.post({ transaction_type: 'credit' }));
-
-      const postTabCoinsResponses = await Promise.all(postTabCoinsPromises);
-
-      const postTabCoinsResponsesBody = postTabCoinsResponses.map(({ responseBody }) => responseBody);
-
-      const postTabCoinsResponsesStatus = postTabCoinsResponses.map(({ response }) => response.status);
-
-      const successPostIndexes = [postTabCoinsResponsesStatus.indexOf(201)];
-
-      for (let i = 0; i < timesSuccessfully; i++) {
-        successPostIndexes.push(postTabCoinsResponsesStatus.indexOf(201, successPostIndexes[i] + 1));
-        expect(successPostIndexes[i]).not.toBe(-1);
-        expect(postTabCoinsResponsesStatus[successPostIndexes[i]]).toBe(201);
-        expect(postTabCoinsResponsesBody).toContainEqual({
-          tabcoins: 2 + i,
-        });
-      }
-
-      expect(successPostIndexes[timesSuccessfully]).toBe(-1);
-
-      successPostIndexes.splice(-1, 1);
-      successPostIndexes.reverse();
-
-      successPostIndexes.forEach((idx) => {
-        postTabCoinsResponsesStatus.splice(idx, 1);
-        postTabCoinsResponsesBody.splice(idx, 1);
-      });
-
-      postTabCoinsResponsesStatus.forEach((status) => expect.soft(status).toBe(422));
-
-      postTabCoinsResponsesBody.forEach((responseBody) =>
-        expect(responseBody).toStrictEqual({
-          name: 'UnprocessableEntityError',
-          message: 'Não foi possível adicionar TabCoins nesta publicação.',
-          action: 'Você precisa de pelo menos 2 TabCoins para realizar esta ação.',
-          status_code: 422,
-          error_id: responseBody.error_id,
-          request_id: responseBody.request_id,
-          error_location_code: 'MODEL:BALANCE:RATE_CONTENT:NOT_ENOUGH',
-        }),
+      const postTabCoinsResponses = await Promise.all(
+        Array.from({ length: timesToFetch }, () => tabcoinsRequestBuilder.post({ transaction_type: 'credit' })),
       );
+
+      const successfulResponsesStatus = postTabCoinsResponses
+        .map(({ response }) => response.status)
+        .filter((status) => status === 201);
+
+      expect(successfulResponsesStatus).toHaveLength(timesSuccessfully);
+
+      postTabCoinsResponses
+        .filter(({ response }) => response.status !== 201)
+        .forEach(({ response, responseBody }) => {
+          if (response.status === 400) {
+            expect(responseBody).toStrictEqual({
+              name: 'ValidationError',
+              message: 'Você está tentando qualificar muitas vezes o mesmo conteúdo.',
+              action: 'Esta operação não poderá ser repetida dentro de 72 horas.',
+              status_code: 400,
+              error_id: responseBody.error_id,
+              request_id: responseBody.request_id,
+            });
+          } else {
+            expect.soft(response.status).toBe(422);
+            expect(responseBody).toStrictEqual({
+              name: 'UnprocessableEntityError',
+              message: 'Não foi possível adicionar TabCoins nesta publicação.',
+              action: 'Você precisa de pelo menos 2 TabCoins para realizar esta ação.',
+              status_code: 422,
+              error_id: responseBody.error_id,
+              request_id: responseBody.request_id,
+              error_location_code: 'MODEL:BALANCE:RATE_CONTENT:NOT_ENOUGH',
+            });
+          }
+        });
 
       const usersRequestBuilder = new RequestBuilder('/api/v1/users');
       const { responseBody: firstUserResponseBody } = await usersRequestBuilder.get(`/${firstUser.username}`);
 
-      expect(firstUserResponseBody.tabcoins).toBe(2 + timesSuccessfully);
+      expect(firstUserResponseBody.tabcoins).toBe(timesSuccessfully);
       expect(firstUserResponseBody.tabcash).toBe(0);
 
       const { responseBody: secondUserResponseBody } = await usersRequestBuilder.get(`/${secondUser.username}`);
@@ -779,9 +765,9 @@ describe('POST /api/v1/contents/tabcoins', () => {
     });
 
     // eslint-disable-next-line vitest/no-disabled-tests
-    test.skip('With 100 simultaneous posts, enough TabCoins for 90, no db resources, but only responses 201 or 422', async () => {
-      const timesToFetch = 100;
-      const timesSuccessfully = 90;
+    test.skip('With 10 simultaneous posts from the same user, and enough TabCoins for more than the rate limit', async () => {
+      const timesToFetch = 10;
+      const rateLimit = 3;
 
       const firstUser = await orchestrator.createUser();
       const firstUserContent = await orchestrator.createContent({
@@ -799,30 +785,144 @@ describe('POST /api/v1/contents/tabcoins', () => {
       await orchestrator.createBalance({
         balanceType: 'user:tabcoin',
         recipientId: secondUser.id,
-        amount: 2 * timesSuccessfully,
+        amount: 2 * timesToFetch,
       });
 
-      const postTabCoinsPromises = Array(timesToFetch)
-        .fill()
-        .map(() => tabcoinsRequestBuilder.post({ transaction_type: 'credit' }));
+      const postTabCoinsResponses = await Promise.all(
+        Array.from({ length: timesToFetch }, () => tabcoinsRequestBuilder.post({ transaction_type: 'credit' })),
+      );
 
-      const postTabCoinsResponses = await Promise.all(postTabCoinsPromises);
+      const successfulResponsesStatus = postTabCoinsResponses
+        .map(({ response }) => response.status)
+        .filter((status) => status === 201);
 
-      const postTabCoinsResponsesBody = postTabCoinsResponses.map(({ responseBody }) => responseBody);
+      expect(successfulResponsesStatus).toHaveLength(rateLimit);
 
-      const postTabCoinsResponsesStatus = postTabCoinsResponses.map(({ response }) => response.status);
+      postTabCoinsResponses
+        .filter(({ response }) => response.status !== 201)
+        .forEach(({ response, responseBody }) => {
+          if (response.status === 400) {
+            expect(responseBody).toStrictEqual({
+              name: 'ValidationError',
+              message: 'Você está tentando qualificar muitas vezes o mesmo conteúdo.',
+              action: 'Esta operação não poderá ser repetida dentro de 72 horas.',
+              status_code: 400,
+              error_id: responseBody.error_id,
+              request_id: responseBody.request_id,
+            });
+          } else {
+            expect.soft(response.status).toBe(422);
+            expect(responseBody).toStrictEqual({
+              name: 'UnprocessableEntityError',
+              message: 'Muitos votos ao mesmo tempo.',
+              action: 'Tente realizar esta operação mais tarde.',
+              status_code: 422,
+              error_id: responseBody.error_id,
+              request_id: responseBody.request_id,
+              error_location_code: 'CONTROLLER:CONTENT:TABCOINS:SERIALIZATION_FAILURE',
+            });
+          }
+        });
 
-      expect([201, 422]).toStrictEqual(expect.arrayContaining(postTabCoinsResponsesStatus));
+      const usersRequestBuilder = new RequestBuilder('/api/v1/users');
+      const { responseBody: firstUserResponseBody } = await usersRequestBuilder.get(`/${firstUser.username}`);
 
-      expect(postTabCoinsResponsesBody).toContainEqual(
-        expect.objectContaining({
+      expect(firstUserResponseBody.tabcoins).toBe(rateLimit);
+      expect(firstUserResponseBody.tabcash).toBe(0);
+
+      const { responseBody: secondUserResponseBody } = await usersRequestBuilder.get(`/${secondUser.username}`);
+
+      expect(secondUserResponseBody.tabcoins).toBe(2 * timesToFetch - 2 * rateLimit);
+      expect(secondUserResponseBody.tabcash).toBe(rateLimit);
+    });
+
+    test('With 100 simultaneous posts from different users and IPs, but only responses 201 or 422', async () => {
+      const timesToFetch = 100;
+
+      const firstUser = await orchestrator.createUser();
+      const firstUserContent = await orchestrator.createContent({
+        owner_id: firstUser.id,
+        title: 'Root',
+        body: 'Body',
+        status: 'published',
+      });
+
+      const tabcoinsUrl = `/api/v1/contents/${firstUser.username}/${firstUserContent.slug}/tabcoins`;
+
+      const requestBuilders = await Promise.all(
+        Array.from({ length: timesToFetch }, async (_, index) => {
+          const requestBuilder = new RequestBuilder(tabcoinsUrl);
+          const voter = await requestBuilder.buildUser();
+          requestBuilder.buildHeaders({ 'x-forwarded-for': `10.0.${Math.floor(index / 256)}.${index % 256}` });
+
+          await orchestrator.createBalance({
+            balanceType: 'user:tabcoin',
+            recipientId: voter.id,
+            amount: 2,
+          });
+
+          return requestBuilder;
+        }),
+      );
+
+      const postTabCoinsResponses = await Promise.all(
+        requestBuilders.map((requestBuilder) => requestBuilder.post({ transaction_type: 'credit' })),
+      );
+
+      const blockedResponses = postTabCoinsResponses.filter(({ response }) => response.status !== 201);
+
+      expect(blockedResponses.length).toBeGreaterThan(0);
+
+      blockedResponses.forEach(({ response, responseBody }) => {
+        expect.soft(response.status).toBe(422);
+        expect(responseBody).toStrictEqual({
           name: 'UnprocessableEntityError',
           message: 'Muitos votos ao mesmo tempo.',
           action: 'Tente realizar esta operação mais tarde.',
           status_code: 422,
+          error_id: responseBody.error_id,
+          request_id: responseBody.request_id,
           error_location_code: 'CONTROLLER:CONTENT:TABCOINS:SERIALIZATION_FAILURE',
+        });
+      });
+    });
+
+    test('With simultaneous posts on different contents from different users (should not block each other)', async () => {
+      const timesToFetch = 10;
+
+      const requestBuilders = await Promise.all(
+        Array.from({ length: timesToFetch }, async (_, index) => {
+          const contentOwner = await orchestrator.createUser();
+          const content = await orchestrator.createContent({
+            owner_id: contentOwner.id,
+            title: `Content ${index}`,
+            body: 'Body',
+            status: 'published',
+          });
+
+          const requestBuilder = new RequestBuilder(
+            `/api/v1/contents/${contentOwner.username}/${content.slug}/tabcoins`,
+          );
+          const voter = await requestBuilder.buildUser();
+          requestBuilder.buildHeaders({ 'x-forwarded-for': `10.0.0.${index + 1}` });
+
+          await orchestrator.createBalance({
+            balanceType: 'user:tabcoin',
+            recipientId: voter.id,
+            amount: 2,
+          });
+
+          return requestBuilder;
         }),
       );
+
+      const postTabCoinsResponses = await Promise.all(
+        requestBuilders.map((requestBuilder) => requestBuilder.post({ transaction_type: 'credit' })),
+      );
+
+      const statuses = postTabCoinsResponses.map(({ response }) => response.status);
+
+      expect(statuses).toStrictEqual(Array(timesToFetch).fill(201));
     });
   });
 });

--- a/tests/integration/api/v1/contents/[username]/[slug]/tabcoins/post.test.js
+++ b/tests/integration/api/v1/contents/[username]/[slug]/tabcoins/post.test.js
@@ -334,6 +334,224 @@ describe('POST /api/v1/contents/tabcoins', () => {
       expect(secondUserResponseBody.tabcash).toBe(3);
     });
 
+    test('With "transaction_type" set to "credit" four times from the same user but different IPs (should be blocked)', async () => {
+      const firstUser = await orchestrator.createUser();
+      const firstUserContent = await orchestrator.createContent({
+        owner_id: firstUser.id,
+        title: 'Root',
+        body: 'Body',
+        status: 'published',
+      });
+
+      const tabcoinsRequestBuilder = new RequestBuilder(
+        `/api/v1/contents/${firstUser.username}/${firstUserContent.slug}/tabcoins`,
+      );
+      const secondUser = await tabcoinsRequestBuilder.buildUser();
+
+      await orchestrator.createBalance({
+        balanceType: 'user:tabcoin',
+        recipientId: secondUser.id,
+        amount: 8,
+      });
+
+      // ROUND 1 OF CREDIT
+      tabcoinsRequestBuilder.buildHeaders({ 'x-forwarded-for': '200.0.0.1' });
+      const { response: postTabCoinsResponse1 } = await tabcoinsRequestBuilder.post({
+        transaction_type: 'credit',
+      });
+
+      expect.soft(postTabCoinsResponse1.status).toBe(201);
+
+      const event1 = await orchestrator.getLastEvent();
+      expect(event1.originator_ip).toBe('200.0.0.1');
+
+      // ROUND 2 OF CREDIT
+      tabcoinsRequestBuilder.buildHeaders({ 'x-forwarded-for': '200.0.0.2' });
+      const { response: postTabCoinsResponse2 } = await tabcoinsRequestBuilder.post({
+        transaction_type: 'credit',
+      });
+
+      expect.soft(postTabCoinsResponse2.status).toBe(201);
+
+      const event2 = await orchestrator.getLastEvent();
+      expect(event2.originator_ip).toBe('200.0.0.2');
+
+      // ROUND 3 OF CREDIT
+      tabcoinsRequestBuilder.buildHeaders({ 'x-forwarded-for': '200.0.0.3' });
+      const { response: postTabCoinsResponse3 } = await tabcoinsRequestBuilder.post({
+        transaction_type: 'credit',
+      });
+
+      expect.soft(postTabCoinsResponse3.status).toBe(201);
+
+      const event3 = await orchestrator.getLastEvent();
+      expect(event3.originator_ip).toBe('200.0.0.3');
+
+      // ROUND 4 OF CREDIT
+      tabcoinsRequestBuilder.buildHeaders({ 'x-forwarded-for': '200.0.0.4' });
+      const { response: postTabCoinsResponse4, responseBody: postTabCoinsResponse4Body } =
+        await tabcoinsRequestBuilder.post({
+          transaction_type: 'credit',
+        });
+
+      expect.soft(postTabCoinsResponse4.status).toBe(400);
+      expect(postTabCoinsResponse4Body).toStrictEqual({
+        name: 'ValidationError',
+        message: 'Você está tentando qualificar muitas vezes o mesmo conteúdo.',
+        action: 'Esta operação não poderá ser repetida dentro de 72 horas.',
+        status_code: 400,
+        error_id: postTabCoinsResponse4Body.error_id,
+        request_id: postTabCoinsResponse4Body.request_id,
+      });
+
+      const usersRequestBuilder = new RequestBuilder('/api/v1/users');
+      const { responseBody: firstUserResponseBody } = await usersRequestBuilder.get(`/${firstUser.username}`);
+
+      expect(firstUserResponseBody.tabcoins).toBe(3);
+      expect(firstUserResponseBody.tabcash).toBe(0);
+
+      const { responseBody: secondUserResponseBody } = await usersRequestBuilder.get(`/${secondUser.username}`);
+
+      expect(secondUserResponseBody.tabcoins).toBe(2);
+      expect(secondUserResponseBody.tabcash).toBe(3);
+    });
+
+    test('With "transaction_type" set to "debit" four times from the same user but different IPs (should be blocked)', async () => {
+      const firstUser = await orchestrator.createUser();
+      const firstUserContent = await orchestrator.createContent({
+        owner_id: firstUser.id,
+        title: 'Root',
+        body: 'Body',
+        status: 'published',
+      });
+
+      const tabcoinsRequestBuilder = new RequestBuilder(
+        `/api/v1/contents/${firstUser.username}/${firstUserContent.slug}/tabcoins`,
+      );
+      const secondUser = await tabcoinsRequestBuilder.buildUser();
+
+      await orchestrator.createBalance({
+        balanceType: 'user:tabcoin',
+        recipientId: secondUser.id,
+        amount: 8,
+      });
+
+      // ROUND 1 OF DEBIT
+      tabcoinsRequestBuilder.buildHeaders({ 'x-forwarded-for': '200.0.0.1' });
+      const { response: postTabCoinsResponse1 } = await tabcoinsRequestBuilder.post({
+        transaction_type: 'debit',
+      });
+
+      expect.soft(postTabCoinsResponse1.status).toBe(201);
+
+      const event1 = await orchestrator.getLastEvent();
+      expect(event1.originator_ip).toBe('200.0.0.1');
+
+      // ROUND 2 OF DEBIT
+      tabcoinsRequestBuilder.buildHeaders({ 'x-forwarded-for': '200.0.0.2' });
+      const { response: postTabCoinsResponse2 } = await tabcoinsRequestBuilder.post({
+        transaction_type: 'debit',
+      });
+
+      expect.soft(postTabCoinsResponse2.status).toBe(201);
+
+      const event2 = await orchestrator.getLastEvent();
+      expect(event2.originator_ip).toBe('200.0.0.2');
+
+      // ROUND 3 OF DEBIT
+      tabcoinsRequestBuilder.buildHeaders({ 'x-forwarded-for': '200.0.0.3' });
+      const { response: postTabCoinsResponse3 } = await tabcoinsRequestBuilder.post({
+        transaction_type: 'debit',
+      });
+
+      expect.soft(postTabCoinsResponse3.status).toBe(201);
+
+      const event3 = await orchestrator.getLastEvent();
+      expect(event3.originator_ip).toBe('200.0.0.3');
+
+      // ROUND 4 OF DEBIT
+      tabcoinsRequestBuilder.buildHeaders({ 'x-forwarded-for': '200.0.0.4' });
+      const { response: postTabCoinsResponse4, responseBody: postTabCoinsResponse4Body } =
+        await tabcoinsRequestBuilder.post({
+          transaction_type: 'debit',
+        });
+
+      expect.soft(postTabCoinsResponse4.status).toBe(400);
+      expect(postTabCoinsResponse4Body).toStrictEqual({
+        name: 'ValidationError',
+        message: 'Você está tentando qualificar muitas vezes o mesmo conteúdo.',
+        action: 'Esta operação não poderá ser repetida dentro de 72 horas.',
+        status_code: 400,
+        error_id: postTabCoinsResponse4Body.error_id,
+        request_id: postTabCoinsResponse4Body.request_id,
+      });
+
+      const usersRequestBuilder = new RequestBuilder('/api/v1/users');
+      const { responseBody: firstUserResponseBody } = await usersRequestBuilder.get(`/${firstUser.username}`);
+
+      expect(firstUserResponseBody.tabcoins).toBe(-3);
+      expect(firstUserResponseBody.tabcash).toBe(0);
+
+      const { responseBody: secondUserResponseBody } = await usersRequestBuilder.get(`/${secondUser.username}`);
+
+      expect(secondUserResponseBody.tabcoins).toBe(2);
+      expect(secondUserResponseBody.tabcash).toBe(3);
+    });
+
+    test('With "transaction_type" set to "credit" four times from different users and different IPs (should not be blocked)', async () => {
+      const firstUser = await orchestrator.createUser();
+      const firstUserContent = await orchestrator.createContent({
+        owner_id: firstUser.id,
+        title: 'Root',
+        body: 'Body',
+        status: 'published',
+      });
+
+      const tabcoinsRequestBuilder = new RequestBuilder(
+        `/api/v1/contents/${firstUser.username}/${firstUserContent.slug}/tabcoins`,
+      );
+
+      const voterIps = ['200.0.0.1', '200.0.0.2', '200.0.0.3', '200.0.0.4'];
+      const usersRequestBuilder = new RequestBuilder('/api/v1/users');
+
+      for (const [index, ip] of voterIps.entries()) {
+        const voter = await tabcoinsRequestBuilder.buildUser();
+
+        await orchestrator.createBalance({
+          balanceType: 'user:tabcoin',
+          recipientId: voter.id,
+          amount: 2,
+        });
+
+        tabcoinsRequestBuilder.buildHeaders({ 'x-forwarded-for': ip });
+
+        const { response: postTabCoinsResponse, responseBody: postTabCoinsResponseBody } =
+          await tabcoinsRequestBuilder.post({
+            transaction_type: 'credit',
+          });
+
+        expect.soft(postTabCoinsResponse.status).toBe(201);
+        expect(postTabCoinsResponseBody).toStrictEqual({
+          tabcoins: index + 1,
+          tabcoins_credit: index + 1,
+          tabcoins_debit: 0,
+        });
+
+        const createdEvent = await orchestrator.getLastEvent();
+        expect(createdEvent.originator_ip).toBe(ip);
+
+        const { responseBody: voterResponseBody } = await usersRequestBuilder.get(`/${voter.username}`);
+
+        expect(voterResponseBody.tabcoins).toBe(0);
+        expect(voterResponseBody.tabcash).toBe(1);
+      }
+
+      const { responseBody: firstUserResponseBody } = await usersRequestBuilder.get(`/${firstUser.username}`);
+
+      expect(firstUserResponseBody.tabcoins).toBe(4);
+      expect(firstUserResponseBody.tabcash).toBe(0);
+    });
+
     test('With "transaction_type" set to "debit" twice to make content "tabcoins" negative', async () => {
       const firstUser = await orchestrator.createUser();
       const firstUserContent = await orchestrator.createContent({


### PR DESCRIPTION
## Mudanças realizadas

A restrição de limitação de 3 votos em janelas de 72h por usuário, ao invés de apenas por IP, já foi levantada algumas vezes. Como moderador do TabNews, confirmo que essa restrição auxiliaria a prevenir alguns casos de abusos que já tivemos ao longo dos anos, sejam abusos leves ou graves. Contexto relevante: #1166, #1519.

Além de expandir essa restrição (que, na prática, para quem usa o TabNews normalmente, não mudou nada), revisei os testes de concorrência de votos e adicionei um cobrindo que votos em conteúdos diferentes não interferem uns nos outros.

## Tipo de mudança

- [x] Nova funcionalidade

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
