### PR TITLE
Corrige renderização inicial do MarkdownViewer

### DIFF
--- a/packages/ui/src/Markdown/Markdown.jsx
+++ b/packages/ui/src/Markdown/Markdown.jsx
@@ -75,11 +75,16 @@ export function MarkdownViewer({
   clobberPrefix = clobberPrefix?.toLowerCase();
   const bytemdPluginList = usePlugins({ areLinksTrusted, clobberPrefix, copyAnchorLink, shouldAddNofollow });
   const [value, setValue] = useState(_value);
+  const hasMounted = useRef(false);
 
   useEffect(() => {
+    if (!hasMounted.current) {
+      hasMounted.current = true;
+      return;
+    }
+
     let timeout;
 
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     setValue((value) => {
       timeout = setTimeout(() => setValue(value));
       return value + '\n\u0160';

--- a/packages/ui/src/Markdown/Markdown.test.jsx
+++ b/packages/ui/src/Markdown/Markdown.test.jsx
@@ -1,0 +1,41 @@
+import { render } from '@testing-library/react';
+
+import { MarkdownViewer } from './Markdown';
+
+const viewerValues = [];
+
+vi.mock('@bytemd/react', () => ({
+  Editor: vi.fn(() => null),
+  Viewer: vi.fn(({ value }) => {
+    viewerValues.push(value);
+    return <div data-testid="markdown-viewer">{value}</div>;
+  }),
+}));
+
+vi.mock('@primer/react', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useTheme: vi.fn(() => ({ colorScheme: 'light' })),
+}));
+
+describe('MarkdownViewer', () => {
+  beforeEach(() => {
+    viewerValues.length = 0;
+  });
+
+  it('does not force a temporary value update on first render', async () => {
+    const markdown = `$$
+\\begin{array}{r}
+  1010 \\\\
++ 0011 \\\\
+\\hline
+  1101
+\\end{array}
+$$`;
+
+    render(<MarkdownViewer value={markdown} />);
+
+    await new Promise((resolve) => setTimeout(resolve));
+
+    expect(viewerValues).not.toContain(`${markdown}\n\u0160`);
+  });
+});


### PR DESCRIPTION
Closes #2019.

## Mudanças
- evita forçar uma atualização temporária do valor no primeiro render do MarkdownViewer
- mantém a atualização forçada apenas para mudanças posteriores na lista de plugins
- adiciona teste cobrindo a notação LaTeX com array para impedir regressão do marcador temporário

## Validação
- npm run test:run --workspace @tabnews/ui -- Markdown.test.jsx
- npx eslint packages/ui/src/Markdown/Markdown.jsx packages/ui/src/Markdown/Markdown.test.jsx
- npx prettier --check packages/ui/src/Markdown/Markdown.jsx packages/ui/src/Markdown/Markdown.test.jsx