### PR TITLE
Aplica os estilos Katex corretamente após o preload

### DIFF
--- a/packages/ui/src/KatexLoader/KatexLoader.jsx
+++ b/packages/ui/src/KatexLoader/KatexLoader.jsx
@@ -1,7 +1,10 @@
+const KATEX_LINK_ID = 'katex-css';
+
 export function KatexLoader() {
   return (
     <>
       <link
+        id={KATEX_LINK_ID}
         rel="preload"
         href="https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.css"
         as="style"
@@ -11,11 +14,13 @@ export function KatexLoader() {
       <script
         dangerouslySetInnerHTML={{
           __html: `
-            var katexLink = document.currentScript.previousElementSibling;
-            katexLink.onload = function () {
-              this.onload = null;
-              this.rel = 'stylesheet';
-            };
+            var katexLink = document.getElementById('${KATEX_LINK_ID}');
+            if (katexLink) {
+              katexLink.onload = function () {
+                this.onload = null;
+                this.rel = 'stylesheet';
+              };
+            }
           `,
         }}
       />

--- a/packages/ui/src/KatexLoader/KatexLoader.test.jsx
+++ b/packages/ui/src/KatexLoader/KatexLoader.test.jsx
@@ -1,0 +1,35 @@
+import { render } from '@testing-library/react';
+
+import { KatexLoader } from './KatexLoader';
+
+describe('ui', () => {
+  describe('KatexLoader', () => {
+    it('preloads the stylesheet', () => {
+      render(<KatexLoader />);
+
+      const link = document.getElementById('katex-css');
+
+      expect(link).not.toBeNull();
+      expect(link.getAttribute('rel')).toBe('preload');
+      expect(link.getAttribute('as')).toBe('style');
+      expect(link.getAttribute('href')).toContain('katex');
+      expect(link.getAttribute('crossorigin')).toBe('anonymous');
+      expect(link.getAttribute('integrity')).toContain('sha384-');
+    });
+
+    it('promotes the preload to a stylesheet on load, even after the link is moved', () => {
+      const { container } = render(<KatexLoader />);
+
+      const link = document.getElementById('katex-css');
+      const script = container.querySelector('script') || document.head.querySelector('script');
+
+      document.head.insertBefore(link, document.head.firstChild);
+
+      new Function(script.innerHTML)();
+      link.dispatchEvent(new Event('load'));
+
+      expect(link.getAttribute('rel')).toBe('stylesheet');
+      expect(link.onload).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Mudanças realizadas

O `KatexLoader` carrega o CSS do KaTeX com o padrão "preload agora, vira stylesheet no `onload`", e localizava o `<link>` por `document.currentScript.previousElementSibling`.

Só que React e Next reordenam o `<head>`. O vizinho anterior passa a ser outro elemento, então o `onload` era atribuído ao
elemento errado, o `rel` nunca virava `stylesheet` e o CSS era baixado em toda página sem nunca ser aplicado. Fórmulas em conteúdo de usuário renderizavam sem estilo, e o Firefox avisava `preloaded with link preload was not used within a few seconds`.

O `<link>` passa a ter `id`, e o script o busca por `getElementById`.

O novo teste move o link para outra posição do `<head>` antes de executar o script, justamente para cobrir a reordenação; ele falha na implementação anterior.

Resolve #2019

| Antes | Depois |
| --- | --- |
| <img width="240" alt="Katex não funcionando" src="https://github.com/user-attachments/assets/34222fbf-59c1-475c-b535-896174104099" /> | <img width="768" height="406" alt="Katex funcionando" src="https://github.com/user-attachments/assets/6bd734eb-fd39-43f6-849a-dd633ec1a88d" /> |

## Tipo de mudança

- [x] Correção de bug

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
