### PR TITLE
Inicia o editor markdown em modo "escrita" sem focá-lo

### DIFF
--- a/interface/components/Content/index.jsx
+++ b/interface/components/Content/index.jsx
@@ -502,6 +502,7 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
           <FormControl id="body" required={!contentObject?.parent_id}>
             <FormControl.Label>{contentObject?.parent_id ? 'Seu comentário' : 'Corpo da publicação'}</FormControl.Label>
             <Editor
+              autoFocus={!!contentObject?.parent_id}
               isInvalid={errorObject?.key === 'body' || newData.body.length > BODY_MAX_LENGTH}
               value={newData.body}
               onChange={handleChange}

--- a/packages/ui/src/Markdown/Editor.test.jsx
+++ b/packages/ui/src/Markdown/Editor.test.jsx
@@ -1,0 +1,108 @@
+import { ThemeProvider } from '@primer/react';
+import { userEvent } from '@testing-library/user-event';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { MarkdownEditor } from './Markdown';
+import classes from './Markdown.module.css';
+
+// The table of contents, write-only and preview-only icons of the toolbar, in the order bytemd
+// builds them.
+const tableOfContentsIcon = '.bytemd-toolbar-right [bytemd-tippy-path="1"]';
+const writeOnlyIcon = '.bytemd-toolbar-right [bytemd-tippy-path="2"]';
+const previewOnlyIcon = '.bytemd-toolbar-right [bytemd-tippy-path="3"]';
+
+describe('ui', () => {
+  describe('MarkdownEditor', () => {
+    it('starts write-only, without bytemd having been asked for a tab', async () => {
+      const container = await renderEditor();
+
+      expect(editorWrapper(container)).toHaveClass('is-write-only');
+      expect(container.querySelector('.bytemd-toolbar-icon-active')).toBeNull();
+      expect(container.querySelector('.bytemd-editor').style.width).toBe('50%');
+    });
+
+    it('does not take the focus away from the page when it mounts', async () => {
+      const container = await renderEditor(focusableEditor);
+
+      expect(container.contains(document.activeElement)).toBe(false);
+    });
+
+    it('keeps the panes to itself when the table of contents opens', async () => {
+      const container = await renderEditor();
+
+      await click(container, tableOfContentsIcon);
+
+      expect(editorWrapper(container)).toHaveClass('is-write-only');
+      expect(container.querySelector('.bytemd-editor').style.width).toBe('calc(50% - 140px)');
+    });
+
+    it('gives the panes back to bytemd once the reader asks for the preview', async () => {
+      const container = await renderEditor();
+
+      await click(container, previewOnlyIcon);
+
+      expect(editorWrapper(container)).not.toHaveClass('is-write-only');
+      expect(container.querySelector('.bytemd-editor').style.display).toBe('none');
+    });
+
+    it('gives the panes back to bytemd once the reader asks for the write-only pane', async () => {
+      const container = await renderEditor(focusableEditor);
+
+      await click(container, writeOnlyIcon);
+
+      expect(editorWrapper(container)).not.toHaveClass('is-write-only');
+      expect(container.querySelector('.bytemd-preview').style.display).toBe('none');
+      // bytemd focuses the editor whenever the write tab becomes active, which is why the mode is
+      // not asked for on mount.
+      expect(container.contains(document.activeElement)).toBe(true);
+    });
+
+    it('focuses the text area when it is asked to', async () => {
+      const container = await renderEditor({ ...focusableEditor, autoFocus: true });
+
+      expect(container.contains(document.activeElement)).toBe(true);
+    });
+
+    it('leaves the layout to bytemd outside the split mode, which opens in a single pane', async () => {
+      const container = await renderEditor({ mode: 'tab' });
+
+      expect(editorWrapper(container)).not.toHaveClass('is-write-only');
+    });
+
+    it('keeps the toolbar actions of the split mode', async () => {
+      const container = await renderEditor();
+
+      expect(container.querySelectorAll('.bytemd-toolbar-left > *').length).toBeGreaterThan(2);
+      expect(container.querySelector(writeOnlyIcon)).not.toBeNull();
+    });
+  });
+});
+
+// jsdom has no `contentEditable`, the input style of the editor everywhere else, and only focuses
+// what it takes for a focusable area — a textarea being one.
+const focusableEditor = { editorConfig: { inputStyle: 'textarea' } };
+
+function editorWrapper(container) {
+  return container.querySelector(`.${classes.Editor}`);
+}
+
+function click(container, selector) {
+  return userEvent.setup().click(container.querySelector(selector));
+}
+
+async function renderEditor(props) {
+  const container = document.createElement('div');
+
+  document.body.appendChild(container);
+
+  await act(() => {
+    createRoot(container).render(
+      <ThemeProvider>
+        <MarkdownEditor value="" onChange={() => {}} {...props} />
+      </ThemeProvider>,
+    );
+  });
+
+  return container;
+}

--- a/packages/ui/src/Markdown/Markdown.jsx
+++ b/packages/ui/src/Markdown/Markdown.jsx
@@ -11,7 +11,7 @@ import { Editor as ByteMdEditor } from '@bytemd/react';
 import { useTheme } from '@primer/react';
 import byteMDLocale from 'bytemd/locales/pt_BR.json';
 import { clsx } from 'clsx';
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import classes from './Markdown.module.css';
 import {
@@ -176,6 +176,11 @@ export function MarkdownEditor({
   const clobberPrefix = clobberPrefixProp?.toLowerCase();
   const bytemdPluginList = usePlugins({ areLinksTrusted, clobberPrefix, katexStylesheetHref, shouldAddNofollow });
   const editorRef = useRef();
+  // The write-only layout is ours until the reader picks a pane in the toolbar. bytemd only leaves
+  // the split on its own when `activeTab` becomes `'write'`, and it focuses the editor whenever
+  // that happens — which drags the page to whichever comment box is halfway down it. The other
+  // modes already open in a single pane.
+  const [isWriteOnly, setIsWriteOnly] = useState(mode === 'split');
 
   useEffect(() => {
     const editorElement = editorRef.current;
@@ -184,14 +189,26 @@ export function MarkdownEditor({
   }, [onKeyDown]);
 
   useEffect(() => {
-    editorRef.current
-      ?.getElementsByClassName('bytemd-toolbar-right')[0]
-      ?.querySelector('[bytemd-tippy-path="2"]')
-      ?.click();
+    const editorPane = editorRef.current?.querySelector('.bytemd-editor');
+
+    if (!editorPane) return;
+
+    // Every layout bytemd computes for the split gives each pane half of the width, so an inline
+    // style without it means the reader has chosen, and from there on the panes are bytemd's again.
+    const observer = new MutationObserver(() => {
+      if (editorPane.style.cssText.includes('50%')) return;
+
+      observer.disconnect();
+      setIsWriteOnly(false);
+    });
+
+    observer.observe(editorPane, { attributeFilter: ['style'] });
+
+    return () => observer.disconnect();
   }, []);
 
   return (
-    <div className={clsx(classes.Editor, isInvalid && 'is-invalid')} ref={editorRef}>
+    <div className={clsx(classes.Editor, isInvalid && 'is-invalid', isWriteOnly && 'is-write-only')} ref={editorRef}>
       <ByteMdEditor
         plugins={bytemdPluginList}
         mode={mode}

--- a/packages/ui/src/Markdown/Markdown.jsx
+++ b/packages/ui/src/Markdown/Markdown.jsx
@@ -161,6 +161,7 @@ export function MarkdownViewer({
 
 export function MarkdownEditor({
   areLinksTrusted,
+  autoFocus = false,
   clobberPrefix: clobberPrefixProp,
   editorConfig = {},
   footnoteBackLabel = 'Voltar ao conteúdo',
@@ -214,7 +215,13 @@ export function MarkdownEditor({
         mode={mode}
         locale={byteMDLocale}
         sanitize={sanitize({ clobberPrefix })}
-        editorConfig={{ autocapitalize: 'sentences', inputStyle: 'contenteditable', spellcheck: true, ...editorConfig }}
+        editorConfig={{
+          autofocus: autoFocus,
+          autocapitalize: 'sentences',
+          inputStyle: 'contenteditable',
+          spellcheck: true,
+          ...editorConfig,
+        }}
         remarkRehype={{ clobberPrefix, footnoteBackLabel, footnoteLabel }}
         {...props}
       />

--- a/packages/ui/src/Markdown/styles/editor.css
+++ b/packages/ui/src/Markdown/styles/editor.css
@@ -34,6 +34,24 @@
   outline: 2px solid var(--borderColor-danger-emphasis);
 }
 
+/* Overrides the inline widths bytemd gives the panes in the split. A flex basis wins over them
+   and leaves the sidebar with the width it asks for. */
+.is-write-only .bytemd-body {
+  display: flex;
+}
+
+.is-write-only .bytemd-editor {
+  flex: 1;
+}
+
+.is-write-only .bytemd-sidebar {
+  flex: none;
+}
+
+.is-write-only .bytemd-preview {
+  display: none;
+}
+
 .bytemd-fullscreen {
   display: flex;
   flex-direction: column;

--- a/pages/[username]/index.jsx
+++ b/pages/[username]/index.jsx
@@ -284,6 +284,7 @@ function DescriptionForm({
         {/* Label styled similar to the "read" view so it is in the same position */}
         <FormControl.Label className={classes.FormLabel}>Descrição</FormControl.Label>
         <Editor
+          autoFocus
           isInvalid={errorObject?.key === 'description' || description.length > DESCRIPTION_MAX_LENGTH}
           value={description}
           onChange={handleDescriptionChange}

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -1,4 +1,5 @@
 import { RevalidateProvider } from 'next-swr';
+import { useEffect } from 'react';
 import { SWRConfig } from 'swr';
 import '@tabnews/ui/css';
 
@@ -20,6 +21,15 @@ async function SWRFetcher(resource, init) {
 const fallbackData = { body: null, headers: {} };
 
 function MyApp({ Component, pageProps }) {
+  useEffect(() => {
+    // React never focuses what it hydrates, and leaves the  attribute in the markup for the browser
+    // to honor — which it skips on a reload that restored a focus of its own. Only nodes that came
+    // from the server carry it, so this is the first load.
+    if (document.activeElement === document.body) {
+      document.querySelector('[autofocus]')?.focus({ preventScroll: true });
+    }
+  }, []);
+
   return (
     <ThemeProvider>
       <Turnstile />

--- a/pages/cadastro/index.jsx
+++ b/pages/cadastro/index.jsx
@@ -93,7 +93,7 @@ function SignUpForm() {
 
   return (
     <form style={{ width: '100%' }} onSubmit={handleSubmit(onSubmit)}>
-      <FormField {...getFieldProps('username')} name="name" autoComplete="off" />
+      <FormField {...getFieldProps('username')} name="name" autoComplete="off" autoFocus />
       <FormField {...getFieldProps('email')} autoComplete="username" />
       <FormField {...getFieldProps('password')} autoComplete="new-password" />
       <FormField

--- a/pages/login/index.jsx
+++ b/pages/login/index.jsx
@@ -106,7 +106,7 @@ function LoginForm() {
 
   return (
     <form style={{ width: '100%' }} onSubmit={handleSubmit(onSubmit)}>
-      <FormField {...getFieldProps('email')} />
+      <FormField {...getFieldProps('email')} autoFocus />
       <FormField {...getFieldProps('password')} />
 
       {globalErrorMessage && (

--- a/pages/perfil/index.jsx
+++ b/pages/perfil/index.jsx
@@ -204,6 +204,7 @@ function EditProfileForm() {
             size="large"
             autoCorrect="off"
             autoCapitalize="none"
+            autoFocus
             spellCheck={false}
             block={true}
             className={classes.TextInput}

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -44,6 +44,13 @@ if (typeof document !== 'undefined') {
   // (`[sheet, ...root.adoptedStyleSheets]`), which throws when the value is undefined.
   document.adoptedStyleSheets ??= [];
 
+  // jsdom doesn't implement ResizeObserver, which bytemd observes the editor container with.
+  window.ResizeObserver ??= class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+
   // jsdom doesn't implement matchMedia, which @primer/react's useMedia hook relies on.
   window.matchMedia ??= () => {};
   vi.spyOn(window, 'matchMedia').mockImplementation((query) => ({


### PR DESCRIPTION
## Mudanças realizadas

O editor abria em "somente escrita" por meio de um clique sintético no ícone da toolbar do bytemd, disparado num `useEffect` no `MarkdownEditor`. O bytemd foca o editor sempre que a aba de escrita fica ativa, o que era especialmente ruim na página [/publicar](https://www.tabnews.com.br/publicar).

<img width="1191" height="787" alt="Foco no segundo campo" src="https://github.com/user-attachments/assets/8effc0fc-ddc9-449b-b730-eeb62bdd7d67" />


Agora o layout inicial é nosso: o wrapper nasce com a classe `is-write-only`, e o CSS esconde o preview e dá `flex: 1` ao editor. A `.bytemd-body` vira um container flex, o que faz o `flex-basis` vencer as larguras inline do bytemd sem `!important`. Um `MutationObserver` devolve os painéis ao bytemd assim que o leitor escolhe um deles na toolbar, então escrita, preview e meio a meio continuam todos acessíveis.


https://github.com/user-attachments/assets/37c079b6-6003-42ad-ac11-01332ec35708

Também subi o segundo commit corrigindo o `autofocus` em todas as páginas, inclusive na navegação direta e após atualizar a página.

## Tipo de mudança

 - [x] Correção de bug

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
