### PR TITLE
Renderiza math no servidor

### DIFF
--- a/models/rss.jsx
+++ b/models/rss.jsx
@@ -35,7 +35,11 @@ function generateRss2(contentList) {
       link: contentUrl,
       description: removeMarkdown(contentObject.body, { maxLength: 190 }),
       content: renderToStaticMarkup(
-        <Viewer value={contentObject.body} clobberPrefix={`${contentObject.owner_username}-content-`} />,
+        <Viewer
+          value={contentObject.body}
+          clobberPrefix={`${contentObject.owner_username}-content-`}
+          shouldRenderMath={false}
+        />,
       ).replace(/[\r\n]/gm, ''),
       author: [
         {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -15,6 +15,9 @@
     "./primer": "./src/primer-react.js",
     "./css": "./src/ui.css"
   },
+  "browser": {
+    "./src/Markdown/plugins/katex-math.server.js": "./src/Markdown/plugins/katex-math.browser.js"
+  },
   "scripts": {
     "test": "vitest --root ../.. watch \"$PWD\"",
     "test:run": "vitest --root ../.. run \"$PWD\"",

--- a/packages/ui/src/Markdown/Markdown.jsx
+++ b/packages/ui/src/Markdown/Markdown.jsx
@@ -8,11 +8,11 @@ import mathPlugin from '@bytemd/plugin-math';
 import mathLocale from '@bytemd/plugin-math/locales/pt_BR.json';
 import mermaidPlugin from '@bytemd/plugin-mermaid';
 import mermaidLocale from '@bytemd/plugin-mermaid/locales/pt_BR.json';
-import { Editor as ByteMdEditor, Viewer as ByteMdViewer } from '@bytemd/react';
+import { Editor as ByteMdEditor } from '@bytemd/react';
 import { useTheme } from '@primer/react';
 import byteMDLocale from 'bytemd/locales/pt_BR.json';
 import { clsx } from 'clsx';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 
 import classes from './Markdown.module.css';
 import {
@@ -20,31 +20,47 @@ import {
   copyAnchorLinkPlugin,
   copyCodeToClipboardPlugin,
   externalLinksPlugin,
+  katexMathPlugin,
+  katexRawGuardPlugin,
   katexStylesheetPlugin,
   removeDuplicateClobberPrefix,
 } from './plugins';
 import { EditorStyles } from './styles';
+import { Viewer } from './Viewer';
+
+// Shared, so that a formula comes out the same whether the server or the client rendered it. The
+// MathML is what a screen reader reads, since the visual markup is `aria-hidden`.
+const katexOptions = { output: 'htmlAndMathml' };
 
 const bytemdPluginBaseList = [
   gfmPlugin({ locale: gfmLocale }),
   highlightSsrPlugin(),
   mathPlugin({
     locale: mathLocale,
-    katexOptions: { output: 'html' },
+    katexOptions,
   }),
   breaksPlugin(),
   gemojiPlugin(),
   copyCodeToClipboardPlugin(),
 ];
 
-function usePlugins({ areLinksTrusted, clobberPrefix, katexStylesheetHref, shouldAddNofollow, copyAnchorLink }) {
+export function usePlugins({
+  areLinksTrusted,
+  clobberPrefix,
+  copyAnchorLink,
+  katexStylesheetHref,
+  shouldAddNofollow,
+  shouldRenderMath = true,
+}) {
   const { colorScheme } = useTheme();
 
   const plugins = useMemo(() => {
     const mermaidTheme = colorScheme === 'dark' ? 'dark' : 'default';
     const pluginList = [
       ...bytemdPluginBaseList,
-      katexStylesheetPlugin({ href: katexStylesheetHref }),
+      ...(shouldRenderMath
+        ? [katexStylesheetPlugin({ href: katexStylesheetHref }), katexMathPlugin({ katexOptions })]
+        : []),
       mermaidPlugin({ locale: mermaidLocale, theme: mermaidTheme }),
       anchorHeadersPlugin({ prefix: clobberPrefix ?? 'user-content-' }),
       removeDuplicateClobberPrefix({ clobberPrefix }),
@@ -58,52 +74,56 @@ function usePlugins({ areLinksTrusted, clobberPrefix, katexStylesheetHref, shoul
       pluginList.push(externalLinksPlugin({ shouldAddNofollow }));
     }
 
+    if (shouldRenderMath) {
+      pluginList.push(katexRawGuardPlugin());
+    }
+
     return pluginList;
-  }, [areLinksTrusted, clobberPrefix, colorScheme, copyAnchorLink, katexStylesheetHref, shouldAddNofollow]);
+  }, [
+    areLinksTrusted,
+    clobberPrefix,
+    colorScheme,
+    copyAnchorLink,
+    katexStylesheetHref,
+    shouldAddNofollow,
+    shouldRenderMath,
+  ]);
 
   return plugins;
 }
 
 export function MarkdownViewer({
-  value: _value,
+  value,
   areLinksTrusted,
-  clobberPrefix,
+  clobberPrefix: clobberPrefixProp,
   copyAnchorLink,
   footnoteBackLabel = 'Voltar ao conteúdo',
   footnoteLabel = 'Notas de rodapé',
   katexStylesheetHref,
   shouldAddNofollow,
+  shouldRenderMath,
   ...props
 }) {
-  clobberPrefix = clobberPrefix?.toLowerCase();
+  const clobberPrefix = clobberPrefixProp?.toLowerCase();
   const bytemdPluginList = usePlugins({
     areLinksTrusted,
     clobberPrefix,
     copyAnchorLink,
     katexStylesheetHref,
     shouldAddNofollow,
+    shouldRenderMath,
   });
-  const [value, setValue] = useState(_value);
-
-  useEffect(() => {
-    let timeout;
-
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setValue((value) => {
-      timeout = setTimeout(() => setValue(value));
-      return value + '\n\u0160';
-    });
-
-    return () => clearTimeout(timeout);
-  }, [bytemdPluginList]);
-
-  // eslint-disable-next-line react-hooks/set-state-in-effect
-  useEffect(() => setValue(_value), [_value]);
+  const sanitizeSchema = useMemo(() => sanitize({ clobberPrefix }), [clobberPrefix]);
+  const remarkRehypeOptions = useMemo(
+    () => ({ clobberPrefix, footnoteBackLabel, footnoteLabel }),
+    [clobberPrefix, footnoteBackLabel, footnoteLabel],
+  );
 
   return (
-    <ByteMdViewer
-      sanitize={sanitize({ clobberPrefix })}
-      remarkRehype={{ clobberPrefix, footnoteBackLabel, footnoteLabel }}
+    <Viewer
+      clobberPrefix={clobberPrefix}
+      sanitize={sanitizeSchema}
+      remarkRehype={remarkRehypeOptions}
       plugins={bytemdPluginList}
       value={value}
       {...props}
@@ -113,7 +133,7 @@ export function MarkdownViewer({
 
 export function MarkdownEditor({
   areLinksTrusted,
-  clobberPrefix,
+  clobberPrefix: clobberPrefixProp,
   editorConfig = {},
   footnoteBackLabel = 'Voltar ao conteúdo',
   footnoteLabel = 'Notas de rodapé',
@@ -125,7 +145,7 @@ export function MarkdownEditor({
   shouldAddNofollow,
   ...props
 }) {
-  clobberPrefix = clobberPrefix?.toLowerCase();
+  const clobberPrefix = clobberPrefixProp?.toLowerCase();
   const bytemdPluginList = usePlugins({ areLinksTrusted, clobberPrefix, katexStylesheetHref, shouldAddNofollow });
   const editorRef = useRef();
 

--- a/packages/ui/src/Markdown/Viewer.jsx
+++ b/packages/ui/src/Markdown/Viewer.jsx
@@ -1,0 +1,98 @@
+import { getProcessor } from 'bytemd';
+import { memo, useEffect, useLayoutEffect, useMemo, useRef } from 'react';
+
+/**
+ * Same as the `Viewer` of `@bytemd/react`, except that the markup rendered by the server wins.
+ *
+ * The server renders math that the client cannot reproduce, since `katex` is not in its bundle, so
+ * reprocessing the markdown on every render, as the original does, would paint the raw TeX over it.
+ * @param {Object} props
+ * @param {string} [props.clobberPrefix='user-content-'] - Prefix of the heading ids, to resolve the
+ * anchor links against.
+ */
+export function Viewer({ clobberPrefix = 'user-content-', plugins, remarkRehype, sanitize, value }) {
+  const elementRef = useRef(null);
+  const renderedRef = useRef(null);
+
+  const processed = useMemo(() => {
+    try {
+      const file = getProcessor({ plugins, remarkRehype, sanitize }).processSync(value);
+
+      return { file, html: file.toString() };
+    } catch (error) {
+      console.error(error);
+
+      return { html: '' };
+    }
+  }, [plugins, remarkRehype, sanitize, value]);
+
+  useLayoutEffect(() => {
+    const markdownBody = elementRef.current;
+
+    if (!markdownBody) return;
+
+    const rendered = renderedRef.current;
+
+    if (!rendered) {
+      // On the first run, and only then, what is on screen came from the server.
+      renderedRef.current = { html: markdownBody.innerHTML, remarkRehype, sanitize, value };
+    } else {
+      const isSameSource =
+        rendered.value === value && rendered.remarkRehype === remarkRehype && rendered.sanitize === sanitize;
+
+      // A theme switch only changes the plugins, and then the markup of the server is still the one
+      // to start from: it has the math this side cannot render, and it gives the plugins that
+      // replace their own markup the same input they had on the first run.
+      if (!isSameSource) renderedRef.current = { html: processed.html, remarkRehype, sanitize, value };
+
+      markdownBody.innerHTML = renderedRef.current.html;
+    }
+
+    const { file } = processed;
+
+    if (!file) return;
+
+    const cleanups = plugins?.map(({ viewerEffect }) => viewerEffect?.({ file, markdownBody }));
+
+    return () => cleanups?.forEach((cleanup) => cleanup?.());
+  }, [plugins, processed, remarkRehype, sanitize, value]);
+
+  useEffect(() => {
+    const markdownBody = elementRef.current;
+
+    function scrollToAnchor(event) {
+      // `closest`, and not the target itself, because a link can wrap other elements.
+      const href = event.target.closest('a')?.getAttribute('href');
+
+      if (!href?.startsWith('#')) return;
+
+      const id = (clobberPrefix + href.slice(1)).replace(/["\\]/g, '\\$&');
+
+      markdownBody.querySelector(`[id="${id}"]`)?.scrollIntoView();
+    }
+
+    markdownBody?.addEventListener('click', scrollToAnchor);
+
+    return () => markdownBody?.removeEventListener('click', scrollToAnchor);
+  }, [clobberPrefix]);
+
+  return <MarkdownBody elementRef={elementRef} html={processed.html} />;
+}
+
+const MarkdownBody = memo(
+  function MarkdownBody({ elementRef, html }) {
+    // `suppressHydrationWarning` because the client cannot reproduce the math of the server.
+    return (
+      <div
+        className="markdown-body"
+        dangerouslySetInnerHTML={{ __html: html }}
+        ref={elementRef}
+        suppressHydrationWarning
+      />
+    );
+  },
+  // Never updates: React rewrites `dangerouslySetInnerHTML` on the first update after the hydration
+  // even when the markup did not change, and that rewrite discards the nodes the effects above are
+  // working on — including the diagram `@bytemd/plugin-mermaid` renders after an `await`.
+  () => true,
+);

--- a/packages/ui/src/Markdown/Viewer.test.jsx
+++ b/packages/ui/src/Markdown/Viewer.test.jsx
@@ -1,0 +1,295 @@
+import { ThemeProvider } from '@primer/react';
+import { userEvent } from '@testing-library/user-event';
+import { act } from 'react';
+import { createRoot, hydrateRoot } from 'react-dom/client';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { MarkdownViewer } from './Markdown';
+
+const value = 'Um $x^2$ inline';
+const valueWithDiagram = `${value}\n\n\`\`\`mermaid\ngraph TD\nA-->B\n\`\`\``;
+
+// Stands in for `@bytemd/plugin-mermaid`, which collects its code blocks synchronously and only
+// replaces them after awaiting the `mermaid` import.
+const diagramRuns = [];
+
+function mockMermaidPlugin() {
+  vi.doMock('@bytemd/plugin-mermaid', () => ({
+    default: ({ theme }) => ({
+      viewerEffect({ markdownBody }) {
+        const elements = markdownBody.querySelectorAll('pre>code.language-mermaid');
+
+        diagramRuns.push(theme);
+
+        Promise.resolve().then(() => {
+          elements.forEach((element) => {
+            const diagram = document.createElement('div');
+
+            diagram.className = 'bytemd-mermaid';
+            diagram.textContent = `diagram-${theme}`;
+            element.parentElement.replaceWith(diagram);
+          });
+        });
+      },
+    }),
+  }));
+}
+
+describe('ui', () => {
+  describe('Viewer', () => {
+    beforeAll(() => {
+      // `@bytemd/plugin-math` reads the formula from `innerText`, which jsdom does not implement.
+      Object.defineProperty(HTMLElement.prototype, 'innerText', {
+        configurable: true,
+        get() {
+          return this.textContent;
+        },
+      });
+    });
+
+    beforeEach(() => {
+      diagramRuns.length = 0;
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      vi.doUnmock('./plugins/katex-math.server');
+      vi.doUnmock('@bytemd/plugin-mermaid');
+      vi.resetModules();
+    });
+
+    it('keeps the math rendered by the server through hydration, without warning', async () => {
+      const container = mountServerHTML(value);
+      const errors = spyOnConsoleError();
+      const { ClientMarkdownViewer } = await importAsClient();
+
+      await act(() => {
+        hydrateRoot(container, <ClientMarkdownViewer value={value} />);
+      });
+
+      expect(container.querySelector('.katex')).not.toBeNull();
+      expect(visibleText(container)).not.toContain('x^2');
+      expect(errors.filter((error) => /hydrat/i.test(error))).toStrictEqual([]);
+    });
+
+    it('keeps the math when the parent rerenders', async () => {
+      const container = mountServerHTML(value);
+      const { ClientMarkdownViewer } = await importAsClient();
+      let root;
+
+      await act(() => {
+        root = hydrateRoot(container, <ClientMarkdownViewer value={value} />);
+      });
+
+      const mutations = [];
+      new MutationObserver((records) => mutations.push(...records)).observe(container, {
+        childList: true,
+        subtree: true,
+      });
+
+      await act(() => {
+        root.render(<ClientMarkdownViewer value={value} />);
+      });
+
+      expect(container.querySelector('.katex')).not.toBeNull();
+      expect(visibleText(container)).not.toContain('x^2');
+      expect(
+        mutations.filter((mutation) => [...mutation.addedNodes].some((node) => node.textContent === value)),
+      ).toStrictEqual([]);
+    });
+
+    it('lets a plugin that renders asynchronously finish over the markup on screen', async () => {
+      mockMermaidPlugin();
+
+      const container = mountServerHTML(valueWithDiagram);
+      const { ClientMarkdownViewer } = await importAsClient();
+
+      await act(() => {
+        hydrateRoot(container, <ClientMarkdownViewer value={valueWithDiagram} />);
+      });
+
+      expect(container.querySelector('.bytemd-mermaid')).not.toBeNull();
+      expect(container.querySelector('code.language-mermaid')).toBeNull();
+      expect(diagramRuns).toStrictEqual(['default']);
+    });
+
+    it('rewrites the markup when the value changes, as in the editor', async () => {
+      mockMermaidPlugin();
+
+      const container = mountServerHTML(value);
+      const { ClientMarkdownViewer } = await importAsClient();
+      let root;
+
+      await act(() => {
+        root = hydrateRoot(container, <ClientMarkdownViewer value={value} />);
+      });
+
+      await act(() => {
+        root.render(<ClientMarkdownViewer value={valueWithDiagram} />);
+      });
+
+      expect(container.querySelector('.bytemd-mermaid')).not.toBeNull();
+      expect(diagramRuns).toStrictEqual(['default', 'default']);
+      // Nothing comes from the server here, so `@bytemd/plugin-math` renders the math on the client.
+      expect(container.querySelector('.katex')).not.toBeNull();
+    });
+
+    it('rerenders the plugins over the markup of the server on every theme change', async () => {
+      mockMermaidPlugin();
+
+      const container = mountServerHTML(valueWithDiagram, 'day');
+      const { ClientMarkdownViewer, withTheme } = await importAsClient();
+      let root;
+
+      await act(() => {
+        root = hydrateRoot(container, withTheme(<ClientMarkdownViewer value={valueWithDiagram} />, 'day'));
+      });
+
+      for (const [colorMode, theme] of [
+        ['night', 'dark'],
+        ['day', 'default'],
+      ]) {
+        await act(() => {
+          root.render(withTheme(<ClientMarkdownViewer value={valueWithDiagram} />, colorMode));
+        });
+
+        expect(container.querySelector('.bytemd-mermaid').textContent).toBe(`diagram-${theme}`);
+        expect(container.querySelector('.katex')).not.toBeNull();
+        expect(visibleText(container)).not.toContain('x^2');
+      }
+
+      expect(diagramRuns).toStrictEqual(['default', 'dark', 'default']);
+    });
+
+    it('rerenders the plugins over the markup of the client when nothing came from the server', async () => {
+      mockMermaidPlugin();
+
+      const { ClientMarkdownViewer, withTheme } = await importAsClient();
+      const container = document.createElement('div');
+      let root;
+
+      document.body.append(container);
+
+      await act(() => {
+        root = createRoot(container);
+        root.render(withTheme(<ClientMarkdownViewer value={valueWithDiagram} />, 'day'));
+      });
+
+      for (const [colorMode, theme] of [
+        ['night', 'dark'],
+        ['day', 'default'],
+      ]) {
+        await act(() => {
+          root.render(withTheme(<ClientMarkdownViewer value={valueWithDiagram} />, colorMode));
+        });
+
+        expect(container.querySelector('.bytemd-mermaid').textContent).toBe(`diagram-${theme}`);
+        // `@bytemd/plugin-math` renders the math here, and it has to survive the same way.
+        expect(container.querySelector('.katex')).not.toBeNull();
+        expect(visibleText(container)).not.toContain('x^2');
+      }
+
+      expect(diagramRuns).toStrictEqual(['default', 'dark', 'default']);
+    });
+
+    it.each([
+      ['the default prefix', undefined, 'user-content-titulo'],
+      ['a custom prefix', 'Rafael-Content-', 'rafael-content-titulo'],
+      ['an empty prefix', '', 'titulo'],
+    ])('scrolls an anchor link to the heading with %s', async (_, clobberPrefix, id) => {
+      const markdown = '# Titulo\n\n[ir](#titulo)';
+      const container = mountServerHTML(markdown, undefined, { clobberPrefix });
+      const { ClientMarkdownViewer } = await importAsClient();
+      const scrollIntoView = vi.fn();
+
+      HTMLElement.prototype.scrollIntoView = scrollIntoView;
+
+      await act(() => {
+        hydrateRoot(container, <ClientMarkdownViewer value={markdown} clobberPrefix={clobberPrefix} />);
+      });
+
+      expect(container.querySelector('h1').id).toBe(id);
+
+      await userEvent.setup().click(container.querySelector('a[href="#titulo"]'));
+
+      expect(scrollIntoView).toHaveBeenCalledOnce();
+      expect(scrollIntoView.mock.contexts[0]).toBe(container.querySelector('h1'));
+    });
+
+    it('scrolls an anchor link clicked on an element it wraps', async () => {
+      const markdown = '# Titulo\n\n[**ir**](#titulo)';
+      const container = mountServerHTML(markdown);
+      const { ClientMarkdownViewer } = await importAsClient();
+      const scrollIntoView = vi.fn();
+
+      HTMLElement.prototype.scrollIntoView = scrollIntoView;
+
+      await act(() => {
+        hydrateRoot(container, <ClientMarkdownViewer value={markdown} />);
+      });
+
+      await userEvent.setup().click(container.querySelector('a[href="#titulo"] strong'));
+
+      expect(scrollIntoView.mock.contexts).toStrictEqual([container.querySelector('h1')]);
+    });
+
+    it('does not throw on an anchor link that would not be a valid selector', async () => {
+      const markdown = String.raw`[ir](#a"b)`;
+      const container = mountServerHTML(markdown);
+      const { ClientMarkdownViewer } = await importAsClient();
+      const errors = spyOnConsoleError();
+
+      await act(() => {
+        hydrateRoot(container, <ClientMarkdownViewer value={markdown} />);
+      });
+
+      await userEvent.setup().click(container.querySelector('a'));
+
+      expect(errors).toStrictEqual([]);
+    });
+  });
+});
+
+function mountServerHTML(markdown, colorMode, props) {
+  const viewer = <MarkdownViewer value={markdown} {...props} />;
+  const html = renderToStaticMarkup(colorMode ? <ThemeProvider colorMode={colorMode}>{viewer}</ThemeProvider> : viewer);
+  const container = document.createElement('div');
+
+  // The `<link>` of the KaTeX stylesheet, which React hoists to the `<head>` on the client.
+  container.innerHTML = html.replace(/^(<link[^>]*>)+/, '');
+  document.body.append(container);
+
+  return container;
+}
+
+// The MathML copy of a formula holds the TeX source, and the stylesheet hides it from the reader.
+function visibleText(container) {
+  const clone = container.cloneNode(true);
+
+  clone.querySelectorAll('.katex-mathml').forEach((element) => element.remove());
+
+  return clone.textContent;
+}
+
+function spyOnConsoleError() {
+  const errors = [];
+
+  vi.spyOn(console, 'error').mockImplementation((...args) => errors.push(args.join(' ')));
+
+  return errors;
+}
+
+// The `browser` field of `package.json` does not apply on Vitest, so the client stub comes in as a
+// mock. `@primer/react` has to come from the same module registry, otherwise the `ThemeProvider`
+// lands on another context and the `useTheme` of the viewer never sees the theme change.
+async function importAsClient() {
+  vi.doMock('./plugins/katex-math.server', () => import('./plugins/katex-math.browser'));
+  vi.resetModules();
+
+  const { ThemeProvider: ClientThemeProvider } = await import('@primer/react');
+
+  return {
+    ClientMarkdownViewer: (await import('./Markdown')).MarkdownViewer,
+    withTheme: (children, colorMode) => <ClientThemeProvider colorMode={colorMode}>{children}</ClientThemeProvider>,
+  };
+}

--- a/packages/ui/src/Markdown/plugins/index.js
+++ b/packages/ui/src/Markdown/plugins/index.js
@@ -2,5 +2,6 @@ export * from './anchor-headers';
 export * from './copy-anchor-link';
 export * from './copy-code-to-clipboard';
 export * from './external-links';
+export * from './katex-math';
 export * from './katex-stylesheet';
 export * from './remove-duplicate-clobber-prefix';

--- a/packages/ui/src/Markdown/plugins/katex-math.browser.js
+++ b/packages/ui/src/Markdown/plugins/katex-math.browser.js
@@ -1,0 +1,8 @@
+// Resolved instead of `katex-math.server.js` through the `browser` field of `package.json`, to keep
+// `katex` out of the client bundle. With nothing to render, `katexMathPlugin` becomes a no-op and
+// `@bytemd/plugin-math` keeps rendering the math on demand, as it does in the editor.
+export const canRenderMath = false;
+
+export function renderMath() {
+  return null;
+}

--- a/packages/ui/src/Markdown/plugins/katex-math.js
+++ b/packages/ui/src/Markdown/plugins/katex-math.js
@@ -1,0 +1,86 @@
+import { canRenderMath, renderMath } from './katex-math.server';
+
+// Added by `remark-math`, through `@bytemd/plugin-math`.
+const DISPLAY_MODE_BY_CLASS_NAME = { 'math-inline': false, 'math-display': true };
+
+const katexRawNodes = new WeakSet();
+
+/**
+ * Renders the math while the tree is built, so it reaches the browser painted. `@bytemd/plugin-math`
+ * only renders in its `viewerEffect`, which leaves the raw TeX on screen until React hydrates and
+ * the `katex` chunk arrives.
+ *
+ * Depends on `katexRawGuardPlugin` to emit the markup.
+ * @param {Object} [options]
+ * @param {Object} [options.katexOptions]
+ * @returns {import('bytemd').BytemdPlugin}
+ */
+export function katexMathPlugin({ katexOptions } = {}) {
+  function render(node) {
+    const className = node.properties?.className;
+
+    if (!Array.isArray(className)) return false;
+
+    const mathClassName = Object.keys(DISPLAY_MODE_BY_CLASS_NAME).find((name) => className.includes(name));
+
+    if (!mathClassName) return false;
+
+    node.children = renderMath(toText(node), {
+      displayMode: DISPLAY_MODE_BY_CLASS_NAME[mathClassName],
+      katexOptions,
+    });
+
+    node.children.forEach((child) => katexRawNodes.add(child));
+
+    // The `viewerEffect` of `@bytemd/plugin-math` looks for `.math.math-inline` and rerenders from
+    // `innerText`, which would destroy this markup using the rendered text as its source.
+    node.properties.className = className.filter((name) => name !== 'math');
+
+    return true;
+  }
+
+  function transform(node) {
+    if (render(node)) return;
+
+    node.children?.forEach(transform);
+  }
+
+  return {
+    rehype: (processor) => (canRenderMath ? processor.use(() => transform) : processor),
+  };
+}
+
+/**
+ * Emits the `raw` nodes of `katexMathPlugin`, which `rehype-stringify` would otherwise escape, and
+ * escapes every other one. `allowDangerousHtml` has no granularity — it is read once, when
+ * `rehype-stringify` is attached —, so the only way to scope it is to sweep the tree afterwards.
+ *
+ * Has to be the last plugin, otherwise a `raw` node created after this runs reaches the output
+ * unescaped.
+ * @returns {import('bytemd').BytemdPlugin}
+ */
+export function katexRawGuardPlugin() {
+  function escapeForeignRaw(node) {
+    node.children?.forEach((child, index) => {
+      if (child.type !== 'raw') return escapeForeignRaw(child);
+
+      if (!katexRawNodes.has(child)) node.children[index] = { type: 'text', value: child.value };
+    });
+  }
+
+  return {
+    rehype: (processor) => {
+      if (!canRenderMath) return processor;
+
+      processor.data('settings', { ...processor.data('settings'), allowDangerousHtml: true });
+
+      return processor.use(() => escapeForeignRaw);
+    },
+  };
+}
+
+function toText(node) {
+  if (node.type === 'text') return node.value;
+
+  return node.children?.map(toText).join('') ?? '';
+}

--- a/packages/ui/src/Markdown/plugins/katex-math.server.js
+++ b/packages/ui/src/Markdown/plugins/katex-math.server.js
@@ -1,0 +1,16 @@
+import katex from 'katex';
+
+export const canRenderMath = true;
+
+export function renderMath(tex, { displayMode, katexOptions }) {
+  // `strict: 'ignore'` renders exactly like the default `'warn'`, minus the `console.warn` any
+  // reader could trigger on the server. The client keeps warning, which is where it helps.
+  const value = katex.renderToString(tex, {
+    ...katexOptions,
+    displayMode,
+    strict: 'ignore',
+    throwOnError: false,
+  });
+
+  return [{ type: 'raw', value }];
+}

--- a/packages/ui/src/Markdown/plugins/katex-math.test.jsx
+++ b/packages/ui/src/Markdown/plugins/katex-math.test.jsx
@@ -1,0 +1,194 @@
+import mathPlugin from '@bytemd/plugin-math';
+import { getProcessor } from 'bytemd';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { MarkdownViewer, usePlugins } from '../Markdown';
+import { katexMathPlugin, katexRawGuardPlugin } from './katex-math';
+
+// One goes on the root and the other nested, since the guard has to reach the whole tree.
+const injectedRaw = ['<script>alert(1)</script>', '<img src=x onerror="alert(1)">'];
+
+const rawInjector = {
+  rehype: (processor) =>
+    processor.use(() => (tree) => {
+      tree.children.push({ type: 'raw', value: injectedRaw[0] });
+      tree.children.find(({ children }) => children)?.children.push({ type: 'raw', value: injectedRaw[1] });
+    }),
+};
+
+function expectInjectedRawEscaped(html) {
+  expect(html).not.toContain('<script');
+  expect(html).not.toContain('<img');
+
+  injectedRaw.forEach((value) => expect(html).toContain(value.replaceAll('<', '&#x3C;')));
+}
+
+describe('ui', () => {
+  afterEach(() => {
+    vi.doUnmock('./katex-math.server');
+    vi.resetModules();
+  });
+
+  describe('katexMathPlugin', () => {
+    it('renders inline math on the server', () => {
+      const html = renderSSR('Um $x^2$ inline');
+
+      expect(html).toContain('<span class="katex">');
+      expect(html).not.toContain('$x^2$');
+    });
+
+    it('renders display math on the server', () => {
+      const html = renderSSR('$$\nx^2 + y^2 = z^2\n$$');
+
+      expect(html).toContain('<span class="katex-display">');
+    });
+
+    it('drops the "math" class name, which the client uses to rerender over the markup', () => {
+      const html = renderSSR('$x^2$ e\n\n$$\ny^2\n$$');
+
+      expect(html).toContain('class="math-inline"');
+      expect(html).toContain('class="math-display"');
+      expect(html).not.toContain('math math-inline');
+      expect(html).not.toContain('math math-display');
+    });
+
+    it('renders the MathML copy, which is the only part a screen reader reads', () => {
+      const html = renderSSR('Um $x^2$ inline');
+
+      expect(html).toContain('<span class="katex-mathml">');
+      expect(html).toContain('<annotation encoding="application/x-tex">x^2</annotation>');
+      expect(html).toContain('<span class="katex-html" aria-hidden="true">');
+    });
+
+    it('renders invalid math as text instead of throwing', () => {
+      const html = renderSSR('Um $\\frac{1}{$ quebrado');
+
+      expect(html).toContain('katex-error');
+    });
+
+    it('leaves the raw TeX, and no stylesheet, when `shouldRenderMath` is false, as on the RSS feed', () => {
+      const html = renderSSR('Um $x^2$ inline', { shouldRenderMath: false });
+
+      expect(html).toContain('<span class="math math-inline">x^2</span>');
+      expect(html).not.toContain('katex');
+    });
+
+    it('leaves content without math untouched', () => {
+      const html = renderSSR('Custa 5 reais');
+
+      expect(html).not.toContain('katex');
+    });
+  });
+
+  describe('katexMathPlugin, sanitization', () => {
+    const payloads = {
+      'a script tag': '<script>alert(1)</script>',
+      'an inline event handler': '<img src=x onerror="alert(1)">',
+      'an iframe': '<iframe src="https://evil.com"></iframe>',
+      'a handler on a block element': '<div onclick="alert(1)">clique</div>',
+      'a javascript: link': '[link](javascript:alert(1))',
+      'HTML inside a formula': String.raw`$\text{<img src=x onerror=alert(1)>}$`,
+      'a javascript: URL through \\href': String.raw`$\href{javascript:alert(1)}{x}$`,
+      'markup through \\htmlClass': String.raw`$\htmlClass{<img src=x onerror=alert(1)>}{x}$`,
+    };
+
+    it.each(Object.entries(payloads))('drops %s', (_, payload) => {
+      const html = renderSSR(`Uma fórmula $x^2$ e ${payload}`);
+      const document = new DOMParser().parseFromString(html, 'text/html');
+      const elements = [...document.querySelectorAll('*')];
+
+      expect(html).toContain('<span class="katex">');
+      expect(document.querySelector('script, iframe, object, embed')).toBeNull();
+      expect(
+        elements.filter((element) => element.getAttributeNames().some((name) => name.startsWith('on'))),
+      ).toStrictEqual([]);
+      expect(elements.filter((element) => /javascript:/i.test(element.outerHTML.split('>')[0]))).toStrictEqual([]);
+    });
+
+    it('renders the author HTML exactly as the whole pipeline without the plugin does', async () => {
+      const payload = Object.values(payloads)
+        .filter((value) => !value.includes('$'))
+        .join('\n\n');
+      const props = { clobberPrefix: 'rafael-content-' };
+      const withPlugin = renderSSR(payload, props);
+
+      vi.doMock('./katex-math.server', () => import('./katex-math.browser'));
+      vi.resetModules();
+
+      const { MarkdownViewer: WithoutPlugin } = await import('../Markdown');
+
+      expect(withPlugin).toBe(renderToStaticMarkup(<WithoutPlugin value={payload} {...props} />));
+    });
+
+    it('is the last plugin of the viewer, so that nothing can emit a raw node after it', () => {
+      const html = process('Uma fórmula $x^2$', getPlugins().toSpliced(-1, 0, rawInjector));
+
+      expect(html).toContain('<span class="katex">');
+      expectInjectedRawEscaped(html);
+    });
+
+    it('escapes a raw node created by a plugin that runs after it', () => {
+      const plugins = [mathPlugin(), katexMathPlugin(), rawInjector, katexRawGuardPlugin()];
+      const html = process('Uma fórmula $x^2$', plugins);
+
+      expect(html).toContain('<span class="katex">');
+      expectInjectedRawEscaped(html);
+    });
+
+    it('escapes it on a content without math, where this plugin renders nothing', () => {
+      const plugins = [mathPlugin(), katexMathPlugin(), rawInjector, katexRawGuardPlugin()];
+      const html = process('Custa 5 reais', plugins);
+
+      expect(html).not.toContain('katex');
+      expectInjectedRawEscaped(html);
+    });
+  });
+
+  describe('katexMathPlugin, on the client', () => {
+    it('is replaced by the stub through the `browser` field, so that katex stays out of the bundle', async () => {
+      const packageRoot = resolve(import.meta.dirname, '../../..');
+      const packageJson = JSON.parse(readFileSync(resolve(packageRoot, 'package.json')));
+      const entries = Object.entries(packageJson.browser);
+
+      expect(entries).toHaveLength(1);
+
+      const [[serverPath, browserPath]] = entries;
+
+      expect(serverPath).toMatch(/katex-math\.server\.js$/);
+      expect(browserPath).toMatch(/katex-math\.browser\.js$/);
+      expect(existsSync(resolve(packageRoot, serverPath))).toBe(true);
+      expect(existsSync(resolve(packageRoot, browserPath))).toBe(true);
+
+      const server = await import('./katex-math.server');
+      const browser = await import('./katex-math.browser');
+
+      expect(Object.keys(browser)).toStrictEqual(Object.keys(server));
+      expect(browser.canRenderMath).toBe(false);
+      expect(browser.renderMath()).toBeNull();
+    });
+  });
+});
+
+function renderSSR(value, props) {
+  return renderToStaticMarkup(<MarkdownViewer value={value} {...props} />);
+}
+
+function process(value, plugins) {
+  return String(getProcessor({ plugins }).processSync(value));
+}
+
+function getPlugins(options) {
+  let plugins;
+
+  function Probe() {
+    plugins = usePlugins({ ...options });
+
+    return null;
+  }
+
+  renderToStaticMarkup(<Probe />);
+
+  return plugins;
+}

--- a/packages/ui/src/Markdown/styles/viewer.css
+++ b/packages/ui/src/Markdown/styles/viewer.css
@@ -947,7 +947,9 @@ code.hljs {
   border-radius: 6px;
 }
 
-.markdown-body .math {
+/* `.math` is what the client renders, `.math-display` what the server does. */
+.markdown-body .math,
+.markdown-body .math-display {
   overflow: auto;
 }
 

--- a/tests/unit/models/rss.test.jsx
+++ b/tests/unit/models/rss.test.jsx
@@ -1,0 +1,33 @@
+import rss from 'models/rss';
+
+function generateContent(body) {
+  const feed = rss.generateRss2([
+    {
+      title: 'Título',
+      body,
+      slug: 'titulo',
+      owner_username: 'rafael',
+      published_at: new Date('2026-08-01T00:00:00.000Z'),
+      updated_at: new Date('2026-08-01T00:00:00.000Z'),
+    },
+  ]);
+
+  return /<content:encoded><!\[CDATA\[([\s\S]*?)\]\]><\/content:encoded>/.exec(feed)[1];
+}
+
+describe('rss model', () => {
+  describe('generateRss2', () => {
+    it('should keep the inline math readable, since the feed is read without the KaTeX stylesheet', () => {
+      const content = generateContent('A energia é $E = mc^2$ no total.');
+
+      expect(content).toContain('E = mc^2');
+      expect(content).not.toContain('katex');
+    });
+
+    it('should keep the display math readable', () => {
+      const content = generateContent('$$\nx^2 + y^2 = z^2\n$$');
+
+      expect(content).toContain('x^2 + y^2 = z^2');
+    });
+  });
+});


### PR DESCRIPTION
## Mudanças realizadas

Hoje o TeX aparece cru até o React hidratar e o chunk do `katex` baixar.

https://github.com/user-attachments/assets/cfc6f213-e75e-422b-a436-debac72eca5c

Este PR renderiza o KaTeX na fase `rehype`, então a fórmula já chega pintada no HTML, e funciona sem JavaScript.

O `katex` continua fora do bundle do cliente: o campo `browser` do `package.json` troca o módulo que renderiza por um stub, e o `@bytemd/plugin-math` segue cuidando do editor e dos comentários criados sem reload. Medido com `next build`: 2.140.809 bytes eager na página de publicação, contra 2.139.414 do baseline, com o katex num chunk lazy de 258 KB.

Junto vai uma correção de acessibilidade: o `output` do KaTeX passou de `html` para `htmlAndMathml`. Com `html`, o markup inteiro sai marcado com `aria-hidden="true"` — nenhum leitor de tela anunciava fórmula alguma. A cópia em MathML é o que ele lê, e a folha de estilo a esconde de quem enxerga. Custa cerca de 28% de HTML por fórmula (de 882 bytes para 1.133 bytes numa fórmula curta), pago só nas páginas que têm matemática.

O feed RSS passa a receber `shouldRenderMath={false}`: ele é lido sem a folha de estilo do KaTeX, onde o markup renderizado seria ilegível. Lá o TeX cru continua sendo a melhor saída.

Como o cliente não consegue reproduzir esse markup, o `Viewer` do `@bytemd/react` foi substituído por um nosso, que preserva o HTML do servidor em vez de repintar o TeX cru por cima. Isso também aposentou o hack do `'\nŠ'`, que reprocessava o markdown duas vezes a cada troca de tema.

Guardar o markup num estado do React não bastava: ele reescreve o `dangerouslySetInnerHTML` no primeiro update depois da hidratação mesmo quando a prop não muda, e essa reescrita caía no meio do `viewerEffect` assíncrono do `@bytemd/plugin-mermaid`, o diagrama ia parar num nó fora da tela e sobrava o bloco de código cru. Por isso a `div` do conteúdo mora num `memo` que nunca atualiza: da hidratação em diante o `innerHTML` é escrito pelo `Viewer`, sempre antes dos `viewerEffect`, e a troca de tema parte do markup do servidor.

Para emitir o markup do KaTeX é preciso ligar `allowDangerousHtml` no `rehype-stringify`, e essa flag vale para o processador inteiro. Quem a liga é o `katexRawGuardPlugin`, o último da lista, que em troca escapa qualquer nó `raw` que não tenha vindo do nosso render. Isso não afeta o HTML escrito pelo autor, o `rehype-sanitize` roda antes, e há 12 testes para isso, incluindo `\href` com `javascript:`, HTML dentro da fórmula e um plugin hostil registrado depois do nosso, inclusive num conteúdo sem matemática, onde o nosso render não emite nada.


https://github.com/user-attachments/assets/499a6221-59d9-4715-a525-a63ae1fd2b60

O vídeo é de uma navegação interna, em que a página é renderizada no cliente e nada vem do servidor: por ali quem renderiza continua sendo o `@bytemd/plugin-math`, depois de baixar o chunk do `katex`, daí o TeX cru aparecer por um instante, com o cache limpo. Abrindo a publicação direto pela URL, que é o caminho atacado por este PR, a fórmula já chega pintada do servidor.  Mesmo assim a navegação melhorou: o hack do `'\nŠ'` reprocessava o markdown duas vezes a cada mudança de plugins, então a fórmula piscava duas vezes ao abrir e mais uma a cada troca de tema, agora é só o flash único do vídeo.

## Tipo de mudança

- [x] Melhoria de desempenho

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
