### PR TITLE
Corrige `TypeError` do bytemd ao desmontar logo depois de rolar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18329,6 +18329,7 @@
         "@bytemd/react": "^1.22.0",
         "@primer/octicons-react": "^19.28.0",
         "@primer/react": "^38.26.0",
+        "bytemd": "^1.22.0",
         "clsx": "^2.1.1",
         "katex": "0.16.22",
         "mermaid": "^10.9.6",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -34,6 +34,7 @@
     "@bytemd/react": "^1.22.0",
     "@primer/octicons-react": "^19.28.0",
     "@primer/react": "^38.26.0",
+    "bytemd": "^1.22.0",
     "clsx": "^2.1.1",
     "katex": "0.16.22",
     "mermaid": "^10.9.6",

--- a/packages/ui/src/Markdown/ByteMdEditor.jsx
+++ b/packages/ui/src/Markdown/ByteMdEditor.jsx
@@ -1,0 +1,58 @@
+import { Editor } from 'bytemd';
+import { useEffect, useRef } from 'react';
+
+// bytemd throttles the scroll sync between its panes by a second, and destroying the editor neither
+// cancels the pending call nor unsubscribes it from the scroll. The trailing call then lands after
+// the `bind:this` of Svelte has nulled the preview element it dereferences, and throws. The value
+// mirrors the `throttle(…, 1e3)` of bytemd@1.22.0.
+const scrollSyncThrottle = 1000;
+
+/**
+ * Same as the `Editor` of `@bytemd/react`, except that an editor scrolled moments ago is destroyed
+ * late, so that the scroll sync of bytemd still has the preview element it works on.
+ */
+export function ByteMdEditor({ onChange, ...props }) {
+  const editorRef = useRef(null);
+  const elementRef = useRef(null);
+  const onChangeRef = useRef(onChange);
+
+  useEffect(() => {
+    const target = elementRef.current;
+    const editor = new Editor({ props, target });
+    let lastScroll = -Infinity;
+
+    editor.$on('change', (event) => onChangeRef.current?.(event.detail.value));
+    editorRef.current = editor;
+
+    function rememberScroll() {
+      lastScroll = Date.now();
+    }
+
+    // In the capture phase because scroll events do not bubble, and on the whole editor because
+    // both panes schedule the sync.
+    target.addEventListener('scroll', rememberScroll, { capture: true, passive: true });
+
+    return () => {
+      target.removeEventListener('scroll', rememberScroll, { capture: true });
+
+      const remaining = scrollSyncThrottle - (Date.now() - lastScroll);
+
+      if (remaining > 0) {
+        setTimeout(() => editor.$destroy(), remaining);
+      } else {
+        editor.$destroy();
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
+  useEffect(() => {
+    editorRef.current?.$set(props);
+  }, [props]);
+
+  return <div ref={elementRef} />;
+}

--- a/packages/ui/src/Markdown/Editor.test.jsx
+++ b/packages/ui/src/Markdown/Editor.test.jsx
@@ -15,7 +15,7 @@ const previewOnlyIcon = '.bytemd-toolbar-right [bytemd-tippy-path="3"]';
 describe('ui', () => {
   describe('MarkdownEditor', () => {
     it('starts write-only, without bytemd having been asked for a tab', async () => {
-      const container = await renderEditor();
+      const { container } = await renderEditor();
 
       expect(editorWrapper(container)).toHaveClass('is-write-only');
       expect(container.querySelector('.bytemd-toolbar-icon-active')).toBeNull();
@@ -23,13 +23,13 @@ describe('ui', () => {
     });
 
     it('does not take the focus away from the page when it mounts', async () => {
-      const container = await renderEditor(focusableEditor);
+      const { container } = await renderEditor(focusableEditor);
 
       expect(container.contains(document.activeElement)).toBe(false);
     });
 
     it('keeps the panes to itself when the table of contents opens', async () => {
-      const container = await renderEditor();
+      const { container } = await renderEditor();
 
       await click(container, tableOfContentsIcon);
 
@@ -38,7 +38,7 @@ describe('ui', () => {
     });
 
     it('gives the panes back to bytemd once the reader asks for the preview', async () => {
-      const container = await renderEditor();
+      const { container } = await renderEditor();
 
       await click(container, previewOnlyIcon);
 
@@ -47,7 +47,7 @@ describe('ui', () => {
     });
 
     it('gives the panes back to bytemd once the reader asks for the write-only pane', async () => {
-      const container = await renderEditor(focusableEditor);
+      const { container } = await renderEditor(focusableEditor);
 
       await click(container, writeOnlyIcon);
 
@@ -59,19 +59,70 @@ describe('ui', () => {
     });
 
     it('focuses the text area when it is asked to', async () => {
-      const container = await renderEditor({ ...focusableEditor, autoFocus: true });
+      const { container } = await renderEditor({ ...focusableEditor, autoFocus: true });
 
       expect(container.contains(document.activeElement)).toBe(true);
     });
 
     it('leaves the layout to bytemd outside the split mode, which opens in a single pane', async () => {
-      const container = await renderEditor({ mode: 'tab' });
+      const { container } = await renderEditor({ mode: 'tab' });
 
       expect(editorWrapper(container)).not.toHaveClass('is-write-only');
     });
 
+    it('survives the throttled scroll sync of bytemd when it is unmounted right after a scroll', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+
+      const { container, unmount } = await renderEditor();
+
+      // The first call runs on the leading edge; it takes a second one to schedule the trailing
+      // edge, which is the call that outlives the editor.
+      scroll(container);
+      scroll(container);
+
+      await unmount();
+
+      // bytemd only nulls the preview element the scroll sync dereferences on the next flush of
+      // Svelte, which any other bytemd component mounting triggers.
+      await renderEditor();
+
+      expect(() => vi.advanceTimersByTime(2000)).not.toThrow();
+
+      vi.useRealTimers();
+    });
+
+    it('holds a scrolled editor only until the scroll sync of bytemd has run', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+
+      const { container, unmount } = await renderEditor();
+      const byteMd = container.querySelector('.bytemd');
+
+      scroll(container);
+
+      await unmount();
+
+      // What detaches the markup of bytemd is its `$destroy`; React only takes away the element
+      // around it.
+      expect(byteMd.parentNode).not.toBeNull();
+
+      vi.advanceTimersByTime(2000);
+
+      expect(byteMd.parentNode).toBeNull();
+
+      vi.useRealTimers();
+    });
+
+    it('destroys an editor that was never scrolled as soon as it unmounts', async () => {
+      const { container, unmount } = await renderEditor();
+      const byteMd = container.querySelector('.bytemd');
+
+      await unmount();
+
+      expect(byteMd.parentNode).toBeNull();
+    });
+
     it('keeps the toolbar actions of the split mode', async () => {
-      const container = await renderEditor();
+      const { container } = await renderEditor();
 
       expect(container.querySelectorAll('.bytemd-toolbar-left > *').length).toBeGreaterThan(2);
       expect(container.querySelector(writeOnlyIcon)).not.toBeNull();
@@ -87,22 +138,33 @@ function editorWrapper(container) {
   return container.querySelector(`.${classes.Editor}`);
 }
 
+function scroll(container) {
+  container.querySelector('.CodeMirror-scroll').dispatchEvent(new Event('scroll'));
+
+  // A browser would have CodeMirror emit this one off the event above, but jsdom has no layout and
+  // CodeMirror ignores the scroll of a scroller it measures as having no height.
+  const codeMirror = container.querySelector('.CodeMirror').CodeMirror;
+
+  codeMirror.constructor.signal(codeMirror, 'scroll');
+}
+
 function click(container, selector) {
   return userEvent.setup().click(container.querySelector(selector));
 }
 
 async function renderEditor(props) {
   const container = document.createElement('div');
+  const root = createRoot(container);
 
   document.body.appendChild(container);
 
   await act(() => {
-    createRoot(container).render(
+    root.render(
       <ThemeProvider>
         <MarkdownEditor value="" onChange={() => {}} {...props} />
       </ThemeProvider>,
     );
   });
 
-  return container;
+  return { container, unmount: () => act(() => root.unmount()) };
 }

--- a/packages/ui/src/Markdown/Markdown.jsx
+++ b/packages/ui/src/Markdown/Markdown.jsx
@@ -7,12 +7,12 @@ import highlightSsrPlugin from '@bytemd/plugin-highlight-ssr';
 import mathPlugin from '@bytemd/plugin-math';
 import mathLocale from '@bytemd/plugin-math/locales/pt_BR.json';
 import mermaidLocale from '@bytemd/plugin-mermaid/locales/pt_BR.json';
-import { Editor as ByteMdEditor } from '@bytemd/react';
 import { useTheme } from '@primer/react';
 import byteMDLocale from 'bytemd/locales/pt_BR.json';
 import { clsx } from 'clsx';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
+import { ByteMdEditor } from './ByteMdEditor';
 import classes from './Markdown.module.css';
 import {
   anchorHeadersPlugin,

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -51,6 +51,9 @@ if (typeof document !== 'undefined') {
     disconnect() {}
   };
 
+  // jsdom doesn't implement scrollTo, which bytemd syncs the scroll of its two panes with.
+  Element.prototype.scrollTo ??= () => {};
+
   // jsdom doesn't implement matchMedia, which @primer/react's useMedia hook relies on.
   window.matchMedia ??= () => {};
   vi.spyOn(window, 'matchMedia').mockImplementation((query) => ({


### PR DESCRIPTION
## Mudanças realizadas

Desmontar um editor menos de um segundo depois de rolá-lo joga um `TypeError: previewEl is null` no console. Isso acontece, por exemplo, ao rolar a caixa de resposta e cancelar em seguida.


https://github.com/user-attachments/assets/3da9a3cc-c6a9-4182-a966-3117d8418cf2

O bytemd sincroniza a rolagem dos dois painéis com um `throttle` de 1 segundo que ele não cancela nem desinscreve ao ser destruído. A chamada do exemplo cai depois do unmount, quando o `bind:this` do Svelte já zerou o elemento de preview que ela desreferencia. É bug do bytemd, aberto na versão 1.22.0, que é a última publicada.

Como o `@tabnews/ui` é consumido como dependência git, um patch em `node_modules` não acompanharia o pacote. Então a correçãoadotada foi criar o `ByteMdEditor.jsx`, que substitui o `Editor` do `@bytemd/react` (o mesmo que já fizemos com o `Viewer`) e adia o `$destroy` de um editor rolado há menos de um segundo, o tempo de a chamada atrasada ainda encontrar o elemento de preview no lugar.

Teste novo em `Editor.test.jsx`, que falha com o `Editor` do `@bytemd/react` no lugar.

## Tipo de mudança

- [x] Correção de bug

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
