### PR TITLE
Carrega variáveis de ambiente do `.env.local` além do `.env` nos testes

### DIFF
--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -2,7 +2,7 @@ import defineConfig from '@tabnews/config/vitest';
 import { config } from 'dotenv';
 import { defaultExclude } from 'vitest/config';
 
-config({ quiet: true });
+config({ quiet: true, path: ['.env.local', '.env'] });
 
 export default defineConfig({
   test: {


### PR DESCRIPTION
## Mudanças realizadas

Mudança de configuração do Vitest para considerar as variáveis de ambiente do arquivo `.env.local`.

## Tipo de mudança

- [x] Correção de bug

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
