### PR TITLE
Corrige warning de LCP da imagem nas páginas de erro 404

### DIFF
--- a/pages/404.jsx
+++ b/pages/404.jsx
@@ -10,7 +10,13 @@ export default function Custom404() {
     <DefaultLayout metadata={{ title: '404 - Página não encontrada' }}>
       <div className={classes.Wrapper}>
         <div className={classes.Content}>
-          <Image src={botSleepyFaceDarkTransparent.src} height={100} width={100} alt="Ícone do Bot triste" />
+          <Image
+            src={botSleepyFaceDarkTransparent.src}
+            height={100}
+            width={100}
+            alt="Ícone do Bot triste"
+            loading="eager"
+          />
           <div className={classes.Divider}></div>
           <h1>404</h1>
         </div>

--- a/pages/500.jsx
+++ b/pages/500.jsx
@@ -10,7 +10,13 @@ export default function Custom500() {
     <DefaultLayout metadata={{ title: '500 - Erro Interno Não Esperado' }}>
       <div className={classes.Wrapper}>
         <div className={classes.Content}>
-          <Image src={botDeadFaceDarkTransparent.src} height={100} width={100} alt="Ícone do Bot desacordado" />
+          <Image
+            src={botDeadFaceDarkTransparent.src}
+            height={100}
+            width={100}
+            alt="Ícone do Bot desacordado"
+            loading="eager"
+          />
           <div className={classes.Divider}></div>
           <h1>500</h1>
         </div>


### PR DESCRIPTION
## Mudanças realizadas

O warning abaixo ocorria na página `404` , e como a `500` é um "espelho", implementei a mesma alteração em ambas.

> [browser] Image with src "/_next/static/media/bot-sleepy-face-dark-transparent.0zooi5t734ydd.svg" was detected as the Largest Contentful Paint (LCP). Please add the `loading="eager"` property if this image is above the fold.
Read more: https://nextjs.org/docs/app/api-reference/components/image#loading

## Tipo de mudança


- [x] Correção de bug 

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [ ] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
