### PR TITLE
Corrige o aviso do tippy ao abrir os dropdowns da toolbar do editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18334,7 +18334,8 @@
         "katex": "0.16.22",
         "mermaid": "^10.9.6",
         "rehype-external-links": "^3.0.0",
-        "rehype-slug": "^6.0.0"
+        "rehype-slug": "^6.0.0",
+        "tippy.js": "^6.3.7"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "6.9.1",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -39,7 +39,8 @@
     "katex": "0.16.22",
     "mermaid": "^10.9.6",
     "rehype-external-links": "^3.0.0",
-    "rehype-slug": "^6.0.0"
+    "rehype-slug": "^6.0.0",
+    "tippy.js": "^6.3.7"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "6.9.1",

--- a/packages/ui/src/Markdown/ByteMdEditor.jsx
+++ b/packages/ui/src/Markdown/ByteMdEditor.jsx
@@ -1,5 +1,30 @@
 import { Editor } from 'bytemd';
 import { useEffect, useRef } from 'react';
+import tippy from 'tippy.js';
+
+// tippy warns whenever an interactive tooltip is not the next sibling of its reference, since a
+// keyboard would tab past it. Repeating the placement tippy already gives them only tells it the
+// order is deliberate, which it is: the dropdowns of the toolbar are not focusable to begin with,
+// and they cannot leave it, because bytemd delegates the clicks of their items to the toolbar.
+tippy.setDefaultProps({
+  plugins: [
+    ...tippy.defaultProps.plugins,
+    {
+      name: 'appendDropdownToToolbar',
+      // Not on create: bytemd only marks a dropdown as interactive once tippy has built it.
+      fn: (instance) => ({
+        onShow() {
+          const toolbar = instance.reference.closest('.bytemd-toolbar');
+          const untouched = instance.props.appendTo === tippy.defaultProps.appendTo;
+
+          if (toolbar && untouched && instance.props.interactive) {
+            instance.setProps({ appendTo: () => instance.reference.parentNode });
+          }
+        },
+      }),
+    },
+  ],
+});
 
 // bytemd throttles the scroll sync between its panes by a second, and destroying the editor neither
 // cancels the pending call nor unsubscribes it from the scroll. The trailing call then lands after

--- a/packages/ui/src/Markdown/Editor.test.jsx
+++ b/packages/ui/src/Markdown/Editor.test.jsx
@@ -6,8 +6,9 @@ import { createRoot } from 'react-dom/client';
 import { MarkdownEditor } from './Markdown';
 import classes from './Markdown.module.css';
 
-// The table of contents, write-only and preview-only icons of the toolbar, in the order bytemd
-// builds them.
+// The icons of the toolbar, in the order bytemd builds them: a dropdown on the left, and the table
+// of contents, write-only and preview-only ones on the right.
+const headingIcon = '.bytemd-toolbar-left [bytemd-tippy-path="0"]';
 const tableOfContentsIcon = '.bytemd-toolbar-right [bytemd-tippy-path="1"]';
 const writeOnlyIcon = '.bytemd-toolbar-right [bytemd-tippy-path="2"]';
 const previewOnlyIcon = '.bytemd-toolbar-right [bytemd-tippy-path="3"]';
@@ -121,6 +122,16 @@ describe('ui', () => {
       expect(byteMd.parentNode).toBeNull();
     });
 
+    it('opens a dropdown inside the toolbar, without tippy complaining about it', async () => {
+      const { container } = await renderEditor();
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      await hover(container, headingIcon);
+
+      expect(container.querySelector('.bytemd-toolbar .bytemd-dropdown')).not.toBeNull();
+      expect(warn).not.toHaveBeenCalled();
+    });
+
     it('keeps the toolbar actions of the split mode', async () => {
       const { container } = await renderEditor();
 
@@ -150,6 +161,10 @@ function scroll(container) {
 
 function click(container, selector) {
   return userEvent.setup().click(container.querySelector(selector));
+}
+
+function hover(container, selector) {
+  return userEvent.setup().hover(container.querySelector(selector));
 }
 
 async function renderEditor(props) {


### PR DESCRIPTION
## Mudanças realizadas

Abrir os dropdowns de heading e de math na toolbar do editor logava um aviso de acessibilidade do tippy no console.

```
tippy.js

Interactive tippy element may not be accessible via keyboard navigation because it is not directly after the reference element in the DOM source order.

Using a wrapper <div> or <span> tag around the reference element solves this by creating a new parentNode context.

Specifying `appendTo: document.body` silences this warning, but it assumes you are using a focus management solution to handle keyboard navigation.

See: https://atomiks.github.io/tippyjs/v6/accessibility/#interactivity

👷‍ This is a development-only message. It will be removed in production.
```

### Causa

O `bytemd` cria os tooltips da toolbar com `tippy.delegate()` e nunca passa `appendTo`. Para tooltips `interactive`, que é o caso dos dropdowns, o default do tippy monta o popper no `parentNode` da referência, e em desenvolvimento ele checa se o popper é o `nextElementSibling` do ícone. Como o popper vai para o fim de `.bytemd-toolbar-left`, só o último ícone passa nessa checagem: por isso o mermaid não avisava, mas heading e math sim.

### Correção

Um plugin do tippy registrado via `setDefaultProps` declara explicitamente, para os dropdowns da toolbar, a mesma colocação que eles já recebem (`appendTo: () => reference.parentNode`). Nada muda no DOM: o aviso cai porque o `appendTo` deixa de ser o default, que é o que o tippy usa para reconhecer que ninguém escolheu onde montar o popper.

Dois pontos que ditaram a solução:

- **Não dá para usar `appendTo: document.body`**, a saída que o próprio aviso sugere: o `bytemd` delega os cliques dos itens do dropdown ao elemento da toolbar, então mover o popper para fora dela quebraria todos os itens. Os itens também são `div`s sem `tabindex`, ou seja, a ordem de tabulação que motiva o aviso não existe de qualquer forma.
- **O ajuste precisa ser no `onShow`**, não no `onCreate`: o `bytemd` só marca `interactive: true` no `onCreate` dele, que roda depois dos hooks de plugin, e o `mount()` (onde o aviso mora) roda depois do `onShow`.

Como `setDefaultProps` é global para o módulo do tippy, o plugin se limita ao que é seu: age apenas em referências dentro de `.bytemd-toolbar`, apenas quando o `appendTo` ainda é o default, nunca sobrescrevendo a escolha de outra biblioteca, e preserva os plugins default já registrados em vez de substituí-los. Fora da toolbar, incluindo os tooltips simples dos ícones de ação, tudo segue como antes.

O `tippy.js` passa a ser dependência declarada de `@tabnews/ui` (já vinha transitivo do `bytemd`), o que importa aqui porque o `setDefaultProps` só vale se as duas importações resolverem para a mesma instância do módulo.

## Tipo de mudança

- [x] Correção de bug

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
