### PR TITLE
Bump dos pacotes `@tabnews` para 2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18213,7 +18213,7 @@
     },
     "packages/config": {
       "name": "@tabnews/config",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@eslint/js": "9.39.4",
@@ -18277,7 +18277,7 @@
     },
     "packages/forms": {
       "name": "@tabnews/forms",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@tabnews/helpers": "*",
@@ -18290,12 +18290,12 @@
     },
     "packages/helpers": {
       "name": "@tabnews/helpers",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT"
     },
     "packages/hooks": {
       "name": "@tabnews/hooks",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@tabnews/helpers": "*"
@@ -18306,7 +18306,7 @@
     },
     "packages/infra": {
       "name": "@tabnews/infra",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@tabnews/helpers": "*",
@@ -18317,7 +18317,7 @@
     },
     "packages/ui": {
       "name": "@tabnews/ui",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@bytemd/plugin-breaks": "^1.22.0",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tabnews/config",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Configurações padronizadas dos projetos TabNews",
   "license": "MIT",
   "private": true,

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tabnews/forms",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "TabNews useForm hook and form validators",
   "license": "MIT",
   "private": true,

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tabnews/helpers",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "TabNews helpers",
   "license": "MIT",
   "private": true,

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tabnews/hooks",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "TabNews Hooks",
   "license": "MIT",
   "private": true,

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tabnews/infra",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "TabNews Infra",
   "license": "MIT",
   "private": true,

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tabnews/ui",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "TabNews UI",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Bump dos pacotes `@tabnews` para 2.1.0, incluindo os novos recursos do KaTeX/lint e as correções do editor entregues desde a tag `packages-v2.0.0`.

