### PR TITLE
Corrige scroll no editor markdown no Gecko

### DIFF
--- a/packages/ui/src/Markdown/styles/editor.css
+++ b/packages/ui/src/Markdown/styles/editor.css
@@ -397,6 +397,16 @@
   clip-path: polygon(0 0, 100% 0, 100% calc(100% - 14px), calc(100% - 14px) 100%, 0 100%);
 }
 
+/* The clip above uncovers the handle of the `resize` of `.bytemd-body`, which Gecko lets the reader
+   drag even under the scrollbar of CodeMirror. And a clip path there costs the editor its scroll:
+   Gecko hands the wheel gesture to the root scroller instead of to a scroller inside one, so the
+   page moves and the editor stays put. */
+@supports (-moz-orient: inline) {
+  .bytemd-editor {
+    clip-path: none;
+  }
+}
+
 .bytemd-fullscreen .bytemd-editor {
   clip-path: none;
 }


### PR DESCRIPTION
## Mudanças realizadas

No Firefox, rolar com o cursor sobre o editor rolava a página, e não o editor. Acontecia quando o primeiro gesto da sessão tinha sido na página, o que é o caso sempre que a caixa de resposta está abaixo da dobra. Se o editor rolasse primeiro, continuava funcionando mesmo após scroll da página.


https://github.com/user-attachments/assets/e3655c05-e66f-40d2-bcad-fcd56a2783dd



A causa é o `clip-path` do `.bytemd-editor`: o Gecko não entrega o gesto de roda a um scroller que esteja dentro de um elemento recortado, e manda o scroll para a página. Blink e WebKit não se importam.

O recorte existe para descobrir o handle do resize do `.bytemd-body`, e no Gecko ele é dispensável: lá o handle continua arrastável mesmo por baixo da barra do CodeMirror. Então a regra passa a ser desfeita só nessa engine, via `@supports (-moz-orient: inline);`. Nos demais navegadores nada muda. A diferença visual no Firefox é observável nas prints abaixo.

| Antes | Depois |
| --- | --- |
| <img width="172" height="346" alt="A barra de scroll fica com um recorte para não sobrepor o ícone de arrastar" src="https://github.com/user-attachments/assets/0663c23e-18ea-41c4-9065-efbdae9fe855" /> | <img width="172" height="346" alt="Barra de scroll sobrepõe o ícone de arrastar" src="https://github.com/user-attachments/assets/8d0b1fba-76e7-452c-bff7-7557157592bc" /> |

Testado no Zen, Firefox, Chromium e Safari Mobile, em tela cheia e no modo normal, incluindo o arrasto do resize.


## Tipo de mudança

- [x] Correção de bug

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
