### PR TITLE
Exige uma versão mínima do npm para o min-release-age funcionar

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
 save-exact=true
 min-release-age=7
 ignore-scripts=true
+engine-strict=true

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Rodar o TabNews em sua máquina local é uma tarefa extremamente simples.
 
 Você precisa ter duas principais dependências instaladas:
 
-- Node.js LTS v22 (ou qualquer versão superior)
+- Node.js LTS v24 (v24.14.1 ou qualquer versão superior)
 - Docker Engine v17.12.0 com Docker Compose v1.29.2 (ou qualquer versão superior)
 
 ### Dependências locais

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,8 @@
         "vitest": "4.1.7"
       },
       "engines": {
-        "node": "24.x"
+        "node": "24.x",
+        "npm": ">=11.10.0"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,8 @@
     "pre-commit": "lint-staged"
   },
   "engines": {
-    "node": "24.x"
+    "node": "24.x",
+    "npm": ">=11.10.0"
   },
   "name": "tabnews.com.br",
   "description": "Conteúdos para quem vive de programação e tecnologia.",


### PR DESCRIPTION
## Mudanças realizadas

No [#2033](https://github.com/filipedeschamps/tabnews.com.br/pull/2033) foram adicionados `min-release-age=7` e `ignore-scripts=true` no `.npmrc`, mas ainda não garante que o npm de quem roda `npm install` entende essas chaves. O `min-release-age` só existe a partir do [npm 11.10.0](https://github.com/npm/cli/pull/8965).

Em qualquer npm anterior ela é chave desconhecida e é ignorada (o dev pode achar que tem a garantia e não tem). Dá pra simular com `npx -y npm@11.9.0 install --dry-run`, que não altera nada.

**Antes desse PR (usando npm < 11.10.0):**

```bash
npm warn Unknown project config "min-release-age". This will stop working in the next major version of npm.

added 3 packages in 2s
```

Hoje o `engines` do projeto pede só `"node": "24.x"`, o que aceita desde o Node 24.0.0, que vem com npm 11.3.0. Esse PR então adiciona `"npm": ">=11.10.0"` no `engines` e `engine-strict=true` no `.npmrc`, que transforma o `engines` de aviso em erro ([_"If set to true, then npm will stubbornly refuse to install (or even consider installing) any package that claims to not be compatible with the current Node.js version."_](https://docs.npmjs.com/cli/v11/using-npm/config#engine-strict)) — e vale para o campo `npm` do `engines` também, como a saída abaixo mostra. Também atualiza o README, que ainda pedia Node v22 — a versão certa é a v24.14.1, primeiro Node 24 a embutir um npm >= 11.10.0 (ele traz o 11.11.0).

**Após PR (usando npm < 11.10.0):**

```bash
npm warn Unknown project config "min-release-age". This will stop working in the next major version of npm.
npm error code EBADENGINE
npm error engine Unsupported engine
npm error engine Not compatible with your version of node/npm: tabnews.com.br@1.0.0
npm error notsup Not compatible with your version of node/npm: tabnews.com.br@1.0.0
npm error notsup Required: {"node":"24.x","npm":">=11.10.0"}
npm error notsup Actual:   {"node":"v24.18.0","npm":"11.9.0"}
```

## Tipo de mudança

- [x] Melhoria de segurança

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Tanto os novos testes quanto os antigos estão passando localmente.