### PR TITLE
Não interpreta preços e outros falso-positivos como fórmulas de KaTeX

### DIFF
--- a/packages/ui/src/Markdown/Markdown.jsx
+++ b/packages/ui/src/Markdown/Markdown.jsx
@@ -24,6 +24,7 @@ import {
   katexStylesheetPlugin,
   mermaidPlugin,
   removeDuplicateClobberPrefix,
+  strictInlineMathPlugin,
 } from './plugins';
 import { EditorStyles } from './styles';
 import { Viewer } from './Viewer';
@@ -63,6 +64,7 @@ const bytemdPluginBaseList = [
     locale: mathLocale,
     katexOptions,
   }),
+  strictInlineMathPlugin(),
   breaksPlugin(),
   gemojiPlugin(),
   copyCodeToClipboardPlugin(),

--- a/packages/ui/src/Markdown/plugins/index.js
+++ b/packages/ui/src/Markdown/plugins/index.js
@@ -6,3 +6,4 @@ export * from './katex-math';
 export * from './katex-stylesheet';
 export * from './mermaid';
 export * from './remove-duplicate-clobber-prefix';
+export * from './strict-inline-math';

--- a/packages/ui/src/Markdown/plugins/strict-inline-math.js
+++ b/packages/ui/src/Markdown/plugins/strict-inline-math.js
@@ -1,0 +1,78 @@
+const DOLLAR_SIGN = 36;
+
+// Whitespace that is not a line ending. A formula may be broken across lines, and no price is written
+// with the break glued to the currency symbol, so only the spaces of Pandoc count as padding.
+const PADDED = /^[^\S\r\n]|[^\S\r\n]$/;
+
+/**
+ * Narrows the inline math of `remark-math`, which pairs any two dollar signs of a paragraph and turns
+ * "entre R$ 3 e R$ 5" into a formula. Two rules are enough for every way a price is written:
+ *
+ * 1. the content cannot begin or end with a space, which is the rule of Pandoc ("R$ 3 e R$ 5");
+ * 2. the opening `$` cannot be glued to the right of a letter while the content begins with a digit
+ *    and carries a letter, which is a currency symbol, its value and the symbol of the next price
+ *    ("R$3 e R$5"). A digit on the left is a coefficient ("3$2x$") and a content of digits alone is a
+ *    formula ("x$2$"), so neither is a price.
+ *
+ * The other rule of Pandoc, that the closing `$` cannot be followed by a digit, only adds false
+ * negatives here: it rejects "$n$1" and "2$\times$3" without catching a single price these two miss.
+ *
+ * Has to run after `@bytemd/plugin-math`, since it hardens the construct that plugin registers.
+ * @returns {import('bytemd').BytemdPlugin}
+ */
+export function strictInlineMathPlugin() {
+  return {
+    remark: (processor) =>
+      processor.use(function () {
+        const extensions = this.data('micromarkExtensions') ?? [];
+
+        extensions.forEach((extension, index) => {
+          const construct = extension.text?.[DOLLAR_SIGN];
+
+          if (construct) {
+            extensions[index] = { ...extension, text: { ...extension.text, [DOLLAR_SIGN]: harden(construct) } };
+          }
+        });
+      }),
+  };
+}
+
+/**
+ * Rejects the match only after the original tokenizer runs, which is when the whole span is known.
+ * micromark restores the point of a construct that fails, so the dollar sign goes back to being text
+ * and the rest of the line — emphasis included — is parsed as if math had never matched.
+ */
+function harden(construct) {
+  return {
+    ...construct,
+    tokenize(effects, ok, nok) {
+      const start = this.now();
+      const previousCode = this.previous;
+
+      const after = (code) => {
+        const value = this.sliceSerialize({ start, end: this.now() });
+
+        return isFalsePositive(value, previousCode) ? nok(code) : ok(code);
+      };
+
+      return construct.tokenize.call(this, effects, after, nok);
+    },
+  };
+}
+
+function isFalsePositive(value, previousCode) {
+  // `$$formula$$` is the way out of both rules, and ruling it out is also what makes the slice below
+  // safe: micromark closes a sequence with as many dollar signs as it opened, so a single one is left
+  // on each end.
+  if (value.startsWith('$$')) return false;
+
+  const content = value.slice(1, -1);
+
+  return PADDED.test(content) || (/^\d/.test(content) && /\p{L}/u.test(content) && isLetter(previousCode));
+}
+
+// Codes below zero are the line endings and the virtual spaces of micromark, and `null` is the start
+// of the content.
+function isLetter(code) {
+  return code > 0 && /\p{L}/u.test(String.fromCodePoint(code));
+}

--- a/packages/ui/src/Markdown/plugins/strict-inline-math.test.jsx
+++ b/packages/ui/src/Markdown/plugins/strict-inline-math.test.jsx
@@ -1,0 +1,141 @@
+import mathPlugin from '@bytemd/plugin-math';
+import { getProcessor } from 'bytemd';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { MarkdownViewer, usePlugins } from '../Markdown';
+import { strictInlineMathPlugin } from './strict-inline-math';
+
+const falsePositives = {
+  'a price with a space': 'entre R$ 3 e R$ 5',
+  'a price without a space': 'entre R$3 e R$5',
+  'a price with a space only on the first': 'entre R$ 3 e R$5',
+  'a price with a space only on the second': 'entre R$3 e R$ 5',
+  'a price with a no-break space, as a copy from a website': 'entre R$\u00a03 e R$\u00a05',
+  'a price in dollars': 'de $5 para $10',
+  'a price in a foreign currency': 'US$ 3 e US$ 5',
+  'a decimal price': 'de R$ 1.999,90 para R$ 1.499,90',
+  'a price per unit': 'planos de R$29/mês e R$99/mês',
+  'a price in a list': '- R$ 10\n- R$ 20',
+  'a price with a hyphen between the values': 'saldo de R$3-R$5 hoje',
+  'a currency symbol after the value': 'de 10$ para 20$ dólares',
+  'a conversion between two currencies': '1$ = R$ 5,20 hoje',
+  'a shell variable': 'export PATH=$HOME/bin e $USER',
+  'math whose content is padded': 'a fórmula $ x^2 $ com espaço',
+};
+
+// Every one of these is where a rule against prices is at risk of rejecting a formula: math glued to
+// a number, or padding that no price is written with.
+const formulas = {
+  'an exponent after a number': 'na ordem de 10$^{-3}$ segundos',
+  'a percentage': 'cresceu 50$\\%$ no ano',
+  'a subscript after a letter': 'a variável x$_1$ do vetor',
+  'a digit after a letter': 'a variável x$2$ do vetor',
+  'a decimal after a letter': 'a variável x$2,5$ do vetor',
+  'a coefficient before the formula': 'sobram 3$x$ termos',
+  'a number right after the formula': 'o valor $n$1 do vetor',
+  'an operator between two numbers': 'o dobro 2$\\times$3 disso',
+  'a unit after a number': 'a unidade 5$\\mu$m de largura',
+  'a degree after a number': 'o ângulo 90$^\\circ$ reto',
+  'a coefficient before a formula that begins with a digit': 'o coeficiente 3$2x$ dobrado',
+  'a formula of digits after a number': 'a nota 10$100$ pontos',
+  'a formula padded by a line ending': 'a fórmula $\nx^2\n$ com quebra',
+  'a formula broken across lines': 'uma soma $a +\nb$ quebrada',
+};
+
+describe('ui', () => {
+  describe('strictInlineMathPlugin', () => {
+    it.each(Object.entries(falsePositives))('does not read %s as math', (_, value) => {
+      const html = renderMarkdown(value);
+
+      expect(html).not.toContain('math');
+      expect(html).not.toContain('katex');
+    });
+
+    it.each(Object.entries(formulas))('still reads %s as math', (_, value) => {
+      expect(countFormulas(renderMarkdown(value))).toBe(1);
+    });
+
+    // The narrowest second rule that still catches every price cannot tell this apart from "R$3 e R$5".
+    it('gives up math glued to a word whose content begins with a digit and carries a letter', () => {
+      expect(countFormulas(renderMarkdown('a variável x$2x$ do vetor'))).toBe(0);
+    });
+
+    it('keeps the emphasis around a price, which the false positive used to swallow', () => {
+      const html = renderMarkdown('de **R$ 3** a **R$ 5** por mês');
+
+      expect(html).toContain('<strong>R$ 3</strong>');
+      expect(html).toContain('<strong>R$ 5</strong>');
+    });
+
+    it('keeps a price as text where math is not rendered, as in the feed', () => {
+      const html = renderMarkdown('entre R$ 3 e R$ 5', { shouldRenderMath: false });
+
+      expect(html).toContain('entre R$ 3 e R$ 5');
+      expect(html).not.toContain('math');
+    });
+
+    it('renders inline math', () => {
+      const html = renderMarkdown('a fórmula $x^2$ inline');
+
+      expect(html).toContain('<span class="katex">');
+    });
+
+    it('renders inline math with two dollar signs, the way out of the stricter rules', () => {
+      const html = renderMarkdown('a fórmula $$ x^2 $$ inline');
+
+      expect(html).toContain('<span class="katex">');
+    });
+
+    it('renders display math', () => {
+      const html = renderMarkdown('$$\nx^2 + y^2 = z^2\n$$');
+
+      expect(html).toContain('<span class="katex-display">');
+    });
+
+    it('renders two formulas of the same paragraph', () => {
+      const html = renderMarkdown('a $x$ e a $y$');
+
+      expect(countFormulas(html)).toBe(2);
+    });
+
+    it('renders a formula that shares the paragraph with a price', () => {
+      const html = renderMarkdown('o preço R$ 3 e a fórmula $x^2$');
+
+      expect(html).toContain('R$ 3');
+      expect(countFormulas(html)).toBe(1);
+    });
+
+    it('runs after `@bytemd/plugin-math`, whose construct it hardens', () => {
+      const value = 'entre R$ 3 e R$ 5';
+
+      expect(process(value, getPlugins())).not.toContain('math');
+      expect(process(value, [strictInlineMathPlugin(), mathPlugin()])).toContain('math-inline');
+    });
+  });
+});
+
+function countFormulas(html) {
+  return html.match(/<span class="katex">/g)?.length ?? 0;
+}
+
+function renderMarkdown(value, props) {
+  return renderToStaticMarkup(<MarkdownViewer value={value} {...props} />);
+}
+
+function process(value, plugins) {
+  return String(getProcessor({ plugins }).processSync(value));
+}
+
+function getPlugins() {
+  let plugins;
+
+  function Probe() {
+    plugins = usePlugins({});
+
+    return null;
+  }
+
+  renderToStaticMarkup(<Probe />);
+
+  return plugins.filter(({ remark }) => remark);
+}


### PR DESCRIPTION
## Mudanças realizadas

O `remark-math`, que o `@bytemd/plugin-math` registra sem opções, emparelha **quaisquer** dois `$` de um parágrafo. Por isso "entre R$ 3 e R$ 5" virava uma fórmula com o conteúdo `" 3 e R"`, e geralmente um moderador precisava editar o conteúdo para escapar os `$` com `\`.

A correção é um plugin novo, `strictInlineMathPlugin`, que endurece o construct de math inline registrado pelo `@bytemd/plugin-math`, por isso ele entra logo depois dele na lista de plugins. São duas regras:

1. o conteúdo não pode começar nem terminar com espaço, que é a regra do Pandoc. Pega `R$ 3 e R$ 5`, `de $5 para $10`, `US$ 3 e US$ 5`, `de 10$ para 20$`, `$HOME/bin e $USER`, e também o `&nbsp;` de quem copia o preço de um site;
2. o `$` de abertura não pode estar colado à direita de uma letra quando o conteúdo começa com dígito e contém uma letra, que é um símbolo de moeda, o valor e o símbolo do preço seguinte. Pega `R$3 e R$5`, `R$29/mês e R$99/mês`, `US$3 e US$5`.

Quem realmente quer a fórmula num caso que seja detectado pelas regras acima, pode usar `$$formula$$`.

A rejeição acontece no fim da tokenização, chamando `nok` em vez de `ok`. O micromark restaura o ponto do tokenizer, então o `$` volta a ser texto comum e o resto da linha é parseado como se math nunca tivesse casado, o que também conserta `de **R$ 3** a **R$ 5**`, que hoje perde o negrito porque os `**` são engolidos pela fórmula.

Como toda heurística de `$` é um balanço entre falso positivo e falso negativo, cada regra ficou na versão mais estreita que ainda não deixa preço passar na bateria de fórmulas e preços do teste:

- exigir **letra** à esquerda, e não letra ou dígito, preserva `3$2x$` e `10$100$`, já que dígito à esquerda é coeficiente e nunca moeda;
- exigir uma letra dentro do conteúdo preserva `x$2$` e `n$1$`, já que um valor sozinho não tem o símbolo do preço seguinte;
- só espaço conta como espaço: quebra de linha colada ao delimitador não desqualifica a fórmula, porque preço não é escrito assim;
- a outra regra do Pandoc, que o `$` de fechamento não pode ser seguido de dígito, foi descartada: ela derruba `$n$1` e `2$\times$3` sem pegar um único preço que as duas acima já não peguem.

Ficam três casos conhecidos, todos com saída para o autor: `$ x^2 $`, com espaço colado aos delimitadores, deixa de ser fórmula (é o mesmo trade-off do Pandoc, e sem ele o caso comum de preço não é distinguível); `x$2x$`, dígito e letra colados a uma palavra, é indistinguível de `R$3 e R$5`; e `U$S 3 a U$S 5`, a grafia rio-platense, continua sendo lido como fórmula, porque cobri-la exigiria uma terceira condição que reintroduz risco de falso negativo.

Como o plugin age no parser, tanto o editor quanto o visualizador (e o RSS, que renderiza sem KaTeX) passam a ver o preço como texto, e a folha de estilo do KaTeX deixa de ser baixada em conteúdo que só tem preços.

Resolve #1944

## Tipo de mudança

<!-- Descomente a linha abaixo que corresponde ao tipo de mudança realizada no PR. -->

- [x] Correção de bug

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
