### PR TITLE
Corrige desaparecimento do botão Compartilhar após comentar

### DIFF
--- a/interface/components/Content/index.jsx
+++ b/interface/components/Content/index.jsx
@@ -391,8 +391,7 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
               return;
             }
 
-            setContentObject(responseBody);
-            setComponentMode('view');
+            router.push(router.asPath);
           };
         }
 


### PR DESCRIPTION
## Mudanças realizadas

Após enviar um comentário com sucesso, o componente `EditMode` chamava `setContentObject(responseBody)` e `setComponentMode('view')`, exibindo o comentário recém-criado no lugar do formulário de resposta. Isso removia o botão Compartilhar da tela.

A correção substitui esse comportamento por `router.push(router.asPath)`. A navegação reseta o componente para o modo `compact`, reexibindo o botão Compartilhar, e o SWR atualiza a lista de comentários com o novo item na posição correta da thread.

Resolve #2051

## Tipo de mudança

- [x] Correção de bug

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [ ] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.