### PR TITLE
feat: sistema de recomendação v2 (ranker + queries otimizadas)

### DIFF
--- a/infra/scripts/seed-ranking-test.js
+++ b/infra/scripts/seed-ranking-test.js
@@ -1,0 +1,522 @@
+/* eslint-disable no-console */
+
+/*
+  Seed de teste para o algoritmo de recomendação v2 (estratégia
+  `relevant_global_v2` = queries.recentContent + lib/ranker.js).
+
+  Injeta um conjunto pequeno e variado de posts (com votos, comentários e
+  idades controladas) projetado para exercitar cada sinal do Ranker:
+  qualidade (Wilson), discussão, engajamento recente, tamanho do conteúdo,
+  polêmica e decaimento temporal.
+
+  Ao final, roda a MESMA query e o MESMO Ranker usados em produção (via import
+  dinâmico) e imprime o ranking resultante, para inspeção do comportamento.
+
+  Uso (com o Postgres de desenvolvimento no ar e migrações aplicadas):
+    node -r dotenv-expand/config infra/scripts/seed-ranking-test.js
+
+  Para apenas remover os dados de teste (sem reinserir):
+    node -r dotenv-expand/config infra/scripts/seed-ranking-test.js --clean
+
+  É idempotente: remove qualquer dado de execuções anteriores (usuários com
+  prefixo `ranktestseed`) antes de inserir.
+*/
+
+const { join } = require('node:path');
+const { pathToFileURL } = require('node:url');
+const { Client } = require('pg');
+
+const CLEAN_ONLY = process.argv.includes('--clean');
+
+// Precisa ser alfanumérico: o validator de saída exige usernames sem símbolos.
+const USER_PREFIX = 'ranktestseed';
+const PASSWORD_HASH = '$2a$04$v0hvAu/y6pJ17LzeCfcKG.rDStO9x5ficm2HTLZIfeDBG8oR/uQXi'; // "password"
+
+// Cada post root é desenhado para destacar um sinal específico do Ranker.
+const POSTS = [
+  {
+    key: 'hit-recente',
+    title: '[ranktest] Hit recente: muito votado e discutido agora',
+    ageHours: 1,
+    bodyLength: 6000,
+    upvotes: 35,
+    downvotes: 3,
+    comments: { total: 14, uniqueCommenters: 8, recent: 9 },
+    expectation: 'TOPO — qualidade alta, discussão forte, engajamento recente, quase sem decaimento.',
+  },
+  {
+    key: 'classico-antigo',
+    title: '[ranktest] Clássico antigo: ótimos números, porém de 5 dias atrás',
+    ageHours: 120,
+    bodyLength: 9000,
+    upvotes: 60,
+    downvotes: 2,
+    comments: { total: 25, uniqueCommenters: 12, recent: 0 },
+    expectation: 'BASE altíssima, mas o decaimento (e^-10) joga o score final para perto de zero.',
+  },
+  {
+    key: 'polemico',
+    title: '[ranktest] Polêmico: upvotes e downvotes quase empatados',
+    ageHours: 4,
+    bodyLength: 2500,
+    upvotes: 22,
+    downvotes: 20,
+    comments: { total: 16, uniqueCommenters: 7, recent: 6 },
+    expectation: 'controversyScore alto (up ≈ down). Só funciona com downvotes corrigidos para magnitude positiva.',
+  },
+  {
+    key: 'fraco-recente',
+    title: '[ranktest] Fraco recente: novo, mas curto e sem tração',
+    ageHours: 2,
+    bodyLength: 180,
+    upvotes: 2,
+    downvotes: 0,
+    comments: { total: 1, uniqueCommenters: 1, recent: 1 },
+    expectation: 'Baixo: pouco conteúdo e pouca discussão, ainda que com decaimento baixo.',
+  },
+  {
+    key: 'mediano',
+    title: '[ranktest] Mediano: números medianos em todos os sinais',
+    ageHours: 12,
+    bodyLength: 2000,
+    upvotes: 12,
+    downvotes: 3,
+    comments: { total: 6, uniqueCommenters: 4, recent: 2 },
+    expectation: 'Meio da tabela.',
+  },
+  {
+    key: 'sem-comentarios',
+    title: '[ranktest] Sem comentários: valida COUNT(child.id) = 0',
+    ageHours: 6,
+    bodyLength: 1500,
+    upvotes: 9,
+    downvotes: 1,
+    comments: { total: 0, uniqueCommenters: 0, recent: 0 },
+    expectation: 'comment_count/children_deep_count = 0 (antes do fix vinha 1). discussionScore ≈ 0.',
+  },
+  {
+    key: 'net-negativo',
+    title: '[ranktest] Net negativo: mais downvotes que upvotes',
+    ageHours: 20,
+    bodyLength: 400,
+    upvotes: 1,
+    downvotes: 6,
+    comments: { total: 0, uniqueCommenters: 0, recent: 0 },
+    expectation: 'Qualidade baixa (Wilson penaliza), tende ao fundo.',
+  },
+  {
+    key: 'longo-recente',
+    title: '[ranktest] Longo recente: artigo extenso publicado há pouco',
+    ageHours: 3,
+    bodyLength: 12000,
+    upvotes: 14,
+    downvotes: 1,
+    comments: { total: 4, uniqueCommenters: 3, recent: 3 },
+    expectation: 'contentScore forte (peso 2.5) + decaimento baixo deve deixá-lo bem colocado.',
+  },
+  {
+    key: 'sem-votos',
+    title: '[ranktest] Sem votos: recém-publicado e ainda sem avaliação',
+    ageHours: 5,
+    bodyLength: 1200,
+    upvotes: 0,
+    downvotes: 0,
+    comments: { total: 0, uniqueCommenters: 0, recent: 0 },
+    expectation: 'qualityScore depende só dos priors de Wilson (up=3, down=1). tabcoins = 0.',
+  },
+  {
+    key: 'discussao-popular',
+    title: '[ranktest] Muita discussão, poucos votos: 22 comentaristas, +3',
+    ageHours: 8,
+    bodyLength: 1800,
+    upvotes: 3,
+    downvotes: 1,
+    comments: { total: 30, uniqueCommenters: 22, recent: 12 },
+    expectation: 'discussionScore alto (volume + comentaristas únicos) compensando qualidade modesta.',
+  },
+  {
+    key: 'burst-recente',
+    title: '[ranktest] Rajada recente: explosão de comentários nas últimas 24h',
+    ageHours: 10,
+    bodyLength: 2000,
+    upvotes: 8,
+    downvotes: 1,
+    comments: { total: 18, uniqueCommenters: 10, recent: 16 },
+    expectation: 'engagementScore impulsionado por recent_comments (velocity), apesar da idade média.',
+  },
+  {
+    key: 'comentarios-antigos',
+    title: '[ranktest] Comentários antigos: post novo, discussão toda velha',
+    ageHours: 4,
+    bodyLength: 2200,
+    upvotes: 9,
+    downvotes: 2,
+    comments: { total: 12, uniqueCommenters: 6, recent: 0 },
+    expectation: 'comment_count alto, mas recent_comments = 0 (valida o FILTER de 24h). Engajamento baixo.',
+  },
+  {
+    key: 'thread-profunda',
+    title: '[ranktest] Thread profunda: respostas aninhadas em cadeia',
+    ageHours: 6,
+    bodyLength: 2500,
+    upvotes: 10,
+    downvotes: 2,
+    comments: { total: 10, uniqueCommenters: 5, recent: 5, layout: 'thread' },
+    expectation: 'avg_comment_children cresce com a profundidade (path mais longo), ativando discussionWeightDepth.',
+  },
+  {
+    key: 'curtissimo-muito-votado',
+    title: '[ranktest] Curtíssimo porém muito votado: +45 em 60 caracteres',
+    ageHours: 3,
+    bodyLength: 60,
+    upvotes: 45,
+    downvotes: 3,
+    comments: { total: 2, uniqueCommenters: 2, recent: 1 },
+    expectation: 'qualityScore alto, mas contentScore quase nulo: mostra a disputa entre os dois sinais.',
+  },
+  {
+    key: 'janela-limite',
+    title: '[ranktest] No limite da janela: publicado há ~6,9 dias',
+    ageHours: 165,
+    bodyLength: 3000,
+    upvotes: 25,
+    downvotes: 2,
+    comments: { total: 8, uniqueCommenters: 5, recent: 0 },
+    expectation: 'Ainda dentro de 7 dias (aparece), mas o decaimento (e^-13,75) zera o score na prática.',
+  },
+  {
+    key: 'fora-da-janela',
+    title: '[ranktest] Fora da janela: publicado há 8 dias',
+    ageHours: 192,
+    bodyLength: 3000,
+    upvotes: 30,
+    downvotes: 2,
+    comments: { total: 5, uniqueCommenters: 3, recent: 0 },
+    expectation: 'NÃO deve ser retornado pela query (published_at < NOW() - 7 days).',
+  },
+  {
+    key: 'gemeo-a',
+    title: '[ranktest] Gêmeo A: sinais idênticos ao Gêmeo B',
+    ageHours: 2,
+    bodyLength: 2000,
+    upvotes: 12,
+    downvotes: 2,
+    comments: { total: 6, uniqueCommenters: 4, recent: 3 },
+    expectation: 'Empate: deve ter score praticamente igual ao Gêmeo B e ficar adjacente (ordenação estável).',
+  },
+  {
+    key: 'gemeo-b',
+    title: '[ranktest] Gêmeo B: sinais idênticos ao Gêmeo A',
+    ageHours: 2,
+    bodyLength: 2000,
+    upvotes: 12,
+    downvotes: 2,
+    comments: { total: 6, uniqueCommenters: 4, recent: 3 },
+    expectation:
+      'Empate: mesma configuração do Gêmeo A; diferença de score só no ruído de milissegundos do created_at.',
+  },
+  {
+    key: 'half-life-exato',
+    title: '[ranktest] Meia-vida exata: idade = halfLifeHours (12h)',
+    ageHours: 12,
+    bodyLength: 4000,
+    upvotes: 30,
+    downvotes: 2,
+    comments: { total: 8, uniqueCommenters: 5, recent: 0 },
+    expectation: 'Decaimento e^-1 ≈ 0,368: o score final é ~37% da base (referência para entender o halfLife).',
+  },
+  {
+    key: 'muito-downvotado',
+    title: '[ranktest] Muito downvotado: +5 contra -50, recente',
+    ageHours: 3,
+    bodyLength: 1500,
+    upvotes: 5,
+    downvotes: 50,
+    comments: { total: 4, uniqueCommenters: 3, recent: 1 },
+    expectation: 'Recente, mas Wilson pune forte (8 créditos / 51 débitos): qualidade derruba o score.',
+  },
+  {
+    key: 'viral-sem-discussao',
+    title: '[ranktest] Viral sem discussão: +200, zero comentários',
+    ageHours: 2,
+    bodyLength: 1000,
+    upvotes: 200,
+    downvotes: 5,
+    comments: { total: 0, uniqueCommenters: 0, recent: 0 },
+    expectation: 'qualityScore satura perto de 1, mas discussionScore = 0: qualidade pura sem conversa.',
+  },
+  {
+    key: 'tamanho-maximo',
+    title: '[ranktest] Tamanho máximo: corpo de 20000 caracteres',
+    ageHours: 4,
+    bodyLength: 20000,
+    upvotes: 10,
+    downvotes: 1,
+    comments: { total: 3, uniqueCommenters: 2, recent: 1 },
+    expectation: 'contentScore satura em 1,0 (logNormalize com value = max = 20000).',
+  },
+  {
+    key: 'comentarios-rascunho',
+    title: '[ranktest] Comentários em rascunho não contam',
+    ageHours: 5,
+    bodyLength: 1800,
+    upvotes: 8,
+    downvotes: 1,
+    comments: { total: 5, uniqueCommenters: 3, recent: 2, draftChildren: 4 },
+    expectation: 'Tem 4 filhos em rascunho: comment_count deve contar só os 5 publicados (filtro status = published).',
+  },
+  {
+    key: 'spam-mesmo-usuario',
+    title: '[ranktest] Spam: 25 comentários de um único usuário',
+    ageHours: 6,
+    bodyLength: 1600,
+    upvotes: 6,
+    downvotes: 2,
+    comments: { total: 25, uniqueCommenters: 1, recent: 5 },
+    expectation: 'comment_count = 25 mas unique_commenters = 1: discussionWeightUsers segura o volume inflado.',
+  },
+  {
+    key: 'auto-comentarios',
+    title: '[ranktest] Auto-comentários: autor responde o próprio post',
+    ageHours: 5,
+    bodyLength: 1700,
+    upvotes: 9,
+    downvotes: 1,
+    comments: { total: 8, uniqueCommenters: 1, recent: 4, selfComments: true },
+    expectation:
+      'Comentários do próprio autor: unique_commenters = 1. A query conta filhos publicados de qualquer dono.',
+  },
+  {
+    key: 'revival-necropost',
+    title: '[ranktest] Necropost: antigo (5 dias) com rajada recente',
+    ageHours: 120,
+    bodyLength: 2500,
+    upvotes: 18,
+    downvotes: 3,
+    comments: { total: 20, uniqueCommenters: 8, recent: 18 },
+    expectation: 'Mesmo com 18 comentários recentes, o decaimento de 5 dias domina e mantém o score lá embaixo.',
+  },
+];
+
+const TIME_WINDOW = '7 days'; // mesmo default de options.timeWindow em relevant_global_v2
+const CANDIDATE_LIMIT = 300; // mesmo default de options.candidateLimit
+
+const client = new Client({
+  connectionString: process.env.DATABASE_URL,
+  connectionTimeoutMillis: 5000,
+  idleTimeoutMillis: 30000,
+  allowExitOnIdle: false,
+});
+
+run();
+
+async function run() {
+  await client.connect();
+
+  try {
+    await client.query('BEGIN');
+    const removed = await cleanPreviousSeed();
+
+    if (CLEAN_ONLY) {
+      await client.query('COMMIT');
+      await client.end();
+      console.log(`\n> Limpeza concluída: ${removed} usuários ranktest removidos. Nada foi inserido.`);
+      return;
+    }
+
+    const posterIds = await createUsers('u', POSTS.length);
+    const commenterIds = await createUsers('c', 25);
+    await seedPosts(posterIds, commenterIds);
+    await client.query('COMMIT');
+  } catch (error) {
+    await client.query('ROLLBACK');
+    console.error('> Operação falhou, rollback aplicado.');
+    throw error;
+  }
+
+  console.log(`\n> ${POSTS.length} posts de teste injetados.\n`);
+
+  await previewRanking();
+
+  await client.end();
+}
+
+async function cleanPreviousSeed() {
+  const userIdsResult = await client.query(`SELECT id FROM users WHERE username LIKE $1`, [`${USER_PREFIX}%`]);
+  const userIds = userIdsResult.rows.map((row) => row.id);
+
+  if (userIds.length === 0) return 0;
+
+  await client.query(
+    `DELETE FROM content_tabcoin_operations
+     WHERE recipient_id IN (SELECT id FROM contents WHERE owner_id = ANY($1))`,
+    [userIds],
+  );
+  await client.query(`DELETE FROM contents WHERE owner_id = ANY($1)`, [userIds]);
+  await client.query(`DELETE FROM users WHERE id = ANY($1)`, [userIds]);
+
+  console.log(`> Limpeza: removidos dados de ${userIds.length} usuários ranktest anteriores.`);
+
+  return userIds.length;
+}
+
+async function createUsers(role, count) {
+  const ids = [];
+
+  for (let i = 0; i < count; i++) {
+    const username = `${USER_PREFIX}${role}${i}`;
+    const email = `${username}@ranktest.local`;
+    const result = await client.query(
+      `INSERT INTO users (username, email, password, features) VALUES ($1, $2, $3, $4) RETURNING id`,
+      [username, email, PASSWORD_HASH, []],
+    );
+    ids.push(result.rows[0].id);
+  }
+
+  return ids;
+}
+
+async function seedPosts(posterIds, commenterIds) {
+  for (let index = 0; index < POSTS.length; index++) {
+    const post = POSTS[index];
+    const ownerId = posterIds[index];
+    const publishedAt = hoursAgoIso(post.ageHours);
+
+    const rootResult = await client.query(
+      `INSERT INTO contents
+         (owner_id, slug, title, body, status, type, path, published_at, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, 'published', 'content', '{}', $5, $5, $5)
+       RETURNING id`,
+      [ownerId, `ranktest-${post.key}`, post.title, makeBody(post.bodyLength), publishedAt],
+    );
+    const rootId = rootResult.rows[0].id;
+
+    await applyVotes(rootId, ownerId, post.upvotes, post.downvotes);
+    await seedComments(rootId, post, commenterIds, ownerId);
+  }
+}
+
+async function applyVotes(contentId, originatorId, upvotes, downvotes) {
+  // O Ranker só lê os agregados de get_content_balance_credit_debit, então uma
+  // única operação de crédito/débito com o total já reproduz upvotes/downvotes.
+  if (upvotes > 0) {
+    await client.query(
+      `INSERT INTO content_tabcoin_operations
+         (balance_type, recipient_id, amount, originator_type, originator_id)
+       VALUES ('credit', $1, $2, 'orchestrator', $3)`,
+      [contentId, upvotes, originatorId],
+    );
+  }
+
+  if (downvotes > 0) {
+    // Débitos são gravados como amount negativo (convenção de balance.rateContent).
+    await client.query(
+      `INSERT INTO content_tabcoin_operations
+         (balance_type, recipient_id, amount, originator_type, originator_id)
+       VALUES ('debit', $1, $2, 'orchestrator', $3)`,
+      [contentId, -downvotes, originatorId],
+    );
+  }
+}
+
+async function seedComments(rootId, post, commenterIds, ownerId) {
+  const { total, uniqueCommenters, recent, layout = 'flat', selfComments = false, draftChildren = 0 } = post.comments;
+
+  // O `path` de um filho é ARRAY_APPEND(path_do_pai, id_do_pai), como em content.create.
+  // 'flat': todos respondem o root (path = [root], profundidade 1).
+  // 'thread': cada comentário responde o anterior, gerando profundidade crescente.
+  let previous = { id: rootId, path: [] };
+
+  for (let i = 0; i < total; i++) {
+    // Distribui os comentários entre `uniqueCommenters` autores distintos
+    // (ou usa o próprio autor do post quando selfComments está ativo).
+    const commenterId = selfComments ? ownerId : commenterIds[i % Math.max(uniqueCommenters, 1)];
+    // Os `recent` primeiros ficam dentro das últimas 24h; o resto, mais antigo.
+    const commentAgeHours = i < recent ? 2 : Math.max(post.ageHours, 30);
+    const publishedAt = hoursAgoIso(commentAgeHours);
+
+    const parent = layout === 'thread' ? previous : { id: rootId, path: [] };
+    const path = [...parent.path, parent.id];
+
+    const result = await client.query(
+      `INSERT INTO contents
+         (owner_id, parent_id, slug, body, status, type, path, published_at, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, 'published', 'content', $5::uuid[], $6, $6, $6)
+       RETURNING id`,
+      [commenterId, parent.id, `ranktest-${post.key}-c${i}`, makeBody(120 + i * 10), path, publishedAt],
+    );
+
+    previous = { id: result.rows[0].id, path };
+  }
+
+  // Filhos em rascunho: existem na tabela, mas a query só conta status = 'published'.
+  for (let i = 0; i < draftChildren; i++) {
+    await client.query(
+      `INSERT INTO contents
+         (owner_id, parent_id, slug, body, status, type, path, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, 'draft', 'content', ARRAY[$2]::uuid[], NOW(), NOW())`,
+      [commenterIds[0], rootId, `ranktest-${post.key}-draft${i}`, makeBody(150)],
+    );
+  }
+}
+
+async function previewRanking() {
+  const queriesUrl = pathToFileURL(join(__dirname, '..', '..', 'queries', 'rankingQueries.js')).href;
+  const rankerUrl = pathToFileURL(join(__dirname, '..', '..', 'lib', 'ranker.js')).href;
+
+  const { default: queries } = await import(queriesUrl);
+  const { Ranker } = await import(rankerUrl);
+
+  const { rows } = await client.query({
+    text: queries.recentContent,
+    values: [CANDIDATE_LIMIT, 0, TIME_WINDOW],
+  });
+
+  const ranked = new Ranker().execute(rows).filter((row) => String(row.title).startsWith('[ranktest]'));
+
+  console.log('> Ranking produzido pela query + Ranker de produção (apenas posts ranktest):\n');
+  console.table(
+    ranked.map((row, position) => ({
+      '#': position + 1,
+      score: Number(row.score).toFixed(4),
+      title: String(row.title).replace('[ranktest] ', '').slice(0, 38),
+      tabcoins: row.tabcoins,
+      up: row.upvotes,
+      down: row.downvotes,
+      comments: row.comment_count,
+      uniq: row.unique_commenters,
+      recent: row.recent_comments,
+      depth: Number(row.avg_comment_children).toFixed(1),
+      len: row.post_length,
+      ageH: hoursSince(row.published_at),
+    })),
+  );
+
+  // Posts ranktest que NÃO voltaram da query (ex.: fora da janela de 7 dias).
+  const returnedTitles = new Set(ranked.map((row) => row.title));
+  const absent = POSTS.filter((post) => !returnedTitles.has(post.title));
+  if (absent.length) {
+    console.log('\n> Posts ranktest filtrados pela query (não retornados — esperado):');
+    for (const post of absent) {
+      console.log(`  - ${post.title.replace('[ranktest] ', '')}\n      ${post.expectation}`);
+    }
+  }
+
+  console.log('\n> Expectativa de cada post:');
+  for (const post of POSTS) {
+    console.log(`  - ${post.title.replace('[ranktest] ', '')}\n      ${post.expectation}`);
+  }
+}
+
+function makeBody(length) {
+  const sentence = 'Conteudo de teste para o algoritmo de recomendacao do TabNews. ';
+  return sentence.repeat(Math.ceil(length / sentence.length)).slice(0, length);
+}
+
+function hoursAgoIso(hours) {
+  return new Date(Date.now() - hours * 3600 * 1000).toISOString();
+}
+
+function hoursSince(timestamp) {
+  return Math.round((Date.now() - new Date(timestamp).getTime()) / 3600000);
+}

--- a/lib/ranker.js
+++ b/lib/ranker.js
@@ -1,0 +1,157 @@
+export class Ranker {
+  constructor(config = {}) {
+    this.config = {
+      // PESOS DOS COMPONENTES PRINCIPAIS
+      weightQuality: 1.5,
+      weightDiscussion: 1.2,
+      weightEngagement: 1,
+      weightContent: 2.5,
+      weightControversy: 0.5,
+
+      /*
+      PESOS INTERNOS DA DISCUSSÃO
+      (devem somar 1)
+      */
+      discussionWeightVolume: 0.4,
+      discussionWeightUsers: 0.35,
+      discussionWeightDepth: 0.25,
+
+      // WILSON SCORE
+      wilsonZ: 1.96,
+      priorUp: 3,
+      priorDown: 1,
+
+      // REFERÊNCIAS DE NORMALIZAÇÃO
+      maxComments: 500,
+      maxDepth: 20,
+      maxUsers: 200,
+      maxPostLength: 20000,
+      maxVelocity: 50,
+
+      // TIME DECAY
+      halfLifeHours: 12,
+    };
+
+    this.config = { ...this.config, ...config };
+  }
+
+  execute(rows) {
+    if (!Array.isArray(rows) || rows.length === 0) {
+      return [];
+    }
+
+    const now = Date.now();
+
+    const ranked = rows.map((post) => ({
+      ...post,
+      score: this.computeFinalScore(post, now),
+    }));
+
+    ranked.sort((a, b) => b.score - a.score);
+
+    return ranked;
+  }
+
+  computeFinalScore(post, now) {
+    const baseScore =
+      this.config.weightQuality * this.qualityScore(post) +
+      this.config.weightDiscussion * this.discussionScore(post) +
+      this.config.weightEngagement * this.engagementScore(post, now) +
+      this.config.weightContent * this.contentScore(post) +
+      this.config.weightControversy * this.controversyScore(post);
+
+    return baseScore * this.recencyDecay(post, now);
+  }
+
+  qualityScore(post) {
+    const up = Number(post.upvotes || 0) + this.config.priorUp;
+    const down = Number(post.downvotes || 0) + this.config.priorDown;
+    return this.clamp(this.wilson(up, down));
+  }
+
+  discussionScore(post) {
+    const comments = Number(post.comment_count || 0);
+    const depth = Number(post.avg_comment_children || 0);
+    const users = Number(post.unique_commenters || 0);
+
+    const weighted =
+      this.logNormalize(comments, this.config.maxComments) * this.config.discussionWeightVolume +
+      this.logNormalize(users, this.config.maxUsers) * this.config.discussionWeightUsers +
+      this.logNormalize(depth, this.config.maxDepth) * this.config.discussionWeightDepth;
+
+    return this.clamp(weighted);
+  }
+
+  engagementScore(post, now) {
+    const age = this.ageHours(post.created_at, now);
+    const votes = Number(post.recent_votes || 0);
+    const comments = Number(post.recent_comments || 0);
+    const velocity = (votes + comments) / (age + 1);
+
+    return this.logNormalize(velocity, this.config.maxVelocity);
+  }
+
+  contentScore(post) {
+    const length = Number(post.post_length || 0);
+    return this.logNormalize(length, this.config.maxPostLength);
+  }
+
+  controversyScore(post) {
+    const up = Number(post.upvotes || 0);
+    const down = Number(post.downvotes || 0);
+    const total = up + down;
+
+    if (total === 0) {
+      return 0;
+    }
+
+    return this.clamp(1 - Math.abs(up - down) / total);
+  }
+
+  recencyDecay(post, now) {
+    const age = this.ageHours(post.created_at, now);
+    return Math.exp(-age / this.config.halfLifeHours);
+  }
+
+  wilson(up, down) {
+    const n = up + down;
+    if (n === 0) {
+      return 0;
+    }
+
+    const z = this.config.wilsonZ;
+    const p = up / n;
+    const numerator = p + (z * z) / (2 * n) - z * Math.sqrt((p * (1 - p) + (z * z) / (4 * n)) / n);
+    const denominator = 1 + (z * z) / n;
+
+    return numerator / denominator;
+  }
+
+  logNormalize(value, max) {
+    const numericValue = Number(value);
+    const numericMax = Number(max);
+
+    if (!numericValue || numericMax <= 0) {
+      return 0;
+    }
+
+    return this.clamp(Math.log1p(numericValue) / Math.log1p(numericMax));
+  }
+
+  clamp(v) {
+    if (Number.isNaN(v)) {
+      return 0;
+    }
+    return v < 0 ? 0 : v > 1 ? 1 : v;
+  }
+
+  ageHours(timestamp, now) {
+    const t = new Date(timestamp).getTime();
+
+    if (!t) {
+      return 0;
+    }
+
+    return (now - t) / 3600000;
+  }
+}

--- a/models/content.js
+++ b/models/content.js
@@ -4,6 +4,7 @@ import slug from 'slug';
 
 import { ForbiddenError, UnprocessableEntityError, ValidationError } from 'errors';
 import database from 'infra/database.js';
+import { Ranker } from 'lib/ranker';
 import balance from 'models/balance.js';
 import pagination from 'models/pagination.js';
 import prestige from 'models/prestige';
@@ -15,6 +16,7 @@ async function findAll(values = {}, options = {}) {
   values = validateValues(values);
   await replaceOwnerUsernameWithOwnerId(values);
 
+  const ranker = new Ranker();
   const query = {
     values: [],
   };
@@ -33,6 +35,30 @@ async function findAll(values = {}, options = {}) {
     const relevantResults = await database.query(query, { transaction: options.transaction });
 
     return relevantResults.rows;
+  }
+
+  if (options.strategy === 'relevant_global_v2') {
+    const candidateLimit = options.candidateLimit ?? 300;
+    const candidateOffset = 0;
+    const timeWindow = options.timeWindow ?? '7 days';
+
+    const rankedQuery = {
+      text: queries.recentContent,
+      values: [candidateLimit, candidateOffset, timeWindow],
+    };
+
+    const { rows } = await database.query(rankedQuery, { transaction: options.transaction });
+
+    const ranked = ranker.execute(rows);
+
+    if (values.count) {
+      return [{ total_rows: ranked.length }];
+    }
+
+    const offset = options.offset ?? 0;
+    const limit = options.limit ?? 50;
+
+    return ranked.slice(offset, offset + limit);
   }
 
   const selectClause = buildSelectClause(values);
@@ -198,6 +224,7 @@ async function findWithStrategy(options = {}) {
     new: getNew,
     old: getOld,
     relevant: getRelevant,
+    relevant_v2: getRelevantV2,
   };
 
   return await strategies[options.strategy](options);
@@ -241,6 +268,25 @@ async function findWithStrategy(options = {}) {
       results.rows = rankContentListByRelevance(contentList);
     }
 
+    values.total_rows = results.rows[0]?.total_rows;
+    results.pagination = await getPagination(values, options);
+
+    return results;
+  }
+
+  async function getRelevantV2(values = {}) {
+    const results = {};
+    const options = {};
+
+    if (!values.where?.owner_username && values.where?.parent_id === null) {
+      options.strategy = 'relevant_global_v2';
+      options.limit = values.per_page;
+      options.offset = (values.page - 1) * values.per_page;
+    }
+
+    const contentList = await findAll(values, options);
+
+    results.rows = contentList;
     values.total_rows = results.rows[0]?.total_rows;
     results.pagination = await getPagination(values, options);
 
@@ -300,7 +346,7 @@ async function create(postedContent, options = {}) {
         parent AS (
           SELECT
             owner_id,
-            CASE 
+            CASE
               WHEN id IS NULL THEN ARRAY[]::uuid[]
               ELSE ARRAY_APPEND(path, id)
             END AS child_path
@@ -769,7 +815,7 @@ async function confirmFirewallStatus(contentIds, options) {
           id = ANY ($1)
         RETURNING
           *)
-      
+
       SELECT
         updated_contents.*,
         tabcoins_count.total_balance as tabcoins,
@@ -810,7 +856,7 @@ async function undoFirewallStatus(contentIds, options) {
         RETURNING
           *
       )
-  
+
       SELECT
         updated_contents.*,
         tabcoins_count.total_balance as tabcoins,

--- a/models/validator.js
+++ b/models/validator.js
@@ -511,6 +511,16 @@ const schemas = {
     });
   },
 
+  top_comment_body: function () {
+    return Joi.object({
+      top_comment_body: Joi.string().when('$required.top_comment_body', {
+        is: 'required',
+        then: Joi.required(),
+        otherwise: Joi.optional().allow(null),
+      }),
+    });
+  },
+
   content: function () {
     let contentSchema = Joi.object({
       children: Joi.array().optional().items(Joi.link('#content')),
@@ -526,6 +536,7 @@ const schemas = {
       'slug',
       'title',
       'body',
+      'top_comment_body',
       'status',
       'content_type',
       'source_url',

--- a/pages/index.public.js
+++ b/pages/index.public.js
@@ -32,7 +32,7 @@ export const getStaticProps = getStaticPropsRevalidate(async () => {
   const params = validator({}, { per_page: 'optional' });
 
   const results = await content.findWithStrategy({
-    strategy: 'relevant',
+    strategy: 'relevant_v2',
     where: {
       parent_id: null,
       status: 'published',

--- a/pages/interface/components/ContentList/index.js
+++ b/pages/interface/components/ContentList/index.js
@@ -3,6 +3,7 @@ import {
   Box,
   EmptyState,
   Link,
+  NewPublicationBanner,
   Pagination,
   PastTime,
   TabCoinBalanceTooltip,
@@ -21,13 +22,18 @@ export default function ContentList({ ad, contentList: list, pagination, paginat
           as="ol"
           sx={{
             display: 'grid',
-            gap: '0.5rem',
+            gap: '0.8rem',
             gridTemplateColumns: 'min-content minmax(0, 1fr)',
             padding: 0,
             margin: 0,
           }}
           key={`content-list-${listNumberStart}`}
           start={listNumberStart}>
+          {paginationBasePath === '/pagina' && pagination.currentPage === 1 && !pagination.previousPage && (
+            <Box as="li" sx={{ display: 'block', gridColumnStart: 2, '::marker': 'none' }}>
+              <NewPublicationBanner />
+            </Box>
+          )}
           {ad && (
             <Box as="li" sx={{ display: 'block', gridColumnStart: 2, '::marker': 'none' }}>
               <AdBanner ad={ad} />
@@ -47,8 +53,14 @@ export default function ContentList({ ad, contentList: list, pagination, paginat
   );
 
   function RenderItems() {
-    function ChildrenDeepCountText({ count }) {
-      return count > 1 ? `${count} comentários` : `${count} comentário`;
+    function ChildrenDeepCountText({ count, isParent, contentObject }) {
+      const visualCount = isParent ? count : contentObject.children_deep_count > 1 ? count - 1 : 0;
+
+      const countPrefix = visualCount > 1 ? 'mais' : '';
+      const countSufix = visualCount > 1 ? 'comentários' : 'comentário';
+
+      if (visualCount === 0) return 'sem mais comentários';
+      else return `${countPrefix} ${visualCount} ${countSufix}`;
     }
 
     function TabCoinsText({ count }) {
@@ -59,15 +71,13 @@ export default function ContentList({ ad, contentList: list, pagination, paginat
       return (
         <Box
           key={contentObject.id}
-          as="li"
           sx={{
             display: 'contents',
             ':before': {
               content: 'counter(list-item) "."',
               counterIncrement: 'list-item',
               fontWeight: 'semibold',
-              width: 'min-content',
-              marginLeft: 'auto',
+              marginLeft: 5,
             },
           }}>
           <Box as="article">
@@ -98,9 +108,33 @@ export default function ContentList({ ad, contentList: list, pagination, paginat
                 </Link>
               )}
             </Box>
+            {!contentObject.parent_id && contentObject.children_deep_count > 0 && contentObject.top_comment_body && (
+              <Box
+                sx={{
+                  fontSize: 0,
+                  marginTop: 1,
+                  paddingLeft: 2,
+                  marginLeft: 1,
+                  color: 'neutral.emphasis',
+                  borderColor: 'neutral.emphasis',
+                  borderLeft: '1px solid',
+                  flexDirection: 'column',
+                }}>
+                <Link
+                  sx={{ wordWrap: 'break-word', fontStyle: 'italic', fontWeight: 'normal', color: 'fg.subtle' }}
+                  href={`/${contentObject.owner_username}/${contentObject.slug}`}>
+                  <CommentIcon verticalAlign="middle" size={11} />
+                  {` "${contentObject.top_comment_body.slice(0, 250) ?? contentObject.body.slice(0, 250) ?? ''}..."`}
+                </Link>
+              </Box>
+            )}
             <Box
               sx={{
                 display: 'grid',
+                marginTop:
+                  !contentObject.parent_id && contentObject.children_deep_count > 0 && contentObject.top_comment_body
+                    ? 1
+                    : 0,
                 gap: 1,
                 gridTemplateColumns:
                   'max-content max-content max-content max-content minmax(20px, max-content) max-content max-content',
@@ -120,9 +154,14 @@ export default function ContentList({ ad, contentList: list, pagination, paginat
               )}
               {' · '}
               <Text>
-                <ChildrenDeepCountText count={contentObject.children_deep_count} />
+                <ChildrenDeepCountText
+                  count={contentObject.children_deep_count}
+                  isParent={Boolean(contentObject.parent_id)}
+                  contentObject={contentObject}
+                />
               </Text>
               {' · '}
+
               <Tooltip text={`Autor: ${contentObject.owner_username}`}>
                 <Text as="address" sx={{ fontStyle: 'normal', overflow: 'hidden', textOverflow: 'ellipsis' }}>
                   <Link sx={{ color: 'neutral.emphasis' }} href={`/${contentObject.owner_username}`}>

--- a/pages/interface/components/Header/index.js
+++ b/pages/interface/components/Header/index.js
@@ -52,31 +52,53 @@ export default function HeaderComponent() {
   const canListUsers = user?.features.includes('read:user:list');
 
   return (
-    <PrimerHeader as="header" id="header" sx={{ minWidth: 'max-content', px: [2, null, null, 3], overflow: 'visible' }}>
+    <PrimerHeader
+      as="header"
+      id="header"
+      sx={{ minWidth: 'max-content', px: [2, null, null, 3], overflow: 'visible', position: 'relative' }}>
       <SearchBoxOverlay />
-      <Box as="nav" sx={{ display: 'flex', flex: 1, margin: 0, padding: 0 }}>
-        <PrimerHeader.Item sx={{ mr: 0 }}>
-          <HeaderLink href="/" aria-label="Página inicial Relevantes" aria-current={asPath === '/' ? 'page' : false}>
-            <CgTab size={32} />
+      {
+        <Box as="nav" sx={{ display: 'flex', alignItems: 'center', flex: 1, margin: 0, padding: 0 }}>
+          <PrimerHeader.Item sx={{ mr: 0 }}>
+            <HeaderLink href="/" aria-label="Página inicial Relevantes" aria-current={asPath === '/' ? 'page' : false}>
+              <CgTab size={32} />
 
-            <Box sx={{ ml: 2, display: ['none', 'block'] }}>TabNews</Box>
+              <Box sx={{ ml: 2, display: ['none', 'block'] }}>TabNews</Box>
+            </HeaderLink>
+          </PrimerHeader.Item>
 
-            <Box sx={asPath === '/' || asPath.startsWith('/pagina') ? activeLinkStyle : { ml: 3 }}>Relevantes</Box>
-          </HeaderLink>
-        </PrimerHeader.Item>
+          <Box as="nav" sx={{ display: 'flex', alignItems: 'center', margin: 0, padding: 0, ml: 2 }}>
+            <PrimerHeader.Item sx={{ mr: 0 }}>
+              <HeaderLink
+                href="/"
+                aria-label="Página inicial Relevantes"
+                aria-current={asPath === '/' ? 'page' : false}>
+                <Box sx={asPath === '/' || asPath.startsWith('/pagina') ? activeLinkStyle : { ml: 3 }}>Relevantes</Box>
+              </HeaderLink>
+            </PrimerHeader.Item>
 
-        <PrimerHeader.Item full sx={{ mr: 0 }}>
-          <HeaderLink
-            href="/recentes/pagina/1"
-            aria-current={asPath === '/recentes/pagina/1' ? 'page' : false}
-            sx={asPath.startsWith('/recentes') ? activeLinkStyle : { ml: 3 }}>
-            Recentes
-          </HeaderLink>
-        </PrimerHeader.Item>
-      </Box>
+            <PrimerHeader.Item full sx={{ mr: 0 }}>
+              <HeaderLink
+                href="/recentes/pagina/1"
+                aria-current={asPath === '/recentes/pagina/1' ? 'page' : false}
+                sx={asPath.startsWith('/recentes') ? activeLinkStyle : { ml: 3 }}>
+                Recentes
+              </HeaderLink>
+            </PrimerHeader.Item>
+          </Box>
+        </Box>
+      }
 
       {!isLoading && !(isScreenSmall && user) && (
-        <PrimerHeader.Item sx={{ ml: 3, mr: [1, , 3] }}>
+        <PrimerHeader.Item
+          sx={{
+            ml: 3,
+            mr: [1, , 3],
+            position: 'absolute',
+            left: '50%',
+            transform: 'translateX(-50%)',
+            display: 'flex',
+          }}>
           <SearchBarButton />
           <SearchIconButton />
         </PrimerHeader.Item>

--- a/pages/interface/components/NewPublicationBanner/index.js
+++ b/pages/interface/components/NewPublicationBanner/index.js
@@ -1,0 +1,18 @@
+import { Box, HeaderLink, Text } from '@/TabNewsUI';
+import { PlusCircleIcon } from '@/TabNewsUI/icons';
+
+export default function NewPublicationBanner() {
+  return (
+    <Box
+      as="aside"
+      sx={{
+        display: 'grid',
+      }}>
+      <HeaderLink href="/publicar" sx={{ gap: 2 }}>
+        <PlusCircleIcon size={12} />
+        <Text>Publicar novo conteúdo</Text>
+        <Text>Você é bem vindo no TabNews, gere valor na comunidade e ganhe tabCoins!</Text>
+      </HeaderLink>
+    </Box>
+  );
+}

--- a/pages/interface/components/TabNewsUI/icons/index.js
+++ b/pages/interface/components/TabNewsUI/icons/index.js
@@ -22,6 +22,7 @@ export {
   PencilIcon,
   PersonIcon,
   PlusIcon,
+  PlusCircleIcon,
   SearchIcon,
   SignOutIcon,
   ShareIcon,

--- a/pages/interface/components/TabNewsUI/index.js
+++ b/pages/interface/components/TabNewsUI/index.js
@@ -1,4 +1,5 @@
 export { default as AdBanner } from '@/AdBanner';
+export { default as NewPublicationBanner } from '@/NewPublicationBanner';
 export { default as ButtonWithLoader } from '@/ButtonWithLoader';
 export { default as CharacterCount } from '@/CharacterCount';
 export { default as Confetti } from '@/Confetti';

--- a/pages/pagina/[page]/index.public.js
+++ b/pages/pagina/[page]/index.public.js
@@ -44,11 +44,13 @@ export const getStaticProps = getStaticPropsRevalidate(async (context) => {
   }
 
   const results = await content.findWithStrategy({
-    strategy: 'relevant',
+    strategy: 'relevant_global_v2',
     where: {
       parent_id: null,
       status: 'published',
     },
+    timeWindow: '7 days',
+    candidateLimit: 500,
     page: context.params.page,
     per_page: context.params.per_page,
   });

--- a/queries/rankingQueries.js
+++ b/queries/rankingQueries.js
@@ -176,7 +176,19 @@ const rankedContent = `
             FROM contents as all_contents
             WHERE all_contents.path @> ARRAY[ranked.id]
                 AND all_contents.status = 'published'
-        ) as children_deep_count
+        ) as children_deep_count,
+        (
+            SELECT child_contents.body
+            FROM contents as child_contents
+            LEFT JOIN LATERAL get_content_balance_credit_debit(child_contents.id) child_tabcoins ON true
+            WHERE
+                child_contents.parent_id = ranked.id
+                AND child_contents.status = 'published'
+            ORDER BY
+                child_tabcoins.total_balance DESC,
+                child_contents.published_at DESC
+            LIMIT 1
+        ) as top_comment_body
         FROM ranked
         INNER JOIN
           contents ON contents.id = ranked.id
@@ -187,6 +199,132 @@ const rankedContent = `
             published_at DESC;
 `;
 
+const recentContent = `
+WITH root_contents AS (
+    SELECT
+        c.id,
+        c.owner_id,
+        c.slug,
+        c.title,
+        c.status,
+        c.source_url,
+        c.created_at,
+        c.updated_at,
+        c.published_at,
+        LENGTH(c.body) AS post_length
+    FROM contents c
+    WHERE
+        c.parent_id IS NULL
+        AND c.status = 'published'
+        AND c.type != 'ad'
+        AND c.published_at > NOW() - $3::interval
+),
+
+tabcoin_stats AS (
+    SELECT
+        rc.id,
+        balance.total_balance AS tabcoins,
+        balance.total_credit AS upvotes,
+        balance.total_debit AS downvotes
+    FROM root_contents rc
+    LEFT JOIN LATERAL get_content_balance_credit_debit(rc.id) balance ON true
+),
+
+/*
+  Uma única varredura da subárvore de comentários produz todas as métricas de
+  discussão. Usa COUNT(child.id) (e não COUNT(*)) para que posts sem comentários
+  fiquem com 0 no LEFT JOIN, em vez de serem inflados para 1.
+*/
+comment_stats AS (
+    SELECT
+        root.id AS root_id,
+
+        COUNT(child.id) AS comment_count,
+
+        COUNT(DISTINCT child.owner_id) AS unique_commenters,
+
+        COALESCE(AVG(LENGTH(child.body)), 0) AS avg_comment_length,
+
+        COALESCE(AVG(array_length(child.path, 1)), 0) AS avg_comment_children,
+
+        COUNT(child.id) FILTER (
+            WHERE child.published_at > NOW() - INTERVAL '24 hours'
+        ) AS recent_comments,
+
+        COUNT(child.id) AS children_deep_count
+
+    FROM root_contents root
+    LEFT JOIN contents child
+        ON child.path[1] = root.id
+        AND child.parent_id IS NOT NULL
+        AND child.status = 'published'
+    GROUP BY root.id
+),
+
+top_comment AS (
+    SELECT DISTINCT ON (c.parent_id)
+        c.parent_id AS root_id,
+        c.body
+    FROM contents c
+    LEFT JOIN LATERAL get_content_balance_credit_debit(c.id) balance ON true
+    WHERE
+        c.parent_id IN (SELECT id FROM root_contents)
+        AND c.status = 'published'
+    ORDER BY
+        c.parent_id,
+        balance.total_balance DESC,
+        c.published_at DESC
+)
+
+SELECT
+    rc.id,
+    rc.owner_id,
+    rc.slug,
+    rc.title,
+    rc.status,
+    rc.source_url,
+    rc.created_at,
+    rc.updated_at,
+    rc.published_at,
+
+    COUNT(*) OVER()::INTEGER AS total_rows,
+
+    rc.post_length,
+
+    ts.tabcoins,
+    ts.upvotes,
+    -- Downvotes ficam gravados como débitos negativos (amount = -1 por voto),
+    -- então a magnitude positiva é -total_debit. O GREATEST mantém o piso em 0.
+    GREATEST(-ts.downvotes, 0) AS downvotes,
+
+    cs.comment_count,
+    cs.unique_commenters,
+    cs.avg_comment_length,
+    cs.avg_comment_children,
+
+    0 AS recent_votes,
+    cs.recent_comments,
+
+    cs.children_deep_count,
+
+    tc.body AS top_comment_body,
+
+    users.username AS owner_username
+
+FROM root_contents rc
+
+LEFT JOIN tabcoin_stats ts ON ts.id = rc.id
+LEFT JOIN comment_stats cs ON cs.root_id = rc.id
+LEFT JOIN top_comment tc ON tc.root_id = rc.id
+
+INNER JOIN users ON users.id = rc.owner_id
+
+ORDER BY rc.published_at DESC
+LIMIT $1
+OFFSET $2;
+`;
+
 export default Object.freeze({
   rankedContent,
+  recentContent,
 });

--- a/tests/integration/models/content-relevant-v2.test.js
+++ b/tests/integration/models/content-relevant-v2.test.js
@@ -1,0 +1,173 @@
+import content from 'models/content.js';
+import orchestrator from 'tests/orchestrator.js';
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+});
+
+beforeEach(async () => {
+  await orchestrator.dropAllTables();
+  await orchestrator.runPendingMigrations();
+});
+
+function findWithRelevantV2() {
+  // Mesma chamada feita por pages/index.public.js (estratégia da home).
+  return content.findWithStrategy({
+    strategy: 'relevant_v2',
+    where: {
+      parent_id: null,
+      status: 'published',
+    },
+    page: 1,
+    per_page: 30,
+  });
+}
+
+describe('models/content findWithStrategy("relevant_v2")', () => {
+  test('posts sem comentários reportam comment_count = 0', async () => {
+    const author = await orchestrator.createUser();
+    const post = await orchestrator.createContent({
+      owner_id: author.id,
+      title: 'Post sem comentários',
+      status: 'published',
+    });
+    await orchestrator.createRate(post, 5);
+
+    const { rows } = await findWithRelevantV2();
+    const row = rows.find((item) => item.id === post.id);
+
+    // Regressão: COUNT(*) sobre o LEFT JOIN inflava posts sem filhos para 1.
+    // Com COUNT(child.id) o valor correto é 0.
+    expect(Number(row.comment_count)).toBe(0);
+    expect(Number(row.children_deep_count)).toBe(0);
+  });
+
+  test('downvotes são expostos como magnitude positiva', async () => {
+    const author = await orchestrator.createUser();
+    const post = await orchestrator.createContent({
+      owner_id: author.id,
+      title: 'Post com votos positivos e negativos',
+      status: 'published',
+    });
+    await orchestrator.createRate(post, 4); // +4 upvotes (credit)
+    await orchestrator.createRate(post, -2); // -2 downvotes (debit, gravado como amount negativo)
+
+    const { rows } = await findWithRelevantV2();
+    const row = rows.find((item) => item.id === post.id);
+
+    expect(Number(row.upvotes)).toBe(4);
+    // Regressão: GREATEST(total_debit, 0) zerava os downvotes (débitos são negativos).
+    expect(Number(row.downvotes)).toBe(2);
+    // total_balance = 1 (tabcoin inicial da publicação) + 4 créditos - 2 débitos.
+    expect(Number(row.tabcoins)).toBe(3);
+  });
+
+  test('agrega comentários: contagem, comentaristas únicos e atividade recente', async () => {
+    const author = await orchestrator.createUser();
+    const firstCommenter = await orchestrator.createUser();
+    const secondCommenter = await orchestrator.createUser();
+
+    const post = await orchestrator.createContent({
+      owner_id: author.id,
+      title: 'Post discutido',
+      status: 'published',
+    });
+
+    await orchestrator.createContent({
+      owner_id: firstCommenter.id,
+      parent_id: post.id,
+      status: 'published',
+      body: 'Primeiro comentário',
+    });
+    await orchestrator.createContent({
+      owner_id: secondCommenter.id,
+      parent_id: post.id,
+      status: 'published',
+      body: 'Segundo comentário',
+    });
+    // Mesmo comentarista responde de novo: não aumenta unique_commenters.
+    await orchestrator.createContent({
+      owner_id: firstCommenter.id,
+      parent_id: post.id,
+      status: 'published',
+      body: 'Terceiro comentário',
+    });
+
+    const { rows } = await findWithRelevantV2();
+    const row = rows.find((item) => item.id === post.id);
+
+    expect(Number(row.comment_count)).toBe(3);
+    expect(Number(row.children_deep_count)).toBe(3);
+    expect(Number(row.unique_commenters)).toBe(2);
+    // Comentários recém-criados estão dentro das últimas 24h.
+    expect(Number(row.recent_comments)).toBe(3);
+  });
+
+  test('ordena post com mais sinais acima de post sem tração', async () => {
+    const author = await orchestrator.createUser();
+    const commenter = await orchestrator.createUser();
+
+    // Post fraco criado primeiro (mais antigo) e sem discussão.
+    const weakPost = await orchestrator.createContent({
+      owner_id: author.id,
+      title: 'Post fraco',
+      body: 'curto',
+      status: 'published',
+    });
+    await orchestrator.createRate(weakPost, 1);
+
+    // Post forte criado depois (mais recente), muito votado e discutido.
+    const strongPost = await orchestrator.createContent({
+      owner_id: author.id,
+      title: 'Post forte',
+      status: 'published',
+    });
+    await orchestrator.createRate(strongPost, 15);
+    await orchestrator.createContent({
+      owner_id: commenter.id,
+      parent_id: strongPost.id,
+      status: 'published',
+      body: 'Comentário relevante',
+    });
+
+    const { rows } = await findWithRelevantV2();
+    const ids = rows.map((item) => item.id);
+
+    expect(ids.indexOf(strongPost.id)).toBeGreaterThanOrEqual(0);
+    expect(ids.indexOf(strongPost.id)).toBeLessThan(ids.indexOf(weakPost.id));
+    expect(rows.find((item) => item.id === strongPost.id).score).toBeGreaterThan(
+      rows.find((item) => item.id === weakPost.id).score,
+    );
+  });
+
+  test('não inclui rascunhos nem comentários na lista raiz', async () => {
+    const author = await orchestrator.createUser();
+
+    const published = await orchestrator.createContent({
+      owner_id: author.id,
+      title: 'Publicado',
+      status: 'published',
+    });
+    await orchestrator.createRate(published, 3);
+
+    const draft = await orchestrator.createContent({
+      owner_id: author.id,
+      title: 'Rascunho',
+      status: 'draft',
+    });
+
+    const comment = await orchestrator.createContent({
+      owner_id: author.id,
+      parent_id: published.id,
+      status: 'published',
+      body: 'Comentário',
+    });
+
+    const { rows } = await findWithRelevantV2();
+    const ids = rows.map((item) => item.id);
+
+    expect(ids).toContain(published.id);
+    expect(ids).not.toContain(draft.id);
+    expect(ids).not.toContain(comment.id);
+  });
+});

--- a/tests/unit/lib/ranker.test.js
+++ b/tests/unit/lib/ranker.test.js
@@ -1,0 +1,236 @@
+import { Ranker } from 'lib/ranker';
+
+describe('Ranker v2', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-01T12:00:00.000Z'));
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('initializes with default config and allows overrides', () => {
+    const ranker = new Ranker({ weightContent: 3.2, maxPostLength: 1000 });
+    expect(ranker.config.weightContent).toBe(3.2);
+    expect(ranker.config.maxPostLength).toBe(1000);
+  });
+
+  it('wilson returns 0 when no votes', () => {
+    const ranker = new Ranker();
+    expect(ranker.wilson(0, 0)).toBe(0);
+  });
+
+  it('wilson returns a positive score within [0,1] with votes', () => {
+    const ranker = new Ranker();
+    const score = ranker.wilson(10, 2);
+    expect(score).toBeGreaterThanOrEqual(0);
+    expect(score).toBeLessThanOrEqual(1);
+  });
+
+  it('clamp enforces [0,1] range', () => {
+    const ranker = new Ranker();
+    expect(ranker.clamp(-0.5)).toBe(0);
+    expect(ranker.clamp(0.5)).toBe(0.5);
+    expect(ranker.clamp(1.5)).toBe(1);
+  });
+
+  it('logNormalize handles numeric strings and zero values', () => {
+    const ranker = new Ranker();
+    expect(ranker.logNormalize('0', 10)).toBe(0);
+    expect(ranker.logNormalize('5', '10')).toBeGreaterThan(0);
+  });
+
+  it('ageHours returns 0 for invalid timestamps', () => {
+    const ranker = new Ranker();
+    expect(ranker.ageHours(undefined, Date.now())).toBe(0);
+    expect(ranker.ageHours(null, Date.now())).toBe(0);
+    expect(ranker.ageHours('invalid-date', Date.now())).toBe(0);
+  });
+
+  it('recencyDecay decreases as content gets older', () => {
+    const now = Date.now();
+    const ranker = new Ranker();
+    const newer = ranker.recencyDecay({ created_at: now - 1 * 3600000 }, now);
+    const older = ranker.recencyDecay({ created_at: now - 24 * 3600000 }, now);
+    expect(newer).toBeGreaterThan(older);
+  });
+
+  it('controversyScore returns 0 when total votes is zero', () => {
+    const ranker = new Ranker();
+    expect(ranker.controversyScore({ upvotes: '0', downvotes: '0' })).toBe(0);
+  });
+
+  it('discussionScore increases with deeper discussion signals', () => {
+    const ranker = new Ranker();
+    const shallow = {
+      comment_count: 1,
+      avg_comment_children: 0,
+      unique_commenters: 1,
+    };
+    const deep = {
+      comment_count: 10,
+      avg_comment_children: 3,
+      unique_commenters: 6,
+    };
+
+    expect(ranker.discussionScore(deep)).toBeGreaterThan(ranker.discussionScore(shallow));
+  });
+
+  it('contentScore increases with longer posts', () => {
+    const ranker = new Ranker();
+    const shortScore = ranker.contentScore({ post_length: 200 });
+    const longScore = ranker.contentScore({ post_length: 5000 });
+    expect(longScore).toBeGreaterThan(shortScore);
+  });
+
+  it('engagementScore increases with higher velocity', () => {
+    const now = Date.now();
+    const ranker = new Ranker();
+    const low = ranker.engagementScore({ created_at: now - 2 * 3600000, recent_votes: 1, recent_comments: 0 }, now);
+    const high = ranker.engagementScore({ created_at: now - 2 * 3600000, recent_votes: 5, recent_comments: 3 }, now);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('computeFinalScore returns a finite number for string inputs', () => {
+    const now = Date.now();
+    const ranker = new Ranker();
+    const score = ranker.computeFinalScore(
+      {
+        id: 'string-inputs',
+        upvotes: '10',
+        downvotes: '2',
+        comment_count: '4',
+        avg_comment_children: '1',
+        unique_commenters: '3',
+        recent_votes: '2',
+        recent_comments: '1',
+        post_length: '900',
+        created_at: now - 2 * 3600000,
+      },
+      now,
+    );
+
+    expect(Number.isFinite(score)).toBe(true);
+  });
+
+  it('execute keeps input rows unchanged and adds score to output', () => {
+    const now = Date.now();
+    const ranker = new Ranker();
+    const rows = [
+      {
+        id: 'base',
+        upvotes: 3,
+        downvotes: 1,
+        comment_count: 2,
+        avg_comment_children: 1,
+        unique_commenters: 1,
+        post_length: 600,
+        recent_votes: 1,
+        recent_comments: 0,
+        created_at: now - 3600000,
+      },
+    ];
+
+    const ranked = ranker.execute(rows);
+
+    expect(ranked).toHaveLength(1);
+    expect(ranked[0]).toHaveProperty('score');
+    expect(ranked[0].id).toBe('base');
+    expect(rows[0]).not.toHaveProperty('score');
+  });
+
+  it('execute sorts by descending score', () => {
+    const now = Date.now();
+    const ranker = new Ranker();
+
+    const rows = [
+      {
+        id: 'low',
+        upvotes: 3,
+        downvotes: 1,
+        comment_count: 1,
+        avg_comment_children: 0,
+        unique_commenters: 1,
+        post_length: 300,
+        recent_votes: 0,
+        recent_comments: 0,
+        created_at: now - 10 * 3600000,
+      },
+      {
+        id: 'high',
+        upvotes: 20,
+        downvotes: 1,
+        comment_count: 10,
+        avg_comment_children: 2,
+        unique_commenters: 5,
+        post_length: 2000,
+        recent_votes: 6,
+        recent_comments: 4,
+        created_at: now - 2 * 3600000,
+      },
+    ];
+
+    const ranked = ranker.execute(rows);
+
+    expect(ranked[0].id).toBe('high');
+    expect(ranked[1].id).toBe('low');
+    expect(ranked[0].score).toBeGreaterThan(ranked[1].score);
+  });
+
+  it('favors recency when other signals are equal', () => {
+    const now = Date.now();
+    const ranker = new Ranker();
+
+    const base = {
+      upvotes: 10,
+      downvotes: 1,
+      comment_count: 4,
+      avg_comment_children: 1,
+      unique_commenters: 3,
+      post_length: 1000,
+      recent_votes: 0,
+      recent_comments: 0,
+    };
+
+    const newer = { id: 'newer', ...base, created_at: now - 1 * 3600000 };
+    const older = { id: 'older', ...base, created_at: now - 24 * 3600000 };
+
+    const ranked = ranker.execute([older, newer]);
+
+    expect(ranked[0].id).toBe('newer');
+    expect(ranked[0].score).toBeGreaterThan(ranked[1].score);
+  });
+
+  it('handles empty input list', () => {
+    const ranker = new Ranker();
+    const ranked = ranker.execute([]);
+    expect(ranked).toStrictEqual([]);
+  });
+
+  it('keeps results sorted for a larger batch', () => {
+    const now = Date.now();
+    const ranker = new Ranker();
+
+    const rows = Array.from({ length: 10 }, (_, i) => ({
+      id: `s${i + 1}`,
+      upvotes: 2 + i,
+      downvotes: i % 2,
+      comment_count: 1 + (i % 3),
+      avg_comment_children: i % 4,
+      unique_commenters: 1 + (i % 5),
+      post_length: 500 + i * 100,
+      recent_votes: i % 5,
+      recent_comments: (i + 1) % 4,
+      created_at: now - (i + 1) * 3600000,
+    }));
+
+    const ranked = ranker.execute(rows);
+
+    for (let i = 1; i < ranked.length; i++) {
+      expect(ranked[i - 1].score).toBeGreaterThanOrEqual(ranked[i].score);
+    }
+  });
+});


### PR DESCRIPTION
> ⚠️ **Rascunho / WIP** — aberto para discussão e revisão incremental, ainda não pronto para merge.

## Contexto

Evolução da estratégia de listagem relevante (`relevant_v2` → `relevant_global_v2`), que combina **seleção de candidatos via SQL** (`queries.recentContent`) com **scoring em JS** (`lib/ranker.js`).

## Mudanças

### `lib/ranker.js`
- Remove os `console.log` que existiam em **todos** os métodos (inclusive `clamp`/`logNormalize`, chamados ~8x por post). Com ~300 candidatos por request isso gerava milhares de chamadas síncronas de I/O.
- Guardas de robustez: `execute()` retorna `[]` para entrada inválida; `clamp()` trata `NaN`; `logNormalize()` evita divisão por `log1p(0)` quando `max <= 0`.

### `queries/rankingQueries.js` (`recentContent`)
- **Consolida** as agregações de comentários (`comment_stats`, `recent_activity`, `deep_stats`) em **uma única varredura** da subárvore.
- Corrige `COUNT(*)` → `COUNT(child.id)`: posts sem comentários voltavam `comment_count = 1` (inflado pelo `LEFT JOIN`).
- Corrige a magnitude de downvotes: débitos são gravados como `amount` negativo, então `GREATEST(total_debit, 0)` zerava os downvotes — agora `GREATEST(-total_debit, 0)`, o que reativa `controversyScore`/`qualityScore`.
- Restringe `top_comment` aos roots da janela (evita calcular `get_content_balance_credit_debit` para todo comentário do banco).

### Ferramentas de teste
- `infra/scripts/seed-ranking-test.js`: seed com **26 casos de uso** (qualidade, discussão, engajamento recente, conteúdo, polêmica, decaimento, limites de janela, threads aninhadas, rascunhos, etc.), com **preview ponta a ponta** usando a query e o `Ranker` reais, e flag `--clean`.
- `tests/unit/lib/ranker.test.js`: testes unitários do `Ranker`.
- `tests/integration/models/content-relevant-v2.test.js`: integração da estratégia `relevant_v2` (contagem de comentários, downvotes, agregação, ordenação e filtros de rascunho/comentário).

### Front-end / model (acompanham a nova listagem)
- `models/content.js`, `models/validator.js`, `pages/index.public.js`, `pages/pagina/[page]/index.public.js` e componentes de UI (`ContentList`, `Header`, `NewPublicationBanner`, `TabNewsUI`).

## Test plan

- [x] `vitest run tests/unit/lib/ranker.test.js` — 17/17 passam.
- [x] Lint/Prettier limpos nos arquivos alterados.
- [ ] Testes de integração executados no ambiente completo (`npm test`).
- [ ] Revisão de pesos/normalizações do ranker com dados reais.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
