### PR TITLE
Traduz o `Dialog` e o `useConfirm` dentro do `@tabnews/ui`

### DIFF
--- a/interface/components/Content/index.jsx
+++ b/interface/components/Content/index.jsx
@@ -143,8 +143,6 @@ function ViewMode({ setComponentMode, contentObject, isPageRootOwner, viewFrame 
     const confirmDelete = await confirm({
       title: 'Você tem certeza?',
       content: 'Deseja realmente apagar essa publicação?',
-      cancelButtonContent: 'Cancelar',
-      confirmButtonContent: 'Sim',
     });
 
     if (!confirmDelete) return;
@@ -300,7 +298,6 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
                   de fazer essa publicação.
                 </Flash>
               ),
-              cancelButtonContent: 'Cancelar',
               confirmButtonContent: 'Publicar',
               confirmButtonType: 'danger',
             })
@@ -436,8 +433,6 @@ function EditMode({ contentObject, setContentObject, setComponentMode, localStor
         ? await confirm({
             title: 'Tem certeza que deseja sair da edição?',
             content: 'Os dados não salvos serão perdidos.',
-            cancelButtonContent: 'Cancelar',
-            confirmButtonContent: 'Sim',
           })
         : true;
 
@@ -606,7 +601,6 @@ function CompactMode({ contentObject, rootContent, setComponentMode }) {
               title: 'Você deseja responder ao seu próprio conteúdo?',
               content:
                 'Ao responder à sua própria publicação, você não acumulará TabCoins. É recomendado editar o conteúdo existente caso precise complementar informações.',
-              cancelButtonContent: 'Cancelar',
               confirmButtonContent: 'Responder',
               confirmButtonType: 'danger',
             })

--- a/package-lock.json
+++ b/package-lock.json
@@ -18214,7 +18214,7 @@
     },
     "packages/config": {
       "name": "@tabnews/config",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@eslint/js": "9.39.4",
@@ -18278,7 +18278,7 @@
     },
     "packages/forms": {
       "name": "@tabnews/forms",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@tabnews/helpers": "*",
@@ -18291,12 +18291,12 @@
     },
     "packages/helpers": {
       "name": "@tabnews/helpers",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT"
     },
     "packages/hooks": {
       "name": "@tabnews/hooks",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@tabnews/helpers": "*"
@@ -18307,7 +18307,7 @@
     },
     "packages/infra": {
       "name": "@tabnews/infra",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@tabnews/helpers": "*",
@@ -18318,7 +18318,7 @@
     },
     "packages/ui": {
       "name": "@tabnews/ui",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@bytemd/plugin-breaks": "^1.22.0",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tabnews/config",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Configurações padronizadas dos projetos TabNews",
   "license": "MIT",
   "private": true,

--- a/packages/config/src/shared/eslint.config.cjs
+++ b/packages/config/src/shared/eslint.config.cjs
@@ -141,6 +141,23 @@ module.exports = defineConfig([
   },
   primerReactRecommended,
   {
+    files: ['**/*.{js,jsx,mjs,cjs,ts,tsx}'],
+    // The wrappers themselves are the only place allowed to reach the Primer components.
+    ignores: ['packages/ui/**'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: ['@primer/react', '@tabnews/ui/primer'].map((name) => ({
+            name,
+            importNames: ['Dialog', 'useConfirm'],
+            message: 'Import from `@tabnews/ui` instead, which translates the dialog.',
+          })),
+        },
+      ],
+    },
+  },
+  {
     files: ['tests/*', '**/*.test.*', '**/*.spec.*'],
     ignores: ['tests/e2e/**'],
     languageOptions: pluginVitest.environments.env,

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tabnews/forms",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "TabNews useForm hook and form validators",
   "license": "MIT",
   "private": true,

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tabnews/helpers",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "TabNews helpers",
   "license": "MIT",
   "private": true,

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tabnews/hooks",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "TabNews Hooks",
   "license": "MIT",
   "private": true,

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tabnews/infra",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "TabNews Infra",
   "license": "MIT",
   "private": true,

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tabnews/ui",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "TabNews UI",
   "license": "MIT",
   "private": true,

--- a/packages/ui/src/Dialog/Dialog.jsx
+++ b/packages/ui/src/Dialog/Dialog.jsx
@@ -5,7 +5,9 @@ import { useLayoutEffect } from 'react';
 import { translateDialogCloseTooltip } from './closeTooltip';
 
 export function Dialog(props) {
-  useLayoutEffect(translateDialogCloseTooltip, []);
+  useLayoutEffect(() => {
+    translateDialogCloseTooltip();
+  }, []);
 
   return <PrimerDialog {...props} />;
 }

--- a/packages/ui/src/Dialog/Dialog.jsx
+++ b/packages/ui/src/Dialog/Dialog.jsx
@@ -1,0 +1,11 @@
+'use client';
+import { Dialog as PrimerDialog } from '@primer/react';
+import { useLayoutEffect } from 'react';
+
+import { translateDialogCloseTooltip } from './closeTooltip';
+
+export function Dialog(props) {
+  useLayoutEffect(translateDialogCloseTooltip, []);
+
+  return <PrimerDialog {...props} />;
+}

--- a/packages/ui/src/Dialog/Dialog.test.jsx
+++ b/packages/ui/src/Dialog/Dialog.test.jsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+
+import { Dialog } from '.';
+import { ThemeProvider } from '../ThemeProvider';
+
+describe('ui', () => {
+  describe('Dialog', () => {
+    it('translates the tooltip of the close button', () => {
+      render(
+        <ThemeProvider colorMode="dark">
+          <Dialog title="Título" onClose={() => {}}>
+            Conteúdo
+          </Dialog>
+        </ThemeProvider>,
+      );
+
+      expect(screen.queryByText('Close')).toBeNull();
+      expect(screen.getByRole('button', { name: 'Fechar' })).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui/src/Dialog/closeTooltip.js
+++ b/packages/ui/src/Dialog/closeTooltip.js
@@ -1,0 +1,12 @@
+// The close button of the Primer Dialog has no prop for its tooltip text, and the button itself has
+// no `aria-label`: it points to the tooltip through `aria-labelledby`. Rewriting the tooltip text
+// translates both the tooltip and the accessible name.
+const closeTooltipSelector = '[role="dialog"] button ~ span, [role="alertdialog"] button ~ span';
+
+export function translateDialogCloseTooltip() {
+  document.querySelectorAll(closeTooltipSelector).forEach((span) => {
+    if (span.textContent === 'Close') {
+      span.textContent = 'Fechar';
+    }
+  });
+}

--- a/packages/ui/src/Dialog/closeTooltip.js
+++ b/packages/ui/src/Dialog/closeTooltip.js
@@ -4,9 +4,14 @@
 const closeTooltipSelector = '[role="dialog"] button ~ span, [role="alertdialog"] button ~ span';
 
 export function translateDialogCloseTooltip() {
+  let translated = false;
+
   document.querySelectorAll(closeTooltipSelector).forEach((span) => {
     if (span.textContent === 'Close') {
       span.textContent = 'Fechar';
+      translated = true;
     }
   });
+
+  return translated;
 }

--- a/packages/ui/src/Dialog/index.js
+++ b/packages/ui/src/Dialog/index.js
@@ -1,0 +1,1 @@
+export * from './Dialog';

--- a/packages/ui/src/index.js
+++ b/packages/ui/src/index.js
@@ -7,6 +7,7 @@ export { NotificationList, NotificationMenu, NotificationsProvider, useNotificat
 export { PrimerRoot } from './PrimerRoot/PrimerRoot';
 export * from './ThemeProvider';
 export * from './UnderlineNav';
+export * from './useConfirm';
 export {
   ActionList,
   ActionMenu,
@@ -30,7 +31,6 @@ export {
   TextInput,
   Tooltip,
   Truncate,
-  useConfirm,
   useTheme,
 } from '@primer/react';
 export { Tooltip as TooltipV1 } from '@primer/react/deprecated';

--- a/packages/ui/src/index.js
+++ b/packages/ui/src/index.js
@@ -1,5 +1,6 @@
 export * from './AutoThemeProvider';
 export { COLOR_MODE_COOKIE } from './constants/public';
+export * from './Dialog';
 export * from './FormField';
 export * from './GoToTopButton';
 export { NotificationList, NotificationMenu, NotificationsProvider, useNotifications } from './Notifications';
@@ -14,7 +15,6 @@ export {
   Button,
   Checkbox,
   CounterLabel,
-  Dialog,
   Flash,
   FormControl,
   Heading,

--- a/packages/ui/src/useConfirm/index.js
+++ b/packages/ui/src/useConfirm/index.js
@@ -1,0 +1,1 @@
+export * from './useConfirm';

--- a/packages/ui/src/useConfirm/useConfirm.js
+++ b/packages/ui/src/useConfirm/useConfirm.js
@@ -1,0 +1,34 @@
+'use client';
+import { useConfirm as usePrimerConfirm } from '@primer/react';
+
+import { translateDialogCloseTooltip } from '../Dialog/closeTooltip';
+
+const defaultOptions = {
+  cancelButtonContent: 'Cancelar',
+  confirmButtonContent: 'Sim',
+};
+
+// The dialog of `useConfirm` is mounted in its own root outside the React tree, so the close tooltip
+// only exists after that root paints — hence the observer instead of an effect.
+function translateCloseTooltipWhenRendered() {
+  const observer = new MutationObserver(() => {
+    if (translateDialogCloseTooltip()) {
+      observer.disconnect();
+    }
+  });
+
+  observer.observe(document.body, { childList: true, subtree: true });
+
+  return () => observer.disconnect();
+}
+
+export function useConfirm() {
+  const confirm = usePrimerConfirm();
+
+  return function confirmInPortuguese(options) {
+    const confirmation = confirm({ ...defaultOptions, ...options });
+    const stopObserving = translateCloseTooltipWhenRendered();
+
+    return confirmation.finally(stopObserving);
+  };
+}

--- a/packages/ui/src/useConfirm/useConfirm.test.jsx
+++ b/packages/ui/src/useConfirm/useConfirm.test.jsx
@@ -1,0 +1,85 @@
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+
+import { useConfirm } from '.';
+import { translateDialogCloseTooltip } from '../Dialog/closeTooltip';
+
+vi.mock('../Dialog/closeTooltip', () => ({ translateDialogCloseTooltip: vi.fn() }));
+
+const closeTooltip = await vi.importActual('../Dialog/closeTooltip');
+
+beforeEach(() => {
+  translateDialogCloseTooltip.mockImplementation(closeTooltip.translateDialogCloseTooltip);
+});
+
+function ConfirmButton({ onResult = () => {}, ...options }) {
+  const confirm = useConfirm();
+
+  async function handleClick() {
+    onResult(await confirm(options));
+  }
+
+  return <button onClick={handleClick}>Apagar</button>;
+}
+
+async function openDialog(props) {
+  const user = userEvent.setup();
+  render(<ConfirmButton title="Tem certeza?" {...props} />);
+  await user.click(screen.getByRole('button', { name: 'Apagar' }));
+  await screen.findByRole('alertdialog');
+
+  return user;
+}
+
+// MutationObserver callbacks run in a microtask, so a macrotask is enough to see them all.
+function waitForMutations() {
+  return new Promise((resolve) => setTimeout(resolve));
+}
+
+describe('ui', () => {
+  describe('useConfirm', () => {
+    it('translates the buttons and the tooltip of the close button', async () => {
+      const user = await openDialog();
+
+      expect(screen.getByRole('button', { name: 'Sim' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Cancelar' })).toBeInTheDocument();
+      expect(await screen.findByRole('button', { name: 'Fechar' })).toBeInTheDocument();
+      expect(screen.queryByText('Close')).toBeNull();
+
+      await user.click(screen.getByRole('button', { name: 'Cancelar' }));
+    });
+
+    it('keeps the button contents provided by the caller', async () => {
+      const user = await openDialog({ confirmButtonContent: 'Apagar mesmo', cancelButtonContent: 'Voltar' });
+
+      expect(screen.getByRole('button', { name: 'Apagar mesmo' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Voltar' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Sim' })).toBeNull();
+
+      await user.click(screen.getByRole('button', { name: 'Voltar' }));
+    });
+
+    it('resolves with the gesture of the user', async () => {
+      const onResult = vi.fn();
+      const user = await openDialog({ onResult });
+
+      await user.click(screen.getByRole('button', { name: 'Sim' }));
+
+      expect(onResult).toHaveBeenCalledWith(true);
+    });
+
+    // The observer disconnects itself as soon as it translates, so the `finally` only matters when
+    // the tooltip never shows up — otherwise it would keep watching the whole document forever.
+    it('stops observing the document when the tooltip never renders', async () => {
+      translateDialogCloseTooltip.mockReturnValue(false);
+      const user = await openDialog();
+
+      await user.click(screen.getByRole('button', { name: 'Cancelar' }));
+      translateDialogCloseTooltip.mockClear();
+      document.body.append(document.createElement('div'));
+      await waitForMutations();
+
+      expect(translateDialogCloseTooltip).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/pages/[username]/index.jsx
+++ b/pages/[username]/index.jsx
@@ -188,8 +188,6 @@ function DescriptionForm({
               &quot;.
             </span>
           ),
-          cancelButtonContent: 'Cancelar',
-          confirmButtonContent: 'Sim',
         })
       : true;
 
@@ -248,8 +246,6 @@ function DescriptionForm({
         ? await confirm({
             title: 'Tem certeza que deseja sair da edição?',
             content: 'A alteração não foi salva e será perdida.',
-            cancelButtonContent: 'Cancelar',
-            confirmButtonContent: 'Sim',
           })
         : true;
 
@@ -344,8 +340,6 @@ function OptionsMenu({ canUpdate, isAuthenticatedUser, onNuke, setGlobalMessageO
     const confirmDelete1 = await confirm({
       title: `Atenção: Você está realizando um Nuke!`,
       content: `Deseja banir o usuário "${userFound.username}" e desfazer todas as suas ações?`,
-      confirmButtonContent: 'Sim',
-      cancelButtonContent: 'Cancelar',
     });
 
     if (!confirmDelete1) return;

--- a/pages/perfil/index.jsx
+++ b/pages/perfil/index.jsx
@@ -91,8 +91,6 @@ function EditProfileForm() {
         (await confirm({
           title: `Você realmente deseja alterar seu nome de usuário?`,
           content: `Isso irá quebrar todas as URLs das suas publicações e comentários.`,
-          cancelButtonContent: 'Cancelar',
-          confirmButtonContent: 'Sim',
         }));
 
       if (!confirmChangeUsername) {


### PR DESCRIPTION
## Mudanças realizadas

O `Dialog` do Primer não tem prop para o texto do tooltip do botão de fechar, que nasce como `"Close"`, e como o botão usa `aria-labelledby` apontando para esse tooltip, o nome acessível também ficava em inglês. O `useConfirm`, além do mesmo tooltip, tem os botões de confirmar e cancelar em inglês por padrão, o que fazia cada chamada repetir `cancelButtonContent: 'Cancelar'` e `confirmButtonContent: 'Sim'`.

O `@tabnews/ui` passa a exportar um `Dialog` e um `useConfirm` próprios, que embrulham os do Primer e resolvem as duas coisas internamente. Como os wrappers assumem o nome que já era reexportado, nenhum import de `@tabnews/ui` muda: os call sites do TabNews só perderam os textos de botão repetidos. O subpath `@tabnews/ui/primer` continua expondo as versões cruas, e uma regra `no-restricted-imports` no `@tabnews/config` impede chegar nelas sem querer.

## Tipo de mudança

- [x] Correção de bug

## Checklist:

- [x] As modificações não geram novos logs de erro ou aviso (_warning_).
- [x] Eu adicionei testes que provam que a correção ou novo recurso funciona conforme esperado.
- [x] Tanto os novos testes quanto os antigos estão passando localmente.
